### PR TITLE
Fix bare resource roots in AI dependency snapshots

### DIFF
--- a/addons/gf/tools/ai_developer/gf_ai/dependencies.py
+++ b/addons/gf/tools/ai_developer/gf_ai/dependencies.py
@@ -544,7 +544,7 @@ def _normalize_resource_path(raw_path: str) -> str:
 		return ""
 	relative = normalized.removeprefix("res://")
 	if not relative:
-		return "res://"
+		return ""
 	parts = relative.split("/")
 	if any(part in ("", ".", "..") for part in parts):
 		return ""

--- a/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
+++ b/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
@@ -287,6 +287,20 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 		self.assertNotIn("undeclared_module_dependency", {item["code"] for item in report["drift"]["issues"]})
 		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
 
+	def test_module_dependency_analysis_ignores_bare_resource_root(self) -> None:
+		self._set_modules([self._module("core")])
+		(self.project_root / "features/core/scan_root.gd").write_text(
+			'extends Node\nconst SCAN_ROOT := "res://"\n',
+			encoding="utf-8",
+		)
+
+		report = snapshot.build_snapshot(self.project_root)
+		analysis = report["project"]["module_dependency_analysis"]
+
+		self.assertEqual(analysis["unowned_reference_count"], 0)
+		self.assertEqual(analysis["unowned_references"], [])
+		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
+
 	def test_module_dependency_analysis_enforces_forbidden_before_undeclared_edges(self) -> None:
 		self._set_modules([
 			self._module("core", forbidden=["shared"]),


### PR DESCRIPTION
Closes #16.

## Changes

- Treat bare `res://` as a scan root rather than a concrete project resource dependency.
- Add a regression test proving the dependency report omits the root and the generated snapshot remains schema-valid.

## Verification

- `python tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py`
- 35 tests passed.