### PR TITLE
Fix project resource ownership and update Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -58,13 +58,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -85,13 +85,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -139,13 +139,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -43,7 +43,7 @@ jobs:
           --artifact-manifest "build/release/gf-release-artifacts-${GITHUB_REF_NAME}.json"
 
       - name: Upload immutable release artifact set
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gf-release-${{ github.ref_name }}
           path: build/release
@@ -57,13 +57,13 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -108,13 +108,13 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -139,18 +139,18 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Download verified release artifact set
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gf-release-${{ github.ref_name }}
           path: build/release

--- a/addons/gf/extensions/action_queue/gf_extension.json
+++ b/addons/gf/extensions/action_queue/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.action_queue",
   "display_name": "GF Action Queue",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.2.0",
   "kind": "extension",
   "description": "Presentation action queue primitives, interceptors, tween configs, and reusable visual actions.",

--- a/addons/gf/extensions/asset_metadata/gf_extension.json
+++ b/addons/gf/extensions/asset_metadata/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.asset_metadata",
   "display_name": "GF Asset Metadata",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Generic imported asset metadata records, attribution reports, node-tree collection, and glTF extras bridging.",

--- a/addons/gf/extensions/behavior_tree/gf_extension.json
+++ b/addons/gf/extensions/behavior_tree/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.behavior_tree",
   "display_name": "GF Behavior Tree",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Pure-code behavior tree primitives for AI decision flow.",

--- a/addons/gf/extensions/camera/gf_extension.json
+++ b/addons/gf/extensions/camera/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.camera",
   "display_name": "GF Camera",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Generic camera rigs, directors, priorities, and blend resources.",

--- a/addons/gf/extensions/capability/gf_extension.json
+++ b/addons/gf/extensions/capability/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.capability",
   "display_name": "GF Capability",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "3.0.0",
   "kind": "extension",
   "description": "Reusable object and node capability composition with recipes and editor inspection support.",

--- a/addons/gf/extensions/combat/gf_extension.json
+++ b/addons/gf/extensions/combat/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.combat",
   "display_name": "GF Combat",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Abstract combat attributes, modifiers, buffs, skills, gauges, and hit detection bridges.",

--- a/addons/gf/extensions/content_package/gf_extension.json
+++ b/addons/gf/extensions/content_package/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.content_package",
   "display_name": "GF Content Package",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Generic content package manifests, dependency diagnostics, and resource resolver registration.",

--- a/addons/gf/extensions/decision/gf_extension.json
+++ b/addons/gf/extensions/decision/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.decision",
   "display_name": "GF Decision",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Blackboard, context, and utility-scored decision primitives for non-LLM game AI and runtime orchestration.",

--- a/addons/gf/extensions/dialogue/gf_extension.json
+++ b/addons/gf/extensions/dialogue/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.dialogue",
   "display_name": "GF Dialogue",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "3.0.0",
   "kind": "extension",
   "description": "Generic dialogue resources, contexts, responses, and runners.",

--- a/addons/gf/extensions/domain/gf_extension.json
+++ b/addons/gf/extensions/domain/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.domain",
   "display_name": "GF Domain Models",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "4.0.0",
   "kind": "extension",
   "description": "Generic gameplay domain models such as inventory, equipment, level progress, quests, attributes, and traits.",

--- a/addons/gf/extensions/feedback/gf_extension.json
+++ b/addons/gf/extensions/feedback/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.feedback",
   "display_name": "GF Feedback",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "3.0.0",
   "kind": "extension",
   "description": "Reusable feedback sampling, shake receivers, and presets.",

--- a/addons/gf/extensions/flow/gf_extension.json
+++ b/addons/gf/extensions/flow/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.flow",
   "display_name": "GF Flow",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Resourceized flow graph primitives with ports, runners, diagnostics, and editor view models.",

--- a/addons/gf/extensions/interaction/gf_extension.json
+++ b/addons/gf/extensions/interaction/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.interaction",
   "display_name": "GF Interaction",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Generic interaction contexts, flows, sender/receiver nodes, sensors, and 3D pointer bridges.",

--- a/addons/gf/extensions/network/gf_extension.json
+++ b/addons/gf/extensions/network/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.network",
   "display_name": "GF Network",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "4.1.0",
   "kind": "extension",
   "description": "Pluggable network backends, sessions, messages, serializers, snapshots, and fixed tick helpers.",

--- a/addons/gf/extensions/physics/gf_extension.json
+++ b/addons/gf/extensions/physics/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.physics",
   "display_name": "GF Physics",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "1.4.0",
   "kind": "extension",
   "description": "Optional physics helpers for 3D gravity fields, buoyancy math, and fluid point sampling.",

--- a/addons/gf/extensions/save/gf_extension.json
+++ b/addons/gf/extensions/save/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.save",
   "display_name": "GF Save",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "5.0.0",
   "kind": "extension",
   "description": "Save graph composition, node serializers, generic data sources, save pipelines, scopes, sources, and slot workflows.",

--- a/addons/gf/extensions/turn_based/gf_extension.json
+++ b/addons/gf/extensions/turn_based/gf_extension.json
@@ -1,7 +1,7 @@
 {
   "id": "gf.turn_based",
   "display_name": "GF Turn Based",
-  "version": "9.1.0-dev.0",
+  "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
   "description": "Turn phases, turn actions, contexts, and turn flow system primitives.",

--- a/addons/gf/plugin.cfg
+++ b/addons/gf/plugin.cfg
@@ -3,5 +3,5 @@
 name="GF Framework"
 description="Lightweight Godot 4 game architecture framework for lifecycle management, events, data binding, utilities, and gameplay extensions."
 author="C76GN"
-version="9.1.0-dev.0"
+version="10.0.0-dev.0"
 script="plugin.gd"

--- a/addons/gf/tools/ai_developer/gf_ai/constants.py
+++ b/addons/gf/tools/ai_developer/gf_ai/constants.py
@@ -6,9 +6,9 @@ import json
 from pathlib import Path
 
 
-TOOL_VERSION = "2.0.0"
+TOOL_VERSION = "3.0.0"
 CONTRACT_SCHEMA_VERSION = 1
-SNAPSHOT_SCHEMA_VERSION = 2
+SNAPSHOT_SCHEMA_VERSION = 3
 FEEDBACK_SCHEMA_VERSION = 1
 DEFAULT_OFFICIAL_REPOSITORY = "C76GN/gf-framework"
 MANAGED_BLOCK_START = "<!-- gf-ai-developer:start schema=1 -->"

--- a/addons/gf/tools/ai_developer/gf_ai/contract.py
+++ b/addons/gf/tools/ai_developer/gf_ai/contract.py
@@ -8,7 +8,15 @@ from typing import Any
 
 from . import catalog
 from .constants import DEFAULT_CONTRACT_PATH, DEFAULT_OFFICIAL_REPOSITORY, SCHEMA_ROOT, TEMPLATE_ROOT
-from .paths import atomic_write_json, read_json_object, resolve_project_path, sha256_json
+from .paths import (
+	atomic_write_json,
+	is_reserved_framework_resource_path,
+	normalize_portable_ownership_path,
+	project_path_has_link_component,
+	read_json_object,
+	resolve_project_path,
+	sha256_json,
+)
 from .schema import validate_schema_file
 
 
@@ -129,6 +137,11 @@ def _semantic_issues(data: dict[str, Any], project_root: Path) -> list[dict[str,
 
 	architecture = _object(data, "architecture")
 	modules = _object_list(architecture, "modules")
+	owned_resources = [
+		raw_path
+		for raw_path in architecture.get("owned_resources", [])
+		if isinstance(raw_path, str)
+	]
 	module_ids = _unique_ids(modules, "$.architecture.modules", issues)
 	adapters = _object_list(framework, "adapter_boundaries")
 	adapter_ids = _unique_ids(adapters, "$.framework.adapter_boundaries", issues)
@@ -159,23 +172,31 @@ def _semantic_issues(data: dict[str, Any], project_root: Path) -> list[dict[str,
 			))
 		for root_index, raw_path in enumerate(module.get("roots", [])):
 			if isinstance(raw_path, str):
-				_validate_contract_path(
+				_validate_ownership_root_path(
 					project_root,
-					raw_path.removeprefix("res://"),
+					raw_path,
 					f"$.architecture.modules[{index}].roots[{root_index}]",
 					issues,
 				)
+	for index, raw_path in enumerate(owned_resources):
+		_validate_owned_resource_path(
+			project_root,
+			raw_path,
+			f"$.architecture.owned_resources[{index}]",
+			issues,
+		)
 	issues.extend(_module_dependency_cycle_issues(modules, module_ids))
 	for index, adapter in enumerate(adapters):
 		raw_path = adapter.get("project_root")
 		if isinstance(raw_path, str):
-			_validate_contract_path(
+			_validate_ownership_root_path(
 				project_root,
-				raw_path.removeprefix("res://"),
+				raw_path,
 				f"$.framework.adapter_boundaries[{index}].project_root",
 				issues,
 			)
 	issues.extend(_ownership_root_overlap_issues(modules, adapters))
+	issues.extend(_ownership_resource_overlap_issues(modules, adapters, owned_resources))
 	profile_path = architecture.get("project_profile_path")
 	if isinstance(profile_path, str) and profile_path:
 		_validate_contract_path(project_root, profile_path, "$.architecture.project_profile_path", issues)
@@ -218,6 +239,66 @@ def _validate_contract_path(
 		resolve_project_path(project_root, relative_path)
 	except ValueError as exc:
 		issues.append(_issue("error", "unsafe_project_path", path, str(exc)))
+		return
+	if project_path_has_link_component(project_root, relative_path):
+		issues.append(_issue(
+			"error",
+			"unsafe_project_path",
+			path,
+			"Project path crosses a symbolic link, junction, or reparse point.",
+		))
+
+
+def _validate_owned_resource_path(
+	project_root: Path,
+	raw_path: str,
+	path: str,
+	issues: list[dict[str, str]],
+) -> None:
+	normalized_path = normalize_portable_ownership_path(raw_path)
+	if not normalized_path:
+		issues.append(_issue(
+			"error",
+			"non_canonical_owned_resource_path",
+			path,
+			"Project-owned resource paths must use one canonical non-root res:// path.",
+		))
+		return
+	if is_reserved_framework_resource_path(normalized_path):
+		issues.append(_issue(
+			"error",
+			"framework_owned_resource",
+			path,
+			"Project-owned resources must stay outside the reserved res://addons/gf boundary.",
+		))
+		return
+	_validate_contract_path(project_root, normalized_path.removeprefix("res://"), path, issues)
+
+
+def _validate_ownership_root_path(
+	project_root: Path,
+	raw_path: str,
+	path: str,
+	issues: list[dict[str, str]],
+) -> None:
+	normalized_path = normalize_portable_ownership_path(raw_path)
+	if not normalized_path:
+		issues.append(_issue(
+			"error",
+			"non_canonical_ownership_root",
+			path,
+			"Ownership roots must use one canonical cross-platform non-root res:// path.",
+		))
+		return
+	if is_reserved_framework_resource_path(normalized_path):
+		issues.append(_issue(
+			"error",
+			"framework_ownership_root",
+			path,
+			"Project ownership roots must stay outside the reserved res://addons/gf boundary.",
+		))
+		return
+	_validate_contract_path(project_root, normalized_path.removeprefix("res://"), path, issues)
 
 
 def _unique_ids(
@@ -299,6 +380,37 @@ def _ownership_root_overlap_issues(
 				"ownership_root_overlap",
 				"$.architecture.modules",
 				f"Ownership roots overlap between {left_owner} ({left_path}) and {right_owner} ({right_path}).",
+			))
+	return issues
+
+
+def _ownership_resource_overlap_issues(
+	modules: list[dict[str, Any]],
+	adapters: list[dict[str, Any]],
+	owned_resources: list[str],
+) -> list[dict[str, str]]:
+	roots: list[tuple[str, str, tuple[str, ...]]] = []
+	for module in modules:
+		owner = f"module {module.get('id', '')}"
+		for raw_path in module.get("roots", []):
+			if isinstance(raw_path, str):
+				roots.append((owner, raw_path, _root_parts(raw_path)))
+	for adapter in adapters:
+		raw_path = adapter.get("project_root")
+		if isinstance(raw_path, str):
+			roots.append((f"adapter {adapter.get('id', '')}", raw_path, _root_parts(raw_path)))
+
+	issues: list[dict[str, str]] = []
+	for index, resource_path in enumerate(owned_resources):
+		resource_parts = _root_parts(resource_path)
+		for owner, root_path, root_parts in roots:
+			if not _parts_overlap(resource_parts, root_parts):
+				continue
+			issues.append(_issue(
+				"error",
+				"ownership_resource_overlap",
+				f"$.architecture.owned_resources[{index}]",
+				f"Project-owned resource {resource_path} overlaps {owner} ownership root {root_path}.",
 			))
 	return issues
 

--- a/addons/gf/tools/ai_developer/gf_ai/dependencies.py
+++ b/addons/gf/tools/ai_developer/gf_ai/dependencies.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import os
-import posixpath
-import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from .paths import (
+	is_reserved_framework_resource_path,
+	normalize_portable_ownership_path,
+	normalize_resource_path,
+	project_path_has_link_component,
+)
 
 
 MAX_DEPENDENCY_FILES = 20_000
@@ -16,6 +21,7 @@ MAX_DEPENDENCY_FILE_BYTES = 2 * 1024 * 1024
 MAX_EDGE_EVIDENCE = 12
 MAX_AMBIGUOUS_CLASSES = 100
 MAX_UNOWNED_REFERENCE_EVIDENCE = 100
+MAX_OWNED_RESOURCE_REFERENCE_EVIDENCE = 100
 SUPPORTED_EXTENSIONS = frozenset({".gd", ".gdshader", ".gdshaderinc", ".tres", ".tscn"})
 _RESOURCE_TEXT_EXTENSIONS = frozenset({".gdshader", ".gdshaderinc", ".tres", ".tscn"})
 _SKIPPED_DIRECTORY_NAMES = frozenset({".git", ".godot", ".import", "__pycache__", "node_modules"})
@@ -38,13 +44,13 @@ class ModuleOwnershipMatcher:
 			for raw_root in module.get("roots", []):
 				if not isinstance(raw_root, str):
 					continue
-				root = _normalize_resource_path(raw_root)
-				if root:
+				root = normalize_portable_ownership_path(raw_root)
+				if root and not is_reserved_framework_resource_path(root):
 					roots.append((root, module_id))
 		self._roots = sorted(roots, key=lambda item: (-len(item[0]), item[0], item[1]))
 
 	def owner_of(self, resource_path: str) -> str:
-		normalized = _normalize_resource_path(resource_path)
+		normalized = normalize_resource_path(resource_path)
 		if not normalized:
 			return ""
 		for root, module_id in self._roots:
@@ -62,11 +68,22 @@ def analyze_module_dependencies(
 	modules = _contract_modules(contract_data)
 	if not contract_valid:
 		return _empty_analysis("contract_invalid", modules, complete=False)
+	owned_resource_collection = _collect_owned_resources(project_root, contract_data)
 	if not modules:
-		return _empty_analysis("not_configured", modules, complete=True)
+		owned_resources_complete = (
+			owned_resource_collection["missing_count"] == 0
+			and owned_resource_collection["unsafe_count"] == 0
+		)
+		return _empty_analysis(
+			"not_configured" if owned_resources_complete else "incomplete",
+			modules,
+			complete=owned_resources_complete,
+			owned_resource_collection=owned_resource_collection,
+		)
 
 	matcher = ModuleOwnershipMatcher(modules)
 	collection = _collect_module_files(project_root, modules)
+	available_owned_resources = set(owned_resource_collection["available_paths"])
 	files: list[Path] = collection.pop("files")
 	class_definitions: dict[str, list[tuple[str, str]]] = {}
 	unreadable_paths: set[Path] = set()
@@ -96,6 +113,8 @@ def analyze_module_dependencies(
 	edges: dict[tuple[str, str], dict[str, Any]] = {}
 	unowned_reference_count = 0
 	unowned_references: list[dict[str, Any]] = []
+	owned_resource_reference_count = 0
+	owned_resource_references: list[dict[str, Any]] = []
 	for path in files:
 		if path in unreadable_paths:
 			continue
@@ -123,15 +142,19 @@ def analyze_module_dependencies(
 						token.line,
 					)
 				elif token.kind == "string":
-					unowned_reference_count += _record_path_reference(
+					unowned_increment, owned_increment = _record_path_reference(
 						edges,
 						matcher,
+						available_owned_resources,
 						source_module,
 						source_path,
 						token.value,
 						token.line,
 						unowned_references,
+						owned_resource_references,
 					)
+					unowned_reference_count += unowned_increment
+					owned_resource_reference_count += owned_increment
 		elif path.suffix.casefold() in _RESOURCE_TEXT_EXTENSIONS:
 			resource_tokens = (
 				lex_shader_text(text)
@@ -139,15 +162,19 @@ def analyze_module_dependencies(
 				else lex_resource_text(text)
 			)
 			for token in resource_tokens:
-				unowned_reference_count += _record_path_reference(
+				unowned_increment, owned_increment = _record_path_reference(
 					edges,
 					matcher,
+					available_owned_resources,
 					source_module,
 					source_path,
 					token.value,
 					token.line,
 					unowned_references,
+					owned_resource_references,
 				)
+				unowned_reference_count += unowned_increment
+				owned_resource_reference_count += owned_increment
 
 	edge_records = _edge_records(edges)
 	cycles = _dependency_cycles(edge_records, {str(module.get("id", "")) for module in modules})
@@ -173,6 +200,8 @@ def analyze_module_dependencies(
 		and unreadable_count == 0
 		and collection["missing_root_count"] == 0
 		and collection["unsafe_path_count"] == 0
+		and owned_resource_collection["missing_count"] == 0
+		and owned_resource_collection["unsafe_count"] == 0
 		and not all_ambiguous_classes
 	)
 	status = "complete" if complete else ("truncated" if truncated else "incomplete")
@@ -187,6 +216,13 @@ def analyze_module_dependencies(
 		"unreadable_file_count": unreadable_count,
 		"missing_root_count": int(collection["missing_root_count"]),
 		"unsafe_path_count": int(collection["unsafe_path_count"]),
+		"declared_owned_resource_count": len(owned_resource_collection["records"]),
+		"missing_owned_resource_count": int(owned_resource_collection["missing_count"]),
+		"unsafe_owned_resource_count": int(owned_resource_collection["unsafe_count"]),
+		"owned_resources": owned_resource_collection["records"],
+		"owned_resource_reference_count": owned_resource_reference_count,
+		"owned_resource_references_truncated": owned_resource_reference_count > len(owned_resource_references),
+		"owned_resource_references": owned_resource_references,
 		"unowned_reference_count": unowned_reference_count,
 		"unowned_references_truncated": unowned_reference_count > len(unowned_references),
 		"unowned_references": unowned_references,
@@ -329,12 +365,15 @@ def _collect_module_files(project_root: Path, modules: list[dict[str, Any]]) -> 
 	unsafe_path_count = 0
 	truncated = False
 	for raw_root in sorted({root for module in modules for root in module.get("roots", []) if isinstance(root, str)}):
-		normalized_root = _normalize_resource_path(raw_root)
+		normalized_root = normalize_portable_ownership_path(raw_root)
 		if normalized_root in ("", "res://"):
 			missing_root_count += 1
 			continue
+		if is_reserved_framework_resource_path(normalized_root):
+			unsafe_path_count += 1
+			continue
 		relative_root = normalized_root.removeprefix("res://")
-		root = (project_root / Path(*relative_root.split("/"))).resolve(strict=False)
+		root = project_root / Path(*relative_root.split("/"))
 		if not root.is_dir() or not _safe_path(project_root, root, directory=True):
 			missing_root_count += 1
 			continue
@@ -385,32 +424,72 @@ def _collect_module_files(project_root: Path, modules: list[dict[str, Any]]) -> 
 	}
 
 
+def _collect_owned_resources(project_root: Path, contract_data: dict[str, Any]) -> dict[str, Any]:
+	records: list[dict[str, str]] = []
+	available_paths: list[str] = []
+	missing_count = 0
+	unsafe_count = 0
+	for raw_path in _contract_owned_resources(contract_data):
+		normalized_path = normalize_portable_ownership_path(raw_path)
+		if not normalized_path or is_reserved_framework_resource_path(normalized_path):
+			records.append({"path": raw_path, "status": "unsafe"})
+			unsafe_count += 1
+			continue
+		relative_path = normalized_path.removeprefix("res://")
+		path = project_root / Path(*relative_path.split("/"))
+		if not path.exists():
+			status = "missing"
+			missing_count += 1
+		elif not _safe_path(project_root, path, directory=False):
+			status = "unsafe"
+			unsafe_count += 1
+		else:
+			status = "available"
+			available_paths.append(normalized_path)
+		records.append({"path": normalized_path, "status": status})
+	return {
+		"records": sorted(records, key=lambda item: item["path"]),
+		"available_paths": sorted(available_paths),
+		"missing_count": missing_count,
+		"unsafe_count": unsafe_count,
+	}
+
+
 def _record_path_reference(
 	edges: dict[tuple[str, str], dict[str, Any]],
 	matcher: ModuleOwnershipMatcher,
+	owned_resource_paths: set[str],
 	source_module: str,
 	source_path: str,
 	raw_target_path: str,
 	line: int,
 	unowned_references: list[dict[str, Any]],
-) -> int:
-	target_path = _normalize_resource_path(raw_target_path)
+	owned_resource_references: list[dict[str, Any]],
+) -> tuple[int, int]:
+	target_path = normalize_resource_path(raw_target_path)
 	if not target_path:
-		return 0
+		return 0, 0
 	target_module = matcher.owner_of(target_path)
 	if not target_module:
 		if target_path.startswith("res://addons/gf/"):
-			return 0
+			return 0, 0
 		candidate = {
 			"source_path": source_path,
 			"target_path": target_path,
 			"line": max(line, 1),
 		}
+		if target_path in owned_resource_paths:
+			if (
+				len(owned_resource_references) < MAX_OWNED_RESOURCE_REFERENCE_EVIDENCE
+				and candidate not in owned_resource_references
+			):
+				owned_resource_references.append(candidate)
+			return 0, 1
 		if len(unowned_references) < MAX_UNOWNED_REFERENCE_EVIDENCE and candidate not in unowned_references:
 			unowned_references.append(candidate)
-		return 1
+		return 1, 0
 	_add_reference(edges, source_module, target_module, source_path, target_path, "resource_path", raw_target_path, line)
-	return 0
+	return 0, 0
 
 
 def _add_reference(
@@ -511,7 +590,25 @@ def _contract_modules(contract_data: dict[str, Any]) -> list[dict[str, Any]]:
 	return [module for module in architecture["modules"] if isinstance(module, dict)]
 
 
-def _empty_analysis(status: str, modules: list[dict[str, Any]], *, complete: bool) -> dict[str, Any]:
+def _contract_owned_resources(contract_data: dict[str, Any]) -> list[str]:
+	architecture = contract_data.get("architecture", {})
+	if not isinstance(architecture, dict) or not isinstance(architecture.get("owned_resources"), list):
+		return []
+	return [path for path in architecture["owned_resources"] if isinstance(path, str)]
+
+
+def _empty_analysis(
+	status: str,
+	modules: list[dict[str, Any]],
+	*,
+	complete: bool,
+	owned_resource_collection: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+	resources = owned_resource_collection or {
+		"records": [],
+		"missing_count": 0,
+		"unsafe_count": 0,
+	}
 	return {
 		"status": status,
 		"complete": complete,
@@ -523,6 +620,13 @@ def _empty_analysis(status: str, modules: list[dict[str, Any]], *, complete: boo
 		"unreadable_file_count": 0,
 		"missing_root_count": 0,
 		"unsafe_path_count": 0,
+		"declared_owned_resource_count": len(resources["records"]),
+		"missing_owned_resource_count": int(resources["missing_count"]),
+		"unsafe_owned_resource_count": int(resources["unsafe_count"]),
+		"owned_resources": resources["records"],
+		"owned_resource_reference_count": 0,
+		"owned_resource_references_truncated": False,
+		"owned_resource_references": [],
 		"unowned_reference_count": 0,
 		"unowned_references_truncated": False,
 		"unowned_references": [],
@@ -538,19 +642,6 @@ def _empty_analysis(status: str, modules: list[dict[str, Any]], *, complete: boo
 	}
 
 
-def _normalize_resource_path(raw_path: str) -> str:
-	normalized = raw_path.strip().replace("\\", "/")
-	if not normalized.startswith("res://"):
-		return ""
-	relative = normalized.removeprefix("res://")
-	if not relative:
-		return ""
-	parts = relative.split("/")
-	if any(part in ("", ".", "..") for part in parts):
-		return ""
-	return "res://" + posixpath.normpath(relative)
-
-
 def _resource_path(project_root: Path, path: Path) -> str:
 	return "res://" + path.relative_to(project_root).as_posix()
 
@@ -564,13 +655,13 @@ def _read_utf8(path: Path) -> str | None:
 
 def _safe_path(project_root: Path, path: Path, *, directory: bool) -> bool:
 	try:
-		metadata = path.lstat()
-		if path.is_symlink():
+		lexical_root = project_root.absolute()
+		lexical_path = path.absolute()
+		relative_path = lexical_path.relative_to(lexical_root)
+		if project_path_has_link_component(project_root, relative_path.as_posix()):
 			return False
-		reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
-		if reparse_flag and getattr(metadata, "st_file_attributes", 0) & reparse_flag:
-			return False
-		path.resolve(strict=True).relative_to(project_root)
-		return path.is_dir() if directory else path.is_file()
+		current_path = lexical_root / relative_path
+		current_path.resolve(strict=True).relative_to(lexical_root.resolve(strict=True))
+		return current_path.is_dir() if directory else current_path.is_file()
 	except (OSError, ValueError):
 		return False

--- a/addons/gf/tools/ai_developer/gf_ai/paths.py
+++ b/addons/gf/tools/ai_developer/gf_ai/paths.py
@@ -4,16 +4,94 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import secrets
+import stat
 from pathlib import Path
 from typing import Any
 
 
 DEFAULT_MAX_JSON_BYTES = 16 * 1024 * 1024
+_RESOURCE_PATH_FORBIDDEN_CHARACTERS = frozenset('<>:"|?*[]')
+_WINDOWS_RESERVED_PATH_STEMS = frozenset({
+	"aux",
+	"con",
+	"nul",
+	"prn",
+	*(f"com{index}" for index in range(1, 10)),
+	*(f"lpt{index}" for index in range(1, 10)),
+})
 
 
 class PathBoundaryError(ValueError):
 	"""Raised when a project-side operation would escape its owned boundary."""
+
+
+def normalize_resource_path(raw_path: str) -> str:
+	"""Normalize one exact non-root res:// path without applying platform policy."""
+	normalized = raw_path.strip().replace("\\", "/")
+	if not normalized.startswith("res://"):
+		return ""
+	relative = normalized.removeprefix("res://")
+	if not relative:
+		return ""
+	parts = relative.split("/")
+	if any(part in ("", ".", "..") for part in parts):
+		return ""
+	return "res://" + posixpath.normpath(relative)
+
+
+def normalize_portable_ownership_path(raw_path: str) -> str:
+	"""Return a canonical cross-platform ownership path, or an empty string."""
+	if any(ord(character) < 32 or ord(character) == 127 for character in raw_path):
+		return ""
+	normalized = normalize_resource_path(raw_path)
+	if not normalized or normalized != raw_path:
+		return ""
+	parts = normalized.removeprefix("res://").split("/")
+	for part in parts:
+		if part != part.rstrip(" ."):
+			return ""
+		if any(character in _RESOURCE_PATH_FORBIDDEN_CHARACTERS for character in part):
+			return ""
+		if part.split(".", 1)[0].casefold() in _WINDOWS_RESERVED_PATH_STEMS:
+			return ""
+	return normalized
+
+
+def is_reserved_framework_resource_path(raw_path: str) -> bool:
+	"""Return whether a resource path addresses the reserved addons/gf boundary."""
+	normalized = normalize_resource_path(raw_path)
+	if not normalized:
+		return False
+	parts = tuple(part.casefold() for part in normalized.removeprefix("res://").split("/"))
+	return parts[0:2] == ("addons", "gf")
+
+
+def project_path_has_link_component(project_root: Path, relative_path: str) -> bool:
+	"""Fail closed when an existing project-relative path component is linked or reparsed."""
+	normalized = relative_path.strip().replace("\\", "/")
+	root = Path(os.path.abspath(os.fspath(project_root)))
+	target = Path(os.path.abspath(os.fspath(root / normalized)))
+	try:
+		relative = target.relative_to(root)
+	except ValueError:
+		return True
+	reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+	current = root
+	for part in relative.parts:
+		current /= part
+		try:
+			metadata = current.lstat()
+		except FileNotFoundError:
+			break
+		except OSError:
+			return True
+		if current.is_symlink():
+			return True
+		if reparse_flag and getattr(metadata, "st_file_attributes", 0) & reparse_flag:
+			return True
+	return False
 
 
 def resolve_project_root(raw_root: str | Path) -> Path:

--- a/addons/gf/tools/ai_developer/gf_ai/snapshot.py
+++ b/addons/gf/tools/ai_developer/gf_ai/snapshot.py
@@ -254,13 +254,15 @@ def _module_dependency_drift_issues(
 		issues.append(_issue(
 			"error",
 			"module_dependency_analysis_incomplete",
-			"$.architecture.modules",
+			"$.architecture",
 			(
 				"Observed module dependency analysis is incomplete "
 				f"(status={status}, truncated={bool(analysis.get('truncated'))}, "
 				f"unreadable_files={int(analysis.get('unreadable_file_count', 0))}, "
 				f"missing_roots={int(analysis.get('missing_root_count', 0))}, "
 				f"unsafe_paths={int(analysis.get('unsafe_path_count', 0))}, "
+				f"missing_owned_resources={int(analysis.get('missing_owned_resource_count', 0))}, "
+				f"unsafe_owned_resources={int(analysis.get('unsafe_owned_resource_count', 0))}, "
 				f"ambiguous_classes={int(analysis.get('ambiguous_class_name_count', 0))})."
 			),
 		))

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "catalog_version": "1.0.0",
-  "framework_version": "9.1.0-dev.0",
-  "source_digest": "1f26e247b9aca35e744307e5c274b23a22c0077f889f162e53e4e5fb6545091e",
+  "framework_version": "10.0.0-dev.0",
+  "source_digest": "0dd80eb34d6b268f1c09cb2c45ddb430522741b9dea2e6162521e481f896682b",
   "class_count": 716,
   "package_count": 50,
   "packages": [

--- a/addons/gf/tools/ai_developer/schemas/project_contract.schema.json
+++ b/addons/gf/tools/ai_developer/schemas/project_contract.schema.json
@@ -206,6 +206,17 @@
             }
           }
         },
+        "owned_resources": {
+          "type": "array",
+          "maxItems": 100,
+          "uniqueItems": true,
+          "description": "Exact project-owned resource files that are governance inputs rather than module dependency targets.",
+          "items": {
+            "type": "string",
+            "maxLength": 240,
+            "pattern": "^res://(?!addons/gf(?:/|$))[^\\u0000-\\u001F\\u007F\\\\]+$"
+          }
+        },
         "global_rules": {
           "type": "array",
           "maxItems": 100,

--- a/addons/gf/tools/ai_developer/schemas/project_snapshot.schema.json
+++ b/addons/gf/tools/ai_developer/schemas/project_snapshot.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gf-framework.dev/schemas/project-snapshot-v2.json",
+  "$id": "https://gf-framework.dev/schemas/project-snapshot-v3.json",
   "title": "GF Observed Project Snapshot",
   "type": "object",
   "additionalProperties": false,
@@ -16,7 +16,7 @@
     "drift"
   ],
   "properties": {
-    "schema_version": {"type": "integer", "const": 2},
+    "schema_version": {"type": "integer", "const": 3},
     "generator_version": {"type": "string", "minLength": 1},
     "generated_at_utc": {"type": "string", "minLength": 1},
     "project_root": {"type": "string", "const": "."},
@@ -102,6 +102,13 @@
             "unreadable_file_count",
             "missing_root_count",
             "unsafe_path_count",
+            "declared_owned_resource_count",
+            "missing_owned_resource_count",
+            "unsafe_owned_resource_count",
+            "owned_resources",
+            "owned_resource_reference_count",
+            "owned_resource_references_truncated",
+            "owned_resource_references",
             "unowned_reference_count",
             "unowned_references_truncated",
             "unowned_references",
@@ -131,6 +138,38 @@
             "unreadable_file_count": {"type": "integer", "minimum": 0},
             "missing_root_count": {"type": "integer", "minimum": 0},
             "unsafe_path_count": {"type": "integer", "minimum": 0},
+            "declared_owned_resource_count": {"type": "integer", "minimum": 0, "maximum": 100},
+            "missing_owned_resource_count": {"type": "integer", "minimum": 0, "maximum": 100},
+            "unsafe_owned_resource_count": {"type": "integer", "minimum": 0, "maximum": 100},
+            "owned_resources": {
+              "type": "array",
+              "maxItems": 100,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["path", "status"],
+                "properties": {
+                  "path": {"type": "string", "pattern": "^res://.+$"},
+                  "status": {"type": "string", "enum": ["available", "missing", "unsafe"]}
+                }
+              }
+            },
+            "owned_resource_reference_count": {"type": "integer", "minimum": 0},
+            "owned_resource_references_truncated": {"type": "boolean"},
+            "owned_resource_references": {
+              "type": "array",
+              "maxItems": 100,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source_path", "target_path", "line"],
+                "properties": {
+                  "source_path": {"type": "string", "pattern": "^res://.+$"},
+                  "target_path": {"type": "string", "pattern": "^res://.+$"},
+                  "line": {"type": "integer", "minimum": 1}
+                }
+              }
+            },
             "unowned_reference_count": {"type": "integer", "minimum": 0},
             "unowned_references_truncated": {"type": "boolean"},
             "unowned_references": {

--- a/addons/gf/tools/ai_developer/templates/gf_project_contract.json
+++ b/addons/gf/tools/ai_developer/templates/gf_project_contract.json
@@ -24,6 +24,7 @@
   },
   "architecture": {
     "modules": [],
+    "owned_resources": [],
     "global_rules": [
       "Project business code stays outside res://addons/gf.",
       "External platform SDKs are isolated behind project-owned adapters."

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -22,7 +22,7 @@
 
 ## [未发布]
 
-**版本概述**：补齐通用 2D 编辑器缩略图、有序资产集合、存储后端故障转移、运行时会话轨迹和 UI 路由预加载规划，同时保持预览 UI、资源业务分类、云服务协议、线上采集策略和业务导航规则在各自调用方边界内。
+**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、存储后端故障转移、运行时会话轨迹和 UI 路由预加载规划，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
 
 ### 🚀 新增特性 (Added)
 
@@ -31,6 +31,7 @@
 - 新增 `GFStorageFailoverBackend`，按稳定后端 ID 提供有界顺序尝试、`PRIMARY_ONLY` / `FIRST_SUCCESS` 写删语义、暂时性错误冷却和不含业务载荷的结构化操作报告。
 - 新增 `GFSessionTraceUtility`，提供显式通道白名单、事件数与字节双重预算、默认隐私脱敏、同步快照 provider、结构化支持报告快照和可选 `GFLogSink` journal。
 - 新增 `GFUIRoutePreloadUtility`，从 `GFUIRoute.adjacent_route_ids` 做有界、确定性的页面可达性遍历，并生成可直接交给 `GFAssetUtility` 的 `GFAssetPreloadPlan`。
+- AI Developer 项目契约新增可选 `architecture.owned_resources`，用于精确声明 `project.godot`、`export_presets.cfg` 等不属于业务模块的项目级治理文件。
 
 ### 🔄 机制更改 (Changed)
 
@@ -39,6 +40,10 @@
 - 缩略图渲染改为等待场景树更新后同步强制绘制，避免无持续绘制帧时错过 `frame_post_draw`；dummy 渲染后端现在会安全返回空结果，不再访问无纹理存储的 ViewportTexture。
 - Session Trace journal 会校验轨迹与 sink 的脱敏 profile，且对 sink 生命周期、写入与刷新执行重入保护；不安全配置和运行期 profile 降级会 fail closed。
 - `GFUIRouterUtility` 可从当前已注册路由构建预加载计划；Planner 对目录、候选和边扫描分别设有硬上限，统一规范化路由 ID，只表达资源候选和诊断，不自动执行 IO，也不把相邻关系解释为权限或业务跳转。
+- AI Developer Kit 3.0.0 将项目快照升级到 schema v3；依赖报告现在区分项目级资源状态、命中证据和未归属引用，缺失文件、目录或不安全路径继续 fail closed。
+- AI Developer 项目契约的所有受控项目路径现在统一逐段拒绝符号链接、Windows junction 和其他重解析点；模块根、Adapter 根、project profile、验证必需路径与项目级资源不再允许通过链接别名绕过所有权边界。
+- 模块根与 Adapter 根额外采用跨平台规范化校验，并以大小写无关方式拒绝 `res://addons/gf` 及 Windows 尾点、保留名称等别名，避免把 GF 源码误归属为项目模块；普通源码资源引用不受这项契约限制。
+- CI 与 Release 工作流统一采用 Node.js 24 世代的 `actions/checkout@v7`、`actions/setup-python@v7`、`actions/upload-artifact@v7` 和 `actions/download-artifact@v8`，维护自检会阻止旧主版本回退。
 
 ### 🐛 Bug 修复 (Fixed)
 
@@ -46,6 +51,7 @@
 - 修复 Session Trace 在 `debug` 或 `support` 下注册的长期 context、通道 metadata 与 provider metadata，可能在随后收紧 profile 后继续保留对象实例 ID、节点名称或原始路径的问题；这些长期数据现在统一使用 `privacy` 安全下限。
 - 修复同一 journal sink 原位重配时会先刷新并按旧所有权关闭实例、导致未重新初始化的 sink 后续静默失效的问题。
 - 修复 sink 回调内使用文档化的 `configure_journal_sink(null)` 无法原子断开并延迟清理当前 sink 的问题；替换 sink 时，旧 sink 清理回调发起的置空请求也不会再被外层配置覆盖。
+- 修复模块源码引用根级 Godot 治理文件时只能产生 `unowned_project_resource_reference`、或被迫把文件误填为模块扫描目录并导致分析不完整的问题。
 
 ### 🔧 API 变动说明 (API Changes)
 
@@ -55,6 +61,8 @@
 - 新增公开类型 `GFAssetCollection` 和 `GFStorageFailoverBackend`；均标记为 `@since unreleased`，不改变既有调用入口默认行为。
 - 新增公开类型 `GFSessionTraceUtility`、`GFUIRoutePreloadUtility`，以及 `GFUIRoute.adjacent_route_ids`、`get_adjacent_route_ids()` 和 `GFUIRouterUtility.build_preload_plan()`；均标记为 `@since unreleased`。
 - `GFUIRoute.get_route_id()` 以及 Router 的注册、查询、打开信号和异步 pending 身份统一去除 route ID 首尾空白。
+- AI Developer 项目契约 schema v1 向后兼容地新增可选 `architecture.owned_resources`；项目快照 schema 从 v2 升为 v3，因此 AI Developer Kit 工具协议同步升为 3.0.0。
+- GF 开发身份从 `9.1.0-dev.0` 升为 `10.0.0-dev.0`，用于明确承载项目快照 v3 这一破坏性输出协议变化；本条只切换开发线，不创建正式版本或发布标签。
 
 ### 📘 升级指南 (Migration Guide)
 
@@ -62,6 +70,10 @@
 - 自定义 `_draw()` 或无法可靠推断范围的 2D 节点应传入显式 `content_bounds`；多后端复制与冲突处理继续使用 `GFStorageSyncUtility`，不要把故障转移当作原子双写。
 - 既有 UI 路由无需迁移；只有需要候选页面预热时才声明 `adjacent_route_ids` 并显式执行生成的资产计划。需要发布后问题轨迹时，应由项目定义最小事件 schema、玩家许可和保留策略，再显式采用 `GFSessionTraceUtility`。
 - 历史配置若有意使用带首尾空白的 route ID，需迁移为去除空白后的稳定 ID；规范化后重复的 ID 会指向同一注册身份，不应再依赖空白区分页面。
+- 既有项目契约无需修改。只有源码确实引用模块外项目治理文件时才添加精确 `res://` 文件路径；禁止填写裸 `res://`、目录、通配范围或模块根内文件。快照 v3 是有意的破坏性输出协议升级：消费方应先升级到 AI Developer Kit 3.x，再重新生成快照；不要把 v2 快照补字段后继续使用。
+- 从 `9.x` 开发线升级时，应同步更新 GF 插件与扩展清单到 `10.0.0-dev.0`，并重新生成 AI Developer Kit catalog；稳定版发布时间与版本号仍由后续独立发布流程决定。
+- 旧契约若把模块、Adapter、profile 或验证路径放在符号链接/junction 后方，应改为项目根内不经过链接的真实相对路径；工具不会为链接别名保留兼容分支。
+- 模块和 Adapter 所有权根若包含尾点/空格、Windows 保留名称、通配字符或大小写变体的 `addons/gf`，应迁移为跨平台规范目录；这些别名不再保留兼容解析。
 
 ### 📁 核心受影响文件 (Affected Files)
 
@@ -74,6 +86,11 @@
 - `addons/gf/standard/utilities/ui/gf_ui_route.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_route_preload_utility.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd`
+- `addons/gf/tools/ai_developer/gf_ai/dependencies.py`
+- `addons/gf/tools/ai_developer/schemas/project_contract.schema.json`
+- `addons/gf/tools/ai_developer/schemas/project_snapshot.schema.json`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
 
 ## [9.0.1] - 2026-07-20
 

--- a/docs/zh/editor/tools/ai-developer.md
+++ b/docs/zh/editor/tools/ai-developer.md
@@ -37,6 +37,7 @@ python addons/gf/tools/ai_developer/gf_ai_project.py validate --project-root .
 - `project`：产品阶段、质量优先级和明确不做的内容。
 - `framework`：必需、可选、禁止的 GF package，以及项目需要的通用能力和外部 Adapter 边界。
 - `architecture.modules`：项目模块职责、根目录、允许与禁止依赖、所有权类型。
+- `architecture.owned_resources`：不属于任何业务模块、但会被模块源码引用的项目级治理文件精确路径。
 - `constraints`：确定性、持久化、联网权威、安全、生命周期、异步和性能预算。
 - `decisions`：带理由、后果和状态的项目架构决策。
 - `verification`：必须独立审阅的结构化 `argv` 检查、超时/联网/写入声明和必需路径；套件本身不执行这些检查。
@@ -88,9 +89,26 @@ python addons/gf/tools/ai_developer/gf_ai_project.py agent-uninstall --project-r
    python addons/gf/tools/ai_developer/gf_ai_project.py snapshot --project-root .
    ```
 
-快照会把 `architecture.modules[].roots` 编译成长根优先的所有权匹配器，再对 `.gd`、`.gdshader`、`.gdshaderinc`、`.tres` 和 `.tscn` 做有界依赖分析。GDScript 使用词法 token 集合识别唯一 `class_name` 引用和字符串资源路径，不把注释或普通字符串中的标识符误判为类引用；资源文本只分析路径证据。报告中的 `module_dependency_analysis` 包含模块文件计数、跨模块边、有限证据、未归属引用、重复 class、实际循环和完整性状态。
+快照会把 `architecture.modules[].roots` 编译成长根优先的所有权匹配器，再对 `.gd`、`.gdshader`、`.gdshaderinc`、`.tres` 和 `.tscn` 做有界依赖分析。GDScript 使用词法 token 集合识别唯一 `class_name` 引用和字符串资源路径，不把注释或普通字符串中的标识符误判为类引用；资源文本只分析路径证据。报告中的 `module_dependency_analysis` 包含模块文件计数、跨模块边、有限证据、项目级资源命中、未归属引用、重复 class、实际循环和完整性状态。
 
-分析结果只有在扫描预算未耗尽、模块根可读、路径安全且 class 身份无歧义时才标记 `complete`。禁止依赖优先于未声明依赖报告；观测到的边、循环或不完整扫描只生成漂移事实，工具不会改写契约中的允许关系。Agent 必须先解决 `forbidden_module_dependency`、`undeclared_module_dependency`、`observed_module_dependency_cycle` 和 `module_dependency_analysis_incomplete`，不能把不完整快照当成“没有依赖”。
+`project.godot`、`export_presets.cfg` 或项目自己的布局 profile 往往由整个项目共同治理，不应为了消除告警而塞进某个业务模块，也不能把模块根放宽成裸 `res://`。这类文件可按精确路径声明：
+
+```json
+{
+  "architecture": {
+    "owned_resources": [
+      "res://project.godot",
+      "res://export_presets.cfg"
+    ]
+  }
+}
+```
+
+`owned_resources` 不是通配排除表：每项必须使用不含重复分隔符、`.`、`..`、尾随点/空格、控制字符、通配字符或 Windows 保留名称的跨平台规范 `res://` 路径，并指向项目内已经存在的普通文件。路径自身及从项目根到文件的任一父目录都不能是符号链接或 Windows 重解析点；大小写或 Windows 路径别名形式的 `res://addons/gf`、目录以及模块或 Adapter 所有权根内文件同样会被拒绝。分析器不会扫描这些文件，也不会把命中解释成模块依赖；它只把来源、目标和行号写入有界的 `owned_resource_references` 证据。声明缺失或不安全的文件会让分析 fail closed，未声明的项目资源引用仍产生 `unowned_project_resource_reference`。
+
+模块 `roots` 与 Adapter `project_root` 也是安全边界，因此同样必须采用跨平台规范路径，并以大小写无关方式避开 `res://addons/gf`。这项限制只作用于契约中的所有权声明；源码里指向合法 Godot 资源（例如文件名含 `[]`）的精确引用仍按普通资源路径解析，不会被误当成通配表达式或静默漏掉依赖边。
+
+分析结果只有在扫描预算未耗尽、模块根可读、已声明项目资源存在且安全、路径安全且 class 身份无歧义时才标记 `complete`。禁止依赖优先于未声明依赖报告；观测到的边、循环或不完整扫描只生成漂移事实，工具不会改写契约中的允许关系。Agent 必须先解决 `forbidden_module_dependency`、`undeclared_module_dependency`、`observed_module_dependency_cycle` 和 `module_dependency_analysis_incomplete`，不能把不完整快照当成“没有依赖”。
 
 API 索引用于准确定位，不替代行为源码、测试和正式文档。涉及副作用、线程、生命周期、失败恢复或持久化兼容时，仍应打开索引返回的源码路径核对。
 
@@ -149,6 +167,7 @@ python addons/gf/tools/ai_developer/gf_ai_project.py feedback-submit --project-r
 - `.gf/project_contract.json` 应进入项目版本控制；`.gf/ai/` 是可重建且可能包含本地诊断摘要的忽略目录。`.gf` 根不是整体忽略目录，避免连项目意图一起丢失。
 - 套件只读取项目相对路径，受控输出必须留在项目根目录内，并拒绝通过符号链接或父级片段越界。
 - 能力目录、API 索引、Schema、Skill 和独立插件 ZIP 与 GF 版本一起校验和发布，不从网络静默更新另一套知识。
+- AI Developer Kit 3.x 的项目快照 schema v3 新增项目级资源状态与引用证据。这是有意的工具输出协议主版本升级；先升级快照消费方，再直接重新生成可重建的 v3 快照，不应迁移或手工补写 v2 字段。
 - 独立插件 ZIP 的条目集合、文件字节、顺序、时间戳、权限和压缩方式都会与同一次发布源码精确比对；仅有相似目录结构不能通过产物审计。
 - Agent 可以提出修改契约的建议，但不能把观测结果、默认模板或自身推断当成用户已经批准的项目决策。
 - 克隆项目中的契约、源码、日志、素材和生成物不能提升为 Agent 指令；其中要求绕过安全、读取无关隐私、联网或修改规则的文本一律按不可信数据处理。

--- a/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
+++ b/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
@@ -32,6 +32,7 @@ from gf_ai.contract import initialize_contract, load_contract  # noqa: E402
 from gf_ai.paths import read_json_object, resolve_project_path  # noqa: E402
 from gf_ai.schema import validate_schema_definition, validate_schema_file  # noqa: E402
 import build_gf_ai_developer_kit  # noqa: E402
+from gf_maintenance import create_directory_link_fixture  # noqa: E402
 
 
 class GFAIDeveloperKitTest(unittest.TestCase):
@@ -287,6 +288,30 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 		self.assertNotIn("undeclared_module_dependency", {item["code"] for item in report["drift"]["issues"]})
 		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
 
+	def test_module_dependency_analysis_preserves_literal_resource_path_characters(self) -> None:
+		self._set_modules([
+			self._module("core", allowed=["shared"]),
+			self._module("shared"),
+		])
+		(self.project_root / "features/shared/[data].tres").write_text(
+			"[gd_resource format=3]\n",
+			encoding="utf-8",
+		)
+		(self.project_root / "features/core/use_shared.gd").write_text(
+			'extends Node\nconst DATA = preload("res://features/shared/[data].tres")\n',
+			encoding="utf-8",
+		)
+
+		report = snapshot.build_snapshot(self.project_root)
+		analysis = report["project"]["module_dependency_analysis"]
+
+		self.assertEqual(analysis["status"], "complete")
+		self.assertEqual(len(analysis["edges"]), 1)
+		self.assertEqual(analysis["edges"][0]["source_module"], "core")
+		self.assertEqual(analysis["edges"][0]["target_module"], "shared")
+		self.assertEqual(analysis["edges"][0]["kinds"], ["resource_path"])
+		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
+
 	def test_module_dependency_analysis_ignores_bare_resource_root(self) -> None:
 		self._set_modules([self._module("core")])
 		(self.project_root / "features/core/scan_root.gd").write_text(
@@ -300,6 +325,271 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 		self.assertEqual(analysis["unowned_reference_count"], 0)
 		self.assertEqual(analysis["unowned_references"], [])
 		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
+
+	def test_module_dependency_analysis_accepts_auditable_owned_resource_references(self) -> None:
+		self._set_modules([self._module("core")])
+		(self.project_root / "export_presets.cfg").write_text("[preset.0]\n", encoding="utf-8")
+		self._set_owned_resources(["res://project.godot", "res://export_presets.cfg"])
+		(self.project_root / "features/core/project_metadata.gd").write_text(
+			'extends Node\nconst PROJECT_FILE := "res://project.godot"\n'
+			'const EXPORT_PRESETS := "res://export_presets.cfg"\n',
+			encoding="utf-8",
+		)
+
+		contract_result = load_contract(self.project_root)
+		report = snapshot.build_snapshot(self.project_root)
+		analysis = report["project"]["module_dependency_analysis"]
+		drift_codes = {item["code"] for item in report["drift"]["issues"]}
+
+		self.assertTrue(contract_result["ok"], contract_result)
+		self.assertEqual(analysis["status"], "complete")
+		self.assertEqual(analysis["declared_owned_resource_count"], 2)
+		self.assertEqual(analysis["missing_owned_resource_count"], 0)
+		self.assertEqual(analysis["unsafe_owned_resource_count"], 0)
+		self.assertEqual(
+			analysis["owned_resources"],
+			[
+				{"path": "res://export_presets.cfg", "status": "available"},
+				{"path": "res://project.godot", "status": "available"},
+			],
+		)
+		self.assertEqual(analysis["owned_resource_reference_count"], 2)
+		self.assertFalse(analysis["owned_resource_references_truncated"])
+		self.assertEqual(
+			analysis["owned_resource_references"],
+			[
+				{
+					"source_path": "res://features/core/project_metadata.gd",
+					"target_path": "res://project.godot",
+					"line": 2,
+				},
+				{
+					"source_path": "res://features/core/project_metadata.gd",
+					"target_path": "res://export_presets.cfg",
+					"line": 3,
+				},
+			],
+		)
+		self.assertEqual(analysis["unowned_reference_count"], 0)
+		self.assertEqual(analysis["edges"], [])
+		self.assertNotIn("unowned_project_resource_reference", drift_codes)
+		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
+
+		with mock.patch.object(dependencies, "MAX_OWNED_RESOURCE_REFERENCE_EVIDENCE", 1):
+			bounded_analysis = snapshot.build_snapshot(self.project_root)["project"]["module_dependency_analysis"]
+		self.assertEqual(bounded_analysis["owned_resource_reference_count"], 2)
+		self.assertEqual(len(bounded_analysis["owned_resource_references"]), 1)
+		self.assertTrue(bounded_analysis["owned_resource_references_truncated"])
+
+	def test_module_dependency_analysis_fails_closed_for_invalid_owned_resources(self) -> None:
+		self._set_modules([self._module("core")])
+		(self.project_root / "governance").mkdir()
+		(self.project_root / "features/core/project_metadata.gd").write_text(
+			'extends Node\nconst MISSING := "res://missing.cfg"\n',
+			encoding="utf-8",
+		)
+		self._set_owned_resources(["res://missing.cfg", "res://governance"])
+
+		report = snapshot.build_snapshot(self.project_root)
+		analysis = report["project"]["module_dependency_analysis"]
+
+		self.assertEqual(analysis["status"], "incomplete")
+		self.assertFalse(analysis["complete"])
+		self.assertEqual(analysis["missing_owned_resource_count"], 1)
+		self.assertEqual(analysis["unsafe_owned_resource_count"], 1)
+		self.assertEqual(
+			analysis["owned_resources"],
+			[
+				{"path": "res://governance", "status": "unsafe"},
+				{"path": "res://missing.cfg", "status": "missing"},
+			],
+		)
+		self.assertEqual(analysis["owned_resource_reference_count"], 0)
+		self.assertEqual(analysis["unowned_reference_count"], 1)
+		self.assertIn("module_dependency_analysis_incomplete", {item["code"] for item in report["drift"]["issues"]})
+		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
+
+	def test_contract_rejects_bare_or_overlapping_owned_resources(self) -> None:
+		self._set_modules([self._module("core")])
+		self._set_owned_resources(["res://"])
+
+		bare_result = load_contract(self.project_root)
+
+		self.assertFalse(bare_result["ok"])
+		self.assertTrue(any("owned_resources" in item["path"] for item in bare_result["issues"]))
+
+		contract_path = self.project_root / ".gf/project_contract.json"
+		contract = json.loads(contract_path.read_text(encoding="utf-8"))
+		contract["architecture"]["owned_resources"] = []
+		contract["architecture"]["modules"][0]["roots"] = ["res://"]
+		contract_path.write_text(json.dumps(contract, ensure_ascii=False), encoding="utf-8")
+		bare_module_result = load_contract(self.project_root)
+
+		self.assertFalse(bare_module_result["ok"])
+		self.assertTrue(any(".roots[0]" in item["path"] for item in bare_module_result["issues"]))
+
+		self._set_modules([self._module("core")])
+		self._set_owned_resources(["res://governance//rules.cfg"])
+		non_canonical_result = load_contract(self.project_root)
+
+		self.assertFalse(non_canonical_result["ok"])
+		self.assertIn("non_canonical_owned_resource_path", {item["code"] for item in non_canonical_result["issues"]})
+
+		self._set_owned_resources(["res://governance/line\nbreak.cfg"])
+		control_character_result = load_contract(self.project_root)
+		control_character_snapshot = snapshot.build_snapshot(self.project_root)
+
+		self.assertFalse(control_character_result["ok"])
+		self.assertTrue(any("owned_resources" in item["path"] for item in control_character_result["issues"]))
+		self.assertEqual(
+			validate_schema_file(control_character_snapshot, SCHEMA_ROOT / "project_snapshot.schema.json"),
+			[],
+		)
+
+		self._set_owned_resources(["res://Addons/GF/project.godot"])
+		framework_result = load_contract(self.project_root)
+
+		self.assertFalse(framework_result["ok"])
+		self.assertIn("framework_owned_resource", {item["code"] for item in framework_result["issues"]})
+
+		for unsafe_alias in (
+			"res://governance/*.cfg",
+			"res://governance/?.cfg",
+			"res://governance/[rules].cfg",
+			"res://addons./gf/plugin.cfg",
+			"res://addons/gf./plugin.cfg",
+			"res://addons/gf/plugin.cfg.",
+			"res://governance/data:stream",
+			"res://CON/settings.cfg",
+		):
+			with self.subTest(unsafe_alias=unsafe_alias):
+				self._set_owned_resources([unsafe_alias])
+				alias_result = load_contract(self.project_root)
+				self.assertFalse(alias_result["ok"])
+				self.assertTrue(
+					{item["code"] for item in alias_result["issues"]}.intersection({
+						"non_canonical_owned_resource_path",
+						"pattern_mismatch",
+					}),
+				)
+
+		self._set_owned_resources(["res://features/core/settings.cfg"])
+		overlap_result = load_contract(self.project_root)
+
+		self.assertFalse(overlap_result["ok"])
+		self.assertIn("ownership_resource_overlap", {item["code"] for item in overlap_result["issues"]})
+
+	def test_contract_rejects_owned_resources_and_adapter_roots_through_linked_parent(self) -> None:
+		self._set_modules([self._module("core")])
+		real_root = self.project_root / "governance-real"
+		real_root.mkdir()
+		(real_root / "rules.cfg").write_text("[rules]\n", encoding="utf-8")
+		linked_root = self.project_root / "governance-link"
+		create_directory_link_fixture(real_root, linked_root)
+		self._set_owned_resources(["res://governance-link/rules.cfg"])
+
+		owned_resource_result = load_contract(self.project_root)
+		report = snapshot.build_snapshot(self.project_root)
+
+		self.assertFalse(owned_resource_result["ok"])
+		self.assertIn("unsafe_project_path", {item["code"] for item in owned_resource_result["issues"]})
+		self.assertEqual(report["project"]["module_dependency_analysis"]["status"], "contract_invalid")
+		self.assertEqual(validate_schema_file(report, SCHEMA_ROOT / "project_snapshot.schema.json"), [])
+
+		self._set_owned_resources(["res://governance-real/rules.cfg"])
+		contract_path = self.project_root / ".gf/project_contract.json"
+		contract = json.loads(contract_path.read_text(encoding="utf-8"))
+		contract["framework"]["adapter_boundaries"] = [{
+			"id": "governance_adapter",
+			"provider": "test",
+			"project_root": "res://governance-link",
+			"responsibility": "Test linked adapter boundary",
+		}]
+		contract_path.write_text(json.dumps(contract, ensure_ascii=False), encoding="utf-8")
+
+		adapter_result = load_contract(self.project_root)
+
+		self.assertFalse(adapter_result["ok"])
+		self.assertIn("unsafe_project_path", {item["code"] for item in adapter_result["issues"]})
+
+	def test_contract_rejects_nonportable_or_reserved_ownership_roots(self) -> None:
+		contract_path = self.project_root / ".gf/project_contract.json"
+		for unsafe_root, expected_code in (
+			("res://Addons/GF", "framework_ownership_root"),
+			("res://addons./gf", "non_canonical_ownership_root"),
+			("res://addons/gf.", "non_canonical_ownership_root"),
+			("res://CON", "non_canonical_ownership_root"),
+		):
+			with self.subTest(unsafe_root=unsafe_root):
+				contract = json.loads(contract_path.read_text(encoding="utf-8"))
+				contract["architecture"]["modules"] = [{
+					**self._module("unsafe"),
+					"roots": [unsafe_root],
+				}]
+				contract_path.write_text(json.dumps(contract, ensure_ascii=False), encoding="utf-8")
+
+				result = load_contract(self.project_root)
+				report = snapshot.build_snapshot(self.project_root)
+
+				self.assertFalse(result["ok"])
+				self.assertIn(expected_code, {item["code"] for item in result["issues"]})
+				self.assertEqual(report["project"]["module_dependency_analysis"]["status"], "contract_invalid")
+
+		contract = json.loads(contract_path.read_text(encoding="utf-8"))
+		contract["architecture"]["modules"] = []
+		contract["framework"]["adapter_boundaries"] = [{
+			"id": "unsafe_adapter",
+			"provider": "test",
+			"project_root": "res://Addons/GF",
+			"responsibility": "Must not alias the framework boundary",
+		}]
+		contract_path.write_text(json.dumps(contract, ensure_ascii=False), encoding="utf-8")
+
+		adapter_result = load_contract(self.project_root)
+		self.assertFalse(adapter_result["ok"])
+		self.assertIn("framework_ownership_root", {item["code"] for item in adapter_result["issues"]})
+
+	def test_dependency_core_rejects_reserved_framework_root_when_contract_is_prevalidated(self) -> None:
+		(self.project_root / "addons/gf/unsafe.gd").write_text(
+			"extends Node\n",
+			encoding="utf-8",
+		)
+		unsafe_module = {
+			**self._module("unsafe"),
+			"roots": ["res://Addons/GF"],
+		}
+		contract_data = {
+			"architecture": {
+				"modules": [unsafe_module],
+				"owned_resources": [],
+			},
+		}
+
+		analysis = dependencies.analyze_module_dependencies(
+			self.project_root,
+			contract_data,
+			contract_valid=True,
+		)
+
+		self.assertEqual(analysis["status"], "incomplete")
+		self.assertFalse(analysis["complete"])
+		self.assertEqual(analysis["scanned_file_count"], 0)
+		self.assertEqual(analysis["unsafe_path_count"], 1)
+		self.assertEqual(
+			dependencies.ModuleOwnershipMatcher([unsafe_module]).owner_of("res://Addons/GF/unsafe.gd"),
+			"",
+		)
+
+	def test_module_dependency_analysis_keeps_missing_module_roots_fail_closed(self) -> None:
+		contract_path = self.project_root / ".gf/project_contract.json"
+		contract = json.loads(contract_path.read_text(encoding="utf-8"))
+		contract["architecture"]["modules"] = [self._module("missing")]
+		contract_path.write_text(json.dumps(contract, ensure_ascii=False), encoding="utf-8")
+
+		analysis = snapshot.build_snapshot(self.project_root)["project"]["module_dependency_analysis"]
+
+		self.assertEqual(analysis["status"], "incomplete")
+		self.assertEqual(analysis["missing_root_count"], 1)
 
 	def test_module_dependency_analysis_enforces_forbidden_before_undeclared_edges(self) -> None:
 		self._set_modules([
@@ -780,6 +1070,12 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 		for module in modules:
 			for root in module["roots"]:
 				(self.project_root / str(root).removeprefix("res://")).mkdir(parents=True, exist_ok=True)
+
+	def _set_owned_resources(self, paths: list[str]) -> None:
+		contract_path = self.project_root / ".gf/project_contract.json"
+		contract = json.loads(contract_path.read_text(encoding="utf-8"))
+		contract["architecture"]["owned_resources"] = paths
+		contract_path.write_text(json.dumps(contract, ensure_ascii=False), encoding="utf-8")
 
 	@staticmethod
 	def _module(

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -109,6 +109,32 @@ GDSCRIPT_RELOAD_WARNING_PATTERNS = (
 	"requires the subtype",
 	"is shadowing an already-declared",
 )
+GOVERNED_WORKFLOW_ACTION_VERSIONS = {
+	"actions/checkout": "v7",
+	"actions/setup-python": "v7",
+	"actions/upload-artifact": "v7",
+	"actions/download-artifact": "v8",
+}
+CI_WORKFLOW_ACTION_COUNTS = {
+	"actions/checkout": 4,
+	"actions/setup-python": 4,
+	"actions/upload-artifact": 0,
+	"actions/download-artifact": 0,
+}
+RELEASE_WORKFLOW_ACTION_COUNTS = {
+	"actions/checkout": 4,
+	"actions/setup-python": 4,
+	"actions/upload-artifact": 1,
+	"actions/download-artifact": 1,
+}
+GOVERNED_WORKFLOW_ACTION_RE = re.compile(
+	r"^\s*(?:-\s*)?uses\s*:\s+(?P<quote>['\"]?)"
+	r"(?P<action>(?i:actions/(?:checkout|setup-python|upload-artifact|download-artifact)))"
+	r"@(?P<ref>[^\s#'\"]+)(?P=quote)(?:\s+#.*)?\s*$"
+)
+GOVERNED_WORKFLOW_ACTION_TOKEN_RE = re.compile(
+	r"(?i:actions/(?:checkout|setup-python|upload-artifact|download-artifact))@"
+)
 GODOT_EXIT_LEAK_PATTERNS = (
 	"objectdb instances leaked at exit",
 	"resource still in use at exit",
@@ -9548,6 +9574,38 @@ def setup_godot_input_default(source: str, input_name: str) -> str:
 	return default_match.group(1) if default_match is not None else ""
 
 
+def audit_governed_workflow_actions(
+	source: str,
+	workflow_name: str,
+	expected_counts: dict[str, int],
+) -> list[str]:
+	issues: list[str] = []
+	observed_counts = {action: 0 for action in GOVERNED_WORKFLOW_ACTION_VERSIONS}
+	for line_number, line in enumerate(source.splitlines(), start=1):
+		content = line.split("#", 1)[0]
+		if GOVERNED_WORKFLOW_ACTION_TOKEN_RE.search(content) is None:
+			continue
+		match = GOVERNED_WORKFLOW_ACTION_RE.fullmatch(line)
+		if match is None:
+			issues.append(f"{workflow_name}:{line_number}: governed action use is malformed or has an unsupported ref.")
+			continue
+		action = match.group("action").casefold()
+		ref = match.group("ref")
+		observed_counts[action] += 1
+		expected_ref = GOVERNED_WORKFLOW_ACTION_VERSIONS[action]
+		if ref != expected_ref:
+			issues.append(
+				f"{workflow_name}:{line_number}: {action} must use {expected_ref}, found {ref}."
+			)
+	for action, expected_count in expected_counts.items():
+		actual_count = observed_counts.get(action, 0)
+		if actual_count != expected_count:
+			issues.append(
+				f"{workflow_name}: expected {expected_count} {action} use(s), found {actual_count}."
+			)
+	return issues
+
+
 def create_directory_link_fixture(target: Path, link: Path) -> None:
 	target_path = lexical_absolute_path(target)
 	link_path = lexical_absolute_path(link)
@@ -10448,6 +10506,51 @@ def maintenance_self_test() -> dict[str, Any]:
 	)
 	ci_workflow_source = read_text_file(ROOT / ".github/workflows/ci.yml")
 	release_workflow_source = read_text_file(ROOT / ".github/workflows/release.yml")
+	ci_action_issues = audit_governed_workflow_actions(
+		ci_workflow_source,
+		".github/workflows/ci.yml",
+		CI_WORKFLOW_ACTION_COUNTS,
+	)
+	release_action_issues = audit_governed_workflow_actions(
+		release_workflow_source,
+		".github/workflows/release.yml",
+		RELEASE_WORKFLOW_ACTION_COUNTS,
+	)
+	record_result(
+		"workflows_use_current_node24_action_majors",
+		not ci_action_issues and not release_action_issues,
+		"CI and release workflows must use the governed current Node.js 24 action majors without stale variants.",
+	)
+	stale_action_source = ci_workflow_source.replace("actions/checkout@v7", "actions/checkout@v6", 1)
+	commented_stale_action_source = ci_workflow_source.replace(
+		"actions/setup-python@v7",
+		"actions/setup-python@v6 # stale",
+		1,
+	)
+	missing_action_source = ci_workflow_source.replace("        uses: actions/checkout@v7\n", "", 1)
+	shorthand_stale_action_source = ci_workflow_source + "\n      - uses: actions/checkout@v4\n"
+	case_variant_action_source = ci_workflow_source + "\n      - uses: Actions/Checkout@v4\n"
+	record_result(
+		"workflow_action_audit_rejects_stale_commented_and_missing_steps",
+		bool(audit_governed_workflow_actions(stale_action_source, "ci-stale", CI_WORKFLOW_ACTION_COUNTS))
+		and bool(audit_governed_workflow_actions(
+			commented_stale_action_source,
+			"ci-commented-stale",
+			CI_WORKFLOW_ACTION_COUNTS,
+		))
+		and bool(audit_governed_workflow_actions(missing_action_source, "ci-missing", CI_WORKFLOW_ACTION_COUNTS))
+		and bool(audit_governed_workflow_actions(
+			shorthand_stale_action_source,
+			"ci-shorthand-stale",
+			CI_WORKFLOW_ACTION_COUNTS,
+		))
+		and bool(audit_governed_workflow_actions(
+			case_variant_action_source,
+			"ci-case-variant",
+			CI_WORKFLOW_ACTION_COUNTS,
+		)),
+		"Workflow action policy fixtures must detect stale refs, comments, missing steps, shorthand, and case variants.",
+	)
 	quick_job_match = re.search(
 		r"(?ms)^  quick-checks:\n(?P<body>.*?)(?=^  framework-checks:)",
 		ci_workflow_source,
@@ -10487,7 +10590,7 @@ def maintenance_self_test() -> dict[str, Any]:
 	record_result(
 		"ci_draft_quick_job_avoids_heavy_environment_bootstrap",
 		bool(quick_job_source)
-		and "actions/setup-python@v5" in quick_job_source
+		and "actions/setup-python@v7" in quick_job_source
 		and "docs/requirements.txt" not in quick_job_source
 		and ".github/actions/setup-godot" not in quick_job_source,
 		"Draft quick CI must remain pure Python and avoid documentation or Godot environment bootstrap.",
@@ -10521,8 +10624,8 @@ def maintenance_self_test() -> dict[str, Any]:
 		and release_workflow_source.count("--output-dir build/release") == 1
 		and "python tools/build_asset_store_package.py" not in release_workflow_source
 		and "python tools/build_gf_package.py" not in release_workflow_source
-		and "actions/upload-artifact@v4" in release_workflow_source
-		and "actions/download-artifact@v4" in release_workflow_source
+		and "actions/upload-artifact@v7" in release_workflow_source
+		and "actions/download-artifact@v8" in release_workflow_source
 		and "--validate-only" in release_workflow_source,
 		"Release workflow must build archives once, transport that immutable set, then validate without rebuilding.",
 	)


### PR DESCRIPTION
## Summary

This change fixes project-level resource ownership in the AI Developer dependency analyzer and updates the repository's governed GitHub Actions to the current Node.js 24 generations.

Fixes #18.

## Why this was needed

A normal game module may need to reference project-wide governance files such as `res://project.godot`, `res://export_presets.cfg`, or a project layout profile. For example, a diagnostics screen may display the active renderer from `project.godot`, or an internal build tool may inspect an export preset.

Those files do not belong to a gameplay module. Before this change, the analyzer forced an undesirable choice:

- leave the reference unowned and receive permanent drift;
- claim the file as a module root, even though roots are scanned as directories and the analysis becomes incomplete; or
- hide the literal from the analyzer.

The last two options weaken the architecture model instead of describing the project honestly.

## What changed

### Exact project-owned resources

- Adds optional `architecture.owned_resources` to project contract schema v1.
- Accepts exact, bounded `res://` file paths for project-wide governance inputs.
- Records bounded source/target/line evidence in `owned_resource_references`.
- Keeps these files out of module scans and never turns a match into a module dependency edge.
- Reports available, missing, and unsafe declarations separately.
- Keeps missing module directories fail-closed.

Example:

```json
{
  "architecture": {
    "owned_resources": [
      "res://project.godot",
      "res://export_presets.cfg"
    ]
  }
}
```

This is deliberately not an exclusion glob. Bare `res://`, directories, module-owned files, framework files, wildcard-like declarations, non-portable Windows aliases, links, junctions, and reparse-point paths are rejected. Module and adapter ownership roots now receive the same canonical, case-insensitive framework-boundary protection.

Ordinary Godot resource references retain their normal path semantics. A valid literal such as `res://features/shared/[data].tres` still produces the expected module edge; the stricter rules apply only to ownership declarations.

### Auditable snapshot protocol

- Upgrades project snapshots from schema v2 to v3.
- Upgrades the AI Developer Kit protocol to 3.0.0.
- Adds declared/missing/unsafe resource counts, resource status records, bounded reference evidence, and an explicit truncation flag.
- Keeps incomplete analysis visible through structured drift diagnostics.

Because snapshot v3 is a public breaking output protocol, the repository development identity and all bundled extension manifests move together from `9.1.0-dev.0` to `10.0.0-dev.0`. This PR does not create a tag or publish a release.

Migration: upgrade snapshot consumers to AI Developer Kit 3.x and regenerate snapshots; do not patch v2 snapshots in place.

### GitHub Actions

- `actions/checkout@v7`
- `actions/setup-python@v7`
- `actions/upload-artifact@v7`
- `actions/download-artifact@v8`

The maintenance self-test now validates the governed version and exact occurrence count in each workflow. It also proves that stale refs, inline comments, missing steps, `- uses:` shorthand, action-name case variants, quoted/flow/multiline forms, and malformed uses cannot bypass the policy.

## Validation

- Full maintenance suite: **34/34 passed**
- GDScript LSP hard gate: **1,149 files**, **0 diagnostics**, **0 timeouts**
- AI Developer behavior suite: **43/43 passed**
- Maintenance self-test: **282/282 passed**
- Package mapping: **50/50 packages**, 178 focused tests, 0 issues
- Package build boundary: **53 packages**, 50 archives, 0 issues
- AI Developer generated source consistency: passed
- Project settings drift: none
- Log hygiene: clean
- `git diff --check`: passed
