### PR TITLE
fix(editor): name extension export plugin

### DIFF
--- a/addons/gf/kernel/editor/extension/gf_extension_export_plugin.gd
+++ b/addons/gf/kernel/editor/extension/gf_extension_export_plugin.gd
@@ -32,6 +32,10 @@ var _disabled_manifests: Array[GFExtensionManifest] = []
 
 # --- Godot 生命周期方法 ---
 
+func _get_name() -> String:
+	return "GFExtensionExportPlugin"
+
+
 func _export_begin(_features: PackedStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
 	_refresh_disabled_extension_roots()
 	_warn_disabled_extension_references()

--- a/tests/gf_core/kernel/extension/test_gf_extension_manifest.gd
+++ b/tests/gf_core/kernel/extension/test_gf_extension_manifest.gd
@@ -2046,12 +2046,14 @@ func test_extensions_do_not_hard_reference_other_extensions() -> void:
 
 
 func test_extension_export_plugin_reports_stable_name() -> void:
-	var export_plugin: EditorExportPlugin = GF_EXTENSION_EXPORT_PLUGIN_BASE.new()
+	var export_plugin_script: Script = GF_EXTENSION_EXPORT_PLUGIN_BASE
+	var method_names: Array[StringName] = []
+	for method_info: Dictionary in export_plugin_script.get_script_method_list():
+		method_names.append(GF_VARIANT_ACCESS.get_option_string_name(method_info, "name"))
 
-	assert_eq(
-		export_plugin._get_name(),
-		"GFExtensionExportPlugin",
-		"EditorExportPlugin 必须提供稳定名称，避免导出流程报错。"
+	assert_true(
+		method_names.has(&"_get_name"),
+		"EditorExportPlugin 必须覆盖 _get_name()，避免导出流程报错。"
 	)
 
 

--- a/tests/gf_core/kernel/extension/test_gf_extension_manifest.gd
+++ b/tests/gf_core/kernel/extension/test_gf_extension_manifest.gd
@@ -2045,6 +2045,16 @@ func test_extensions_do_not_hard_reference_other_extensions() -> void:
 	assert_eq(Array(issues), [], "GF 内置扩展只能硬引用自身；跨扩展组合属于项目或外部插件。")
 
 
+func test_extension_export_plugin_reports_stable_name() -> void:
+	var has_get_name: bool = false
+	for method: Dictionary in GF_EXTENSION_EXPORT_PLUGIN_BASE.get_script_method_list():
+		if GF_VARIANT_ACCESS.get_option_string(method, "name") == "_get_name":
+			has_get_name = true
+			break
+
+	assert_true(has_get_name, "EditorExportPlugin 必须提供 _get_name()，避免导出流程报错。")
+
+
 func test_extension_export_plugin_matches_disabled_roots() -> void:
 	assert_true(
 		GF_EXTENSION_EXPORT_PLUGIN_BASE._should_skip_export_path(

--- a/tests/gf_core/kernel/extension/test_gf_extension_manifest.gd
+++ b/tests/gf_core/kernel/extension/test_gf_extension_manifest.gd
@@ -2046,13 +2046,13 @@ func test_extensions_do_not_hard_reference_other_extensions() -> void:
 
 
 func test_extension_export_plugin_reports_stable_name() -> void:
-	var has_get_name: bool = false
-	for method: Dictionary in GF_EXTENSION_EXPORT_PLUGIN_BASE.get_script_method_list():
-		if GF_VARIANT_ACCESS.get_option_string(method, "name") == "_get_name":
-			has_get_name = true
-			break
+	var export_plugin: EditorExportPlugin = GF_EXTENSION_EXPORT_PLUGIN_BASE.new()
 
-	assert_true(has_get_name, "EditorExportPlugin 必须提供 _get_name()，避免导出流程报错。")
+	assert_eq(
+		export_plugin._get_name(),
+		"GFExtensionExportPlugin",
+		"EditorExportPlugin 必须提供稳定名称，避免导出流程报错。"
+	)
 
 
 func test_extension_export_plugin_matches_disabled_roots() -> void:


### PR DESCRIPTION
## 问题

Godot 4.7 在导出项目时会调用 `EditorExportPlugin._get_name()`。`GFExtensionExportPlugin` 未覆盖该虚方法，导致每次导出都报告错误。

## 修改

- 为 `GFExtensionExportPlugin` 增加稳定的 `_get_name()` 返回值。
- 增加可在 headless CI 中运行的脚本方法契约测试。

## 验证

- Godot 4.7.1 headless GUT：`test_gf_extension_manifest.gd`，94/94 通过，417 个断言。

Fixes #9