### PR TITLE
Add trajectory prediction and interception math

### DIFF
--- a/addons/gf/standard/foundation/math/gf_trajectory_math.gd
+++ b/addons/gf/standard/foundation/math/gf_trajectory_math.gd
@@ -1,0 +1,1051 @@
+## GFTrajectoryMath: 通用运动预测、拦截和公式轨迹采样工具。
+##
+## 运动预测和拦截入口是 GF 内部无节点副作用的纯计算，不负责绘制、物理推进、目标选择或业务策略。
+## 公式采样会同步执行项目显式提供的可信 Callable，并在调用前执行硬预算校验；GF 本身不访问节点，
+## 但回调的副作用、阻塞与计算成本由调用方负责。
+## [br]
+## @api public
+## [br]
+## @category runtime_service
+## [br]
+## @since unreleased
+class_name GFTrajectoryMath
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 表示计算成功，没有失败原因。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_NONE: StringName = &""
+
+## 表示输入参数无效、包含非有限数字，或计算结果无法保持有限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_INVALID_ARGUMENT: StringName = &"invalid_argument"
+
+## 表示拦截方程不存在非负实数解。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_NO_SOLUTION: StringName = &"no_solution"
+
+## 表示拦截解超出调用方给定的时间窗口。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_BEYOND_HORIZON: StringName = &"beyond_horizon"
+
+## 表示轨迹公式 Callable 无效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_INVALID_PROVIDER: StringName = &"invalid_provider"
+
+## 表示请求采样数量超过本次预算。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_SAMPLE_LIMIT_EXCEEDED: StringName = &"sample_limit_exceeded"
+
+## 表示公式返回了错误类型或非有限坐标。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_PROVIDER_FAILED: StringName = &"provider_failed"
+
+## 默认浮点容差。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DEFAULT_EPSILON: float = 0.000001
+
+## 单次公式采样的默认点数预算。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DEFAULT_MAX_SAMPLE_COUNT: int = 1024
+
+## 单次公式采样不可绕过的绝对点数上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ABSOLUTE_MAX_SAMPLE_COUNT: int = 16_384
+
+
+# --- 公共方法 ---
+
+## 按恒定加速度预测 2D 未来位置和速度。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param initial_position: 当前世界或局部位置，由调用方保证坐标空间一致。
+## [br]
+## @param initial_velocity: 当前速度。
+## [br]
+## @param acceleration: 在预测区间内保持恒定的加速度。
+## [br]
+## @param time_seconds: 非负预测秒数。
+## [br]
+## @return 运动预测报告。
+## [br]
+## @schema return: Dictionary，字段为 ok: bool、reason: StringName（空或 invalid_argument）、error: String、time_seconds: float、position: Vector2、velocity: Vector2；成功时 time_seconds 等于请求值，失败时 time_seconds 为 0 且向量为零。
+static func predict_motion_2d(
+	initial_position: Vector2,
+	initial_velocity: Vector2,
+	acceleration: Vector2,
+	time_seconds: float
+) -> Dictionary:
+	if (
+		not _is_finite_vector2(initial_position)
+		or not _is_finite_vector2(initial_velocity)
+		or not _is_finite_vector2(acceleration)
+		or not _is_nonnegative_finite_float(time_seconds)
+	):
+		return _make_motion_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Motion inputs and time_seconds must be finite, and time_seconds must be non-negative."
+		)
+
+	var velocity_displacement: Vector2 = _scale_vector2(initial_velocity, time_seconds)
+	var acceleration_velocity_delta: Vector2 = _scale_vector2(acceleration, time_seconds)
+	var acceleration_displacement: Vector2 = _scale_vector2(
+		acceleration_velocity_delta,
+		0.5 * time_seconds
+	)
+	var predicted_position: Vector2 = (
+		initial_position
+		+ velocity_displacement
+		+ acceleration_displacement
+	)
+	var predicted_velocity: Vector2 = initial_velocity + acceleration_velocity_delta
+	if not _is_finite_vector2(predicted_position) or not _is_finite_vector2(predicted_velocity):
+		return _make_motion_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Motion prediction produced non-finite output."
+		)
+
+	return _make_motion_report_2d(
+		true,
+		REASON_NONE,
+		"",
+		time_seconds,
+		predicted_position,
+		predicted_velocity
+	)
+
+
+## 按恒定加速度预测 3D 未来位置和速度。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param initial_position: 当前世界或局部位置，由调用方保证坐标空间一致。
+## [br]
+## @param initial_velocity: 当前速度。
+## [br]
+## @param acceleration: 在预测区间内保持恒定的加速度。
+## [br]
+## @param time_seconds: 非负预测秒数。
+## [br]
+## @return 运动预测报告。
+## [br]
+## @schema return: Dictionary，字段为 ok: bool、reason: StringName（空或 invalid_argument）、error: String、time_seconds: float、position: Vector3、velocity: Vector3；成功时 time_seconds 等于请求值，失败时 time_seconds 为 0 且向量为零。
+static func predict_motion_3d(
+	initial_position: Vector3,
+	initial_velocity: Vector3,
+	acceleration: Vector3,
+	time_seconds: float
+) -> Dictionary:
+	if (
+		not _is_finite_vector3(initial_position)
+		or not _is_finite_vector3(initial_velocity)
+		or not _is_finite_vector3(acceleration)
+		or not _is_nonnegative_finite_float(time_seconds)
+	):
+		return _make_motion_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Motion inputs and time_seconds must be finite, and time_seconds must be non-negative."
+		)
+
+	var velocity_displacement: Vector3 = _scale_vector3(initial_velocity, time_seconds)
+	var acceleration_velocity_delta: Vector3 = _scale_vector3(acceleration, time_seconds)
+	var acceleration_displacement: Vector3 = _scale_vector3(
+		acceleration_velocity_delta,
+		0.5 * time_seconds
+	)
+	var predicted_position: Vector3 = (
+		initial_position
+		+ velocity_displacement
+		+ acceleration_displacement
+	)
+	var predicted_velocity: Vector3 = initial_velocity + acceleration_velocity_delta
+	if not _is_finite_vector3(predicted_position) or not _is_finite_vector3(predicted_velocity):
+		return _make_motion_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Motion prediction produced non-finite output."
+		)
+
+	return _make_motion_report_3d(
+		true,
+		REASON_NONE,
+		"",
+		time_seconds,
+		predicted_position,
+		predicted_velocity
+	)
+
+
+## 求恒速发射体拦截匀速 2D 目标的最早非负解。
+##
+## 发射速度使用当前坐标空间中的绝对速度，不隐式继承发射者速度。若发射体需要继承恒定的
+## source_velocity，应传入 target_velocity - source_velocity；此时 launch_velocity 是相对发射者的速度，
+## 世界速度为 source_velocity + launch_velocity，世界命中点为 position + source_velocity * time_seconds。
+## 该方法不计算发射体加速度、重力或障碍物。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param source_position: 发射位置。
+## [br]
+## @param projectile_speed: 发射体恒定速率，必须大于零。
+## [br]
+## @param target_position: 目标当前位置。
+## [br]
+## @param target_velocity: 目标恒定速度。
+## [br]
+## @param max_time_seconds: 最大预测秒数；负值表示不限制。
+## [br]
+## @param epsilon: 浮点判定容差；非正值使用 DEFAULT_EPSILON。
+## [br]
+## @return 最早拦截解报告。
+## [br]
+## @schema return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、no_solution 或 beyond_horizon）、error: String、time_seconds: float、position: Vector2、launch_velocity: Vector2、distance: float；成功时 time_seconds >= 0，正时间解的 launch_velocity 长度等于 projectile_speed，t=0 时为零；失败时 time_seconds 为 -1，其余数值结果为零。
+static func solve_intercept_2d(
+	source_position: Vector2,
+	projectile_speed: float,
+	target_position: Vector2,
+	target_velocity: Vector2,
+	max_time_seconds: float = -1.0,
+	epsilon: float = DEFAULT_EPSILON
+) -> Dictionary:
+	if (
+		not _is_finite_vector2(source_position)
+		or not _is_finite_vector2(target_position)
+		or not _is_finite_vector2(target_velocity)
+		or not _is_finite_float(projectile_speed)
+		or not _is_finite_float(max_time_seconds)
+		or not _is_finite_float(epsilon)
+	):
+		return _make_intercept_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept inputs must contain only finite values."
+		)
+
+	var safe_epsilon: float = _normalize_epsilon(epsilon)
+	if projectile_speed <= 0.0:
+		return _make_intercept_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"projectile_speed must be greater than zero."
+		)
+
+	var relative_position: Vector2 = target_position - source_position
+	var time_report: Dictionary = _solve_intercept_time(
+		relative_position.length_squared(),
+		relative_position.dot(target_velocity),
+		target_velocity.length_squared(),
+		projectile_speed,
+		max_time_seconds,
+		safe_epsilon
+	)
+	if not _get_report_ok(time_report):
+		return _make_intercept_report_2d(
+			false,
+			_get_report_reason(time_report),
+			_get_report_error(time_report)
+		)
+
+	var intercept_time: float = _get_report_time(time_report)
+	var target_displacement: Vector2 = _scale_vector2(target_velocity, intercept_time)
+	var intercept_position: Vector2 = target_position + target_displacement
+	if not _is_finite_vector2(intercept_position):
+		return _make_intercept_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept calculation produced non-finite output."
+		)
+
+	var launch_velocity: Vector2 = Vector2.ZERO
+	if intercept_time > 0.0:
+		launch_velocity = _scale_vector2(
+			(intercept_position - source_position).normalized(),
+			projectile_speed
+		)
+	var launch_speed_squared: float = launch_velocity.length_squared()
+	if (
+		not _is_finite_vector2(launch_velocity)
+		or (
+			intercept_time > 0.0
+			and (
+				launch_velocity == Vector2.ZERO
+				or not _is_finite_float(launch_speed_squared)
+				or launch_speed_squared <= 0.0
+			)
+		)
+	):
+		return _make_intercept_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept launch_velocity cannot be represented as a finite non-zero Vector2 with usable magnitude."
+		)
+	var intercept_distance: float = projectile_speed * intercept_time
+	if not _is_nonnegative_finite_float(intercept_distance):
+		return _make_intercept_report_2d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept distance cannot be represented as a finite value."
+		)
+	return _make_intercept_report_2d(
+		true,
+		REASON_NONE,
+		"",
+		intercept_time,
+		intercept_position,
+		launch_velocity,
+		intercept_distance
+	)
+
+
+## 求恒速发射体拦截匀速 3D 目标的最早非负解。
+##
+## 发射速度使用当前坐标空间中的绝对速度，不隐式继承发射者速度。若发射体需要继承恒定的
+## source_velocity，应传入 target_velocity - source_velocity；此时 launch_velocity 是相对发射者的速度，
+## 世界速度为 source_velocity + launch_velocity，世界命中点为 position + source_velocity * time_seconds。
+## 该方法不计算发射体加速度、重力或障碍物。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param source_position: 发射位置。
+## [br]
+## @param projectile_speed: 发射体恒定速率，必须大于零。
+## [br]
+## @param target_position: 目标当前位置。
+## [br]
+## @param target_velocity: 目标恒定速度。
+## [br]
+## @param max_time_seconds: 最大预测秒数；负值表示不限制。
+## [br]
+## @param epsilon: 浮点判定容差；非正值使用 DEFAULT_EPSILON。
+## [br]
+## @return 最早拦截解报告。
+## [br]
+## @schema return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、no_solution 或 beyond_horizon）、error: String、time_seconds: float、position: Vector3、launch_velocity: Vector3、distance: float；成功时 time_seconds >= 0，正时间解的 launch_velocity 长度等于 projectile_speed，t=0 时为零；失败时 time_seconds 为 -1，其余数值结果为零。
+static func solve_intercept_3d(
+	source_position: Vector3,
+	projectile_speed: float,
+	target_position: Vector3,
+	target_velocity: Vector3,
+	max_time_seconds: float = -1.0,
+	epsilon: float = DEFAULT_EPSILON
+) -> Dictionary:
+	if (
+		not _is_finite_vector3(source_position)
+		or not _is_finite_vector3(target_position)
+		or not _is_finite_vector3(target_velocity)
+		or not _is_finite_float(projectile_speed)
+		or not _is_finite_float(max_time_seconds)
+		or not _is_finite_float(epsilon)
+	):
+		return _make_intercept_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept inputs must contain only finite values."
+		)
+
+	var safe_epsilon: float = _normalize_epsilon(epsilon)
+	if projectile_speed <= 0.0:
+		return _make_intercept_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"projectile_speed must be greater than zero."
+		)
+
+	var relative_position: Vector3 = target_position - source_position
+	var time_report: Dictionary = _solve_intercept_time(
+		relative_position.length_squared(),
+		relative_position.dot(target_velocity),
+		target_velocity.length_squared(),
+		projectile_speed,
+		max_time_seconds,
+		safe_epsilon
+	)
+	if not _get_report_ok(time_report):
+		return _make_intercept_report_3d(
+			false,
+			_get_report_reason(time_report),
+			_get_report_error(time_report)
+		)
+
+	var intercept_time: float = _get_report_time(time_report)
+	var target_displacement: Vector3 = _scale_vector3(target_velocity, intercept_time)
+	var intercept_position: Vector3 = target_position + target_displacement
+	if not _is_finite_vector3(intercept_position):
+		return _make_intercept_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept calculation produced non-finite output."
+		)
+
+	var launch_velocity: Vector3 = Vector3.ZERO
+	if intercept_time > 0.0:
+		launch_velocity = _scale_vector3(
+			(intercept_position - source_position).normalized(),
+			projectile_speed
+		)
+	var launch_speed_squared: float = launch_velocity.length_squared()
+	if (
+		not _is_finite_vector3(launch_velocity)
+		or (
+			intercept_time > 0.0
+			and (
+				launch_velocity == Vector3.ZERO
+				or not _is_finite_float(launch_speed_squared)
+				or launch_speed_squared <= 0.0
+			)
+		)
+	):
+		return _make_intercept_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept launch_velocity cannot be represented as a finite non-zero Vector3 with usable magnitude."
+		)
+	var intercept_distance: float = projectile_speed * intercept_time
+	if not _is_nonnegative_finite_float(intercept_distance):
+		return _make_intercept_report_3d(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept distance cannot be represented as a finite value."
+		)
+	return _make_intercept_report_3d(
+		true,
+		REASON_NONE,
+		"",
+		intercept_time,
+		intercept_position,
+		launch_velocity,
+		intercept_distance
+	)
+
+
+## 在闭区间内均匀调用同步公式并生成 2D 轨迹点。
+##
+## sample_count 为 1 时只采样 start_time_seconds；否则首尾时间都会被包含。
+## 反向时间区间是合法的。公式必须快速、同步且返回有限 Vector2。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param position_provider: 接收一个 float 秒数并返回 Vector2 的同步 Callable。
+## [br]
+## @param start_time_seconds: 起始采样时间。
+## [br]
+## @param end_time_seconds: 结束采样时间。
+## [br]
+## @param sample_count: 请求采样点数量，必须大于零。
+## [br]
+## @param max_sample_count: 本次预算，必须位于 1 到 ABSOLUTE_MAX_SAMPLE_COUNT。
+## [br]
+## @return 有界 2D 采样报告。
+## [br]
+## @schema return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、invalid_provider、sample_limit_exceeded 或 provider_failed）、error: String、start_time_seconds: float、end_time_seconds: float、requested_sample_count: int、sample_limit: int、sampled_count: int、failed_sample_index: int、times: PackedFloat64Array、points: PackedVector2Array；始终满足 sampled_count == times.size() == points.size()；成功时 failed_sample_index 为 -1，运行中失败时为首个失败索引并保留此前有效前缀，预检失败时数组为空且索引为 -1。
+static func sample_formula_2d(
+	position_provider: Callable,
+	start_time_seconds: float,
+	end_time_seconds: float,
+	sample_count: int,
+	max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT
+) -> Dictionary:
+	var validation_reason: StringName = _validate_sample_request(
+		position_provider,
+		start_time_seconds,
+		end_time_seconds,
+		sample_count,
+		max_sample_count
+	)
+	if validation_reason != REASON_NONE:
+		return _make_sample_report_2d(
+			false,
+			validation_reason,
+			_get_sample_validation_error(validation_reason),
+			start_time_seconds,
+			end_time_seconds,
+			sample_count,
+			max_sample_count
+		)
+
+	var times: PackedFloat64Array = PackedFloat64Array()
+	var points: PackedVector2Array = PackedVector2Array()
+	for sample_index: int in range(sample_count):
+		var sample_time: float = _get_sample_time(
+			start_time_seconds,
+			end_time_seconds,
+			sample_index,
+			sample_count
+		)
+		if not _is_finite_float(sample_time):
+			return _make_sample_report_2d(
+				false,
+				REASON_INVALID_ARGUMENT,
+				"Sample time interpolation produced non-finite output.",
+				start_time_seconds,
+				end_time_seconds,
+				sample_count,
+				max_sample_count,
+				times,
+				points,
+				sample_index
+			)
+		var raw_position: Variant = position_provider.call(sample_time)
+		if not raw_position is Vector2:
+			return _make_sample_report_2d(
+				false,
+				REASON_PROVIDER_FAILED,
+				"position_provider must return Vector2.",
+				start_time_seconds,
+				end_time_seconds,
+				sample_count,
+				max_sample_count,
+				times,
+				points,
+				sample_index
+			)
+		var sample_position: Vector2 = raw_position
+		if not _is_finite_vector2(sample_position):
+			return _make_sample_report_2d(
+				false,
+				REASON_PROVIDER_FAILED,
+				"position_provider returned non-finite Vector2 coordinates.",
+				start_time_seconds,
+				end_time_seconds,
+				sample_count,
+				max_sample_count,
+				times,
+				points,
+				sample_index
+			)
+		var _time_appended: bool = times.append(sample_time)
+		var _point_appended: bool = points.append(sample_position)
+
+	return _make_sample_report_2d(
+		true,
+		REASON_NONE,
+		"",
+		start_time_seconds,
+		end_time_seconds,
+		sample_count,
+		max_sample_count,
+		times,
+		points
+	)
+
+
+## 在闭区间内均匀调用同步公式并生成 3D 轨迹点。
+##
+## sample_count 为 1 时只采样 start_time_seconds；否则首尾时间都会被包含。
+## 反向时间区间是合法的。公式必须快速、同步且返回有限 Vector3。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param position_provider: 接收一个 float 秒数并返回 Vector3 的同步 Callable。
+## [br]
+## @param start_time_seconds: 起始采样时间。
+## [br]
+## @param end_time_seconds: 结束采样时间。
+## [br]
+## @param sample_count: 请求采样点数量，必须大于零。
+## [br]
+## @param max_sample_count: 本次预算，必须位于 1 到 ABSOLUTE_MAX_SAMPLE_COUNT。
+## [br]
+## @return 有界 3D 采样报告。
+## [br]
+## @schema return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、invalid_provider、sample_limit_exceeded 或 provider_failed）、error: String、start_time_seconds: float、end_time_seconds: float、requested_sample_count: int、sample_limit: int、sampled_count: int、failed_sample_index: int、times: PackedFloat64Array、points: PackedVector3Array；始终满足 sampled_count == times.size() == points.size()；成功时 failed_sample_index 为 -1，运行中失败时为首个失败索引并保留此前有效前缀，预检失败时数组为空且索引为 -1。
+static func sample_formula_3d(
+	position_provider: Callable,
+	start_time_seconds: float,
+	end_time_seconds: float,
+	sample_count: int,
+	max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT
+) -> Dictionary:
+	var validation_reason: StringName = _validate_sample_request(
+		position_provider,
+		start_time_seconds,
+		end_time_seconds,
+		sample_count,
+		max_sample_count
+	)
+	if validation_reason != REASON_NONE:
+		return _make_sample_report_3d(
+			false,
+			validation_reason,
+			_get_sample_validation_error(validation_reason),
+			start_time_seconds,
+			end_time_seconds,
+			sample_count,
+			max_sample_count
+		)
+
+	var times: PackedFloat64Array = PackedFloat64Array()
+	var points: PackedVector3Array = PackedVector3Array()
+	for sample_index: int in range(sample_count):
+		var sample_time: float = _get_sample_time(
+			start_time_seconds,
+			end_time_seconds,
+			sample_index,
+			sample_count
+		)
+		if not _is_finite_float(sample_time):
+			return _make_sample_report_3d(
+				false,
+				REASON_INVALID_ARGUMENT,
+				"Sample time interpolation produced non-finite output.",
+				start_time_seconds,
+				end_time_seconds,
+				sample_count,
+				max_sample_count,
+				times,
+				points,
+				sample_index
+			)
+		var raw_position: Variant = position_provider.call(sample_time)
+		if not raw_position is Vector3:
+			return _make_sample_report_3d(
+				false,
+				REASON_PROVIDER_FAILED,
+				"position_provider must return Vector3.",
+				start_time_seconds,
+				end_time_seconds,
+				sample_count,
+				max_sample_count,
+				times,
+				points,
+				sample_index
+			)
+		var sample_position: Vector3 = raw_position
+		if not _is_finite_vector3(sample_position):
+			return _make_sample_report_3d(
+				false,
+				REASON_PROVIDER_FAILED,
+				"position_provider returned non-finite Vector3 coordinates.",
+				start_time_seconds,
+				end_time_seconds,
+				sample_count,
+				max_sample_count,
+				times,
+				points,
+				sample_index
+			)
+		var _time_appended: bool = times.append(sample_time)
+		var _point_appended: bool = points.append(sample_position)
+
+	return _make_sample_report_3d(
+		true,
+		REASON_NONE,
+		"",
+		start_time_seconds,
+		end_time_seconds,
+		sample_count,
+		max_sample_count,
+		times,
+		points
+	)
+
+
+# --- 私有/辅助方法 ---
+
+static func _solve_intercept_time(
+	relative_distance_squared: float,
+	relative_position_dot_velocity: float,
+	target_speed_squared: float,
+	projectile_speed: float,
+	max_time_seconds: float,
+	epsilon: float
+) -> Dictionary:
+	if relative_distance_squared <= epsilon * epsilon:
+		return _make_time_report(true, REASON_NONE, "", 0.0)
+
+	var projectile_speed_squared: float = projectile_speed * projectile_speed
+	var coefficient_a: float = target_speed_squared - projectile_speed_squared
+	var coefficient_b: float = 2.0 * relative_position_dot_velocity
+	var coefficient_c: float = relative_distance_squared
+	if (
+		not _is_finite_float(coefficient_a)
+		or not _is_finite_float(coefficient_b)
+		or not _is_finite_float(coefficient_c)
+	):
+		return _make_time_report(
+			false,
+			REASON_INVALID_ARGUMENT,
+			"Intercept coefficients are non-finite."
+		)
+
+	var roots: PackedFloat64Array = PackedFloat64Array()
+	var coefficient_scale: float = maxf(
+		absf(target_speed_squared),
+		absf(projectile_speed_squared)
+	)
+	if absf(coefficient_a) <= epsilon * coefficient_scale:
+		if coefficient_b == 0.0:
+			return _make_time_report(false, REASON_NO_SOLUTION, "No non-negative intercept solution exists.")
+		_append_nonnegative_root(roots, -coefficient_c / coefficient_b)
+	else:
+		var discriminant: float = (
+			coefficient_b * coefficient_b
+			- 4.0 * coefficient_a * coefficient_c
+		)
+		if not _is_finite_float(discriminant):
+			return _make_time_report(
+				false,
+				REASON_INVALID_ARGUMENT,
+				"Intercept discriminant is non-finite."
+			)
+		var discriminant_scale: float = maxf(
+			absf(coefficient_b * coefficient_b),
+			absf(4.0 * coefficient_a * coefficient_c)
+		)
+		var discriminant_epsilon: float = epsilon * discriminant_scale
+		if discriminant < -discriminant_epsilon:
+			return _make_time_report(false, REASON_NO_SOLUTION, "No real intercept solution exists.")
+
+		var sqrt_discriminant: float = sqrt(maxf(discriminant, 0.0))
+		var sqrt_discriminant_scale: float = sqrt(discriminant_scale)
+		if sqrt_discriminant <= epsilon * sqrt_discriminant_scale:
+			_append_nonnegative_root(
+				roots,
+				-coefficient_b / (2.0 * coefficient_a)
+			)
+		else:
+			var b_sign: float = 1.0 if coefficient_b >= 0.0 else -1.0
+			var stable_term: float = -0.5 * (coefficient_b + b_sign * sqrt_discriminant)
+			var stable_term_scale: float = maxf(absf(coefficient_b), sqrt_discriminant)
+			if absf(stable_term) <= epsilon * stable_term_scale:
+				_append_nonnegative_root(
+					roots,
+					(-coefficient_b - sqrt_discriminant) / (2.0 * coefficient_a)
+				)
+				_append_nonnegative_root(
+					roots,
+					(-coefficient_b + sqrt_discriminant) / (2.0 * coefficient_a)
+				)
+			else:
+				_append_nonnegative_root(roots, stable_term / coefficient_a)
+				_append_nonnegative_root(roots, coefficient_c / stable_term)
+
+	if roots.is_empty():
+		return _make_time_report(false, REASON_NO_SOLUTION, "No non-negative intercept solution exists.")
+	roots.sort()
+	var intercept_time: float = roots[0]
+	if max_time_seconds >= 0.0 and intercept_time > max_time_seconds + epsilon:
+		return _make_time_report(
+			false,
+			REASON_BEYOND_HORIZON,
+			"The earliest intercept solution exceeds max_time_seconds."
+		)
+	return _make_time_report(true, REASON_NONE, "", intercept_time)
+
+
+static func _append_nonnegative_root(
+	roots: PackedFloat64Array,
+	root: float
+) -> void:
+	if not _is_finite_float(root) or root < 0.0:
+		return
+	var normalized_root: float = maxf(root, 0.0)
+	var _root_appended: bool = roots.append(normalized_root)
+
+
+static func _validate_sample_request(
+	position_provider: Callable,
+	start_time_seconds: float,
+	end_time_seconds: float,
+	sample_count: int,
+	max_sample_count: int
+) -> StringName:
+	if not position_provider.is_valid():
+		return REASON_INVALID_PROVIDER
+	if not _is_finite_float(start_time_seconds) or not _is_finite_float(end_time_seconds):
+		return REASON_INVALID_ARGUMENT
+	if sample_count <= 0:
+		return REASON_INVALID_ARGUMENT
+	if max_sample_count <= 0 or max_sample_count > ABSOLUTE_MAX_SAMPLE_COUNT:
+		return REASON_INVALID_ARGUMENT
+	if sample_count > max_sample_count:
+		return REASON_SAMPLE_LIMIT_EXCEEDED
+	return REASON_NONE
+
+
+static func _get_sample_validation_error(reason: StringName) -> String:
+	match reason:
+		REASON_INVALID_PROVIDER:
+			return "position_provider must be a valid Callable."
+		REASON_SAMPLE_LIMIT_EXCEEDED:
+			return "sample_count exceeds max_sample_count."
+		_:
+			return "Sample times and limits must be finite and within the documented bounds."
+
+
+static func _get_sample_time(
+	start_time_seconds: float,
+	end_time_seconds: float,
+	sample_index: int,
+	sample_count: int
+) -> float:
+	if sample_count <= 1:
+		return start_time_seconds
+	var ratio: float = float(sample_index) / float(sample_count - 1)
+	return start_time_seconds * (1.0 - ratio) + end_time_seconds * ratio
+
+
+static func _make_motion_report_2d(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	time_seconds: float = 0.0,
+	predicted_position: Vector2 = Vector2.ZERO,
+	predicted_velocity: Vector2 = Vector2.ZERO
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"time_seconds": time_seconds if _is_finite_float(time_seconds) else 0.0,
+		"position": predicted_position if _is_finite_vector2(predicted_position) else Vector2.ZERO,
+		"velocity": predicted_velocity if _is_finite_vector2(predicted_velocity) else Vector2.ZERO,
+	}
+
+
+static func _make_motion_report_3d(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	time_seconds: float = 0.0,
+	predicted_position: Vector3 = Vector3.ZERO,
+	predicted_velocity: Vector3 = Vector3.ZERO
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"time_seconds": time_seconds if _is_finite_float(time_seconds) else 0.0,
+		"position": predicted_position if _is_finite_vector3(predicted_position) else Vector3.ZERO,
+		"velocity": predicted_velocity if _is_finite_vector3(predicted_velocity) else Vector3.ZERO,
+	}
+
+
+static func _make_intercept_report_2d(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	time_seconds: float = -1.0,
+	intercept_position: Vector2 = Vector2.ZERO,
+	launch_velocity: Vector2 = Vector2.ZERO,
+	distance: float = 0.0
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"time_seconds": time_seconds if _is_finite_float(time_seconds) else -1.0,
+		"position": intercept_position if _is_finite_vector2(intercept_position) else Vector2.ZERO,
+		"launch_velocity": launch_velocity if _is_finite_vector2(launch_velocity) else Vector2.ZERO,
+		"distance": distance if _is_nonnegative_finite_float(distance) else 0.0,
+	}
+
+
+static func _make_intercept_report_3d(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	time_seconds: float = -1.0,
+	intercept_position: Vector3 = Vector3.ZERO,
+	launch_velocity: Vector3 = Vector3.ZERO,
+	distance: float = 0.0
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"time_seconds": time_seconds if _is_finite_float(time_seconds) else -1.0,
+		"position": intercept_position if _is_finite_vector3(intercept_position) else Vector3.ZERO,
+		"launch_velocity": launch_velocity if _is_finite_vector3(launch_velocity) else Vector3.ZERO,
+		"distance": distance if _is_nonnegative_finite_float(distance) else 0.0,
+	}
+
+
+static func _make_sample_report_2d(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	start_time_seconds: float,
+	end_time_seconds: float,
+	requested_sample_count: int,
+	sample_limit: int,
+	times: PackedFloat64Array = PackedFloat64Array(),
+	points: PackedVector2Array = PackedVector2Array(),
+	failed_sample_index: int = -1
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"start_time_seconds": _finite_or_zero(start_time_seconds),
+		"end_time_seconds": _finite_or_zero(end_time_seconds),
+		"requested_sample_count": requested_sample_count,
+		"sample_limit": sample_limit,
+		"sampled_count": points.size(),
+		"failed_sample_index": failed_sample_index,
+		"times": times,
+		"points": points,
+	}
+
+
+static func _make_sample_report_3d(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	start_time_seconds: float,
+	end_time_seconds: float,
+	requested_sample_count: int,
+	sample_limit: int,
+	times: PackedFloat64Array = PackedFloat64Array(),
+	points: PackedVector3Array = PackedVector3Array(),
+	failed_sample_index: int = -1
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"start_time_seconds": _finite_or_zero(start_time_seconds),
+		"end_time_seconds": _finite_or_zero(end_time_seconds),
+		"requested_sample_count": requested_sample_count,
+		"sample_limit": sample_limit,
+		"sampled_count": points.size(),
+		"failed_sample_index": failed_sample_index,
+		"times": times,
+		"points": points,
+	}
+
+
+static func _make_time_report(
+	ok: bool,
+	reason: StringName,
+	error: String,
+	time_seconds: float = -1.0
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"reason": reason,
+		"error": error,
+		"time_seconds": time_seconds,
+	}
+
+
+static func _get_report_ok(report: Dictionary) -> bool:
+	var value: Variant = report.get("ok", false)
+	return value if value is bool else false
+
+
+static func _get_report_reason(report: Dictionary) -> StringName:
+	var value: Variant = report.get("reason", REASON_INVALID_ARGUMENT)
+	if value is StringName:
+		var reason: StringName = value
+		return reason
+	if value is String:
+		var reason_text: String = value
+		return StringName(reason_text)
+	return REASON_INVALID_ARGUMENT
+
+
+static func _get_report_error(report: Dictionary) -> String:
+	var value: Variant = report.get("error", "")
+	if value is String:
+		var error_text: String = value
+		return error_text
+	if value is StringName:
+		var error_name: StringName = value
+		return String(error_name)
+	return ""
+
+
+static func _get_report_time(report: Dictionary) -> float:
+	var value: Variant = report.get("time_seconds", -1.0)
+	if value is float:
+		var float_value: float = value
+		return float_value
+	if value is int:
+		var int_value: int = value
+		return float(int_value)
+	return -1.0
+
+
+static func _normalize_epsilon(epsilon: float) -> float:
+	return epsilon if epsilon > 0.0 else DEFAULT_EPSILON
+
+
+static func _finite_or_zero(value: float) -> float:
+	return value if _is_finite_float(value) else 0.0
+
+
+static func _scale_vector2(value: Vector2, scalar: float) -> Vector2:
+	return Vector2(value.x * scalar, value.y * scalar)
+
+
+static func _scale_vector3(value: Vector3, scalar: float) -> Vector3:
+	return Vector3(value.x * scalar, value.y * scalar, value.z * scalar)
+
+
+static func _is_nonnegative_finite_float(value: float) -> bool:
+	return value >= 0.0 and _is_finite_float(value)
+
+
+static func _is_finite_float(value: float) -> bool:
+	return not is_nan(value) and not is_inf(value)
+
+
+static func _is_finite_vector2(value: Vector2) -> bool:
+	return _is_finite_float(value.x) and _is_finite_float(value.y)
+
+
+static func _is_finite_vector3(value: Vector3) -> bool:
+	return (
+		_is_finite_float(value.x)
+		and _is_finite_float(value.y)
+		and _is_finite_float(value.z)
+	)

--- a/addons/gf/standard/foundation/math/gf_trajectory_math.gd.uid
+++ b/addons/gf/standard/foundation/math/gf_trajectory_math.gd.uid
@@ -1,0 +1,1 @@
+uid://ddikf8crc8vef

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "0dd80eb34d6b268f1c09cb2c45ddb430522741b9dea2e6162521e481f896682b",
-  "class_count": 716,
+  "source_digest": "25291a15383b9bb57ebc01ce8f469147b1f50c177be59acf4631adae31af7364",
+  "class_count": 717,
   "package_count": 50,
   "packages": [
     {
@@ -77778,6 +77778,130 @@
           "name": "clear",
           "signature": "func clear() -> void",
           "summary": "清空特征。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFTrajectoryMath": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.spatial",
+      "path": "addons/gf/standard/foundation/math/gf_trajectory_math.gd",
+      "summary": "GFTrajectoryMath: 通用运动预测、拦截和公式轨迹采样工具。 运动预测和拦截入口是 GF 内部无节点副作用的纯计算，不负责绘制、物理推进、目标选择或业务策略。 公式采样会同步执行项目显式提供的可信 Callable，并在调用前执行硬预算校验；GF 本身不访问节点，",
+      "visibility": "public",
+      "category": "runtime_service",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "REASON_NONE",
+          "signature": "const REASON_NONE: StringName = &\"\"",
+          "summary": "表示计算成功，没有失败原因。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_INVALID_ARGUMENT",
+          "signature": "const REASON_INVALID_ARGUMENT: StringName = &\"invalid_argument\"",
+          "summary": "表示输入参数无效、包含非有限数字，或计算结果无法保持有限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_NO_SOLUTION",
+          "signature": "const REASON_NO_SOLUTION: StringName = &\"no_solution\"",
+          "summary": "表示拦截方程不存在非负实数解。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_BEYOND_HORIZON",
+          "signature": "const REASON_BEYOND_HORIZON: StringName = &\"beyond_horizon\"",
+          "summary": "表示拦截解超出调用方给定的时间窗口。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_INVALID_PROVIDER",
+          "signature": "const REASON_INVALID_PROVIDER: StringName = &\"invalid_provider\"",
+          "summary": "表示轨迹公式 Callable 无效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_SAMPLE_LIMIT_EXCEEDED",
+          "signature": "const REASON_SAMPLE_LIMIT_EXCEEDED: StringName = &\"sample_limit_exceeded\"",
+          "summary": "表示请求采样数量超过本次预算。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_PROVIDER_FAILED",
+          "signature": "const REASON_PROVIDER_FAILED: StringName = &\"provider_failed\"",
+          "summary": "表示公式返回了错误类型或非有限坐标。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DEFAULT_EPSILON",
+          "signature": "const DEFAULT_EPSILON: float = 0.000001",
+          "summary": "默认浮点容差。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DEFAULT_MAX_SAMPLE_COUNT",
+          "signature": "const DEFAULT_MAX_SAMPLE_COUNT: int = 1024",
+          "summary": "单次公式采样的默认点数预算。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ABSOLUTE_MAX_SAMPLE_COUNT",
+          "signature": "const ABSOLUTE_MAX_SAMPLE_COUNT: int = 16_384",
+          "summary": "单次公式采样不可绕过的绝对点数上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "predict_motion_2d",
+          "signature": "static func predict_motion_2d( initial_position: Vector2, initial_velocity: Vector2, acceleration: Vector2, time_seconds: float ) -> Dictionary",
+          "summary": "按恒定加速度预测 2D 未来位置和速度。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "predict_motion_3d",
+          "signature": "static func predict_motion_3d( initial_position: Vector3, initial_velocity: Vector3, acceleration: Vector3, time_seconds: float ) -> Dictionary",
+          "summary": "按恒定加速度预测 3D 未来位置和速度。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "solve_intercept_2d",
+          "signature": "static func solve_intercept_2d( source_position: Vector2, projectile_speed: float, target_position: Vector2, target_velocity: Vector2, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -> Dictionary",
+          "summary": "求恒速发射体拦截匀速 2D 目标的最早非负解。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "solve_intercept_3d",
+          "signature": "static func solve_intercept_3d( source_position: Vector3, projectile_speed: float, target_position: Vector3, target_velocity: Vector3, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -> Dictionary",
+          "summary": "求恒速发射体拦截匀速 3D 目标的最早非负解。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "sample_formula_2d",
+          "signature": "static func sample_formula_2d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -> Dictionary",
+          "summary": "在闭区间内均匀调用同步公式并生成 2D 轨迹点。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "sample_formula_3d",
+          "signature": "static func sample_formula_3d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -> Dictionary",
+          "summary": "在闭区间内均匀调用同步公式并生成 3D 轨迹点。",
           "visibility": "public"
         }
       ]

--- a/docs/api_catalog/classes/GFTrajectoryMath.xml
+++ b/docs/api_catalog/classes/GFTrajectoryMath.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTrajectoryMath" path="addons/gf/standard/foundation/math/gf_trajectory_math.gd" module="standard" extends="RefCounted" classDigest="f06df9be701926a9ea5e7bae560d71c228e9cfbbb43a92323e4cd38812ff0a47">
+	<description>GFTrajectoryMath: 通用运动预测、拦截和公式轨迹采样工具。
+运动预测和拦截入口是 GF 内部无节点副作用的纯计算，不负责绘制、物理推进、目标选择或业务策略。
+公式采样会同步执行项目显式提供的可信 Callable，并在调用前执行硬预算校验；GF 本身不访问节点，
+但回调的副作用、阻塞与计算成本由调用方负责。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_service</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="REASON_NONE">
+			<signature>const REASON_NONE: StringName = &amp;""</signature>
+			<description>表示计算成功，没有失败原因。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_INVALID_ARGUMENT">
+			<signature>const REASON_INVALID_ARGUMENT: StringName = &amp;"invalid_argument"</signature>
+			<description>表示输入参数无效、包含非有限数字，或计算结果无法保持有限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_NO_SOLUTION">
+			<signature>const REASON_NO_SOLUTION: StringName = &amp;"no_solution"</signature>
+			<description>表示拦截方程不存在非负实数解。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_BEYOND_HORIZON">
+			<signature>const REASON_BEYOND_HORIZON: StringName = &amp;"beyond_horizon"</signature>
+			<description>表示拦截解超出调用方给定的时间窗口。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_INVALID_PROVIDER">
+			<signature>const REASON_INVALID_PROVIDER: StringName = &amp;"invalid_provider"</signature>
+			<description>表示轨迹公式 Callable 无效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_SAMPLE_LIMIT_EXCEEDED">
+			<signature>const REASON_SAMPLE_LIMIT_EXCEEDED: StringName = &amp;"sample_limit_exceeded"</signature>
+			<description>表示请求采样数量超过本次预算。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_PROVIDER_FAILED">
+			<signature>const REASON_PROVIDER_FAILED: StringName = &amp;"provider_failed"</signature>
+			<description>表示公式返回了错误类型或非有限坐标。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DEFAULT_EPSILON">
+			<signature>const DEFAULT_EPSILON: float = 0.000001</signature>
+			<description>默认浮点容差。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DEFAULT_MAX_SAMPLE_COUNT">
+			<signature>const DEFAULT_MAX_SAMPLE_COUNT: int = 1024</signature>
+			<description>单次公式采样的默认点数预算。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ABSOLUTE_MAX_SAMPLE_COUNT">
+			<signature>const ABSOLUTE_MAX_SAMPLE_COUNT: int = 16_384</signature>
+			<description>单次公式采样不可绕过的绝对点数上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="predict_motion_2d">
+			<signature>static func predict_motion_2d( initial_position: Vector2, initial_velocity: Vector2, acceleration: Vector2, time_seconds: float ) -&gt; Dictionary:</signature>
+			<description>按恒定加速度预测 2D 未来位置和速度。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">initial_position: 当前世界或局部位置，由调用方保证坐标空间一致。</tag>
+				<tag name="param">initial_velocity: 当前速度。</tag>
+				<tag name="param">acceleration: 在预测区间内保持恒定的加速度。</tag>
+				<tag name="param">time_seconds: 非负预测秒数。</tag>
+				<tag name="return">运动预测报告。</tag>
+				<tag name="schema">return: Dictionary，字段为 ok: bool、reason: StringName（空或 invalid_argument）、error: String、time_seconds: float、position: Vector2、velocity: Vector2；成功时 time_seconds 等于请求值，失败时 time_seconds 为 0 且向量为零。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="predict_motion_3d">
+			<signature>static func predict_motion_3d( initial_position: Vector3, initial_velocity: Vector3, acceleration: Vector3, time_seconds: float ) -&gt; Dictionary:</signature>
+			<description>按恒定加速度预测 3D 未来位置和速度。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">initial_position: 当前世界或局部位置，由调用方保证坐标空间一致。</tag>
+				<tag name="param">initial_velocity: 当前速度。</tag>
+				<tag name="param">acceleration: 在预测区间内保持恒定的加速度。</tag>
+				<tag name="param">time_seconds: 非负预测秒数。</tag>
+				<tag name="return">运动预测报告。</tag>
+				<tag name="schema">return: Dictionary，字段为 ok: bool、reason: StringName（空或 invalid_argument）、error: String、time_seconds: float、position: Vector3、velocity: Vector3；成功时 time_seconds 等于请求值，失败时 time_seconds 为 0 且向量为零。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="solve_intercept_2d">
+			<signature>static func solve_intercept_2d( source_position: Vector2, projectile_speed: float, target_position: Vector2, target_velocity: Vector2, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -&gt; Dictionary:</signature>
+			<description>求恒速发射体拦截匀速 2D 目标的最早非负解。
+发射速度使用当前坐标空间中的绝对速度，不隐式继承发射者速度。若发射体需要继承恒定的
+source_velocity，应传入 target_velocity - source_velocity；此时 launch_velocity 是相对发射者的速度，
+世界速度为 source_velocity + launch_velocity，世界命中点为 position + source_velocity * time_seconds。
+该方法不计算发射体加速度、重力或障碍物。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">source_position: 发射位置。</tag>
+				<tag name="param">projectile_speed: 发射体恒定速率，必须大于零。</tag>
+				<tag name="param">target_position: 目标当前位置。</tag>
+				<tag name="param">target_velocity: 目标恒定速度。</tag>
+				<tag name="param">max_time_seconds: 最大预测秒数；负值表示不限制。</tag>
+				<tag name="param">epsilon: 浮点判定容差；非正值使用 DEFAULT_EPSILON。</tag>
+				<tag name="return">最早拦截解报告。</tag>
+				<tag name="schema">return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、no_solution 或 beyond_horizon）、error: String、time_seconds: float、position: Vector2、launch_velocity: Vector2、distance: float；成功时 time_seconds &gt;= 0，正时间解的 launch_velocity 长度等于 projectile_speed，t=0 时为零；失败时 time_seconds 为 -1，其余数值结果为零。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="solve_intercept_3d">
+			<signature>static func solve_intercept_3d( source_position: Vector3, projectile_speed: float, target_position: Vector3, target_velocity: Vector3, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -&gt; Dictionary:</signature>
+			<description>求恒速发射体拦截匀速 3D 目标的最早非负解。
+发射速度使用当前坐标空间中的绝对速度，不隐式继承发射者速度。若发射体需要继承恒定的
+source_velocity，应传入 target_velocity - source_velocity；此时 launch_velocity 是相对发射者的速度，
+世界速度为 source_velocity + launch_velocity，世界命中点为 position + source_velocity * time_seconds。
+该方法不计算发射体加速度、重力或障碍物。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">source_position: 发射位置。</tag>
+				<tag name="param">projectile_speed: 发射体恒定速率，必须大于零。</tag>
+				<tag name="param">target_position: 目标当前位置。</tag>
+				<tag name="param">target_velocity: 目标恒定速度。</tag>
+				<tag name="param">max_time_seconds: 最大预测秒数；负值表示不限制。</tag>
+				<tag name="param">epsilon: 浮点判定容差；非正值使用 DEFAULT_EPSILON。</tag>
+				<tag name="return">最早拦截解报告。</tag>
+				<tag name="schema">return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、no_solution 或 beyond_horizon）、error: String、time_seconds: float、position: Vector3、launch_velocity: Vector3、distance: float；成功时 time_seconds &gt;= 0，正时间解的 launch_velocity 长度等于 projectile_speed，t=0 时为零；失败时 time_seconds 为 -1，其余数值结果为零。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="sample_formula_2d">
+			<signature>static func sample_formula_2d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -&gt; Dictionary:</signature>
+			<description>在闭区间内均匀调用同步公式并生成 2D 轨迹点。
+sample_count 为 1 时只采样 start_time_seconds；否则首尾时间都会被包含。
+反向时间区间是合法的。公式必须快速、同步且返回有限 Vector2。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">position_provider: 接收一个 float 秒数并返回 Vector2 的同步 Callable。</tag>
+				<tag name="param">start_time_seconds: 起始采样时间。</tag>
+				<tag name="param">end_time_seconds: 结束采样时间。</tag>
+				<tag name="param">sample_count: 请求采样点数量，必须大于零。</tag>
+				<tag name="param">max_sample_count: 本次预算，必须位于 1 到 ABSOLUTE_MAX_SAMPLE_COUNT。</tag>
+				<tag name="return">有界 2D 采样报告。</tag>
+				<tag name="schema">return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、invalid_provider、sample_limit_exceeded 或 provider_failed）、error: String、start_time_seconds: float、end_time_seconds: float、requested_sample_count: int、sample_limit: int、sampled_count: int、failed_sample_index: int、times: PackedFloat64Array、points: PackedVector2Array；始终满足 sampled_count == times.size() == points.size()；成功时 failed_sample_index 为 -1，运行中失败时为首个失败索引并保留此前有效前缀，预检失败时数组为空且索引为 -1。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="sample_formula_3d">
+			<signature>static func sample_formula_3d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -&gt; Dictionary:</signature>
+			<description>在闭区间内均匀调用同步公式并生成 3D 轨迹点。
+sample_count 为 1 时只采样 start_time_seconds；否则首尾时间都会被包含。
+反向时间区间是合法的。公式必须快速、同步且返回有限 Vector3。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">position_provider: 接收一个 float 秒数并返回 Vector3 的同步 Callable。</tag>
+				<tag name="param">start_time_seconds: 起始采样时间。</tag>
+				<tag name="param">end_time_seconds: 结束采样时间。</tag>
+				<tag name="param">sample_count: 请求采样点数量，必须大于零。</tag>
+				<tag name="param">max_sample_count: 本次预算，必须位于 1 到 ABSOLUTE_MAX_SAMPLE_COUNT。</tag>
+				<tag name="return">有界 3D 采样报告。</tag>
+				<tag name="schema">return: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、invalid_provider、sample_limit_exceeded 或 provider_failed）、error: String、start_time_seconds: float、end_time_seconds: float、requested_sample_count: int、sample_limit: int、sampled_count: int、failed_sample_index: int、times: PackedFloat64Array、points: PackedVector3Array；始终满足 sampled_count == times.size() == points.size()；成功时 failed_sample_index 为 -1，运行中失败时为首个失败索引并保留此前有效前缀，预检失败时数组为空且索引为 -1。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="32da46f19164356a2b472ca809c0e6f1e894dad8c7ea146bd66caecb91517699" classCount="740" methodCount="6615">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="2cdd80586ec8b09d628d836fb1c912ab38d566b03322829b696007b5a4a42ec6" classCount="741" methodCount="6621">
 	<module id="kernel" label="Kernel" classCount="70" methodCount="715">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -72,7 +72,7 @@
 		<class name="GFTypeEventSystem" path="classes/GFTypeEventSystem.xml" sourcePath="addons/gf/kernel/core/gf_type_event_system.gd" extends="Object" />
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 	</module>
-	<module id="standard" label="Standard" classCount="413" methodCount="4147">
+	<module id="standard" label="Standard" classCount="414" methodCount="4153">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsUtility" path="classes/GFAnalyticsUtility.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_utility.gd" extends="GFUtility" />
@@ -454,6 +454,7 @@
 		<class name="GFTouchButton" path="classes/GFTouchButton.xml" sourcePath="addons/gf/standard/input/touch/gf_touch_button.gd" extends="GFTouchControl2D" />
 		<class name="GFTouchControl2D" path="classes/GFTouchControl2D.xml" sourcePath="addons/gf/standard/input/touch/gf_touch_control_2d.gd" extends="Node2D" />
 		<class name="GFTouchJoystick" path="classes/GFTouchJoystick.xml" sourcePath="addons/gf/standard/input/touch/gf_touch_joystick.gd" extends="GFTouchControl2D" />
+		<class name="GFTrajectoryMath" path="classes/GFTrajectoryMath.xml" sourcePath="addons/gf/standard/foundation/math/gf_trajectory_math.gd" extends="RefCounted" />
 		<class name="GFTransform3DMath" path="classes/GFTransform3DMath.xml" sourcePath="addons/gf/standard/foundation/math/gf_transform_3d_math.gd" extends="RefCounted" />
 		<class name="GFUILayerDefinition" path="classes/GFUILayerDefinition.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_layer_definition.gd" extends="Resource" />
 		<class name="GFUIRoute" path="classes/GFUIRoute.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_route.gd" extends="Resource" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -22,7 +22,7 @@
 
 ## [未发布]
 
-**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、存储后端故障转移、运行时会话轨迹和 UI 路由预加载规划，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
+**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、存储后端故障转移、运行时会话轨迹、UI 路由预加载规划和轨迹预测数学，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
 
 ### 🚀 新增特性 (Added)
 
@@ -31,6 +31,7 @@
 - 新增 `GFStorageFailoverBackend`，按稳定后端 ID 提供有界顺序尝试、`PRIMARY_ONLY` / `FIRST_SUCCESS` 写删语义、暂时性错误冷却和不含业务载荷的结构化操作报告。
 - 新增 `GFSessionTraceUtility`，提供显式通道白名单、事件数与字节双重预算、默认隐私脱敏、同步快照 provider、结构化支持报告快照和可选 `GFLogSink` journal。
 - 新增 `GFUIRoutePreloadUtility`，从 `GFUIRoute.adjacent_route_ids` 做有界、确定性的页面可达性遍历，并生成可直接交给 `GFAssetUtility` 的 `GFAssetPreloadPlan`。
+- 新增 `GFTrajectoryMath`，提供 2D/3D 恒加速度未来状态、恒速发射体对匀速目标的最早拦截解，以及带绝对点数上限的同步公式轨迹采样。
 - AI Developer 项目契约新增可选 `architecture.owned_resources`，用于精确声明 `project.godot`、`export_presets.cfg` 等不属于业务模块的项目级治理文件。
 
 ### 🔄 机制更改 (Changed)
@@ -60,6 +61,7 @@
 - 新增 `GFThumbnailRenderer.render_canvas_item()` 与 `render_canvas_item_texture()`。
 - 新增公开类型 `GFAssetCollection` 和 `GFStorageFailoverBackend`；均标记为 `@since unreleased`，不改变既有调用入口默认行为。
 - 新增公开类型 `GFSessionTraceUtility`、`GFUIRoutePreloadUtility`，以及 `GFUIRoute.adjacent_route_ids`、`get_adjacent_route_ids()` 和 `GFUIRouterUtility.build_preload_plan()`；均标记为 `@since unreleased`。
+- 新增公开类型 `GFTrajectoryMath`，以及运动预测、恒速拦截和有界公式采样入口；均标记为 `@since unreleased`，不改变既有 Steering 行为。
 - `GFUIRoute.get_route_id()` 以及 Router 的注册、查询、打开信号和异步 pending 身份统一去除 route ID 首尾空白。
 - AI Developer 项目契约 schema v1 向后兼容地新增可选 `architecture.owned_resources`；项目快照 schema 从 v2 升为 v3，因此 AI Developer Kit 工具协议同步升为 3.0.0。
 - GF 开发身份从 `9.1.0-dev.0` 升为 `10.0.0-dev.0`，用于明确承载项目快照 v3 这一破坏性输出协议变化；本条只切换开发线，不创建正式版本或发布标签。
@@ -69,6 +71,7 @@
 - 既有 3D 缩略图、资产目录、存储后端与同步代码无需迁移。需要 2D 预览、有序资产集合或故障转移时显式采用新入口即可。
 - 自定义 `_draw()` 或无法可靠推断范围的 2D 节点应传入显式 `content_bounds`；多后端复制与冲突处理继续使用 `GFStorageSyncUtility`，不要把故障转移当作原子双写。
 - 既有 UI 路由无需迁移；只有需要候选页面预热时才声明 `adjacent_route_ids` 并显式执行生成的资产计划。需要发布后问题轨迹时，应由项目定义最小事件 schema、玩家许可和保留策略，再显式采用 `GFSessionTraceUtility`。
+- 既有曲线、Steering、发射体和节点移动逻辑无需迁移。只有需要结构化未来状态、拦截时间或公式点集时才显式采用 `GFTrajectoryMath`；绘制、物理推进、速度继承、重力拦截和业务命中规则继续由项目负责。
 - 历史配置若有意使用带首尾空白的 route ID，需迁移为去除空白后的稳定 ID；规范化后重复的 ID 会指向同一注册身份，不应再依赖空白区分页面。
 - 既有项目契约无需修改。只有源码确实引用模块外项目治理文件时才添加精确 `res://` 文件路径；禁止填写裸 `res://`、目录、通配范围或模块根内文件。快照 v3 是有意的破坏性输出协议升级：消费方应先升级到 AI Developer Kit 3.x，再重新生成快照；不要把 v2 快照补字段后继续使用。
 - 从 `9.x` 开发线升级时，应同步更新 GF 插件与扩展清单到 `10.0.0-dev.0`，并重新生成 AI Developer Kit catalog；稳定版发布时间与版本号仍由后续独立发布流程决定。
@@ -86,6 +89,7 @@
 - `addons/gf/standard/utilities/ui/gf_ui_route.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_route_preload_utility.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd`
+- `addons/gf/standard/foundation/math/gf_trajectory_math.gd`
 - `addons/gf/tools/ai_developer/gf_ai/dependencies.py`
 - `addons/gf/tools/ai_developer/schemas/project_contract.schema.json`
 - `addons/gf/tools/ai_developer/schemas/project_snapshot.schema.json`

--- a/docs/zh/reference/api/classes/GFTrajectoryMath.md
+++ b/docs/zh/reference/api/classes/GFTrajectoryMath.md
@@ -1,0 +1,341 @@
+# GFTrajectoryMath
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/foundation/math/gf_trajectory_math.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时服务 (`runtime_service`)
+- 首次版本：`unreleased`
+
+通用运动预测、拦截和公式轨迹采样工具。 运动预测和拦截入口是 GF 内部无节点副作用的纯计算，不负责绘制、物理推进、目标选择或业务策略。 公式采样会同步执行项目显式提供的可信 Callable，并在调用前执行硬预算校验；GF 本身不访问节点， 但回调的副作用、阻塞与计算成本由调用方负责。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`REASON_NONE`](#member-gftrajectorymath-constants-reason_none) | `const REASON_NONE: StringName = &""` |
+| 常量 | [`REASON_INVALID_ARGUMENT`](#member-gftrajectorymath-constants-reason_invalid_argument) | `const REASON_INVALID_ARGUMENT: StringName = &"invalid_argument"` |
+| 常量 | [`REASON_NO_SOLUTION`](#member-gftrajectorymath-constants-reason_no_solution) | `const REASON_NO_SOLUTION: StringName = &"no_solution"` |
+| 常量 | [`REASON_BEYOND_HORIZON`](#member-gftrajectorymath-constants-reason_beyond_horizon) | `const REASON_BEYOND_HORIZON: StringName = &"beyond_horizon"` |
+| 常量 | [`REASON_INVALID_PROVIDER`](#member-gftrajectorymath-constants-reason_invalid_provider) | `const REASON_INVALID_PROVIDER: StringName = &"invalid_provider"` |
+| 常量 | [`REASON_SAMPLE_LIMIT_EXCEEDED`](#member-gftrajectorymath-constants-reason_sample_limit_exceeded) | `const REASON_SAMPLE_LIMIT_EXCEEDED: StringName = &"sample_limit_exceeded"` |
+| 常量 | [`REASON_PROVIDER_FAILED`](#member-gftrajectorymath-constants-reason_provider_failed) | `const REASON_PROVIDER_FAILED: StringName = &"provider_failed"` |
+| 常量 | [`DEFAULT_EPSILON`](#member-gftrajectorymath-constants-default_epsilon) | `const DEFAULT_EPSILON: float = 0.000001` |
+| 常量 | [`DEFAULT_MAX_SAMPLE_COUNT`](#member-gftrajectorymath-constants-default_max_sample_count) | `const DEFAULT_MAX_SAMPLE_COUNT: int = 1024` |
+| 常量 | [`ABSOLUTE_MAX_SAMPLE_COUNT`](#member-gftrajectorymath-constants-absolute_max_sample_count) | `const ABSOLUTE_MAX_SAMPLE_COUNT: int = 16_384` |
+| 方法 | [`predict_motion_2d`](#member-gftrajectorymath-methods-predict_motion_2d) | `static func predict_motion_2d( initial_position: Vector2, initial_velocity: Vector2, acceleration: Vector2, time_seconds: float ) -> Dictionary:` |
+| 方法 | [`predict_motion_3d`](#member-gftrajectorymath-methods-predict_motion_3d) | `static func predict_motion_3d( initial_position: Vector3, initial_velocity: Vector3, acceleration: Vector3, time_seconds: float ) -> Dictionary:` |
+| 方法 | [`solve_intercept_2d`](#member-gftrajectorymath-methods-solve_intercept_2d) | `static func solve_intercept_2d( source_position: Vector2, projectile_speed: float, target_position: Vector2, target_velocity: Vector2, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -> Dictionary:` |
+| 方法 | [`solve_intercept_3d`](#member-gftrajectorymath-methods-solve_intercept_3d) | `static func solve_intercept_3d( source_position: Vector3, projectile_speed: float, target_position: Vector3, target_velocity: Vector3, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -> Dictionary:` |
+| 方法 | [`sample_formula_2d`](#member-gftrajectorymath-methods-sample_formula_2d) | `static func sample_formula_2d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -> Dictionary:` |
+| 方法 | [`sample_formula_3d`](#member-gftrajectorymath-methods-sample_formula_3d) | `static func sample_formula_3d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -> Dictionary:` |
+
+## 常量
+
+<a id="member-gftrajectorymath-constants-reason_none"></a>
+
+### `REASON_NONE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_NONE: StringName = &""
+```
+
+表示计算成功，没有失败原因。
+
+<a id="member-gftrajectorymath-constants-reason_invalid_argument"></a>
+
+### `REASON_INVALID_ARGUMENT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_INVALID_ARGUMENT: StringName = &"invalid_argument"
+```
+
+表示输入参数无效、包含非有限数字，或计算结果无法保持有限。
+
+<a id="member-gftrajectorymath-constants-reason_no_solution"></a>
+
+### `REASON_NO_SOLUTION`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_NO_SOLUTION: StringName = &"no_solution"
+```
+
+表示拦截方程不存在非负实数解。
+
+<a id="member-gftrajectorymath-constants-reason_beyond_horizon"></a>
+
+### `REASON_BEYOND_HORIZON`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_BEYOND_HORIZON: StringName = &"beyond_horizon"
+```
+
+表示拦截解超出调用方给定的时间窗口。
+
+<a id="member-gftrajectorymath-constants-reason_invalid_provider"></a>
+
+### `REASON_INVALID_PROVIDER`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_INVALID_PROVIDER: StringName = &"invalid_provider"
+```
+
+表示轨迹公式 Callable 无效。
+
+<a id="member-gftrajectorymath-constants-reason_sample_limit_exceeded"></a>
+
+### `REASON_SAMPLE_LIMIT_EXCEEDED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_SAMPLE_LIMIT_EXCEEDED: StringName = &"sample_limit_exceeded"
+```
+
+表示请求采样数量超过本次预算。
+
+<a id="member-gftrajectorymath-constants-reason_provider_failed"></a>
+
+### `REASON_PROVIDER_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_PROVIDER_FAILED: StringName = &"provider_failed"
+```
+
+表示公式返回了错误类型或非有限坐标。
+
+<a id="member-gftrajectorymath-constants-default_epsilon"></a>
+
+### `DEFAULT_EPSILON`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DEFAULT_EPSILON: float = 0.000001
+```
+
+默认浮点容差。
+
+<a id="member-gftrajectorymath-constants-default_max_sample_count"></a>
+
+### `DEFAULT_MAX_SAMPLE_COUNT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DEFAULT_MAX_SAMPLE_COUNT: int = 1024
+```
+
+单次公式采样的默认点数预算。
+
+<a id="member-gftrajectorymath-constants-absolute_max_sample_count"></a>
+
+### `ABSOLUTE_MAX_SAMPLE_COUNT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ABSOLUTE_MAX_SAMPLE_COUNT: int = 16_384
+```
+
+单次公式采样不可绕过的绝对点数上限。
+
+## 方法
+
+<a id="member-gftrajectorymath-methods-predict_motion_2d"></a>
+
+### `predict_motion_2d`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func predict_motion_2d( initial_position: Vector2, initial_velocity: Vector2, acceleration: Vector2, time_seconds: float ) -> Dictionary:
+```
+
+按恒定加速度预测 2D 未来位置和速度。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `initial_position` | 当前世界或局部位置，由调用方保证坐标空间一致。 |
+| `initial_velocity` | 当前速度。 |
+| `acceleration` | 在预测区间内保持恒定的加速度。 |
+| `time_seconds` | 非负预测秒数。 |
+
+返回：运动预测报告。
+
+结构：
+
+- `return`: Dictionary，字段为 ok: bool、reason: StringName（空或 invalid_argument）、error: String、time_seconds: float、position: Vector2、velocity: Vector2；成功时 time_seconds 等于请求值，失败时 time_seconds 为 0 且向量为零。
+
+<a id="member-gftrajectorymath-methods-predict_motion_3d"></a>
+
+### `predict_motion_3d`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func predict_motion_3d( initial_position: Vector3, initial_velocity: Vector3, acceleration: Vector3, time_seconds: float ) -> Dictionary:
+```
+
+按恒定加速度预测 3D 未来位置和速度。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `initial_position` | 当前世界或局部位置，由调用方保证坐标空间一致。 |
+| `initial_velocity` | 当前速度。 |
+| `acceleration` | 在预测区间内保持恒定的加速度。 |
+| `time_seconds` | 非负预测秒数。 |
+
+返回：运动预测报告。
+
+结构：
+
+- `return`: Dictionary，字段为 ok: bool、reason: StringName（空或 invalid_argument）、error: String、time_seconds: float、position: Vector3、velocity: Vector3；成功时 time_seconds 等于请求值，失败时 time_seconds 为 0 且向量为零。
+
+<a id="member-gftrajectorymath-methods-solve_intercept_2d"></a>
+
+### `solve_intercept_2d`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func solve_intercept_2d( source_position: Vector2, projectile_speed: float, target_position: Vector2, target_velocity: Vector2, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -> Dictionary:
+```
+
+求恒速发射体拦截匀速 2D 目标的最早非负解。 发射速度使用当前坐标空间中的绝对速度，不隐式继承发射者速度。若发射体需要继承恒定的 source_velocity，应传入 target_velocity - source_velocity；此时 launch_velocity 是相对发射者的速度， 世界速度为 source_velocity + launch_velocity，世界命中点为 position + source_velocity * time_seconds。 该方法不计算发射体加速度、重力或障碍物。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `source_position` | 发射位置。 |
+| `projectile_speed` | 发射体恒定速率，必须大于零。 |
+| `target_position` | 目标当前位置。 |
+| `target_velocity` | 目标恒定速度。 |
+| `max_time_seconds` | 最大预测秒数；负值表示不限制。 |
+| `epsilon` | 浮点判定容差；非正值使用 DEFAULT_EPSILON。 |
+
+返回：最早拦截解报告。
+
+结构：
+
+- `return`: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、no_solution 或 beyond_horizon）、error: String、time_seconds: float、position: Vector2、launch_velocity: Vector2、distance: float；成功时 time_seconds >= 0，正时间解的 launch_velocity 长度等于 projectile_speed，t=0 时为零；失败时 time_seconds 为 -1，其余数值结果为零。
+
+<a id="member-gftrajectorymath-methods-solve_intercept_3d"></a>
+
+### `solve_intercept_3d`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func solve_intercept_3d( source_position: Vector3, projectile_speed: float, target_position: Vector3, target_velocity: Vector3, max_time_seconds: float = -1.0, epsilon: float = DEFAULT_EPSILON ) -> Dictionary:
+```
+
+求恒速发射体拦截匀速 3D 目标的最早非负解。 发射速度使用当前坐标空间中的绝对速度，不隐式继承发射者速度。若发射体需要继承恒定的 source_velocity，应传入 target_velocity - source_velocity；此时 launch_velocity 是相对发射者的速度， 世界速度为 source_velocity + launch_velocity，世界命中点为 position + source_velocity * time_seconds。 该方法不计算发射体加速度、重力或障碍物。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `source_position` | 发射位置。 |
+| `projectile_speed` | 发射体恒定速率，必须大于零。 |
+| `target_position` | 目标当前位置。 |
+| `target_velocity` | 目标恒定速度。 |
+| `max_time_seconds` | 最大预测秒数；负值表示不限制。 |
+| `epsilon` | 浮点判定容差；非正值使用 DEFAULT_EPSILON。 |
+
+返回：最早拦截解报告。
+
+结构：
+
+- `return`: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、no_solution 或 beyond_horizon）、error: String、time_seconds: float、position: Vector3、launch_velocity: Vector3、distance: float；成功时 time_seconds >= 0，正时间解的 launch_velocity 长度等于 projectile_speed，t=0 时为零；失败时 time_seconds 为 -1，其余数值结果为零。
+
+<a id="member-gftrajectorymath-methods-sample_formula_2d"></a>
+
+### `sample_formula_2d`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func sample_formula_2d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -> Dictionary:
+```
+
+在闭区间内均匀调用同步公式并生成 2D 轨迹点。 sample_count 为 1 时只采样 start_time_seconds；否则首尾时间都会被包含。 反向时间区间是合法的。公式必须快速、同步且返回有限 Vector2。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `position_provider` | 接收一个 float 秒数并返回 Vector2 的同步 Callable。 |
+| `start_time_seconds` | 起始采样时间。 |
+| `end_time_seconds` | 结束采样时间。 |
+| `sample_count` | 请求采样点数量，必须大于零。 |
+| `max_sample_count` | 本次预算，必须位于 1 到 ABSOLUTE_MAX_SAMPLE_COUNT。 |
+
+返回：有界 2D 采样报告。
+
+结构：
+
+- `return`: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、invalid_provider、sample_limit_exceeded 或 provider_failed）、error: String、start_time_seconds: float、end_time_seconds: float、requested_sample_count: int、sample_limit: int、sampled_count: int、failed_sample_index: int、times: PackedFloat64Array、points: PackedVector2Array；始终满足 sampled_count == times.size() == points.size()；成功时 failed_sample_index 为 -1，运行中失败时为首个失败索引并保留此前有效前缀，预检失败时数组为空且索引为 -1。
+
+<a id="member-gftrajectorymath-methods-sample_formula_3d"></a>
+
+### `sample_formula_3d`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func sample_formula_3d( position_provider: Callable, start_time_seconds: float, end_time_seconds: float, sample_count: int, max_sample_count: int = DEFAULT_MAX_SAMPLE_COUNT ) -> Dictionary:
+```
+
+在闭区间内均匀调用同步公式并生成 3D 轨迹点。 sample_count 为 1 时只采样 start_time_seconds；否则首尾时间都会被包含。 反向时间区间是合法的。公式必须快速、同步且返回有限 Vector3。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `position_provider` | 接收一个 float 秒数并返回 Vector3 的同步 Callable。 |
+| `start_time_seconds` | 起始采样时间。 |
+| `end_time_seconds` | 结束采样时间。 |
+| `sample_count` | 请求采样点数量，必须大于零。 |
+| `max_sample_count` | 本次预算，必须位于 1 到 ABSOLUTE_MAX_SAMPLE_COUNT。 |
+
+返回：有界 3D 采样报告。
+
+结构：
+
+- `return`: Dictionary，字段为 ok: bool、reason: StringName（空、invalid_argument、invalid_provider、sample_limit_exceeded 或 provider_failed）、error: String、start_time_seconds: float、end_time_seconds: float、requested_sample_count: int、sample_limit: int、sampled_count: int、failed_sample_index: int、times: PackedFloat64Array、points: PackedVector3Array；始终满足 sampled_count == times.size() == points.size()；成功时 failed_sample_index 为 -1，运行中失败时为首个失败索引并保留此前有效前缀，预检失败时数组为空且索引为 -1。

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 70 | 987 | [Kernel](#module-kernel) |
-| Standard | 413 | 6510 | [Standard](#module-standard) |
+| Standard | 414 | 6526 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -274,6 +274,7 @@
 | [`GFTimerUtility`](GFTimerUtility.md#gftimerutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 10 | `addons/gf/standard/utilities/time/gf_timer_utility.gd` |
 | [`GFTouchButton`](GFTouchButton.md#gftouchbutton) | 运行时服务 (`runtime_service`) | `GFTouchControl2D` | 12 | `addons/gf/standard/input/touch/gf_touch_button.gd` |
 | [`GFTouchJoystick`](GFTouchJoystick.md#gftouchjoystick) | 运行时服务 (`runtime_service`) | `GFTouchControl2D` | 26 | `addons/gf/standard/input/touch/gf_touch_joystick.gd` |
+| [`GFTrajectoryMath`](GFTrajectoryMath.md#gftrajectorymath) | 运行时服务 (`runtime_service`) | `RefCounted` | 16 | `addons/gf/standard/foundation/math/gf_trajectory_math.gd` |
 | [`GFTransform3DMath`](GFTransform3DMath.md#gftransform3dmath) | 运行时服务 (`runtime_service`) | `RefCounted` | 11 | `addons/gf/standard/foundation/math/gf_transform_3d_math.gd` |
 | [`GFUIRoutePreloadUtility`](GFUIRoutePreloadUtility.md#gfuiroutepreloadutility) | 运行时服务 (`runtime_service`) | `RefCounted` | 6 | `addons/gf/standard/utilities/ui/gf_ui_route_preload_utility.gd` |
 | [`GFUIRouterUtility`](GFUIRouterUtility.md#gfuirouterutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 27 | `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,16 +5,16 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`740`
-- 公开成员：`10651`
-- 公开方法：`6615`
+- 公开类：`741`
+- 公开成员：`10667`
+- 公开方法：`6621`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 70 | 987 | 715 | [kernel.md](kernel.md) |
-| Standard | 413 | 6510 | 4147 | [standard.md](standard.md) |
+| Standard | 414 | 6526 | 4153 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 181 | 3186 | 2154 |
+| [运行时服务](#category-runtime_service) | 182 | 3202 | 2160 |
 | [协议与扩展点](#category-protocol) | 22 | 309 | 251 |
 | [资源定义](#category-resource_definition) | 111 | 1442 | 747 |
 | [运行时句柄](#category-runtime_handle) | 41 | 704 | 457 |
@@ -186,6 +186,7 @@
 | [`GFTimerUtility`](classes/GFTimerUtility.md#gftimerutility) | `GFUtility` | `addons/gf/standard/utilities/time/gf_timer_utility.gd` |
 | [`GFTouchButton`](classes/GFTouchButton.md#gftouchbutton) | `GFTouchControl2D` | `addons/gf/standard/input/touch/gf_touch_button.gd` |
 | [`GFTouchJoystick`](classes/GFTouchJoystick.md#gftouchjoystick) | `GFTouchControl2D` | `addons/gf/standard/input/touch/gf_touch_joystick.gd` |
+| [`GFTrajectoryMath`](classes/GFTrajectoryMath.md#gftrajectorymath) | `RefCounted` | `addons/gf/standard/foundation/math/gf_trajectory_math.gd` |
 | [`GFTransform3DMath`](classes/GFTransform3DMath.md#gftransform3dmath) | `RefCounted` | `addons/gf/standard/foundation/math/gf_transform_3d_math.gd` |
 | [`GFUIRoutePreloadUtility`](classes/GFUIRoutePreloadUtility.md#gfuiroutepreloadutility) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_ui_route_preload_utility.gd` |
 | [`GFUIRouterUtility`](classes/GFUIRouterUtility.md#gfuirouterutility) | `GFUtility` | `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd` |

--- a/docs/zh/standard/foundation/grid-spatial/index.md
+++ b/docs/zh/standard/foundation/grid-spatial/index.md
@@ -18,7 +18,7 @@
 - [弹簧平滑数学](spring-math.md)：`GFSpringMath` 的标量、角度、Vector2 与 Vector3 二阶弹簧步进。
 - [2D 网格、生成管线与 Hex 网格](grid-2d-hex/index.md)：`GFGridMath`、`GFGridTransform2D`、`GFGridSelection2D`、`GFGridGenerationStep2D`、`GFGridGenerationPipeline2D` 与 `GFHexGridMath`。
 - [图搜索、布局与 3D 网格](graph-layout-3d/index.md)：`GFGraphMath`、`GFGraphLayoutUtility`、`GFVoronoi2D`、`GFGrid3DMath`、`GFGridKey3D` 与 `GFGridPlaneMapper3D`。
-- [Pattern2D 与 Steering](patterns-steering/index.md)：`GFPattern2D`、`GFSteeringAgent`、`GFSteeringMath` 和资源化 steering 组合。
+- [Pattern2D、轨迹与 Steering](patterns-steering/index.md)：`GFPattern2D`、`GFTrajectoryMath`、`GFSteeringAgent`、`GFSteeringMath` 和资源化 steering 组合。
 - [占用、TileMap 缓存、规则表与空间哈希](occupancy-tile-spatial/index.md)：`GFGridOccupancy`、`GFTileMapCache`、`GFTileRuleSet` 与 `GFSpatialHash3D`。
 
 ## 使用边界

--- a/docs/zh/standard/foundation/grid-spatial/patterns-steering/index.md
+++ b/docs/zh/standard/foundation/grid-spatial/patterns-steering/index.md
@@ -1,13 +1,14 @@
-# Pattern2D 与 Steering
+# Pattern2D、轨迹与 Steering
 
-本组页面覆盖资源化二维格子模式和 steering 运动计算原语。GF 只计算模式、目标、加速度和组合结果，不移动 Godot 节点，也不定义 AI、阵营、路径点来源或碰撞响应。
+本组页面覆盖资源化二维格子模式、通用运动轨迹和 steering 运动计算原语。GF 只计算模式、未来状态、采样点、拦截解、目标、加速度和组合结果，不移动 Godot 节点，也不定义 AI、阵营、路径点来源或碰撞响应。
 
 ## 阅读入口
 
 - [Pattern2D](pattern-2d.md)：`GFPattern2D` 的格子模式、尺寸、去重、边界过滤和 Inspector 编辑。
+- [轨迹预测与公式采样](trajectory-math.md)：`GFTrajectoryMath` 的恒加速度预测、恒速拦截和有界 2D/3D 公式采样。
 - [Steering 算法](steering-math.md)：`GFSteeringAgent`、`GFSteeringAcceleration` 和 `GFSteeringMath`。
 - [资源化 Steering 组合](steering-resources.md)：`GFSteeringBehaviorResource` 与 `GFSteeringBehaviorStack`。
 
 ## 使用边界
 
-Pattern2D 和 Steering 只输出格子候选、目标方向或加速度建议。实际节点移动、碰撞避让、AI 决策、阵营规则和动画表现仍由项目逻辑负责。
+这些能力只输出格子候选、数学报告、轨迹点、目标方向或加速度建议。实际绘制、节点移动、碰撞避让、AI 决策、阵营规则和动画表现仍由项目逻辑负责。

--- a/docs/zh/standard/foundation/grid-spatial/patterns-steering/trajectory-math.md
+++ b/docs/zh/standard/foundation/grid-spatial/patterns-steering/trajectory-math.md
@@ -1,0 +1,99 @@
+# 轨迹预测与公式采样
+
+`GFTrajectoryMath` 提供不依赖节点实例的 2D/3D 运动计算与受控公式采样。GF 自身不访问场景树；它适合弹道预览、移动目标瞄准、航线提示、AI 追踪候选和编辑器轨迹可视化，但不负责绘制、移动节点或解释玩法规则。公式回调的副作用与阻塞边界见下文。
+
+## 预测未来位置
+
+`predict_motion_2d()` 和 `predict_motion_3d()` 使用恒定加速度公式，同时返回目标时刻的位置和速度。重力可以直接作为加速度传入。
+
+```gdscript
+var prediction := GFTrajectoryMath.predict_motion_2d(
+	projectile.global_position,
+	projectile.velocity,
+	Vector2(0.0, 980.0),
+	0.75
+)
+
+if prediction["ok"]:
+	var future_position: Vector2 = prediction["position"]
+	var future_velocity: Vector2 = prediction["velocity"]
+```
+
+时间必须大于等于零，位置、速度、加速度和时间都必须是有限数字。失败报告使用 `reason = "invalid_argument"`，不会把 NaN 或 Infinity 继续传给绘制和物理层。
+
+## 计算移动目标拦截点
+
+`solve_intercept_2d()` 和 `solve_intercept_3d()` 求“恒速发射体追上匀速目标”的最早非负时间。比如塔防炮塔需要瞄准敌人将来所在的位置，而不是敌人当前的位置：
+
+```gdscript
+var solution := GFTrajectoryMath.solve_intercept_2d(
+	turret.global_position,
+	bullet_speed,
+	enemy.global_position,
+	enemy.velocity,
+	3.0
+)
+
+if solution["ok"]:
+	var aim_position: Vector2 = solution["position"]
+	var launch_velocity: Vector2 = solution["launch_velocity"]
+```
+
+`max_time_seconds` 是可选预测窗口；负值表示不限制。报告会明确区分：
+
+- `no_solution`：目标持续远离且无法追上，或方程没有非负实数解；
+- `beyond_horizon`：存在数学解，但发生时间超过项目允许的预测窗口；
+- `invalid_argument`：速度、坐标、时间窗口或容差非法。
+
+这个解假设发射体从 `source_position` 开始以固定世界空间速率运动，不自动继承发射者速度，也不处理重力、加速、制导和障碍。
+
+飞船、载具或移动炮台若要让弹体继承发射者的恒定速度，需要明确切换到相对发射者的参考系。假设发射者世界速度为 `source_velocity`，调用时传入 `enemy.velocity - source_velocity`。此时报告里的 `launch_velocity` 是弹体相对发射者的速度，`position` 也是平移参考系中的命中点；转换回世界空间的方式是：
+
+```gdscript
+var relative_solution := GFTrajectoryMath.solve_intercept_2d(
+	launcher.global_position,
+	bullet_relative_speed,
+	enemy.global_position,
+	enemy.velocity - source_velocity
+)
+
+if relative_solution["ok"]:
+	var time_seconds: float = relative_solution["time_seconds"]
+	var world_launch_velocity: Vector2 = source_velocity + relative_solution["launch_velocity"]
+	var world_hit_position: Vector2 = relative_solution["position"] + source_velocity * time_seconds
+```
+
+这里假设 `source_velocity` 在拦截区间内恒定。带重力弹道应使用项目公式采样或专门的弹道求解器。
+
+## 采样任意项目公式
+
+`sample_formula_2d()` 和 `sample_formula_3d()` 在闭区间中均匀采样一个同步 `Callable(time_seconds)`。这允许项目表达圆、正弦、指数、参数曲线或自己的轨道公式，而不要求 GF 认识这些业务含义。
+
+```gdscript
+var orbit_center := Vector2(640.0, 360.0)
+var radius := 180.0
+var orbit_formula := func(time_seconds: float) -> Vector2:
+	return orbit_center + Vector2(cos(time_seconds), sin(time_seconds)) * radius
+
+var sample := GFTrajectoryMath.sample_formula_2d(
+	orbit_formula,
+	0.0,
+	TAU,
+	128
+)
+
+if sample["ok"]:
+	var points: PackedVector2Array = sample["points"]
+	# 项目可以把 points 交给 Line2D、编辑器 Overlay 或自己的渲染器。
+```
+
+采样数量必须在本次 `max_sample_count` 内，且不能超过 `ABSOLUTE_MAX_SAMPLE_COUNT`。预算校验会在执行项目回调前完成；超限时返回 `sample_limit_exceeded`，不会先执行一部分公式。公式返回错误类型或非有限坐标时返回 `provider_failed`，并保留失败前的有效点和对应时间，便于定位具体采样位置。
+
+公式回调属于项目提供的受信任同步代码。它应保持快速、确定、无副作用，不应在其中等待信号、访问网络或改变场景树。如果计算需要分帧、取消或后台执行，应由项目的任务层分批调用纯数学入口。
+
+## 与其他模块的关系
+
+- `GFCurve2DMath` / `GFCurve3DMath` 处理已经得到的折线长度、姿态、投影和简化；`GFTrajectoryMath` 负责按时间产生点。
+- `GFSteeringMath.pursue()` 是面向 steering 加速度的轻量追逐启发式；需要明确拦截时间和发射速度时使用 `solve_intercept_2d()` / `solve_intercept_3d()`。
+- `Line2D`、`ImmediateMesh`、地图编辑器画布和调试 Overlay 属于展示层，不由轨迹数学自动创建。
+- 天体力学、N 体模拟、制导策略、武器参数和命中规则仍属于项目或独立扩展。

--- a/packages/standard/gf.standard.spatial.json
+++ b/packages/standard/gf.standard.spatial.json
@@ -107,6 +107,8 @@
     "addons/gf/standard/foundation/math/gf_tile_metadata_layer.gd.uid",
     "addons/gf/standard/foundation/math/gf_tile_rule_set.gd",
     "addons/gf/standard/foundation/math/gf_tile_rule_set.gd.uid",
+    "addons/gf/standard/foundation/math/gf_trajectory_math.gd",
+    "addons/gf/standard/foundation/math/gf_trajectory_math.gd.uid",
     "addons/gf/standard/foundation/math/gf_transform_3d_math.gd",
     "addons/gf/standard/foundation/math/gf_transform_3d_math.gd.uid",
     "addons/gf/standard/foundation/math/gf_voronoi_2d.gd",

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -208,6 +208,7 @@
       "res://tests/gf_core/standard/foundation/math/test_gf_grid_math.gd",
       "res://tests/gf_core/standard/foundation/math/test_gf_heightfield_and_surface_scatter.gd",
       "res://tests/gf_core/standard/foundation/math/test_gf_noise_field_tools.gd",
+      "res://tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd",
       "res://tests/gf_core/standard/foundation/math/test_gf_wave_function_collapse_2d.gd",
       "res://tests/gf_core/standard/foundation/math/test_gf_tile_utilities.gd",
       "res://tests/gf_core/standard/utilities/spatial/test_gf_physics_query_utility.gd",

--- a/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd
+++ b/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd
@@ -1,0 +1,533 @@
+## 测试 GFTrajectoryMath 的运动预测、拦截解和有界公式采样。
+extends GutTest
+
+
+const GF_TRAJECTORY_MATH_SCRIPT = preload("res://addons/gf/standard/foundation/math/gf_trajectory_math.gd")
+
+
+var _provider_call_count: int = 0
+
+
+# --- 测试 ---
+
+func test_predict_motion_2d_uses_constant_acceleration() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.predict_motion_2d(
+		Vector2(1.0, 2.0),
+		Vector2(3.0, 4.0),
+		Vector2(0.0, -2.0),
+		2.0
+	)
+
+	assert_true(_get_bool(report, "ok"), "有限的未来时间应生成 2D 运动预测。")
+	_assert_vector2_close(_get_vector2(report, "position"), Vector2(7.0, 6.0))
+	_assert_vector2_close(_get_vector2(report, "velocity"), Vector2(3.0, 0.0))
+	assert_almost_eq(_get_float(report, "time_seconds"), 2.0, 0.000001)
+
+
+func test_predict_motion_3d_uses_constant_acceleration() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.predict_motion_3d(
+		Vector3(1.0, 2.0, 3.0),
+		Vector3(2.0, 0.0, -1.0),
+		Vector3(0.0, 4.0, 2.0),
+		0.5
+	)
+
+	assert_true(_get_bool(report, "ok"), "有限的未来时间应生成 3D 运动预测。")
+	_assert_vector3_close(_get_vector3(report, "position"), Vector3(2.0, 2.5, 2.75))
+	_assert_vector3_close(_get_vector3(report, "velocity"), Vector3(2.0, 2.0, 0.0))
+
+
+func test_predict_motion_rejects_negative_time() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.predict_motion_2d(
+		Vector2.ZERO,
+		Vector2.RIGHT,
+		Vector2.ZERO,
+		-0.1
+	)
+
+	assert_false(_get_bool(report, "ok"), "未来位置入口不应接受负时间。")
+	assert_eq(_get_reason(report), &"invalid_argument")
+
+
+func test_predict_motion_rejects_non_finite_vectors() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.predict_motion_3d(
+		Vector3(NAN, 0.0, 0.0),
+		Vector3.ZERO,
+		Vector3.ZERO,
+		1.0
+	)
+
+	assert_false(_get_bool(report, "ok"), "非有限运动状态不应进入预测结果。")
+	assert_eq(_get_reason(report), &"invalid_argument")
+
+
+func test_predict_motion_zero_acceleration_avoids_time_square_overflow() -> void:
+	var report_2d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.predict_motion_2d(
+		Vector2(1.0, 2.0),
+		Vector2.ZERO,
+		Vector2.ZERO,
+		1.0e308
+	)
+	var report_3d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.predict_motion_3d(
+		Vector3(1.0, 2.0, 3.0),
+		Vector3.ZERO,
+		Vector3.ZERO,
+		1.0e308
+	)
+
+	assert_true(_get_bool(report_2d, "ok"), "零加速度不应因先计算 t² 而产生伪溢出。")
+	assert_true(_get_bool(report_3d, "ok"), "2D 与 3D 应使用相同的稳定计算顺序。")
+	_assert_vector2_close(_get_vector2(report_2d, "position"), Vector2(1.0, 2.0))
+	_assert_vector3_close(_get_vector3(report_3d, "position"), Vector3(1.0, 2.0, 3.0))
+
+
+func test_solve_intercept_2d_finds_stationary_target() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		5.0,
+		Vector2(10.0, 0.0),
+		Vector2.ZERO
+	)
+
+	assert_true(_get_bool(report, "ok"), "静止目标应有直接拦截解。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 2.0, 0.000001)
+	_assert_vector2_close(_get_vector2(report, "position"), Vector2(10.0, 0.0))
+	_assert_vector2_close(_get_vector2(report, "launch_velocity"), Vector2(5.0, 0.0))
+
+
+func test_solve_intercept_2d_leads_moving_target() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		5.0,
+		Vector2(10.0, 0.0),
+		Vector2(1.0, 0.0)
+	)
+
+	assert_true(_get_bool(report, "ok"), "速度较慢的远离目标应有超前拦截解。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 2.5, 0.000001)
+	_assert_vector2_close(_get_vector2(report, "position"), Vector2(12.5, 0.0))
+	_assert_vector2_close(_get_vector2(report, "launch_velocity"), Vector2(5.0, 0.0))
+
+
+func test_solve_intercept_3d_handles_off_axis_motion() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_3d(
+		Vector3.ZERO,
+		5.0,
+		Vector3(10.0, 0.0, 0.0),
+		Vector3(0.0, 3.0, 0.0)
+	)
+
+	assert_true(_get_bool(report, "ok"), "3D 横向移动目标应有拦截解。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 2.5, 0.000001)
+	_assert_vector3_close(_get_vector3(report, "position"), Vector3(10.0, 7.5, 0.0))
+	assert_almost_eq(_get_vector3(report, "launch_velocity").length(), 5.0, 0.000001)
+
+
+func test_solve_intercept_handles_equal_speed_approach() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		5.0,
+		Vector2(10.0, 0.0),
+		Vector2(-5.0, 0.0)
+	)
+
+	assert_true(_get_bool(report, "ok"), "等速相向运动应走线性退化分支并得到有效解。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 1.0, 0.000001)
+	_assert_vector2_close(_get_vector2(report, "position"), Vector2(5.0, 0.0))
+
+
+func test_solve_intercept_respects_small_positive_epsilon_at_small_scale() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		0.0001,
+		Vector2(0.001, 0.0),
+		Vector2.ZERO,
+		-1.0,
+		0.000000000001
+	)
+
+	assert_true(_get_bool(report, "ok"), "小尺度速度不应被固定绝对容差误判为零。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 10.0, 0.000001)
+
+
+func test_solve_intercept_negative_epsilon_uses_default() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		5.0,
+		Vector2(10.0, 0.0),
+		Vector2.ZERO,
+		-1.0,
+		-10.0
+	)
+
+	assert_true(_get_bool(report, "ok"), "非正 epsilon 应按文档回退到默认值。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 2.0, 0.000001)
+
+
+func test_solve_intercept_keeps_tiny_positive_time_and_discards_negative_root() -> void:
+	var report_2d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		10.0,
+		Vector2(0.000002, 0.0),
+		Vector2.ZERO
+	)
+	var report_3d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_3d(
+		Vector3.ZERO,
+		10.0,
+		Vector3(0.000002, 0.0, 0.0),
+		Vector3.ZERO
+	)
+
+	assert_true(_get_bool(report_2d, "ok"), "容差内的过去根不应被提升为 t=0。")
+	assert_true(_get_bool(report_3d, "ok"), "2D 与 3D 应共享相同的非负根语义。")
+	assert_almost_eq(_get_float(report_2d, "time_seconds"), 0.0000002, 0.000000000001)
+	assert_almost_eq(_get_float(report_3d, "time_seconds"), 0.0000002, 0.000000000001)
+	assert_almost_eq(_get_vector2(report_2d, "launch_velocity").length(), 10.0, 0.000001)
+	assert_almost_eq(_get_vector3(report_3d, "launch_velocity").length(), 10.0, 0.000001)
+
+
+func test_solve_intercept_reports_no_solution_when_target_is_too_fast() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		5.0,
+		Vector2(10.0, 0.0),
+		Vector2(6.0, 0.0)
+	)
+
+	assert_false(_get_bool(report, "ok"), "持续远离且更快的目标不应伪造拦截解。")
+	assert_eq(_get_reason(report), &"no_solution")
+
+
+func test_solve_intercept_reports_beyond_horizon() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		5.0,
+		Vector2(10.0, 0.0),
+		Vector2.ZERO,
+		1.0
+	)
+
+	assert_false(_get_bool(report, "ok"), "超出预测窗口的解不应被当作可执行解。")
+	assert_eq(_get_reason(report), &"beyond_horizon")
+
+
+func test_solve_intercept_accepts_immediate_overlap() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_3d(
+		Vector3(2.0, 3.0, 4.0),
+		8.0,
+		Vector3(2.0, 3.0, 4.0),
+		Vector3(20.0, 0.0, 0.0)
+	)
+
+	assert_true(_get_bool(report, "ok"), "当前位置重合应作为 t=0 的有效拦截。")
+	assert_almost_eq(_get_float(report, "time_seconds"), 0.0, 0.000001)
+	_assert_vector3_close(_get_vector3(report, "launch_velocity"), Vector3.ZERO)
+
+
+func test_solve_intercept_rejects_invalid_speed() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		0.0,
+		Vector2.RIGHT,
+		Vector2.ZERO
+	)
+
+	assert_false(_get_bool(report, "ok"), "非正发射速度应被拒绝。")
+	assert_eq(_get_reason(report), &"invalid_argument")
+
+
+func test_solve_intercept_rejects_unusable_launch_velocity_magnitude() -> void:
+	var report_2d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		1.0e30,
+		Vector2(10.0, 0.0),
+		Vector2.ZERO
+	)
+	var report_3d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_3d(
+		Vector3.ZERO,
+		1.0e30,
+		Vector3(10.0, 0.0, 0.0),
+		Vector3.ZERO
+	)
+
+	assert_false(_get_bool(report_2d, "ok"), "长度溢出的 2D 发射速度不应进入成功报告。")
+	assert_false(_get_bool(report_3d, "ok"), "长度溢出的 3D 发射速度不应进入成功报告。")
+	assert_eq(_get_reason(report_2d), &"invalid_argument")
+	assert_eq(_get_reason(report_3d), &"invalid_argument")
+
+
+func test_solve_intercept_stationary_target_handles_large_finite_time() -> void:
+	var report_2d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		1.0e-20,
+		Vector2(1.0e19, 0.0),
+		Vector2.ZERO
+	)
+	var report_3d: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_3d(
+		Vector3.ZERO,
+		1.0e-20,
+		Vector3(1.0e19, 0.0, 0.0),
+		Vector3.ZERO
+	)
+
+	assert_true(_get_bool(report_2d, "ok"), "零目标速度不应因极长有限时间的 Vector 标量转换而失败。")
+	assert_true(_get_bool(report_3d, "ok"), "2D 与 3D 应共享稳定的目标位移计算。")
+	assert_almost_eq(_get_float(report_2d, "time_seconds") / 1.0e39, 1.0, 0.000001)
+	assert_almost_eq(_get_float(report_3d, "time_seconds") / 1.0e39, 1.0, 0.000001)
+	assert_almost_eq(_get_vector2(report_2d, "launch_velocity").length() / 1.0e-20, 1.0, 0.001)
+	assert_almost_eq(_get_vector3(report_3d, "launch_velocity").length() / 1.0e-20, 1.0, 0.001)
+
+
+func test_sample_formula_2d_includes_both_interval_endpoints() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_circle_formula_2d"),
+		0.0,
+		PI,
+		3
+	)
+	var points: PackedVector2Array = _get_vector2_array(report, "points")
+	var times: PackedFloat64Array = _get_float_array(report, "times")
+
+	assert_true(_get_bool(report, "ok"), "有限公式应完整采样。")
+	assert_eq(points.size(), 3)
+	assert_eq(times.size(), 3)
+	_assert_vector2_close(points[0], Vector2(1.0, 0.0))
+	_assert_vector2_close(points[1], Vector2(0.0, 1.0))
+	_assert_vector2_close(points[2], Vector2(-1.0, 0.0))
+	assert_almost_eq(times[0], 0.0, 0.000001)
+	assert_almost_eq(times[2], PI, 0.000001)
+
+
+func test_sample_formula_3d_supports_reverse_time_ranges() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_3d(
+		Callable(self, &"_polynomial_formula_3d"),
+		2.0,
+		0.0,
+		3
+	)
+	var points: PackedVector3Array = _get_vector3_array(report, "points")
+
+	assert_true(_get_bool(report, "ok"), "通用公式采样应允许反向时间区间。")
+	assert_eq(points.size(), 3)
+	_assert_vector3_close(points[0], Vector3(2.0, 4.0, -2.0))
+	_assert_vector3_close(points[1], Vector3(1.0, 1.0, -1.0))
+	_assert_vector3_close(points[2], Vector3.ZERO)
+
+
+func test_sample_formula_with_one_sample_uses_start_time() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_circle_formula_2d"),
+		0.5,
+		8.0,
+		1
+	)
+	var times: PackedFloat64Array = _get_float_array(report, "times")
+
+	assert_true(_get_bool(report, "ok"))
+	assert_eq(times.size(), 1)
+	assert_almost_eq(times[0], 0.5, 0.000001)
+
+
+func test_sample_formula_keeps_extreme_finite_time_range_finite() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_constant_formula_2d"),
+		-1.0e308,
+		1.0e308,
+		3
+	)
+	var times: PackedFloat64Array = _get_float_array(report, "times")
+
+	assert_true(_get_bool(report, "ok"), "有限端点不应因插值中间步骤溢出。")
+	assert_eq(times.size(), 3)
+	assert_false(is_nan(times[1]) or is_inf(times[1]))
+	assert_almost_eq(times[1], 0.0, 0.000001)
+
+
+func test_sample_formula_rejects_limit_before_calling_provider() -> void:
+	_provider_call_count = 0
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_counted_formula_2d"),
+		0.0,
+		1.0,
+		5,
+		4
+	)
+
+	assert_false(_get_bool(report, "ok"), "超预算采样应 fail closed。")
+	assert_eq(_get_reason(report), &"sample_limit_exceeded")
+	assert_eq(_provider_call_count, 0, "预算校验失败时不应执行项目回调。")
+
+
+func test_sample_formula_rejects_limit_above_absolute_cap() -> void:
+	_provider_call_count = 0
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_counted_formula_2d"),
+		0.0,
+		1.0,
+		1,
+		GF_TRAJECTORY_MATH_SCRIPT.ABSOLUTE_MAX_SAMPLE_COUNT + 1
+	)
+
+	assert_false(_get_bool(report, "ok"), "调用方不能绕过绝对采样上限。")
+	assert_eq(_get_reason(report), &"invalid_argument")
+	assert_eq(_provider_call_count, 0)
+
+
+func test_sample_formula_reports_provider_type_mismatch() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_wrong_type_formula"),
+		0.0,
+		1.0,
+		3
+	)
+
+	assert_false(_get_bool(report, "ok"), "返回错误类型的公式不应生成可用轨迹。")
+	assert_eq(_get_reason(report), &"provider_failed")
+	assert_eq(_get_int(report, "failed_sample_index"), 0)
+	assert_eq(_get_int(report, "sampled_count"), 0)
+
+
+func test_sample_formula_reports_non_finite_provider_output() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_2d(
+		Callable(self, &"_non_finite_formula_2d"),
+		0.0,
+		1.0,
+		3
+	)
+
+	assert_false(_get_bool(report, "ok"), "公式输出 NaN 时应终止采样。")
+	assert_eq(_get_reason(report), &"provider_failed")
+	assert_eq(_get_int(report, "failed_sample_index"), 1)
+	assert_eq(_get_int(report, "sampled_count"), 1)
+	var times: PackedFloat64Array = _get_float_array(report, "times")
+	var points: PackedVector2Array = _get_vector2_array(report, "points")
+	assert_eq(times.size(), 1, "失败报告应保留已完成采样的时间前缀。")
+	assert_eq(points.size(), 1, "失败报告应保留已完成采样的位置前缀。")
+	assert_almost_eq(times[0], 0.0, 0.000001)
+	_assert_vector2_close(points[0], Vector2.ZERO)
+
+
+func test_sample_formula_rejects_invalid_callable() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.sample_formula_3d(
+		Callable(),
+		0.0,
+		1.0,
+		3
+	)
+
+	assert_false(_get_bool(report, "ok"), "无效 Callable 应在采样前被拒绝。")
+	assert_eq(_get_reason(report), &"invalid_provider")
+
+
+# --- 私有/辅助方法 ---
+
+func _circle_formula_2d(time_seconds: float) -> Vector2:
+	return Vector2(cos(time_seconds), sin(time_seconds))
+
+
+func _polynomial_formula_3d(time_seconds: float) -> Vector3:
+	return Vector3(time_seconds, time_seconds * time_seconds, -time_seconds)
+
+
+func _counted_formula_2d(time_seconds: float) -> Vector2:
+	_provider_call_count += 1
+	return Vector2(time_seconds, 0.0)
+
+
+func _constant_formula_2d(_time_seconds: float) -> Vector2:
+	return Vector2.ZERO
+
+
+func _wrong_type_formula(_time_seconds: float) -> String:
+	return "not-a-vector"
+
+
+func _non_finite_formula_2d(time_seconds: float) -> Vector2:
+	if time_seconds > 0.0:
+		return Vector2(NAN, 0.0)
+	return Vector2.ZERO
+
+
+func _get_bool(report: Dictionary, key: String) -> bool:
+	var value: Variant = report.get(key, false)
+	return value if value is bool else false
+
+
+func _get_int(report: Dictionary, key: String) -> int:
+	var value: Variant = report.get(key, 0)
+	if value is int:
+		var int_value: int = value
+		return int_value
+	return 0
+
+
+func _get_float(report: Dictionary, key: String) -> float:
+	var value: Variant = report.get(key, 0.0)
+	if value is float:
+		var float_value: float = value
+		return float_value
+	if value is int:
+		var int_value: int = value
+		return float(int_value)
+	return 0.0
+
+
+func _get_reason(report: Dictionary) -> StringName:
+	var value: Variant = report.get("reason", &"")
+	if value is StringName:
+		return value
+	if value is String:
+		var text: String = value
+		return StringName(text)
+	return &""
+
+
+func _get_vector2(report: Dictionary, key: String) -> Vector2:
+	var value: Variant = report.get(key, Vector2.ZERO)
+	if value is Vector2:
+		var vector_value: Vector2 = value
+		return vector_value
+	return Vector2.ZERO
+
+
+func _get_vector3(report: Dictionary, key: String) -> Vector3:
+	var value: Variant = report.get(key, Vector3.ZERO)
+	if value is Vector3:
+		var vector_value: Vector3 = value
+		return vector_value
+	return Vector3.ZERO
+
+
+func _get_float_array(report: Dictionary, key: String) -> PackedFloat64Array:
+	var value: Variant = report.get(key, PackedFloat64Array())
+	if value is PackedFloat64Array:
+		var array_value: PackedFloat64Array = value
+		return array_value
+	return PackedFloat64Array()
+
+
+func _get_vector2_array(report: Dictionary, key: String) -> PackedVector2Array:
+	var value: Variant = report.get(key, PackedVector2Array())
+	if value is PackedVector2Array:
+		var array_value: PackedVector2Array = value
+		return array_value
+	return PackedVector2Array()
+
+
+func _get_vector3_array(report: Dictionary, key: String) -> PackedVector3Array:
+	var value: Variant = report.get(key, PackedVector3Array())
+	if value is PackedVector3Array:
+		var array_value: PackedVector3Array = value
+		return array_value
+	return PackedVector3Array()
+
+
+func _assert_vector2_close(actual: Vector2, expected: Vector2, epsilon: float = 0.000001) -> void:
+	assert_almost_eq(actual.x, expected.x, epsilon)
+	assert_almost_eq(actual.y, expected.y, epsilon)
+
+
+func _assert_vector3_close(actual: Vector3, expected: Vector3, epsilon: float = 0.000001) -> void:
+	assert_almost_eq(actual.x, expected.x, epsilon)
+	assert_almost_eq(actual.y, expected.y, epsilon)
+	assert_almost_eq(actual.z, expected.z, epsilon)

--- a/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd.uid
+++ b/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd.uid
@@ -1,0 +1,1 @@
+uid://bt8fiemjc8f33


### PR DESCRIPTION
## Summary

- add `GFTrajectoryMath` for 2D/3D constant-acceleration future-state prediction
- solve the earliest non-negative intercept for a constant-speed projectile and constant-velocity target
- sample trusted synchronous trajectory formulas with per-call and absolute point budgets
- add structured reports, numerical fail-closed guards, focused tests, package ownership, API references, and usage documentation

## Why

Projects repeatedly need future positions, moving-target lead calculation, and bounded trajectory samples for aiming previews, orbit or route visualization, AI candidate evaluation, and editor overlays. Keeping these primitives in a stateless math boundary avoids duplicating fragile solvers while leaving drawing, physics advancement, gravity ballistics, collision, and gameplay policy in project code.

## Developer impact

This adds a new opt-in public class and does not change existing steering behavior. Moving-launcher use is documented with explicit relative/world-space conversion. Formula providers remain trusted synchronous project code and are called only after budget validation.

## Validation

- focused GUT: 27/27 tests, 127 assertions
- full suite: 34/34 checks; 4431/4431 GUT tests, 30217 assertions
- LSP hard gate: 1151 files, 0 diagnostics, 0 timeouts (`error` and `warning` fail)
- API baseline vs 9.0.1: no removals or breaking signature changes
- project settings drift, package boundaries, docs/API generation, and diff hygiene passed

## Release scope

This PR keeps the existing `10.0.0-dev.0` development identity. It does not create a tag or publish a release.