### PR TITLE
Harden GFTextFitter single-line fitting

### DIFF
--- a/addons/gf/standard/utilities/ui/gf_text_fitter.gd
+++ b/addons/gf/standard/utilities/ui/gf_text_fitter.gd
@@ -34,20 +34,21 @@ const DEFAULT_MAX_FONT_SIZE: int = 64
 ## [br]
 ## @param control: 目标文本控件，支持 Label、RichTextLabel、Button、LineEdit 与 TextEdit，也可通过 options.text 适配自定义控件。
 ## [br]
-## @param options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、text、content_insets、use_placeholder、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
+## @param options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、text、content_insets、use_placeholder、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
 ## [br]
 ## @return 计算出的字体尺寸；目标无效或无法读取文本时返回 0。
 ## [br]
-## @schema options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、text、content_insets、use_placeholder、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。
+## @schema options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、text、content_insets、use_placeholder、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。
 static func fit_control(control: Control, options: Dictionary = {}) -> int:
 	if control == null:
 		return 0
-	if control is RichTextLabel:
-		var rich_label: RichTextLabel = control
-		return fit_rich_text_label(rich_label, options)
-	if control is Label:
-		var label: Label = control
-		return fit_label(label, options)
+	if not options.has("text"):
+		if control is RichTextLabel:
+			var rich_label: RichTextLabel = control
+			return fit_rich_text_label(rich_label, options)
+		if control is Label:
+			var label: Label = control
+			return fit_label(label, options)
 
 	var text_info: Dictionary = _get_control_text_info(control, options)
 	if text_info.is_empty():
@@ -77,11 +78,11 @@ static func fit_control(control: Control, options: Dictionary = {}) -> int:
 ## [br]
 ## @param label: 目标 Label。
 ## [br]
-## @param options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
+## @param options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
 ## [br]
 ## @return 计算出的字体尺寸；目标无效时返回 0。
 ## [br]
-## @schema options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。
+## @schema options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。
 static func fit_label(label: Label, options: Dictionary = {}) -> int:
 	if label == null:
 		return 0
@@ -110,11 +111,11 @@ static func fit_label(label: Label, options: Dictionary = {}) -> int:
 ## [br]
 ## @param label: 目标 RichTextLabel。
 ## [br]
-## @param options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
+## @param options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
 ## [br]
 ## @return 计算出的字体尺寸；目标无效时返回 0。
 ## [br]
-## @schema options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。
+## @schema options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。
 static func fit_rich_text_label(label: RichTextLabel, options: Dictionary = {}) -> int:
 	if label == null:
 		return 0
@@ -143,6 +144,8 @@ static func fit_rich_text_label(label: RichTextLabel, options: Dictionary = {}) 
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param control: 目标文本控件。
 ## [br]
 ## @param font_size: 字体尺寸。
@@ -151,7 +154,7 @@ static func fit_rich_text_label(label: RichTextLabel, options: Dictionary = {}) 
 ## [br]
 ## @return 文本尺寸；目标无效或字体缺失时返回 Vector2.ZERO。
 ## [br]
-## @schema options: Dictionary，字段同 fit_control() 的 options。
+## @schema options: Dictionary，字段同 fit_control() 的 options；use_multiline_measurement 可显式覆盖控件自身的换行测量模式。
 static func measure_control_text(control: Control, font_size: int, options: Dictionary = {}) -> Vector2:
 	if control == null:
 		return Vector2.ZERO
@@ -169,6 +172,8 @@ static func measure_control_text(control: Control, font_size: int, options: Dict
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param control: 提供主题字体的控件。
 ## [br]
 ## @param text: 待测量文本。
@@ -179,7 +184,7 @@ static func measure_control_text(control: Control, font_size: int, options: Dict
 ## [br]
 ## @return 文本尺寸；字体缺失时返回 Vector2.ZERO。
 ## [br]
-## @schema options: Dictionary，支持 available_size、fit_width、font_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
+## @schema options: Dictionary，支持 available_size、fit_width、font_name、font、use_multiline_measurement、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
 static func measure_text(control: Control, text: String, font_size: int, options: Dictionary = {}) -> Vector2:
 	if control == null:
 		return Vector2.ZERO
@@ -196,6 +201,8 @@ static func measure_text(control: Control, text: String, font_size: int, options
 	var wrap_width: float = available_size.x if fit_width and available_size.x > 0.0 else -1.0
 	if _uses_multiline_text_measurement(options):
 		return _measure_multiline_text(font, text, font_size, wrap_width, options)
+	if options.has("use_multiline_measurement"):
+		wrap_width = -1.0
 	return _measure_lines(font, text, font_size, wrap_width)
 
 
@@ -356,6 +363,8 @@ static func _find_largest_fitting_font_size(control: Control, text: String, opti
 	var font_size_candidates: Array[int] = _resolve_font_size_candidates(options, min_font_size, max_font_size)
 	if not font_size_candidates.is_empty():
 		return _find_largest_candidate_font_size(control, text, options, font_size_candidates, min_font_size)
+	if GFVariantData.get_option_bool(options, "use_single_pass_fit", false):
+		return _find_single_pass_font_size(control, text, options, min_font_size, max_font_size)
 
 	var best_size: int = min_font_size
 	var low: int = min_font_size
@@ -370,6 +379,27 @@ static func _find_largest_fitting_font_size(control: Control, text: String, opti
 			high = candidate - 1
 
 	return best_size
+
+
+static func _find_single_pass_font_size(
+	control: Control,
+	text: String,
+	options: Dictionary,
+	min_font_size: int,
+	max_font_size: int
+) -> int:
+	var available_size: Vector2 = _resolve_available_size(control, options)
+	var measured_size: Vector2 = measure_text(control, text, max_font_size, options)
+	var scale_factor: float = 1.0
+	if GFVariantData.get_option_bool(options, "fit_width", true) and available_size.x > 0.0:
+		scale_factor = minf(scale_factor, available_size.x / maxf(measured_size.x, 1.0))
+	if GFVariantData.get_option_bool(options, "fit_height", true) and available_size.y > 0.0:
+		scale_factor = minf(scale_factor, available_size.y / maxf(measured_size.y, 1.0))
+	return clampi(
+		floori(float(max_font_size) * clampf(scale_factor, 0.0, 1.0)),
+		min_font_size,
+		max_font_size
+	)
 
 
 static func _find_largest_candidate_font_size(
@@ -468,8 +498,8 @@ static func _get_stylebox_insets(control: Control, stylebox_name: StringName) ->
 
 
 static func _uses_multiline_text_measurement(options: Dictionary) -> bool:
-	if GFVariantData.get_option_bool(options, "use_multiline_measurement", false):
-		return true
+	if options.has("use_multiline_measurement"):
+		return GFVariantData.get_option_bool(options, "use_multiline_measurement", false)
 	for key: String in [
 		"horizontal_alignment",
 		"line_break_flags",

--- a/docs/api_catalog/classes/GFTextFitter.xml
+++ b/docs/api_catalog/classes/GFTextFitter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTextFitter" path="addons/gf/standard/utilities/ui/gf_text_fitter.gd" module="standard" extends="RefCounted" classDigest="f0d306bb00f6be393d7bf74fdff1cb1750d51cde1a12eac366cfd51d0f9fd101">
+<class name="GFTextFitter" path="addons/gf/standard/utilities/ui/gf_text_fitter.gd" module="standard" extends="RefCounted" classDigest="81b47549c83b5081aee2991663cbab96d4bb958a6ad5d8acdb2309b352e4b010">
 	<description>GFTextFitter: 文本尺寸适配器。
 为常见文本控件提供通用字体大小计算，不接管控件布局、主题或项目文本规则。</description>
 	<tags>
@@ -33,9 +33,9 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">control: 目标文本控件，支持 Label、RichTextLabel、Button、LineEdit 与 TextEdit，也可通过 options.text 适配自定义控件。</tag>
-				<tag name="param">options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、text、content_insets、use_placeholder、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
+				<tag name="param">options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、text、content_insets、use_placeholder、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
 				<tag name="return">计算出的字体尺寸；目标无效或无法读取文本时返回 0。</tag>
-				<tag name="schema">options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、text、content_insets、use_placeholder、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。</tag>
+				<tag name="schema">options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、text、content_insets、use_placeholder、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
@@ -45,9 +45,9 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">label: 目标 Label。</tag>
-				<tag name="param">options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
+				<tag name="param">options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
 				<tag name="return">计算出的字体尺寸；目标无效时返回 0。</tag>
-				<tag name="schema">options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。</tag>
+				<tag name="schema">options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
@@ -57,9 +57,9 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">label: 目标 RichTextLabel。</tag>
-				<tag name="param">options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
+				<tag name="param">options: 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
 				<tag name="return">计算出的字体尺寸；目标无效时返回 0。</tag>
-				<tag name="schema">options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。</tag>
+				<tag name="schema">options: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
@@ -72,7 +72,8 @@
 				<tag name="param">font_size: 字体尺寸。</tag>
 				<tag name="param">options: fit_control() 使用的设置。</tag>
 				<tag name="return">文本尺寸；目标无效或字体缺失时返回 Vector2.ZERO。</tag>
-				<tag name="schema">options: Dictionary，字段同 fit_control() 的 options。</tag>
+				<tag name="schema">options: Dictionary，字段同 fit_control() 的 options；use_multiline_measurement 可显式覆盖控件自身的换行测量模式。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="measure_text">
@@ -85,7 +86,8 @@
 				<tag name="param">font_size: 字体尺寸。</tag>
 				<tag name="param">options: fit_label() 或 fit_rich_text_label() 使用的设置。</tag>
 				<tag name="return">文本尺寸；字体缺失时返回 Vector2.ZERO。</tag>
-				<tag name="schema">options: Dictionary，支持 available_size、fit_width、font_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
+				<tag name="schema">options: Dictionary，支持 available_size、fit_width、font_name、font、use_multiline_measurement、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="07456ab71d580ce62082a3ae3748c8c31312dfbf1c6ba77cc184e9759f1a74ed" classCount="709" methodCount="6299">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="64c8466396a34eb2e6a5aed0bba716842062b043f8b8e360f21e09e8e079f9df" classCount="709" methodCount="6299">
 	<module id="kernel" label="Kernel" classCount="69" methodCount="697">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -20,6 +20,20 @@
 
 ---
 
+## [未发布]
+
+### 🚀 新增特性 (Added)
+
+- `GFTextFitter` 新增 `use_single_pass_fit` 选项，为固定单行数字和计数器提供一次测量的比例字号适配。
+
+### 🐛 Bug 修复 (Fixed)
+
+- `use_multiline_measurement = false` 现在会覆盖 Label 自身的换行元数据，避免单行适配仍走多行塑形；`fit_control()` 的显式 `text` 也不再被 Label / RichTextLabel 专用分派忽略。
+
+### 🔧 API 变动说明 (API Changes)
+
+- `GFTextFitter.fit_control()`、`fit_label()` 与 `fit_rich_text_label()` 的 options 新增兼容选项 `use_single_pass_fit`；文本测量 options 明确支持 `use_multiline_measurement` 覆盖。
+
 ## [8.1.0] - 2026-07-17
 
 ### 🚀 新增特性 (Added)

--- a/docs/zh/reference/api/classes/GFTextFitter.md
+++ b/docs/zh/reference/api/classes/GFTextFitter.md
@@ -69,13 +69,13 @@ static func fit_control(control: Control, options: Dictionary = {}) -> int:
 | 名称 | 说明 |
 |---|---|
 | `control` | 目标文本控件，支持 Label、RichTextLabel、Button、LineEdit 与 TextEdit，也可通过 options.text 适配自定义控件。 |
-| `options` | 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、text、content_insets、use_placeholder、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。 |
+| `options` | 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、text、content_insets、use_placeholder、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。 |
 
 返回：计算出的字体尺寸；目标无效或无法读取文本时返回 0。
 
 结构：
 
-- `options`: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、text、content_insets、use_placeholder、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。
+- `options`: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、text、content_insets、use_placeholder、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。
 
 <a id="member-gftextfitter-methods-fit_label"></a>
 
@@ -95,13 +95,13 @@ static func fit_label(label: Label, options: Dictionary = {}) -> int:
 | 名称 | 说明 |
 |---|---|
 | `label` | 目标 Label。 |
-| `options` | 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。 |
+| `options` | 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。 |
 
 返回：计算出的字体尺寸；目标无效时返回 0。
 
 结构：
 
-- `options`: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。
+- `options`: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。
 
 <a id="member-gftextfitter-methods-fit_rich_text_label"></a>
 
@@ -121,19 +121,20 @@ static func fit_rich_text_label(label: RichTextLabel, options: Dictionary = {}) 
 | 名称 | 说明 |
 |---|---|
 | `label` | 目标 RichTextLabel。 |
-| `options` | 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。 |
+| `options` | 可选设置，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。 |
 
 返回：计算出的字体尺寸；目标无效时返回 0。
 
 结构：
 
-- `options`: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值。
+- `options`: Dictionary，支持 min_font_size、max_font_size、font_size_candidates、available_size、fit_width、fit_height、apply、font_name、font_size_name、font、use_multiline_measurement、use_single_pass_fit、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction；font_size_candidates 为整数候选字号数组，非空时只从合法候选字号中挑选最大适配值；use_single_pass_fit 仅用于尺寸随字号线性变化的非换行文本，并优先减少字体塑形次数。
 
 <a id="member-gftextfitter-methods-measure_control_text"></a>
 
 ### `measure_control_text`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 static func measure_control_text(control: Control, font_size: int, options: Dictionary = {}) -> Vector2:
@@ -153,13 +154,14 @@ static func measure_control_text(control: Control, font_size: int, options: Dict
 
 结构：
 
-- `options`: Dictionary，字段同 fit_control() 的 options。
+- `options`: Dictionary，字段同 fit_control() 的 options；use_multiline_measurement 可显式覆盖控件自身的换行测量模式。
 
 <a id="member-gftextfitter-methods-measure_text"></a>
 
 ### `measure_text`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 static func measure_text(control: Control, text: String, font_size: int, options: Dictionary = {}) -> Vector2:
@@ -180,4 +182,4 @@ static func measure_text(control: Control, text: String, font_size: int, options
 
 结构：
 
-- `options`: Dictionary，支持 available_size、fit_width、font_name、font、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。
+- `options`: Dictionary，支持 available_size、fit_width、font_name、font、use_multiline_measurement、horizontal_alignment、autowrap_mode、line_break_flags、justification_flags、text_direction。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/text-richtext.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/text-richtext.md
@@ -21,6 +21,13 @@ GFTextFitter.fit_control(%ApplyButton, {
 GFTextFitter.fit_label(%CounterLabel, {
 	"font_size_candidates": [12, 16, 20, 24],
 })
+
+GFTextFitter.fit_label(%ScoreLabel, {
+	"min_font_size": 12,
+	"max_font_size": 48,
+	"use_multiline_measurement": false,
+	"use_single_pass_fit": true,
+})
 ```
 
 `fit_control()` 会按常见 Godot 控件推导文本、主题字体名和内容边距，支持 `Button`、`LineEdit`、`TextEdit`、`Label` 和 `RichTextLabel`；无法识别的自定义控件可以通过 `options.text`、`font_name`、`font_size_name` 和 `content_insets` 显式提供信息。
@@ -28,6 +35,8 @@ GFTextFitter.fit_label(%CounterLabel, {
 `Label`、`RichTextLabel`、`Button`、`LineEdit` 和 `TextEdit` 的测量会尽量读取控件自身的 `horizontal_alignment` / `alignment`、`autowrap_mode`、`justification_flags` 和 `text_direction`，让自动字号与 Godot 实际文本排版保持一致。自定义控件也可以在 options 中显式传入 `horizontal_alignment`、`autowrap_mode`、`line_break_flags`、`justification_flags` 或 `text_direction`。
 
 如果界面有固定字阶或品牌字体规范，可以传入 `font_size_candidates`。候选集会先按 `min_font_size` / `max_font_size` 过滤并去重，然后从大到小选择第一个适配值；没有合法候选时仍回到普通连续字号搜索。
+
+固定单行数字、计数器等文本可以同时设置 `use_multiline_measurement = false` 和 `use_single_pass_fit = true`。该策略只在最大字号测量一次，再按宽高比例计算目标字号，适合尺寸随字号线性变化且不会换行的内容；正文、自动换行文本和需要候选字阶的品牌排版仍应使用默认搜索或 `font_size_candidates`。显式设置 `use_multiline_measurement` 会覆盖控件自身的换行元数据。
 
 需要随控件 resize 或语言变化自动刷新时，把 `GFTextAutoFit` 挂到目标控件下，或用 `target_path` 指向目标 Control。`GFTextFitter` / `GFTextAutoFit` 只处理通用文本尺寸适配；换行策略、截断、省略号、本地化长词拆分和具体 UI 视觉仍应由项目自己的控件或主题决定。
 

--- a/tests/gf_core/standard/utilities/ui/test_gf_text_fitter.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_text_fitter.gd
@@ -97,6 +97,74 @@ func test_measure_control_text_uses_label_autowrap() -> void:
 	assert_lt(wrapped_size.x, single_line_size.x, "开启自动换行时测量宽度应小于单行文本。")
 
 
+## 验证显式关闭多行测量会覆盖 Label 自身的换行元数据。
+func test_measure_control_text_allows_explicit_single_line_override() -> void:
+	var label: Label = Label.new()
+	label.text = "Alpha Beta Gamma Delta"
+	label.size = Vector2(72.0, 160.0)
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART as TextServer.AutowrapMode
+	add_child_autofree(label)
+
+	var measured_size: Vector2 = GFTextFitter.measure_control_text(label, 20, {
+		"available_size": Vector2(72.0, 160.0),
+		"use_multiline_measurement": false,
+	})
+	var expected_size: Vector2 = label.get_theme_font(&"font").get_string_size(
+		label.text,
+		HORIZONTAL_ALIGNMENT_LEFT,
+		-1.0,
+		20
+	)
+
+	assert_almost_eq(measured_size.x, expected_size.x, 0.01, "显式单行测量不应按可用宽度换行。")
+	assert_almost_eq(measured_size.y, expected_size.y, 0.01, "显式单行测量应只保留一行高度。")
+
+
+## 验证固定单行文本可用一次测量按比例求得字号。
+func test_fit_label_supports_single_pass_proportional_fit() -> void:
+	var label: Label = Label.new()
+	label.text = "2147483647"
+	label.size = Vector2(90.0, 40.0)
+	add_child_autofree(label)
+
+	var font: Font = label.get_theme_font(&"font")
+	var max_size: Vector2 = font.get_string_size(label.text, HORIZONTAL_ALIGNMENT_LEFT, -1.0, 40)
+	var expected_size: int = clampi(
+		floori(40.0 * minf(90.0 / maxf(max_size.x, 1.0), 40.0 / maxf(max_size.y, 1.0))),
+		6,
+		40
+	)
+	var font_size: int = GFTextFitter.fit_label(label, {
+		"min_font_size": 6,
+		"max_font_size": 40,
+		"available_size": Vector2(90.0, 40.0),
+		"use_multiline_measurement": false,
+		"use_single_pass_fit": true,
+	})
+
+	assert_eq(font_size, expected_size, "单次比例策略应按最大字号测量结果直接计算字号。")
+	assert_eq(label.get_theme_font_size(&"font_size"), expected_size, "计算结果应写入 Label 主题覆盖。")
+
+
+## 验证 fit_control 的显式文本优先于具体控件当前文本。
+func test_fit_control_respects_explicit_text_for_label() -> void:
+	var label: Label = Label.new()
+	label.text = "Fit"
+	label.size = Vector2(90.0, 40.0)
+	add_child_autofree(label)
+
+	var font_size: int = GFTextFitter.fit_control(label, {
+		"text": "2147483647",
+		"min_font_size": 6,
+		"max_font_size": 40,
+		"available_size": Vector2(90.0, 40.0),
+		"use_multiline_measurement": false,
+		"use_single_pass_fit": true,
+	})
+
+	assert_lt(font_size, 40, "显式长文本应覆盖 Label 当前短文本并触发字号收缩。")
+
+
 ## 验证 Label 适配会按换行后的高度寻找字号。
 func test_fit_label_uses_label_autowrap_for_height() -> void:
 	var label: Label = Label.new()


### PR DESCRIPTION
Fixes #6.

## Summary
- add opt-in `use_single_pass_fit` proportional sizing for fixed single-line text
- make `use_multiline_measurement = false` override Label/RichTextLabel layout metadata
- honor explicit `text` passed to `fit_control()` before concrete Label dispatch
- document the new options and regenerate the API reference

## Validation
- focused `GFTextFitter` GUT: 13/13 passed
- full `gf_core` GUT: 4207/4207 tests, 28590/28590 assertions
- `gdscript_warnings`, dependency boundary, public API boundary, docs quality, and API reference checks passed