### PR TITLE
Fix trajectory intercept numerical stability

### DIFF
--- a/addons/gf/standard/foundation/math/gf_trajectory_math.gd
+++ b/addons/gf/standard/foundation/math/gf_trajectory_math.gd
@@ -717,11 +717,8 @@ static func _solve_intercept_time(
 		)
 
 	var roots: PackedFloat64Array = PackedFloat64Array()
-	var coefficient_scale: float = maxf(
-		absf(target_speed_squared),
-		absf(projectile_speed_squared)
-	)
-	if absf(coefficient_a) <= epsilon * coefficient_scale:
+	# 非零二次项即使很小，也可能表示有效的远期拦截，不能用调用方容差降阶。
+	if coefficient_a == 0.0:
 		if coefficient_b == 0.0:
 			return _make_time_report(false, REASON_NO_SOLUTION, "No non-negative intercept solution exists.")
 		_append_nonnegative_root(roots, -coefficient_c / coefficient_b)
@@ -740,11 +737,11 @@ static func _solve_intercept_time(
 			absf(coefficient_b * coefficient_b),
 			absf(4.0 * coefficient_a * coefficient_c)
 		)
-		var discriminant_epsilon: float = epsilon * discriminant_scale
-		if discriminant < -discriminant_epsilon:
+		# 负判别式没有实根；按尺度放宽再钳制为零会制造无法到达的伪命中。
+		if discriminant < 0.0:
 			return _make_time_report(false, REASON_NO_SOLUTION, "No real intercept solution exists.")
 
-		var sqrt_discriminant: float = sqrt(maxf(discriminant, 0.0))
+		var sqrt_discriminant: float = sqrt(discriminant)
 		var sqrt_discriminant_scale: float = sqrt(discriminant_scale)
 		if sqrt_discriminant <= epsilon * sqrt_discriminant_scale:
 			_append_nonnegative_root(

--- a/addons/gf/standard/foundation/math/gf_trajectory_math.gd
+++ b/addons/gf/standard/foundation/math/gf_trajectory_math.gd
@@ -85,6 +85,12 @@ const DEFAULT_MAX_SAMPLE_COUNT: int = 1024
 ## @since unreleased
 const ABSOLUTE_MAX_SAMPLE_COUNT: int = 16_384
 
+# Godot 标准构建的 real_t 为 float32；双精度构建使用 float64。
+const _FLOAT32_MACHINE_EPSILON: float = 0.00000011920928955078125
+const _FLOAT64_MACHINE_EPSILON: float = 0.0000000000000002220446049250313
+const _FLOAT32_HALF_ULP_AT_ONE: float = 0.000000059604644775390625
+const _DISCRIMINANT_ROUNDOFF_FACTOR: float = 1.0
+
 
 # --- 公共方法 ---
 
@@ -277,6 +283,7 @@ static func solve_intercept_2d(
 		relative_position.length_squared(),
 		relative_position.dot(target_velocity),
 		target_velocity.length_squared(),
+		target_velocity.length(),
 		projectile_speed,
 		max_time_seconds,
 		safe_epsilon
@@ -400,6 +407,7 @@ static func solve_intercept_3d(
 		relative_position.length_squared(),
 		relative_position.dot(target_velocity),
 		target_velocity.length_squared(),
+		target_velocity.length(),
 		projectile_speed,
 		max_time_seconds,
 		safe_epsilon
@@ -694,6 +702,7 @@ static func _solve_intercept_time(
 	relative_distance_squared: float,
 	relative_position_dot_velocity: float,
 	target_speed_squared: float,
+	target_speed: float,
 	projectile_speed: float,
 	max_time_seconds: float,
 	epsilon: float
@@ -702,7 +711,10 @@ static func _solve_intercept_time(
 		return _make_time_report(true, REASON_NONE, "", 0.0)
 
 	var projectile_speed_squared: float = projectile_speed * projectile_speed
-	var coefficient_a: float = target_speed_squared - projectile_speed_squared
+	var coefficient_a: float = 0.0
+	# 先比较未平方的速度，避免同一 Vector.length() 的平方往返误差伪造二次项。
+	if target_speed != projectile_speed:
+		coefficient_a = target_speed_squared - projectile_speed_squared
 	var coefficient_b: float = 2.0 * relative_position_dot_velocity
 	var coefficient_c: float = relative_distance_squared
 	if (
@@ -737,11 +749,16 @@ static func _solve_intercept_time(
 			absf(coefficient_b * coefficient_b),
 			absf(4.0 * coefficient_a * coefficient_c)
 		)
-		# 负判别式没有实根；按尺度放宽再钳制为零会制造无法到达的伪命中。
-		if discriminant < 0.0:
+		# 只吸收 real_t 和后续运算的机器舍入；调用方 epsilon 不能改变实根拓扑。
+		var discriminant_roundoff_limit: float = (
+			_get_real_component_machine_epsilon()
+			* _DISCRIMINANT_ROUNDOFF_FACTOR
+			* discriminant_scale
+		)
+		if discriminant < -discriminant_roundoff_limit:
 			return _make_time_report(false, REASON_NO_SOLUTION, "No real intercept solution exists.")
 
-		var sqrt_discriminant: float = sqrt(discriminant)
+		var sqrt_discriminant: float = sqrt(maxf(discriminant, 0.0))
 		var sqrt_discriminant_scale: float = sqrt(discriminant_scale)
 		if sqrt_discriminant <= epsilon * sqrt_discriminant_scale:
 			_append_nonnegative_root(
@@ -776,6 +793,13 @@ static func _solve_intercept_time(
 			"The earliest intercept solution exceeds max_time_seconds."
 		)
 	return _make_time_report(true, REASON_NONE, "", intercept_time)
+
+
+static func _get_real_component_machine_epsilon() -> float:
+	var precision_probe: float = Vector2(1.0 + _FLOAT32_HALF_ULP_AT_ONE, 0.0).x
+	if precision_probe == 1.0:
+		return _FLOAT32_MACHINE_EPSILON
+	return _FLOAT64_MACHINE_EPSILON
 
 
 static func _append_nonnegative_root(

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -53,7 +53,7 @@
 - 修复同一 journal sink 原位重配时会先刷新并按旧所有权关闭实例、导致未重新初始化的 sink 后续静默失效的问题。
 - 修复 sink 回调内使用文档化的 `configure_journal_sink(null)` 无法原子断开并延迟清理当前 sink 的问题；替换 sink 时，旧 sink 清理回调发起的置空请求也不会再被外层配置覆盖。
 - 修复模块源码引用根级 Godot 治理文件时只能产生 `unowned_project_resource_reference`、或被迫把文件误填为模块扫描目录并导致分析不完整的问题。
-- 修复 `GFTrajectoryMath` 将近似等速目标的非零二次项误降阶而漏掉远期拦截，以及按大尺度相对容差把负判别式钳制成伪命中的问题；无实根场景现在稳定返回 `no_solution`。
+- 修复 `GFTrajectoryMath` 将近似等速目标的非零二次项误降阶而漏掉远期拦截，以及按大尺度相对容差把负判别式钳制成伪命中的问题；等速退化现在按未平方速度判定，判别式只在 Godot `real_t` 的单个机器精度包络内恢复切线根，从而同时保留 `length()` 派生等速、舍入后的有效切线和真实 `no_solution` 边界。
 
 ### 🔧 API 变动说明 (API Changes)
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -53,6 +53,7 @@
 - 修复同一 journal sink 原位重配时会先刷新并按旧所有权关闭实例、导致未重新初始化的 sink 后续静默失效的问题。
 - 修复 sink 回调内使用文档化的 `configure_journal_sink(null)` 无法原子断开并延迟清理当前 sink 的问题；替换 sink 时，旧 sink 清理回调发起的置空请求也不会再被外层配置覆盖。
 - 修复模块源码引用根级 Godot 治理文件时只能产生 `unowned_project_resource_reference`、或被迫把文件误填为模块扫描目录并导致分析不完整的问题。
+- 修复 `GFTrajectoryMath` 将近似等速目标的非零二次项误降阶而漏掉远期拦截，以及按大尺度相对容差把负判别式钳制成伪命中的问题；无实根场景现在稳定返回 `no_solution`。
 
 ### 🔧 API 变动说明 (API Changes)
 

--- a/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd
+++ b/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd
@@ -136,6 +136,19 @@ func test_solve_intercept_handles_equal_speed_approach() -> void:
 	_assert_vector2_close(_get_vector2(report, "position"), Vector2(5.0, 0.0))
 
 
+func test_solve_intercept_treats_length_derived_equal_speed_as_degenerate() -> void:
+	var target_velocity: Vector2 = Vector2(1.1, 2.2)
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		target_velocity.length(),
+		Vector2(-2.2, 1.1),
+		target_velocity
+	)
+
+	assert_false(_get_bool(report, "ok"), "同一向量推导的等速不应因平方往返误差伪造远期解。")
+	assert_eq(_get_reason(report), &"no_solution")
+
+
 func test_solve_intercept_preserves_near_equal_speed_quadratic_solution() -> void:
 	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
 		Vector2.ZERO,
@@ -165,6 +178,22 @@ func test_solve_intercept_rejects_negative_discriminant_at_large_scale() -> void
 
 	assert_false(_get_bool(report, "ok"), "负判别式不能因大尺度容差被钳制成伪命中。")
 	assert_eq(_get_reason(report), &"no_solution")
+
+
+func test_solve_intercept_preserves_tangent_solution_with_roundoff() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		1.0,
+		Vector2(1000.0, 577.3502691896258),
+		Vector2(-2.0, 0.0)
+	)
+
+	assert_true(_get_bool(report, "ok"), "有效切线解不应因判别式抵消误差被拒绝。")
+	assert_almost_eq(
+		_get_float(report, "time_seconds") / 666.6666666666666,
+		1.0,
+		0.000001
+	)
 
 
 func test_solve_intercept_respects_small_positive_epsilon_at_small_scale() -> void:

--- a/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd
+++ b/tests/gf_core/standard/foundation/math/test_gf_trajectory_math.gd
@@ -136,6 +136,37 @@ func test_solve_intercept_handles_equal_speed_approach() -> void:
 	_assert_vector2_close(_get_vector2(report, "position"), Vector2(5.0, 0.0))
 
 
+func test_solve_intercept_preserves_near_equal_speed_quadratic_solution() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		10.0,
+		Vector2(10.0, 0.0),
+		Vector2(0.0, 9.999999)
+	)
+
+	assert_true(_get_bool(report, "ok"), "近似等速的横向目标仍应保留远期二次方程解。")
+	var intercept_time: float = _get_float(report, "time_seconds")
+	var intercept_distance: float = _get_float(report, "distance")
+	assert_gt(intercept_time, 2000.0, "该场景应得到远期解，而不是被错误降阶。")
+	assert_almost_eq(
+		_get_vector2(report, "position").length() / intercept_distance,
+		1.0,
+		0.000001
+	)
+
+
+func test_solve_intercept_rejects_negative_discriminant_at_large_scale() -> void:
+	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
+		Vector2.ZERO,
+		0.01,
+		Vector2(1000.0, 0.5),
+		Vector2(-1000.0, 0.0)
+	)
+
+	assert_false(_get_bool(report, "ok"), "负判别式不能因大尺度容差被钳制成伪命中。")
+	assert_eq(_get_reason(report), &"no_solution")
+
+
 func test_solve_intercept_respects_small_positive_epsilon_at_small_scale() -> void:
 	var report: Dictionary = GF_TRAJECTORY_MATH_SCRIPT.solve_intercept_2d(
 		Vector2.ZERO,


### PR DESCRIPTION
## Summary

- Preserve every non-zero quadratic term when solving constant-speed intercepts, including near-equal target and projectile speeds.
- Reject negative discriminants before root evaluation instead of clamping scale-relative negative values to zero.
- Add focused regressions for long-horizon near-equal-speed interception and impossible high-speed flyby interception.
- Record the correction under the unreleased changelog.

## Root cause

`GFTrajectoryMath` used the caller's geometric epsilon to decide whether the quadratic coefficient was effectively zero. When the target was only slightly slower than the projectile and moved almost perpendicular to the line of sight, that comparison erased a small but meaningful quadratic term. The solver then entered the linear branch and reported `no_solution`, even though a valid long-horizon intercept existed.

The discriminant check used the same scale-relative tolerance. At large coordinate and velocity scales, this could admit a materially negative discriminant and clamp it to zero, fabricating a tangent root for a projectile that could not physically reach the target.

The fix keeps topology-changing decisions exact: a computed non-zero quadratic coefficient remains quadratic, and every negative discriminant is rejected as having no real root.

## Practical impact

- A turret, guided projectile, or spacecraft can now lead a target moving nearly at projectile speed across the firing line when the project allows a long or unlimited prediction horizon.
- A very slow projectile no longer receives a false intercept point when a fast target merely passes near the shooter without entering the projectile's reachable envelope.
- Public method signatures, report schemas, horizon behavior, and the documented `no_solution` failure contract remain unchanged.

This is a follow-up to the two unresolved numerical-stability review threads on merged PR #21.

## Verification

- Focused trajectory GUT: 29/29 tests, 132 assertions.
- GF full suite: 34/34 checks.
- Full GUT: 4433/4433 tests, 30222 assertions.
- GDScript LSP hard gate: 1151 files, 0 diagnostics, 0 timeouts.
- GDScript reload-warning gate, API/docs checks, package matrices, repository policy, and `git diff --check`: passed.

## Compatibility

This is a compatible correctness fix. It does not add or change public API, serialized data, package metadata, configuration, or migration requirements.