### PR TITLE
Add mountable content package asset catalogs

### DIFF
--- a/addons/gf/extensions/content_package/gf_extension.json
+++ b/addons/gf/extensions/content_package/gf_extension.json
@@ -4,7 +4,7 @@
   "version": "10.0.0-dev.0",
   "extension_version": "2.0.0",
   "kind": "extension",
-  "description": "Generic content package manifests, dependency diagnostics, and resource resolver registration.",
+  "description": "Generic content package manifests, owner-scoped discovery, deterministic queries, asset catalog adaptation, dependency diagnostics, and resource resolver registration.",
   "dependencies": ["gf.kernel", "gf.standard"],
   "installer_paths": [
     "res://addons/gf/extensions/content_package/extension.gd"

--- a/addons/gf/extensions/content_package/resources/gf_content_package_query.gd
+++ b/addons/gf/extensions/content_package/resources/gf_content_package_query.gd
@@ -1,0 +1,251 @@
+## GFContentPackageQuery: 内容包目录的确定性通用查询条件。
+##
+## 查询只描述 package、content type、依赖、资源键、安全分类和 metadata 约束，
+## 不解释项目业务语义。所有非空条件采用 AND 语义，列表条件要求 manifest 包含全部值。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFContentPackageQuery
+extends Resource
+
+
+# --- 导出变量 ---
+
+## 查询稳定标识，仅用于诊断和追踪。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var query_id: StringName = &""
+
+## 允许返回的 package ID；为空表示不限制。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var package_ids: PackedStringArray = PackedStringArray()
+
+## 在 package ID、显示名、版本和 content type 中匹配的大小写无关文本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var search_text: String = ""
+
+## manifest 必须包含的全部 content type。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var required_content_types: PackedStringArray = PackedStringArray()
+
+## manifest 必须声明的全部直接依赖 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var required_dependencies: PackedStringArray = PackedStringArray()
+
+## manifest 必须声明的全部资源键。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var required_resource_keys: PackedStringArray = PackedStringArray()
+
+## 允许的安全分类；为空表示不限制。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var allowed_safety_kinds: PackedStringArray = PackedStringArray()
+
+## manifest metadata 必须精确匹配的键值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @schema required_metadata: Dictionary with exact manifest metadata key/value filters.
+@export var required_metadata: Dictionary = {}
+
+## 是否把直接命中包的传递依赖加入结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var include_dependencies: bool = false
+
+## 直接命中包的最大数量；小于等于 0 表示不限制。依赖闭包不计入该限制。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var max_results: int = 0
+
+## 调用方自定义查询元数据；GF 只负责复制和序列化。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @schema metadata: Dictionary with caller-defined query metadata.
+@export var metadata: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 检查 manifest 是否满足全部非空查询条件。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param manifest: 要检查的内容包 manifest。
+## [br]
+## @return 满足查询条件返回 true。
+func matches(manifest: GFContentPackageManifest) -> bool:
+	if manifest == null:
+		return false
+	var normalized_package_ids: PackedStringArray = _normalize_string_set(package_ids)
+	if not normalized_package_ids.is_empty() and not normalized_package_ids.has(String(manifest.package_id)):
+		return false
+	if not _matches_search_text(manifest):
+		return false
+	if not _contains_all(manifest.content_types, _normalize_string_set(required_content_types)):
+		return false
+	if not _contains_all(manifest.dependencies, _normalize_string_set(required_dependencies)):
+		return false
+	if not _contains_all(manifest.get_resource_keys(), _normalize_string_set(required_resource_keys)):
+		return false
+	var normalized_safety_kinds: PackedStringArray = _normalize_string_set(allowed_safety_kinds)
+	if not normalized_safety_kinds.is_empty() and not normalized_safety_kinds.has(String(manifest.safety_kind)):
+		return false
+	for metadata_key: Variant in required_metadata.keys():
+		if not manifest.metadata.has(metadata_key) or manifest.metadata[metadata_key] != required_metadata[metadata_key]:
+			return false
+	return true
+
+
+## 从字典应用查询字段并执行集合归一化。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param data: 查询字典。
+## [br]
+## @schema data: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.
+func apply_dict(data: Dictionary) -> void:
+	query_id = GFVariantData.get_option_string_name(data, "query_id")
+	package_ids = _normalize_string_set(GFVariantData.get_option_packed_string_array(data, "package_ids"))
+	search_text = GFVariantData.get_option_string(data, "search_text").strip_edges()
+	required_content_types = _normalize_string_set(
+		GFVariantData.get_option_packed_string_array(data, "required_content_types")
+	)
+	required_dependencies = _normalize_string_set(
+		GFVariantData.get_option_packed_string_array(data, "required_dependencies")
+	)
+	required_resource_keys = _normalize_string_set(
+		GFVariantData.get_option_packed_string_array(data, "required_resource_keys")
+	)
+	allowed_safety_kinds = _normalize_string_set(
+		GFVariantData.get_option_packed_string_array(data, "allowed_safety_kinds")
+	)
+	required_metadata = GFVariantData.get_option_dictionary(data, "required_metadata").duplicate(true)
+	include_dependencies = GFVariantData.get_option_bool(data, "include_dependencies", false)
+	max_results = maxi(0, GFVariantData.get_option_int(data, "max_results", 0))
+	metadata = GFVariantData.get_option_dictionary(data, "metadata").duplicate(true)
+
+
+## 转换为归一化字典。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 查询字典副本。
+## [br]
+## @schema return: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.
+func to_dict() -> Dictionary:
+	return {
+		"query_id": query_id,
+		"package_ids": _normalize_string_set(package_ids),
+		"search_text": search_text.strip_edges(),
+		"required_content_types": _normalize_string_set(required_content_types),
+		"required_dependencies": _normalize_string_set(required_dependencies),
+		"required_resource_keys": _normalize_string_set(required_resource_keys),
+		"allowed_safety_kinds": _normalize_string_set(allowed_safety_kinds),
+		"required_metadata": required_metadata.duplicate(true),
+		"include_dependencies": include_dependencies,
+		"max_results": maxi(0, max_results),
+		"metadata": metadata.duplicate(true),
+	}
+
+
+## 创建查询深拷贝。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新查询。
+func duplicate_query() -> GFContentPackageQuery:
+	return GFContentPackageQuery.from_dict(to_dict())
+
+
+## 从字典创建查询。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param data: 查询字典。
+## [br]
+## @schema data: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.
+## [br]
+## @return 新查询。
+static func from_dict(data: Dictionary) -> GFContentPackageQuery:
+	var result: GFContentPackageQuery = GFContentPackageQuery.new()
+	result.apply_dict(data)
+	return result
+
+
+# --- 私有/辅助方法 ---
+
+func _matches_search_text(manifest: GFContentPackageManifest) -> bool:
+	var normalized_search: String = search_text.strip_edges().to_lower()
+	if normalized_search.is_empty():
+		return true
+	var candidates: PackedStringArray = PackedStringArray([
+		String(manifest.package_id),
+		manifest.display_name,
+		manifest.version,
+	])
+	for content_type: String in manifest.content_types:
+		var _content_type_appended: bool = candidates.append(content_type)
+	for candidate: String in candidates:
+		if candidate.to_lower().contains(normalized_search):
+			return true
+	return false
+
+
+static func _contains_all(source: PackedStringArray, required: PackedStringArray) -> bool:
+	for item: String in required:
+		if not source.has(item):
+			return false
+	return true
+
+
+static func _normalize_string_set(items: PackedStringArray) -> PackedStringArray:
+	var result: PackedStringArray = PackedStringArray()
+	for item: String in items:
+		var normalized_item: String = item.strip_edges()
+		if normalized_item.is_empty() or result.has(normalized_item):
+			continue
+		var _item_appended: bool = result.append(normalized_item)
+	result.sort()
+	return result

--- a/addons/gf/extensions/content_package/resources/gf_content_package_query.gd.uid
+++ b/addons/gf/extensions/content_package/resources/gf_content_package_query.gd.uid
@@ -1,0 +1,1 @@
+uid://bqlian7f5htmp

--- a/addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd
+++ b/addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd
@@ -1,0 +1,209 @@
+## GFContentPackageAssetCatalogProvider: 内容包目录到通用资产目录的适配器。
+##
+## Provider 持有内容包目录快照，通过可选 GFContentPackageQuery 选择 manifest，
+## 再把资源映射转换为 GFAssetCatalogEntry。它不挂载目录、不下载内容，也不解释业务分类。
+## [br]
+## @api public
+## [br]
+## @category protocol
+## [br]
+## @since unreleased
+class_name GFContentPackageAssetCatalogProvider
+extends GFAssetCatalogSourceProvider
+
+
+# --- 常量 ---
+
+const _GF_PATH_TOOLS = preload("res://addons/gf/kernel/core/gf_path_tools.gd")
+
+
+# --- 私有变量 ---
+
+var _content_catalog: GFContentPackageCatalog = GFContentPackageCatalog.new()
+var _query: GFContentPackageQuery = GFContentPackageQuery.new()
+
+
+# --- 公共方法 ---
+
+## 配置内容包目录快照和可选查询。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param catalog: 内容包目录；Provider 保存其深拷贝。
+## [br]
+## @param p_source_id: 资产来源 ID。
+## [br]
+## @param query: 可选内容包查询；为空时选择全部有效包。
+## [br]
+## @param options: Provider 配置选项，支持 priority。
+## [br]
+## @schema options: Dictionary with optional priority: int.
+## [br]
+## @return 当前 Provider。
+func configure_catalog(
+	catalog: GFContentPackageCatalog,
+	p_source_id: StringName = &"content_packages",
+	query: GFContentPackageQuery = null,
+	options: Dictionary = {}
+) -> GFContentPackageAssetCatalogProvider:
+	_content_catalog = catalog.duplicate_catalog() if catalog != null else GFContentPackageCatalog.new()
+	_query = query.duplicate_query() if query != null else GFContentPackageQuery.new()
+	var _base_configured: GFAssetCatalogSourceProvider = configure(p_source_id, options)
+	return self
+
+
+## 构建资产目录快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param options: 可选字段映射，支持 title_fields、description_fields、tag_fields、category_fields 和 preview_path_fields。
+## [br]
+## @schema options: Dictionary with optional PackedStringArray field-name lists for title_fields, description_fields, tag_fields, category_fields, and preview_path_fields.
+## [br]
+## @return 转换后的资产目录；内容包目录无效时返回 null。
+func build_catalog(options: Dictionary = {}) -> GFAssetCatalog:
+	var query_result: GFContentPackageQueryResult = _content_catalog.query_packages(_query)
+	if not query_result.is_successful():
+		return null
+	var result: GFAssetCatalog = GFAssetCatalog.new()
+	for manifest: GFContentPackageManifest in query_result.get_manifests():
+		for resource_record: Dictionary in manifest.get_normalized_resources():
+			var entry: GFAssetCatalogEntry = _make_asset_entry(manifest, resource_record, options)
+			if entry == null:
+				continue
+			var _entry_set: bool = result.set_entry(entry)
+	return result
+
+
+## 获取 Provider 诊断快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 来源、内容包目录和查询摘要。
+## [br]
+## @schema return: Dictionary with source_id, priority, provider_class, content_catalog, and query.
+func get_debug_snapshot() -> Dictionary:
+	var result: Dictionary = super.get_debug_snapshot()
+	result["content_catalog"] = _content_catalog.get_debug_snapshot()
+	result["query"] = _query.to_dict()
+	return result
+
+
+# --- 私有/辅助方法 ---
+
+func _make_asset_entry(
+	manifest: GFContentPackageManifest,
+	resource_record: Dictionary,
+	options: Dictionary
+) -> GFAssetCatalogEntry:
+	var resource_key: StringName = GFVariantData.get_option_string_name(resource_record, "key")
+	if resource_key == &"":
+		return null
+	var resource_metadata: Dictionary = GFVariantData.get_option_dictionary(resource_record, "metadata").duplicate(true)
+	var asset_metadata: Dictionary = resource_metadata.duplicate(true)
+	asset_metadata["content_package_id"] = manifest.package_id
+	asset_metadata["content_package_version"] = manifest.version
+	asset_metadata["content_package_resource_key"] = resource_key
+	asset_metadata["content_package_root_path"] = manifest.root_path
+	asset_metadata["content_package_source_path"] = manifest.source_path
+	asset_metadata["_gf_content_package_asset"] = true
+	var preview_path: String = _get_first_text(
+		resource_metadata,
+		_get_field_names(options, "preview_path_fields", ["preview_path", "thumbnail_path", "icon_path"])
+	)
+	preview_path = _normalize_package_optional_path(preview_path, manifest.root_path)
+	var entry_options: Dictionary = {
+		"title": _get_first_text(resource_metadata, _get_field_names(options, "title_fields", ["title", "display_name", "name"])),
+		"description": _get_first_text(resource_metadata, _get_field_names(options, "description_fields", ["description", "summary", "notes"])),
+		"tags": _get_tags(resource_metadata, _get_field_names(options, "tag_fields", ["tags", "keywords"])),
+		"category": _get_first_text(resource_metadata, _get_field_names(options, "category_fields", ["category", "group"])),
+		"type_hint": GFVariantData.get_option_string(resource_record, "type_hint"),
+		"preview_path": preview_path,
+		"resource_entry_ids": PackedStringArray([String(resource_key)]),
+		"source_id": get_source_id(),
+		"metadata": asset_metadata,
+	}
+	var asset_id: StringName = StringName("%s/%s" % [String(manifest.package_id), String(resource_key)])
+	return GFAssetCatalogEntry.new().configure(
+		asset_id,
+		GFVariantData.get_option_string(resource_record, "path"),
+		entry_options
+	)
+
+
+static func _get_field_names(options: Dictionary, key: String, defaults: Array[String]) -> PackedStringArray:
+	var result: PackedStringArray = GFVariantData.get_option_packed_string_array(options, key)
+	if not result.is_empty():
+		return result
+	for default_field: String in defaults:
+		var _field_appended: bool = result.append(default_field)
+	return result
+
+
+static func _get_first_text(metadata: Dictionary, field_names: PackedStringArray) -> String:
+	for field_name: String in field_names:
+		if not metadata.has(field_name):
+			continue
+		var field_value: Variant = metadata[field_name]
+		if field_value is String or field_value is StringName:
+			var text_value: String = _text_from_variant(field_value).strip_edges()
+			if not text_value.is_empty():
+				return text_value
+	return ""
+
+
+static func _get_tags(metadata: Dictionary, field_names: PackedStringArray) -> PackedStringArray:
+	var result: PackedStringArray = PackedStringArray()
+	for field_name: String in field_names:
+		if not metadata.has(field_name):
+			continue
+		var field_value: Variant = metadata[field_name]
+		if field_value is PackedStringArray:
+			var packed_tags: PackedStringArray = field_value
+			_append_tags(result, packed_tags)
+		elif field_value is Array:
+			var tag_values: Array = field_value
+			for tag_value: Variant in tag_values:
+				if tag_value is String or tag_value is StringName:
+					_append_tag(result, _text_from_variant(tag_value))
+	result.sort()
+	return result
+
+
+static func _append_tags(result: PackedStringArray, tags: PackedStringArray) -> void:
+	for tag: String in tags:
+		_append_tag(result, tag)
+
+
+static func _append_tag(result: PackedStringArray, tag: String) -> void:
+	var normalized_tag: String = tag.strip_edges()
+	if normalized_tag.is_empty() or result.has(normalized_tag):
+		return
+	var _tag_appended: bool = result.append(normalized_tag)
+
+
+static func _text_from_variant(value: Variant) -> String:
+	if value is String:
+		var text_value: String = value
+		return text_value
+	if value is StringName:
+		var text_name: StringName = value
+		return String(text_name)
+	return ""
+
+
+static func _normalize_package_optional_path(path: String, root_path: String) -> String:
+	var normalized_path: String = _GF_PATH_TOOLS.normalize_resource_path(path)
+	if normalized_path.is_empty() or root_path.is_empty():
+		return ""
+	if not normalized_path.begins_with("res://") and not normalized_path.begins_with("user://"):
+		normalized_path = _GF_PATH_TOOLS.normalize_resource_path(root_path.path_join(normalized_path))
+	if not _GF_PATH_TOOLS.is_path_under_root(normalized_path, root_path):
+		return ""
+	return normalized_path

--- a/addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd.uid
+++ b/addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd.uid
@@ -1,0 +1,1 @@
+uid://dp1ix7yibh1w6

--- a/addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd
+++ b/addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd
@@ -166,6 +166,78 @@ func get_ordered_package_ids() -> PackedStringArray:
 	return GFVariantData.get_option_packed_string_array(graph_report, "ordered_ids", PackedStringArray())
 
 
+## 查询有效内容包并返回隔离结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param query: 通用内容包查询。
+## [br]
+## @param options: manifest 和依赖图校验选项。
+## [br]
+## @return 类型化查询终态；目录无效时不返回部分结果。
+## [br]
+## @schema options: Dictionary，可包含 check_resource_exists: bool、check_resource_dependencies: bool 和 dependency_options: Dictionary。
+func query_packages(
+	query: GFContentPackageQuery,
+	options: Dictionary = {}
+) -> GFContentPackageQueryResult:
+	if query == null:
+		return _make_query_failure(
+			GFContentPackageQueryResult.STATUS_INVALID_QUERY,
+			&"",
+			&"invalid_query",
+			"content package query is required"
+		)
+	var graph_report: Dictionary = get_graph_report(options)
+	if not GFVariantData.get_option_bool(graph_report, "ok", false):
+		return GFContentPackageQueryResult.new().configure_result(
+			false,
+			GFContentPackageQueryResult.STATUS_INVALID_CATALOG,
+			query.query_id,
+			PackedStringArray(),
+			PackedStringArray(),
+			[],
+			graph_report
+		)
+
+	var direct_package_ids: PackedStringArray = PackedStringArray()
+	for package_id_text: String in get_ordered_package_ids():
+		var manifest: GFContentPackageManifest = _get_manifest_ref(StringName(package_id_text))
+		if manifest == null or not query.matches(manifest):
+			continue
+		var _direct_id_appended: bool = direct_package_ids.append(package_id_text)
+		if query.max_results > 0 and direct_package_ids.size() >= query.max_results:
+			break
+
+	var package_ids: PackedStringArray = direct_package_ids.duplicate()
+	if query.include_dependencies:
+		package_ids = _expand_dependency_closure(direct_package_ids)
+	var manifests: Array[GFContentPackageManifest] = []
+	for package_id_text: String in package_ids:
+		var manifest: GFContentPackageManifest = _get_manifest_ref(StringName(package_id_text))
+		if manifest != null:
+			manifests.append(manifest.duplicate_manifest())
+	var report: Dictionary = _make_report("Content package query")
+	report["query_id"] = query.query_id
+	report["status"] = GFContentPackageQueryResult.STATUS_COMPLETED
+	report["direct_package_ids"] = direct_package_ids.duplicate()
+	report["package_ids"] = package_ids.duplicate()
+	report["direct_package_count"] = direct_package_ids.size()
+	report["package_count"] = package_ids.size()
+	report = _finalize_report(report, "Content package query")
+	return GFContentPackageQueryResult.new().configure_result(
+		true,
+		GFContentPackageQueryResult.STATUS_COMPLETED,
+		query.query_id,
+		direct_package_ids,
+		package_ids,
+		manifests,
+		report
+	)
+
+
 ## 获取依赖图和 manifest 诊断报告。
 ## [br]
 ## @api public
@@ -305,6 +377,57 @@ func _get_manifest_ref(package_id: StringName) -> GFContentPackageManifest:
 		var manifest: GFContentPackageManifest = manifest_value
 		return manifest
 	return null
+
+
+func _expand_dependency_closure(direct_package_ids: PackedStringArray) -> PackedStringArray:
+	var included_ids: Dictionary = {}
+	var pending_ids: PackedStringArray = direct_package_ids.duplicate()
+	while not pending_ids.is_empty():
+		var package_id_text: String = pending_ids[pending_ids.size() - 1]
+		pending_ids.remove_at(pending_ids.size() - 1)
+		if included_ids.has(package_id_text):
+			continue
+		included_ids[package_id_text] = true
+		var manifest: GFContentPackageManifest = _get_manifest_ref(StringName(package_id_text))
+		if manifest == null:
+			continue
+		for dependency_id_text: String in manifest.dependencies:
+			if _manifests.has(StringName(dependency_id_text)) and not included_ids.has(dependency_id_text):
+				var _pending_id_appended: bool = pending_ids.append(dependency_id_text)
+	var result: PackedStringArray = PackedStringArray()
+	for package_id_text: String in get_ordered_package_ids():
+		if included_ids.has(package_id_text):
+			var _result_id_appended: bool = result.append(package_id_text)
+	return result
+
+
+func _make_query_failure(
+	status: StringName,
+	query_id: StringName,
+	kind: StringName,
+	message: String
+) -> GFContentPackageQueryResult:
+	var report: Dictionary = _make_report("Content package query")
+	var _issue: Dictionary = GFValidationReportDictionary.append_issue(
+		report,
+		"error",
+		kind,
+		message
+	)
+	report["query_id"] = query_id
+	report["status"] = status
+	report["direct_package_ids"] = PackedStringArray()
+	report["package_ids"] = PackedStringArray()
+	report = _finalize_report(report, "Content package query")
+	return GFContentPackageQueryResult.new().configure_result(
+		false,
+		status,
+		query_id,
+		PackedStringArray(),
+		PackedStringArray(),
+		[],
+		report
+	)
 
 func _add_duplicate_package_id(package_id: StringName) -> void:
 	var package_id_text: String = String(package_id)

--- a/addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd
+++ b/addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd
@@ -1,0 +1,229 @@
+## GFContentPackageQueryResult: 内容包查询的不可变结果快照。
+##
+## 结果区分直接命中与依赖闭包，并保留隔离的 manifest 和验证报告，
+## 调用方不需要从空数组推断查询失败或无匹配。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFContentPackageQueryResult
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 查询成功完成。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_COMPLETED: StringName = &"completed"
+
+## 查询对象为空或无效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_QUERY: StringName = &"invalid_query"
+
+## 内容包目录依赖图或 manifest 无效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_CATALOG: StringName = &"invalid_catalog"
+
+
+# --- 私有变量 ---
+
+var _successful: bool = false
+var _status: StringName = STATUS_INVALID_QUERY
+var _query_id: StringName = &""
+var _direct_package_ids: PackedStringArray = PackedStringArray()
+var _package_ids: PackedStringArray = PackedStringArray()
+var _manifests: Dictionary = {}
+var _report: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 检查查询是否成功完成。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 查询成功返回 true；零匹配仍属于成功。
+func is_successful() -> bool:
+	return _successful
+
+
+## 获取稳定终态状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATUS_*` 常量之一。
+func get_status() -> StringName:
+	return _status
+
+
+## 获取查询 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 查询稳定 ID。
+func get_query_id() -> StringName:
+	return _query_id
+
+
+## 获取不含自动依赖扩展的直接命中 package ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return dependency-first 排序的 ID 副本。
+func get_direct_package_ids() -> PackedStringArray:
+	return _direct_package_ids.duplicate()
+
+
+## 获取最终 package ID，包括请求的依赖闭包。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return dependency-first 排序的 ID 副本。
+func get_package_ids() -> PackedStringArray:
+	return _package_ids.duplicate()
+
+
+## 获取一个命中 manifest 的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param package_id: 内容包 ID。
+## [br]
+## @return manifest 深拷贝；未命中返回 null。
+func get_manifest(package_id: StringName) -> GFContentPackageManifest:
+	var manifest: GFContentPackageManifest = _get_manifest_ref(package_id)
+	return manifest.duplicate_manifest() if manifest != null else null
+
+
+## 获取全部命中 manifest 的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 与 get_package_ids() 同序的 manifest 数组。
+func get_manifests() -> Array[GFContentPackageManifest]:
+	var result: Array[GFContentPackageManifest] = []
+	for package_id_text: String in _package_ids:
+		var manifest: GFContentPackageManifest = _get_manifest_ref(StringName(package_id_text))
+		if manifest != null:
+			result.append(manifest.duplicate_manifest())
+	return result
+
+
+## 获取验证报告副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return GFValidationReportDictionary 兼容字典。
+## [br]
+## @schema return: GFValidationReportDictionary-compatible Dictionary with query_id, status, direct_package_ids, and package_ids.
+func get_report() -> Dictionary:
+	return _report.duplicate(true)
+
+
+## 转换为 JSON-safe 结果摘要。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 不包含 Resource 对象的结果字典。
+## [br]
+## @schema return: Dictionary with successful, status, query_id, direct_package_ids, package_ids, manifests, and report.
+func to_dict() -> Dictionary:
+	var manifest_records: Array[Dictionary] = []
+	for manifest: GFContentPackageManifest in get_manifests():
+		manifest_records.append(manifest.to_report_dictionary())
+	return {
+		"successful": _successful,
+		"status": String(_status),
+		"query_id": String(_query_id),
+		"direct_package_ids": _direct_package_ids.duplicate(),
+		"package_ids": _package_ids.duplicate(),
+		"manifests": manifest_records,
+		"report": GFReportValueCodec.to_report_dictionary(_report),
+	}
+
+
+# --- 框架内部方法 ---
+
+## 写入查询终态快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param successful: 查询是否成功。
+## [br]
+## @param status: 稳定终态状态。
+## [br]
+## @param query_id: 查询 ID。
+## [br]
+## @param direct_package_ids: 直接命中 ID。
+## [br]
+## @param package_ids: 最终命中 ID。
+## [br]
+## @param manifests: 与最终命中 ID 对应的 manifest 快照。
+## [br]
+## @param report: 验证报告。
+## [br]
+## @return 当前结果。
+## [br]
+## @schema report: GFValidationReportDictionary-compatible Dictionary.
+func configure_result(
+	successful: bool,
+	status: StringName,
+	query_id: StringName,
+	direct_package_ids: PackedStringArray,
+	package_ids: PackedStringArray,
+	manifests: Array[GFContentPackageManifest],
+	report: Dictionary
+) -> GFContentPackageQueryResult:
+	_successful = successful
+	_status = status
+	_query_id = query_id
+	_direct_package_ids = direct_package_ids.duplicate()
+	_package_ids = package_ids.duplicate()
+	_manifests.clear()
+	for manifest: GFContentPackageManifest in manifests:
+		if manifest == null or manifest.package_id == &"":
+			continue
+		_manifests[manifest.package_id] = manifest.duplicate_manifest()
+	_report = report.duplicate(true)
+	return self
+
+
+# --- 私有/辅助方法 ---
+
+func _get_manifest_ref(package_id: StringName) -> GFContentPackageManifest:
+	var manifest_value: Variant = _manifests.get(package_id)
+	if manifest_value is GFContentPackageManifest:
+		var manifest: GFContentPackageManifest = manifest_value
+		return manifest
+	return null

--- a/addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd.uid
+++ b/addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd.uid
@@ -1,0 +1,1 @@
+uid://01vyyghyvy40

--- a/addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd
+++ b/addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd
@@ -25,12 +25,19 @@ signal catalog_rebuilt(catalog: GFContentPackageCatalog)
 
 # --- 常量 ---
 
+## register_source_root() 等便捷入口使用的显式 owner scope。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DEFAULT_SOURCE_ROOT_OWNER_ID: StringName = &"gf.content_package.manual"
+
 const _GF_PATH_TOOLS = preload("res://addons/gf/kernel/core/gf_path_tools.gd")
 
 
 # --- 私有变量 ---
 
-var _source_roots: PackedStringArray = PackedStringArray()
+var _source_roots_by_owner: Dictionary = {}
 var _catalog: GFContentPackageCatalog = GFContentPackageCatalog.new()
 
 
@@ -40,7 +47,7 @@ var _catalog: GFContentPackageCatalog = GFContentPackageCatalog.new()
 ## [br]
 ## @api framework_internal
 func init() -> void:
-	_source_roots.clear()
+	_source_roots_by_owner.clear()
 	_catalog = GFContentPackageCatalog.new()
 
 
@@ -48,13 +55,13 @@ func init() -> void:
 ## [br]
 ## @api framework_internal
 func dispose() -> void:
-	_source_roots.clear()
+	_source_roots_by_owner.clear()
 	_catalog = GFContentPackageCatalog.new()
 
 
 # --- 公共方法 ---
 
-## 注册内容包 source root。
+## 把内容包 source root 注册到默认 manual owner scope。
 ## [br]
 ## @api public
 ## [br]
@@ -64,41 +71,194 @@ func dispose() -> void:
 ## [br]
 ## @return 注册成功返回 true。
 func register_source_root(root_path: String) -> bool:
-	var normalized_root: String = _normalize_root_path(root_path)
-	if normalized_root.is_empty() or not _is_supported_source_root(normalized_root):
-		return false
-	if _source_roots.has(normalized_root):
-		return false
-
-	var _append_result: bool = _source_roots.append(normalized_root)
-	_reset_catalog_after_roots_changed()
-	return true
+	return register_source_root_for_owner(DEFAULT_SOURCE_ROOT_OWNER_ID, root_path)
 
 
-## 注销内容包 source root。
+## 从默认 manual owner scope 注销内容包 source root。
 ## [br]
 ## @api public
+## [br]
+## @since 6.0.0
 ## [br]
 ## @param root_path: 已注册的 source root。
 ## [br]
 ## @return 注销成功返回 true。
 func unregister_source_root(root_path: String) -> bool:
-	var normalized_root: String = _normalize_root_path(root_path)
-	for index: int in range(_source_roots.size()):
-		if _source_roots[index] != normalized_root:
-			continue
-		_source_roots.remove_at(index)
-		_reset_catalog_after_roots_changed()
-		return true
-	return false
+	return unregister_source_root_for_owner(DEFAULT_SOURCE_ROOT_OWNER_ID, root_path)
 
 
-## 清空内容包 source root。
+## 清空默认 manual owner scope 的内容包 source root。
 ## [br]
 ## @api public
+## [br]
+## @since 6.0.0
 func clear_source_roots() -> void:
-	_source_roots.clear()
-	_reset_catalog_after_roots_changed()
+	var _cleared_count: int = clear_owner_source_roots(DEFAULT_SOURCE_ROOT_OWNER_ID)
+
+
+## 为稳定 owner 注册内容包 source root。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 非空 owner ID，用于批量释放来源。
+## [br]
+## @param root_path: `res://` 或 `user://` 根目录。
+## [br]
+## @return owner 首次取得该 root 时返回 true。
+func register_source_root_for_owner(owner_id: StringName, root_path: String) -> bool:
+	if owner_id == &"":
+		return false
+	var normalized_root: String = _normalize_root_path(root_path)
+	if normalized_root.is_empty() or not _is_supported_source_root(normalized_root):
+		return false
+	var owner_roots: PackedStringArray = _get_owner_roots_ref(owner_id).duplicate()
+	if owner_roots.has(normalized_root):
+		return false
+	var previous_effective_roots: PackedStringArray = get_source_roots()
+	var _root_appended: bool = owner_roots.append(normalized_root)
+	owner_roots.sort()
+	_source_roots_by_owner[owner_id] = owner_roots
+	_reset_catalog_if_effective_roots_changed(previous_effective_roots)
+	return true
+
+
+## 从稳定 owner 注销一个内容包 source root。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 注册时使用的 owner ID。
+## [br]
+## @param root_path: 已注册 root。
+## [br]
+## @return 找到并释放时返回 true。
+func unregister_source_root_for_owner(owner_id: StringName, root_path: String) -> bool:
+	if owner_id == &"":
+		return false
+	var normalized_root: String = _normalize_root_path(root_path)
+	var owner_roots: PackedStringArray = _get_owner_roots_ref(owner_id).duplicate()
+	var root_index: int = owner_roots.find(normalized_root)
+	if root_index < 0:
+		return false
+	var previous_effective_roots: PackedStringArray = get_source_roots()
+	owner_roots.remove_at(root_index)
+	if owner_roots.is_empty():
+		var _owner_erased: bool = _source_roots_by_owner.erase(owner_id)
+	else:
+		_source_roots_by_owner[owner_id] = owner_roots
+	_reset_catalog_if_effective_roots_changed(previous_effective_roots)
+	return true
+
+
+## 原子替换一个 owner 的全部 source root。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 非空 owner ID。
+## [br]
+## @param root_paths: 新 root 集合；空集合表示释放 owner。
+## [br]
+## @return 类型化验证报告；任一 root 无效时不修改现有状态。
+func replace_owner_source_roots(
+	owner_id: StringName,
+	root_paths: PackedStringArray
+) -> GFValidationReport:
+	var report: GFValidationReport = GFValidationReport.new("Content package owner source roots", {
+		"owner_id": String(owner_id),
+	})
+	var normalized_roots: PackedStringArray = PackedStringArray()
+	if owner_id == &"":
+		var _owner_issue: RefCounted = report.add_error(
+			&"invalid_owner_id",
+			"owner_id must not be empty",
+			owner_id,
+			"owner_id"
+		)
+	for root_path: String in root_paths:
+		var normalized_root: String = _normalize_root_path(root_path)
+		if normalized_root.is_empty() or not _is_supported_source_root(normalized_root):
+			var _root_issue: RefCounted = report.add_error(
+				&"invalid_source_root",
+				"source root must use res:// or user://",
+				root_path,
+				"source_roots"
+			)
+			continue
+		if not normalized_roots.has(normalized_root):
+			var _root_appended: bool = normalized_roots.append(normalized_root)
+	normalized_roots.sort()
+	report.extra_fields["requested_source_roots"] = normalized_roots.duplicate()
+	if not report.is_ok():
+		report.extra_fields["applied"] = false
+		report.extra_fields["source_roots"] = get_owner_source_roots(owner_id)
+		return report
+
+	var previous_effective_roots: PackedStringArray = get_source_roots()
+	if normalized_roots.is_empty():
+		var _owner_erased: bool = _source_roots_by_owner.erase(owner_id)
+	else:
+		_source_roots_by_owner[owner_id] = normalized_roots
+	_reset_catalog_if_effective_roots_changed(previous_effective_roots)
+	report.extra_fields["applied"] = true
+	report.extra_fields["source_roots"] = normalized_roots.duplicate()
+	return report
+
+
+## 释放一个 owner 的全部 source root。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 要释放的 owner ID。
+## [br]
+## @return 释放的 owner-root 关系数量。
+func clear_owner_source_roots(owner_id: StringName) -> int:
+	if owner_id == &"":
+		return 0
+	var owner_roots: PackedStringArray = _get_owner_roots_ref(owner_id)
+	if owner_roots.is_empty():
+		return 0
+	var removed_count: int = owner_roots.size()
+	var previous_effective_roots: PackedStringArray = get_source_roots()
+	var _owner_erased: bool = _source_roots_by_owner.erase(owner_id)
+	_reset_catalog_if_effective_roots_changed(previous_effective_roots)
+	return removed_count
+
+
+## 获取一个 owner 持有的 source root。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: owner ID。
+## [br]
+## @return 排序后的 root 副本。
+func get_owner_source_roots(owner_id: StringName) -> PackedStringArray:
+	return _get_owner_roots_ref(owner_id).duplicate()
+
+
+## 获取当前持有 source root 的 owner ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 排序后的 owner ID 文本。
+func get_source_root_owner_ids() -> PackedStringArray:
+	var result: PackedStringArray = PackedStringArray()
+	for owner_key: Variant in _source_roots_by_owner.keys():
+		var owner_id: StringName = _variant_to_owner_id(owner_key)
+		if owner_id != &"":
+			var _owner_appended: bool = result.append(String(owner_id))
+	result.sort()
+	return result
 
 
 ## 获取内容包 source root 列表。
@@ -107,7 +267,13 @@ func clear_source_roots() -> void:
 ## [br]
 ## @return source root 副本。
 func get_source_roots() -> PackedStringArray:
-	return _source_roots.duplicate()
+	var result: PackedStringArray = PackedStringArray()
+	for owner_id_text: String in get_source_root_owner_ids():
+		for root_path: String in _get_owner_roots_ref(StringName(owner_id_text)):
+			if not result.has(root_path):
+				var _root_appended: bool = result.append(root_path)
+	result.sort()
+	return result
 
 
 ## 获取当前内容包目录。
@@ -131,7 +297,7 @@ func get_catalog() -> GFContentPackageCatalog:
 func discover_manifest_paths(root_path: String = "") -> PackedStringArray:
 	var result: PackedStringArray = PackedStringArray()
 	if root_path.strip_edges().is_empty():
-		for source_root: String in _source_roots:
+		for source_root: String in get_source_roots():
 			_append_manifest_paths_for_root(source_root, result)
 	else:
 		_append_manifest_paths_for_root(_normalize_root_path(root_path), result)
@@ -250,12 +416,18 @@ func register_resources(resolver: GFResourceResolverUtility, options: Dictionary
 ## [br]
 ## @api public
 ## [br]
+## @since 4.4.0
+## [br]
 ## @return 调试快照。
 ## [br]
-## @schema return: Dictionary，包含 source_roots 和 catalog。
+## @schema return: Dictionary，包含 source_roots、source_root_owners 和 catalog。
 func get_debug_snapshot() -> Dictionary:
+	var source_root_owners: Dictionary = {}
+	for owner_id_text: String in get_source_root_owner_ids():
+		source_root_owners[owner_id_text] = get_owner_source_roots(StringName(owner_id_text))
 	return {
-		"source_roots": _source_roots.duplicate(),
+		"source_roots": get_source_roots(),
+		"source_root_owners": source_root_owners,
 		"catalog": _catalog.get_debug_snapshot(),
 	}
 
@@ -325,6 +497,30 @@ func _report_ok(report: Dictionary) -> bool:
 func _reset_catalog_after_roots_changed() -> void:
 	_catalog = GFContentPackageCatalog.new()
 	catalog_rebuilt.emit(_catalog.duplicate_catalog())
+
+
+func _reset_catalog_if_effective_roots_changed(previous_roots: PackedStringArray) -> void:
+	if previous_roots == get_source_roots():
+		return
+	_reset_catalog_after_roots_changed()
+
+
+func _get_owner_roots_ref(owner_id: StringName) -> PackedStringArray:
+	var roots_value: Variant = _source_roots_by_owner.get(owner_id)
+	if roots_value is PackedStringArray:
+		var roots: PackedStringArray = roots_value
+		return roots
+	return PackedStringArray()
+
+
+static func _variant_to_owner_id(value: Variant) -> StringName:
+	if value is StringName:
+		var owner_id: StringName = value
+		return owner_id
+	if value is String:
+		var owner_text: String = value
+		return StringName(owner_text)
+	return &""
 
 
 static func _normalize_root_path(path: String) -> String:

--- a/addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd
+++ b/addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd
@@ -1,0 +1,379 @@
+## GFAssetCatalogMount: 资产目录运行时挂载的生命周期句柄。
+##
+## 句柄保存提交时的目录快照、owner、mount ID、来源和 revision，
+## 并提供幂等显式卸载入口。失败请求也返回带稳定状态与报告的非活动句柄。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFAssetCatalogMount
+extends RefCounted
+
+
+# --- 常量 ---
+
+## Mount 已提交且仍活动。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ACTIVE: StringName = &"active"
+
+## Mount 已由调用方或 owner scope 释放。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_UNMOUNTED: StringName = &"unmounted"
+
+## Mount 与已提交资产 ID 冲突。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_CONFLICT: StringName = &"conflict"
+
+## Provider 未能构建目录。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_BUILD_FAILED: StringName = &"build_failed"
+
+## 同一 owner 已存在相同 mount ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_DUPLICATE_MOUNT: StringName = &"duplicate_mount"
+
+## Mount 请求缺少 owner、mount ID 或有效目录。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_REQUEST: StringName = &"invalid_request"
+
+## 所属 Runtime 已释放。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_DISPOSED: StringName = &"disposed"
+
+
+# --- 私有变量 ---
+
+var _runtime_ref: WeakRef = null
+var _token: int = 0
+var _owner_id: StringName = &""
+var _mount_id: StringName = &""
+var _source_id: StringName = &""
+var _priority: int = 0
+var _revision: int = 0
+var _status: StringName = STATUS_INVALID_REQUEST
+var _active: bool = false
+var _catalog: GFAssetCatalog = GFAssetCatalog.new()
+var _report: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 检查 Mount 是否仍在 Runtime 中活动。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 活动返回 true。
+func is_active() -> bool:
+	return _active
+
+
+## 获取稳定终态状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATUS_*` 常量之一。
+func get_status() -> StringName:
+	return _status
+
+
+## 获取 owner ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Mount owner ID。
+func get_owner_id() -> StringName:
+	return _owner_id
+
+
+## 获取 owner scope 内稳定 mount ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Mount ID。
+func get_mount_id() -> StringName:
+	return _mount_id
+
+
+## 获取来源 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Provider 来源 ID；直接目录 Mount 默认等于 mount ID。
+func get_source_id() -> StringName:
+	return _source_id
+
+
+## 获取 Mount 优先级。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 合并优先级。
+func get_priority() -> int:
+	return _priority
+
+
+## 获取最近一次提交该 Mount 的 Runtime revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非负 revision。
+func get_revision() -> int:
+	return _revision
+
+
+## 获取 Mount 自身的资产目录快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 深拷贝目录。
+func get_catalog() -> GFAssetCatalog:
+	return GFAssetCatalog.from_dict(_catalog.to_dict())
+
+
+## 获取 Mount 请求或提交报告。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return GFValidationReport 兼容字典副本。
+## [br]
+## @schema return: GFValidationReport-compatible Dictionary with status, owner_id, mount_id, source_id, priority, and revision.
+func get_report() -> Dictionary:
+	return _report.duplicate(true)
+
+
+## 从所属 Runtime 卸载当前 Mount。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 本次调用完成卸载返回 true；已终态返回 false。
+func unmount() -> bool:
+	if not _active or _runtime_ref == null:
+		return false
+	var runtime_value: Variant = _runtime_ref.get_ref()
+	if not (runtime_value is GFAssetCatalogRuntime):
+		_active = false
+		_status = STATUS_DISPOSED
+		return false
+	var runtime: GFAssetCatalogRuntime = runtime_value
+	return runtime.release_mount(_token)
+
+
+## 转换为 JSON-safe 诊断摘要。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Mount 摘要。
+## [br]
+## @schema return: Dictionary with active, status, owner_id, mount_id, source_id, priority, revision, token, asset_ids, and report.
+func to_dict() -> Dictionary:
+	return {
+		"active": _active,
+		"status": String(_status),
+		"owner_id": String(_owner_id),
+		"mount_id": String(_mount_id),
+		"source_id": String(_source_id),
+		"priority": _priority,
+		"revision": _revision,
+		"token": _token,
+		"asset_ids": _catalog.get_all_ids(),
+		"report": GFReportValueCodec.to_report_dictionary(_report),
+	}
+
+
+# --- 框架内部方法 ---
+
+## 配置已提交 Mount。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param runtime: 所属 Runtime。
+## [br]
+## @param token: Runtime 内部 token。
+## [br]
+## @param owner_id: owner ID。
+## [br]
+## @param mount_id: mount ID。
+## [br]
+## @param source_id: 来源 ID。
+## [br]
+## @param priority: 合并优先级。
+## [br]
+## @param revision: 提交 revision。
+## [br]
+## @param catalog: Mount 目录快照。
+## [br]
+## @param report: 提交报告。
+## [br]
+## @return 当前 Mount。
+## [br]
+## @schema report: GFValidationReport-compatible Dictionary.
+func configure_active(
+	runtime: GFAssetCatalogRuntime,
+	token: int,
+	owner_id: StringName,
+	mount_id: StringName,
+	source_id: StringName,
+	priority: int,
+	revision: int,
+	catalog: GFAssetCatalog,
+	report: Dictionary
+) -> GFAssetCatalogMount:
+	_runtime_ref = weakref(runtime) if runtime != null else null
+	_token = token
+	_owner_id = owner_id
+	_mount_id = mount_id
+	_source_id = source_id
+	_priority = priority
+	_revision = revision
+	_status = STATUS_ACTIVE
+	_active = runtime != null
+	_catalog = GFAssetCatalog.from_dict(catalog.to_dict()) if catalog != null else GFAssetCatalog.new()
+	_report = report.duplicate(true)
+	_report["status"] = String(STATUS_ACTIVE)
+	_report["owner_id"] = String(owner_id)
+	_report["mount_id"] = String(mount_id)
+	_report["source_id"] = String(source_id)
+	_report["priority"] = priority
+	_report["revision"] = revision
+	return self
+
+
+## 配置未提交的失败 Mount。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param status: 失败状态。
+## [br]
+## @param owner_id: owner ID。
+## [br]
+## @param mount_id: mount ID。
+## [br]
+## @param source_id: 来源 ID。
+## [br]
+## @param priority: 请求优先级。
+## [br]
+## @param report: 失败报告。
+## [br]
+## @return 当前 Mount。
+## [br]
+## @schema report: GFValidationReport-compatible Dictionary.
+func configure_failure(
+	status: StringName,
+	owner_id: StringName,
+	mount_id: StringName,
+	source_id: StringName,
+	priority: int,
+	report: Dictionary
+) -> GFAssetCatalogMount:
+	_runtime_ref = null
+	_token = 0
+	_owner_id = owner_id
+	_mount_id = mount_id
+	_source_id = source_id
+	_priority = priority
+	_revision = 0
+	_status = status
+	_active = false
+	_catalog = GFAssetCatalog.new()
+	_report = report.duplicate(true)
+	_report["status"] = String(status)
+	_report["owner_id"] = String(owner_id)
+	_report["mount_id"] = String(mount_id)
+	_report["source_id"] = String(source_id)
+	_report["priority"] = priority
+	_report["revision"] = 0
+	return self
+
+
+## 标记 Mount 离开 Runtime。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param status: unmounted 或 disposed。
+## [br]
+## @param revision: 终态 revision。
+func complete(status: StringName, revision: int) -> void:
+	_active = false
+	_status = status
+	_revision = revision
+	_runtime_ref = null
+	_report["status"] = String(status)
+	_report["revision"] = revision
+
+
+## 刷新已原子替换的 Mount 快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param catalog: 新目录快照。
+## [br]
+## @param revision: 提交 revision。
+## [br]
+## @param report: 提交报告。
+## [br]
+## @schema report: GFValidationReport-compatible Dictionary.
+func refresh_catalog(catalog: GFAssetCatalog, revision: int, report: Dictionary) -> void:
+	if not _active or catalog == null:
+		return
+	_catalog = GFAssetCatalog.from_dict(catalog.to_dict())
+	_revision = revision
+	_report = report.duplicate(true)
+	_report["status"] = String(STATUS_ACTIVE)
+	_report["owner_id"] = String(_owner_id)
+	_report["mount_id"] = String(_mount_id)
+	_report["source_id"] = String(_source_id)
+	_report["priority"] = _priority
+	_report["revision"] = revision

--- a/addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd.uid
+++ b/addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd.uid
@@ -1,0 +1,1 @@
+uid://yk5jurmphyni

--- a/addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd
+++ b/addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd
@@ -1,0 +1,692 @@
+## GFAssetCatalogRuntime: owner-scoped 资产目录快照挂载与原子合并服务。
+##
+## Runtime 只接收已经构建的目录快照或 Provider 输出，按稳定优先级合并并以 revision 发布。
+## 任何无效请求、Provider 失败或严格冲突都不会替换上一份已提交目录。
+## [br]
+## @api public
+## [br]
+## @category runtime_service
+## [br]
+## @since unreleased
+class_name GFAssetCatalogRuntime
+extends GFUtility
+
+
+# --- 信号 ---
+
+## 资产目录成功提交新 revision 后发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param catalog: 已提交目录的隔离快照。
+## [br]
+## @param revision: 新 revision。
+signal catalog_changed(catalog: GFAssetCatalog, revision: int)
+
+
+# --- 常量 ---
+
+## 任一重复 asset ID 都拒绝整次事务。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const CONFLICT_REJECT: StringName = &"reject"
+
+## 重复 asset ID 显式保留高优先级 Mount 的条目。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const CONFLICT_KEEP_HIGH_PRIORITY: StringName = &"keep_high_priority"
+
+
+# --- 私有变量 ---
+
+var _conflict_policy: StringName = CONFLICT_REJECT
+var _mount_records: Array[Dictionary] = []
+var _catalog: GFAssetCatalog = GFAssetCatalog.new()
+var _revision: int = 0
+var _next_token: int = 1
+var _last_report: Dictionary = {}
+var _disposed: bool = false
+
+
+# --- GF 生命周期方法 ---
+
+## 初始化空目录和 Mount 状态，同时保留 configure() 选择的冲突政策。
+## [br]
+## @api framework_internal
+func init() -> void:
+	_complete_all_mounts(GFAssetCatalogMount.STATUS_DISPOSED, _revision)
+	_mount_records.clear()
+	_catalog = GFAssetCatalog.new()
+	_revision = 0
+	_next_token = 1
+	_last_report = {}
+	_disposed = false
+
+
+## 释放全部 Mount 并使外部句柄进入 disposed 终态。
+## [br]
+## @api framework_internal
+func dispose() -> void:
+	if _disposed:
+		return
+	_disposed = true
+	_complete_all_mounts(GFAssetCatalogMount.STATUS_DISPOSED, _revision)
+	_mount_records.clear()
+	_catalog = GFAssetCatalog.new()
+	_last_report = _make_runtime_report(true, &"disposed", [])
+
+
+# --- 公共方法 ---
+
+## 配置全局 asset ID 冲突政策。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param conflict_policy: CONFLICT_REJECT 或 CONFLICT_KEEP_HIGH_PRIORITY。
+## [br]
+## @return 当前 Runtime；已有 Mount 或政策无效时保持原配置。
+func configure(conflict_policy: StringName = CONFLICT_REJECT) -> GFAssetCatalogRuntime:
+	if not _mount_records.is_empty():
+		return self
+	if conflict_policy == CONFLICT_REJECT or conflict_policy == CONFLICT_KEEP_HIGH_PRIORITY:
+		_conflict_policy = conflict_policy
+	return self
+
+
+## 原子挂载一个资产目录快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 非空 owner ID。
+## [br]
+## @param mount_id: owner scope 内非空稳定 ID。
+## [br]
+## @param catalog: 要挂载的目录；Runtime 保存深拷贝。
+## [br]
+## @param priority: 合并优先级，数值越大越先处理。
+## [br]
+## @param source_id: 可选来源 ID；为空时使用 mount_id。
+## [br]
+## @return 活动 Mount 或带稳定失败状态的非活动 Mount。
+func mount_catalog(
+	owner_id: StringName,
+	mount_id: StringName,
+	catalog: GFAssetCatalog,
+	priority: int = 0,
+	source_id: StringName = &""
+) -> GFAssetCatalogMount:
+	var effective_source_id: StringName = source_id if source_id != &"" else mount_id
+	if _disposed:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_DISPOSED,
+			owner_id,
+			mount_id,
+			effective_source_id,
+			priority,
+			&"runtime_disposed",
+			"asset catalog runtime is disposed"
+		)
+	if owner_id == &"" or mount_id == &"" or catalog == null:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_INVALID_REQUEST,
+			owner_id,
+			mount_id,
+			effective_source_id,
+			priority,
+			&"invalid_mount_request",
+			"owner_id, mount_id, and catalog are required"
+		)
+	if _find_mount_record_index(owner_id, mount_id) >= 0:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_DUPLICATE_MOUNT,
+			owner_id,
+			mount_id,
+			effective_source_id,
+			priority,
+			&"duplicate_mount",
+			"owner already has this mount_id"
+		)
+
+	var token: int = _next_token
+	var catalog_snapshot: GFAssetCatalog = _duplicate_catalog(catalog)
+	var candidate_records: Array[Dictionary] = _copy_mount_records(_mount_records)
+	candidate_records.append({
+		"token": token,
+		"owner_id": owner_id,
+		"mount_id": mount_id,
+		"source_id": effective_source_id,
+		"priority": priority,
+		"catalog": catalog_snapshot,
+		"handle": null,
+	})
+	var composition: Dictionary = _compose_mount_records(candidate_records)
+	if not GFVariantData.get_option_bool(composition, "ok", false):
+		var failure_status: StringName = (
+			GFAssetCatalogMount.STATUS_CONFLICT
+			if GFVariantData.get_option_bool(composition, "has_conflicts", false)
+			else GFAssetCatalogMount.STATUS_BUILD_FAILED
+		)
+		var failure_report: Dictionary = GFVariantData.get_option_dictionary(composition, "report")
+		_last_report = failure_report.duplicate(true)
+		return GFAssetCatalogMount.new().configure_failure(
+			failure_status,
+			owner_id,
+			mount_id,
+			effective_source_id,
+			priority,
+			failure_report
+		)
+
+	_next_token += 1
+	var committed_catalog: GFAssetCatalog = _get_composed_catalog(composition)
+	_revision += 1
+	var report: Dictionary = GFVariantData.get_option_dictionary(composition, "report")
+	var mount: GFAssetCatalogMount = GFAssetCatalogMount.new().configure_active(
+		self,
+		token,
+		owner_id,
+		mount_id,
+		effective_source_id,
+		priority,
+		_revision,
+		catalog_snapshot,
+		report
+	)
+	candidate_records[candidate_records.size() - 1]["handle"] = mount
+	_commit_composition(candidate_records, committed_catalog, report)
+	return mount
+
+
+## 构建 Provider 快照并原子挂载。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 非空 owner ID。
+## [br]
+## @param mount_id: owner scope 内稳定 ID。
+## [br]
+## @param provider: 资产目录来源 Provider。
+## [br]
+## @param options: 传给 Provider 的构建选项。
+## [br]
+## @schema options: Dictionary with provider-defined build options.
+## [br]
+## @return 活动 Mount 或带构建失败状态的非活动 Mount。
+func mount_provider(
+	owner_id: StringName,
+	mount_id: StringName,
+	provider: GFAssetCatalogSourceProvider,
+	options: Dictionary = {}
+) -> GFAssetCatalogMount:
+	if provider == null:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_INVALID_REQUEST,
+			owner_id,
+			mount_id,
+			&"",
+			0,
+			&"missing_provider",
+			"asset catalog provider is required"
+		)
+	if _disposed:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_DISPOSED,
+			owner_id,
+			mount_id,
+			provider.get_source_id(),
+			provider.get_priority(),
+			&"runtime_disposed",
+			"asset catalog runtime is disposed"
+		)
+	if owner_id == &"" or mount_id == &"":
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_INVALID_REQUEST,
+			owner_id,
+			mount_id,
+			provider.get_source_id(),
+			provider.get_priority(),
+			&"invalid_mount_request",
+			"owner_id and mount_id are required"
+		)
+	if _find_mount_record_index(owner_id, mount_id) >= 0:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_DUPLICATE_MOUNT,
+			owner_id,
+			mount_id,
+			provider.get_source_id(),
+			provider.get_priority(),
+			&"duplicate_mount",
+			"owner already has this mount_id"
+		)
+	var source_catalog: GFAssetCatalog = provider.build_catalog(options)
+	if source_catalog == null:
+		return _make_failed_mount(
+			GFAssetCatalogMount.STATUS_BUILD_FAILED,
+			owner_id,
+			mount_id,
+			provider.get_source_id(),
+			provider.get_priority(),
+			&"provider_build_failed",
+			"asset catalog provider returned no catalog"
+		)
+	return mount_catalog(
+		owner_id,
+		mount_id,
+		source_catalog,
+		provider.get_priority(),
+		provider.get_source_id()
+	)
+
+
+## 原子替换一个活动 Mount 的目录快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param mount: 当前 Runtime 返回的活动 Mount。
+## [br]
+## @param catalog: 新目录快照。
+## [br]
+## @return 完整候选成功提交返回 true；失败时保留原 Mount、目录和 revision。
+func replace_mount_catalog(mount: GFAssetCatalogMount, catalog: GFAssetCatalog) -> bool:
+	if _disposed or mount == null or not mount.is_active() or catalog == null:
+		return false
+	var record_index: int = _find_mount_record_index_by_handle(mount)
+	if record_index < 0:
+		return false
+	var catalog_snapshot: GFAssetCatalog = _duplicate_catalog(catalog)
+	var candidate_records: Array[Dictionary] = _copy_mount_records(_mount_records)
+	candidate_records[record_index]["catalog"] = catalog_snapshot
+	var composition: Dictionary = _compose_mount_records(candidate_records)
+	var report: Dictionary = GFVariantData.get_option_dictionary(composition, "report")
+	if not GFVariantData.get_option_bool(composition, "ok", false):
+		_last_report = report.duplicate(true)
+		return false
+	_revision += 1
+	mount.refresh_catalog(catalog_snapshot, _revision, report)
+	_commit_composition(candidate_records, _get_composed_catalog(composition), report)
+	return true
+
+
+## 批量释放一个 owner 的全部 Mount，并只提交一个新 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner_id: 要释放的 owner ID。
+## [br]
+## @return 释放的 Mount 数量。
+func unmount_owner(owner_id: StringName) -> int:
+	if _disposed or owner_id == &"":
+		return 0
+	var candidate_records: Array[Dictionary] = []
+	var removed_records: Array[Dictionary] = []
+	for mount_record: Dictionary in _mount_records:
+		if GFVariantData.get_option_string_name(mount_record, "owner_id") == owner_id:
+			removed_records.append(mount_record)
+		else:
+			candidate_records.append(_copy_mount_record(mount_record))
+	if removed_records.is_empty():
+		return 0
+	var composition: Dictionary = _compose_mount_records(candidate_records)
+	if not GFVariantData.get_option_bool(composition, "ok", false):
+		return 0
+	_revision += 1
+	for removed_record: Dictionary in removed_records:
+		var mount: GFAssetCatalogMount = _get_mount_handle(removed_record)
+		if mount != null:
+			mount.complete(GFAssetCatalogMount.STATUS_UNMOUNTED, _revision)
+	_commit_composition(
+		candidate_records,
+		_get_composed_catalog(composition),
+		GFVariantData.get_option_dictionary(composition, "report")
+	)
+	return removed_records.size()
+
+
+## 获取当前已提交资产目录快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 深拷贝目录。
+func get_catalog() -> GFAssetCatalog:
+	return _duplicate_catalog(_catalog)
+
+
+## 获取当前目录 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 从 0 开始、仅成功提交时递增的 revision。
+func get_revision() -> int:
+	return _revision
+
+
+## 获取全部活动 Mount。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 按合并顺序排列的 Mount 句柄。
+func get_mounts() -> Array[GFAssetCatalogMount]:
+	var result: Array[GFAssetCatalogMount] = []
+	var ordered_records: Array[Dictionary] = _copy_mount_records(_mount_records)
+	ordered_records.sort_custom(_compare_mount_records)
+	for mount_record: Dictionary in ordered_records:
+		var mount: GFAssetCatalogMount = _get_mount_handle(mount_record)
+		if mount != null and mount.is_active():
+			result.append(mount)
+	return result
+
+
+## 获取最近一次运行时报告。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return GFValidationReport 兼容字典副本。
+## [br]
+## @schema return: GFValidationReport-compatible Dictionary with conflict_policy, revision, mount_count, asset_count, and issues.
+func get_last_report() -> Dictionary:
+	return _last_report.duplicate(true)
+
+
+## 获取 JSON-safe 调试快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Runtime、Mount 和目录摘要。
+## [br]
+## @schema return: Dictionary with conflict_policy, disposed, revision, mount_count, mounts, catalog, and last_report.
+func get_debug_snapshot() -> Dictionary:
+	var mount_records: Array[Dictionary] = []
+	for mount: GFAssetCatalogMount in get_mounts():
+		mount_records.append(mount.to_dict())
+	return {
+		"conflict_policy": String(_conflict_policy),
+		"disposed": _disposed,
+		"revision": _revision,
+		"mount_count": mount_records.size(),
+		"mounts": mount_records,
+		"catalog": _catalog.get_debug_snapshot(),
+		"last_report": GFReportValueCodec.to_report_dictionary(_last_report),
+	}
+
+
+# --- 框架内部方法 ---
+
+## 按内部 token 释放一个 Mount。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param token: GFAssetCatalogMount 持有的 Runtime token。
+## [br]
+## @return 本次调用完成释放返回 true。
+func release_mount(token: int) -> bool:
+	if _disposed or token <= 0:
+		return false
+	var record_index: int = _find_mount_record_index_by_token(token)
+	if record_index < 0:
+		return false
+	var removed_record: Dictionary = _mount_records[record_index]
+	var candidate_records: Array[Dictionary] = _copy_mount_records(_mount_records)
+	candidate_records.remove_at(record_index)
+	var composition: Dictionary = _compose_mount_records(candidate_records)
+	if not GFVariantData.get_option_bool(composition, "ok", false):
+		return false
+	_revision += 1
+	var mount: GFAssetCatalogMount = _get_mount_handle(removed_record)
+	if mount != null:
+		mount.complete(GFAssetCatalogMount.STATUS_UNMOUNTED, _revision)
+	_commit_composition(
+		candidate_records,
+		_get_composed_catalog(composition),
+		GFVariantData.get_option_dictionary(composition, "report")
+	)
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+func _compose_mount_records(records: Array[Dictionary]) -> Dictionary:
+	var ordered_records: Array[Dictionary] = _copy_mount_records(records)
+	ordered_records.sort_custom(_compare_mount_records)
+	var result_catalog: GFAssetCatalog = GFAssetCatalog.new()
+	var issues: Array[Dictionary] = []
+	var has_conflicts: bool = false
+	for mount_record: Dictionary in ordered_records:
+		var source_catalog: GFAssetCatalog = _get_mount_catalog(mount_record)
+		if source_catalog == null:
+			issues.append({
+				"severity": "error",
+				"kind": "missing_mount_catalog",
+				"owner_id": String(GFVariantData.get_option_string_name(mount_record, "owner_id")),
+				"mount_id": String(GFVariantData.get_option_string_name(mount_record, "mount_id")),
+			})
+			continue
+		for asset_id_text: String in source_catalog.get_all_ids():
+			var asset_id: StringName = StringName(asset_id_text)
+			if result_catalog.has_entry(asset_id):
+				has_conflicts = true
+				issues.append({
+					"severity": "error" if _conflict_policy == CONFLICT_REJECT else "warning",
+					"kind": "duplicate_asset_id",
+					"asset_id": asset_id_text,
+					"owner_id": String(GFVariantData.get_option_string_name(mount_record, "owner_id")),
+					"mount_id": String(GFVariantData.get_option_string_name(mount_record, "mount_id")),
+				})
+				continue
+			var entry: GFAssetCatalogEntry = source_catalog.get_entry(asset_id)
+			if entry == null or not result_catalog.set_entry(entry):
+				issues.append({
+					"severity": "error",
+					"kind": "invalid_asset_entry",
+					"asset_id": asset_id_text,
+				})
+	var ok: bool = _issues_have_no_errors(issues)
+	return {
+		"ok": ok,
+		"has_conflicts": has_conflicts,
+		"catalog": result_catalog,
+		"report": _make_runtime_report(ok, &"composed", issues, records.size(), result_catalog.get_all_ids().size()),
+	}
+
+
+func _commit_composition(
+	records: Array[Dictionary],
+	committed_catalog: GFAssetCatalog,
+	report: Dictionary
+) -> void:
+	_mount_records = _copy_mount_records(records)
+	_catalog = _duplicate_catalog(committed_catalog)
+	_last_report = report.duplicate(true)
+	_last_report["revision"] = _revision
+	_last_report["mount_count"] = _mount_records.size()
+	_last_report["asset_count"] = _catalog.get_all_ids().size()
+	catalog_changed.emit(_duplicate_catalog(_catalog), _revision)
+
+
+func _make_failed_mount(
+	status: StringName,
+	owner_id: StringName,
+	mount_id: StringName,
+	source_id: StringName,
+	priority: int,
+	kind: StringName,
+	message: String
+) -> GFAssetCatalogMount:
+	var issue: Dictionary = {
+		"severity": "error",
+		"kind": String(kind),
+		"message": message,
+		"owner_id": String(owner_id),
+		"mount_id": String(mount_id),
+		"source_id": String(source_id),
+	}
+	var report: Dictionary = _make_runtime_report(false, status, [issue])
+	_last_report = report.duplicate(true)
+	return GFAssetCatalogMount.new().configure_failure(
+		status,
+		owner_id,
+		mount_id,
+		source_id,
+		priority,
+		report
+	)
+
+
+func _make_runtime_report(
+	ok: bool,
+	status: StringName,
+	issues: Array[Dictionary],
+	mount_count: int = -1,
+	asset_count: int = -1
+) -> Dictionary:
+	var error_count: int = 0
+	var warning_count: int = 0
+	for issue: Dictionary in issues:
+		var severity: String = GFVariantData.get_option_string(issue, "severity")
+		if severity == "error":
+			error_count += 1
+		elif severity == "warning":
+			warning_count += 1
+	return {
+		"ok": ok,
+		"healthy": ok and warning_count == 0,
+		"subject": "Asset catalog runtime",
+		"status": String(status),
+		"conflict_policy": String(_conflict_policy),
+		"revision": _revision,
+		"mount_count": _mount_records.size() if mount_count < 0 else mount_count,
+		"asset_count": _catalog.get_all_ids().size() if asset_count < 0 else asset_count,
+		"issues": issues.duplicate(true),
+		"error_count": error_count,
+		"warning_count": warning_count,
+		"issue_count": issues.size(),
+	}
+
+
+func _find_mount_record_index(owner_id: StringName, mount_id: StringName) -> int:
+	for index: int in range(_mount_records.size()):
+		var mount_record: Dictionary = _mount_records[index]
+		if (
+			GFVariantData.get_option_string_name(mount_record, "owner_id") == owner_id
+			and GFVariantData.get_option_string_name(mount_record, "mount_id") == mount_id
+		):
+			return index
+	return -1
+
+
+func _find_mount_record_index_by_token(token: int) -> int:
+	for index: int in range(_mount_records.size()):
+		if GFVariantData.get_option_int(_mount_records[index], "token") == token:
+			return index
+	return -1
+
+
+func _find_mount_record_index_by_handle(mount: GFAssetCatalogMount) -> int:
+	for index: int in range(_mount_records.size()):
+		if _get_mount_handle(_mount_records[index]) == mount:
+			return index
+	return -1
+
+
+func _copy_mount_records(records: Array[Dictionary]) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for mount_record: Dictionary in records:
+		result.append(_copy_mount_record(mount_record))
+	return result
+
+
+func _copy_mount_record(mount_record: Dictionary) -> Dictionary:
+	return {
+		"token": GFVariantData.get_option_int(mount_record, "token"),
+		"owner_id": GFVariantData.get_option_string_name(mount_record, "owner_id"),
+		"mount_id": GFVariantData.get_option_string_name(mount_record, "mount_id"),
+		"source_id": GFVariantData.get_option_string_name(mount_record, "source_id"),
+		"priority": GFVariantData.get_option_int(mount_record, "priority"),
+		"catalog": _get_mount_catalog(mount_record),
+		"handle": GFVariantData.get_option_value(mount_record, "handle"),
+	}
+
+
+func _get_mount_catalog(mount_record: Dictionary) -> GFAssetCatalog:
+	var catalog_value: Variant = mount_record.get("catalog")
+	if catalog_value is GFAssetCatalog:
+		var source_catalog: GFAssetCatalog = catalog_value
+		return source_catalog
+	return null
+
+
+func _get_mount_handle(mount_record: Dictionary) -> GFAssetCatalogMount:
+	var handle_value: Variant = mount_record.get("handle")
+	if handle_value is GFAssetCatalogMount:
+		var mount: GFAssetCatalogMount = handle_value
+		return mount
+	return null
+
+
+func _complete_all_mounts(status: StringName, revision: int) -> void:
+	for mount_record: Dictionary in _mount_records:
+		var mount: GFAssetCatalogMount = _get_mount_handle(mount_record)
+		if mount != null:
+			mount.complete(status, revision)
+
+
+func _get_composed_catalog(composition: Dictionary) -> GFAssetCatalog:
+	var catalog_value: Variant = composition.get("catalog")
+	if catalog_value is GFAssetCatalog:
+		var composed_catalog: GFAssetCatalog = catalog_value
+		return composed_catalog
+	return GFAssetCatalog.new()
+
+
+static func _duplicate_catalog(catalog: GFAssetCatalog) -> GFAssetCatalog:
+	return GFAssetCatalog.from_dict(catalog.to_dict()) if catalog != null else GFAssetCatalog.new()
+
+
+static func _compare_mount_records(left: Dictionary, right: Dictionary) -> bool:
+	var left_priority: int = GFVariantData.get_option_int(left, "priority")
+	var right_priority: int = GFVariantData.get_option_int(right, "priority")
+	if left_priority != right_priority:
+		return left_priority > right_priority
+	var left_owner: String = GFVariantData.get_option_string(left, "owner_id")
+	var right_owner: String = GFVariantData.get_option_string(right, "owner_id")
+	if left_owner != right_owner:
+		return left_owner < right_owner
+	var left_mount: String = GFVariantData.get_option_string(left, "mount_id")
+	var right_mount: String = GFVariantData.get_option_string(right, "mount_id")
+	if left_mount != right_mount:
+		return left_mount < right_mount
+	return GFVariantData.get_option_int(left, "token") < GFVariantData.get_option_int(right, "token")
+
+
+static func _issues_have_no_errors(issues: Array[Dictionary]) -> bool:
+	for issue: Dictionary in issues:
+		if GFVariantData.get_option_string(issue, "severity") == "error":
+			return false
+	return true

--- a/addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd.uid
+++ b/addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd.uid
@@ -1,0 +1,1 @@
+uid://dy37teuksjvw1

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "3cf947188dce2072a524e639c013e198a0a2c4433546be4c63f10e2b2e4f4b4e",
-  "class_count": 726,
+  "source_digest": "f2609ebd2e0c744075069f32394747d391ed58ca21429cd9f37db064892f2eaa",
+  "class_count": 731,
   "package_count": 50,
   "packages": [
     {
@@ -2945,6 +2945,247 @@
           "name": "from_resource_registry_entry",
           "signature": "static func from_resource_registry_entry( registry_entry: GFResourceRegistryEntry, options: Dictionary = {} ) -> GFAssetCatalogEntry",
           "summary": "从资源注册表条目创建资产条目。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFAssetCatalogMount": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.assets",
+      "path": "addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd",
+      "summary": "GFAssetCatalogMount: 资产目录运行时挂载的生命周期句柄。 句柄保存提交时的目录快照、owner、mount ID、来源和 revision， 并提供幂等显式卸载入口。失败请求也返回带稳定状态与报告的非活动句柄。",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_ACTIVE",
+          "signature": "const STATUS_ACTIVE: StringName = &\"active\"",
+          "summary": "Mount 已提交且仍活动。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_UNMOUNTED",
+          "signature": "const STATUS_UNMOUNTED: StringName = &\"unmounted\"",
+          "summary": "Mount 已由调用方或 owner scope 释放。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_CONFLICT",
+          "signature": "const STATUS_CONFLICT: StringName = &\"conflict\"",
+          "summary": "Mount 与已提交资产 ID 冲突。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_BUILD_FAILED",
+          "signature": "const STATUS_BUILD_FAILED: StringName = &\"build_failed\"",
+          "summary": "Provider 未能构建目录。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_DUPLICATE_MOUNT",
+          "signature": "const STATUS_DUPLICATE_MOUNT: StringName = &\"duplicate_mount\"",
+          "summary": "同一 owner 已存在相同 mount ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_REQUEST",
+          "signature": "const STATUS_INVALID_REQUEST: StringName = &\"invalid_request\"",
+          "summary": "Mount 请求缺少 owner、mount ID 或有效目录。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_DISPOSED",
+          "signature": "const STATUS_DISPOSED: StringName = &\"disposed\"",
+          "summary": "所属 Runtime 已释放。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_active",
+          "signature": "func is_active() -> bool",
+          "summary": "检查 Mount 是否仍在 Runtime 中活动。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> StringName",
+          "summary": "获取稳定终态状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_owner_id",
+          "signature": "func get_owner_id() -> StringName",
+          "summary": "获取 owner ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_mount_id",
+          "signature": "func get_mount_id() -> StringName",
+          "summary": "获取 owner scope 内稳定 mount ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_id",
+          "signature": "func get_source_id() -> StringName",
+          "summary": "获取来源 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_priority",
+          "signature": "func get_priority() -> int",
+          "summary": "获取 Mount 优先级。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_revision",
+          "signature": "func get_revision() -> int",
+          "summary": "获取最近一次提交该 Mount 的 Runtime revision。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_catalog",
+          "signature": "func get_catalog() -> GFAssetCatalog",
+          "summary": "获取 Mount 自身的资产目录快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_report",
+          "signature": "func get_report() -> Dictionary",
+          "summary": "获取 Mount 请求或提交报告。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unmount",
+          "signature": "func unmount() -> bool",
+          "summary": "从所属 Runtime 卸载当前 Mount。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为 JSON-safe 诊断摘要。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFAssetCatalogRuntime": {
+      "extends": "GFUtility",
+      "module": "standard",
+      "package_id": "gf.standard.assets",
+      "path": "addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd",
+      "summary": "GFAssetCatalogRuntime: owner-scoped 资产目录快照挂载与原子合并服务。 Runtime 只接收已经构建的目录快照或 Provider 输出，按稳定优先级合并并以 revision 发布。 任何无效请求、Provider 失败或严格冲突都不会替换上一份已提交目录。",
+      "visibility": "public",
+      "category": "runtime_service",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "catalog_changed",
+          "signature": "signal catalog_changed(catalog: GFAssetCatalog, revision: int)",
+          "summary": "资产目录成功提交新 revision 后发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "CONFLICT_REJECT",
+          "signature": "const CONFLICT_REJECT: StringName = &\"reject\"",
+          "summary": "任一重复 asset ID 都拒绝整次事务。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "CONFLICT_KEEP_HIGH_PRIORITY",
+          "signature": "const CONFLICT_KEEP_HIGH_PRIORITY: StringName = &\"keep_high_priority\"",
+          "summary": "重复 asset ID 显式保留高优先级 Mount 的条目。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "configure",
+          "signature": "func configure(conflict_policy: StringName = CONFLICT_REJECT) -> GFAssetCatalogRuntime",
+          "summary": "配置全局 asset ID 冲突政策。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "mount_catalog",
+          "signature": "func mount_catalog( owner_id: StringName, mount_id: StringName, catalog: GFAssetCatalog, priority: int = 0, source_id: StringName = &\"\" ) -> GFAssetCatalogMount",
+          "summary": "原子挂载一个资产目录快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "mount_provider",
+          "signature": "func mount_provider( owner_id: StringName, mount_id: StringName, provider: GFAssetCatalogSourceProvider, options: Dictionary = {} ) -> GFAssetCatalogMount",
+          "summary": "构建 Provider 快照并原子挂载。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "replace_mount_catalog",
+          "signature": "func replace_mount_catalog(mount: GFAssetCatalogMount, catalog: GFAssetCatalog) -> bool",
+          "summary": "原子替换一个活动 Mount 的目录快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unmount_owner",
+          "signature": "func unmount_owner(owner_id: StringName) -> int",
+          "summary": "批量释放一个 owner 的全部 Mount，并只提交一个新 revision。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_catalog",
+          "signature": "func get_catalog() -> GFAssetCatalog",
+          "summary": "获取当前已提交资产目录快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_revision",
+          "signature": "func get_revision() -> int",
+          "summary": "获取当前目录 revision。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_mounts",
+          "signature": "func get_mounts() -> Array[GFAssetCatalogMount]",
+          "summary": "获取全部活动 Mount。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_last_report",
+          "signature": "func get_last_report() -> Dictionary",
+          "summary": "获取最近一次运行时报告。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_debug_snapshot",
+          "signature": "func get_debug_snapshot() -> Dictionary",
+          "summary": "获取 JSON-safe 调试快照。",
           "visibility": "public"
         }
       ]
@@ -19313,6 +19554,39 @@
         }
       ]
     },
+    "GFContentPackageAssetCatalogProvider": {
+      "extends": "GFAssetCatalogSourceProvider",
+      "module": "extensions/content_package",
+      "package_id": "gf.extension.content_package",
+      "path": "addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd",
+      "summary": "GFContentPackageAssetCatalogProvider: 内容包目录到通用资产目录的适配器。 Provider 持有内容包目录快照，通过可选 GFContentPackageQuery 选择 manifest， 再把资源映射转换为 GFAssetCatalogEntry。它不挂载目录、不下载内容，也不解释业务分类。",
+      "visibility": "public",
+      "category": "protocol",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "configure_catalog",
+          "signature": "func configure_catalog( catalog: GFContentPackageCatalog, p_source_id: StringName = &\"content_packages\", query: GFContentPackageQuery = null, options: Dictionary = {} ) -> GFContentPackageAssetCatalogProvider",
+          "summary": "配置内容包目录快照和可选查询。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "build_catalog",
+          "signature": "func build_catalog(options: Dictionary = {}) -> GFAssetCatalog",
+          "summary": "构建资产目录快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_debug_snapshot",
+          "signature": "func get_debug_snapshot() -> Dictionary",
+          "summary": "获取 Provider 诊断快照。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFContentPackageCatalog": {
       "extends": "RefCounted",
       "module": "extensions/content_package",
@@ -19384,6 +19658,13 @@
           "name": "get_ordered_package_ids",
           "signature": "func get_ordered_package_ids() -> PackedStringArray",
           "summary": "获取按依赖优先排序的内容包 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "query_packages",
+          "signature": "func query_packages( query: GFContentPackageQuery, options: Dictionary = {} ) -> GFContentPackageQueryResult",
+          "summary": "查询有效内容包并返回隔离结果。",
           "visibility": "public"
         },
         {
@@ -19748,6 +20029,226 @@
         }
       ]
     },
+    "GFContentPackageQuery": {
+      "extends": "Resource",
+      "module": "extensions/content_package",
+      "package_id": "gf.extension.content_package",
+      "path": "addons/gf/extensions/content_package/resources/gf_content_package_query.gd",
+      "summary": "GFContentPackageQuery: 内容包目录的确定性通用查询条件。 查询只描述 package、content type、依赖、资源键、安全分类和 metadata 约束， 不解释项目业务语义。所有非空条件采用 AND 语义，列表条件要求 manifest 包含全部值。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "var",
+          "name": "query_id",
+          "signature": "var query_id: StringName = &\"\"",
+          "summary": "查询稳定标识，仅用于诊断和追踪。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "package_ids",
+          "signature": "var package_ids: PackedStringArray = PackedStringArray()",
+          "summary": "允许返回的 package ID；为空表示不限制。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "search_text",
+          "signature": "var search_text: String = \"\"",
+          "summary": "在 package ID、显示名、版本和 content type 中匹配的大小写无关文本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "required_content_types",
+          "signature": "var required_content_types: PackedStringArray = PackedStringArray()",
+          "summary": "manifest 必须包含的全部 content type。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "required_dependencies",
+          "signature": "var required_dependencies: PackedStringArray = PackedStringArray()",
+          "summary": "manifest 必须声明的全部直接依赖 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "required_resource_keys",
+          "signature": "var required_resource_keys: PackedStringArray = PackedStringArray()",
+          "summary": "manifest 必须声明的全部资源键。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "allowed_safety_kinds",
+          "signature": "var allowed_safety_kinds: PackedStringArray = PackedStringArray()",
+          "summary": "允许的安全分类；为空表示不限制。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "required_metadata",
+          "signature": "var required_metadata: Dictionary = {}",
+          "summary": "manifest metadata 必须精确匹配的键值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "include_dependencies",
+          "signature": "var include_dependencies: bool = false",
+          "summary": "是否把直接命中包的传递依赖加入结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "max_results",
+          "signature": "var max_results: int = 0",
+          "summary": "直接命中包的最大数量；小于等于 0 表示不限制。依赖闭包不计入该限制。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "metadata",
+          "signature": "var metadata: Dictionary = {}",
+          "summary": "调用方自定义查询元数据；GF 只负责复制和序列化。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "matches",
+          "signature": "func matches(manifest: GFContentPackageManifest) -> bool",
+          "summary": "检查 manifest 是否满足全部非空查询条件。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "apply_dict",
+          "signature": "func apply_dict(data: Dictionary) -> void",
+          "summary": "从字典应用查询字段并执行集合归一化。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为归一化字典。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_query",
+          "signature": "func duplicate_query() -> GFContentPackageQuery",
+          "summary": "创建查询深拷贝。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "from_dict",
+          "signature": "static func from_dict(data: Dictionary) -> GFContentPackageQuery",
+          "summary": "从字典创建查询。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFContentPackageQueryResult": {
+      "extends": "RefCounted",
+      "module": "extensions/content_package",
+      "package_id": "gf.extension.content_package",
+      "path": "addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd",
+      "summary": "GFContentPackageQueryResult: 内容包查询的不可变结果快照。 结果区分直接命中与依赖闭包，并保留隔离的 manifest 和验证报告， 调用方不需要从空数组推断查询失败或无匹配。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_COMPLETED",
+          "signature": "const STATUS_COMPLETED: StringName = &\"completed\"",
+          "summary": "查询成功完成。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_QUERY",
+          "signature": "const STATUS_INVALID_QUERY: StringName = &\"invalid_query\"",
+          "summary": "查询对象为空或无效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_CATALOG",
+          "signature": "const STATUS_INVALID_CATALOG: StringName = &\"invalid_catalog\"",
+          "summary": "内容包目录依赖图或 manifest 无效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "检查查询是否成功完成。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> StringName",
+          "summary": "获取稳定终态状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_query_id",
+          "signature": "func get_query_id() -> StringName",
+          "summary": "获取查询 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_direct_package_ids",
+          "signature": "func get_direct_package_ids() -> PackedStringArray",
+          "summary": "获取不含自动依赖扩展的直接命中 package ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_package_ids",
+          "signature": "func get_package_ids() -> PackedStringArray",
+          "summary": "获取最终 package ID，包括请求的依赖闭包。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_manifest",
+          "signature": "func get_manifest(package_id: StringName) -> GFContentPackageManifest",
+          "summary": "获取一个命中 manifest 的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_manifests",
+          "signature": "func get_manifests() -> Array[GFContentPackageManifest]",
+          "summary": "获取全部命中 manifest 的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_report",
+          "signature": "func get_report() -> Dictionary",
+          "summary": "获取验证报告副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为 JSON-safe 结果摘要。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFContentPackageUtility": {
       "extends": "GFUtility",
       "module": "extensions/content_package",
@@ -19766,24 +20267,73 @@
           "visibility": "public"
         },
         {
+          "kind": "const",
+          "name": "DEFAULT_SOURCE_ROOT_OWNER_ID",
+          "signature": "const DEFAULT_SOURCE_ROOT_OWNER_ID: StringName = &\"gf.content_package.manual\"",
+          "summary": "register_source_root() 等便捷入口使用的显式 owner scope。",
+          "visibility": "public"
+        },
+        {
           "kind": "func",
           "name": "register_source_root",
           "signature": "func register_source_root(root_path: String) -> bool",
-          "summary": "注册内容包 source root。",
+          "summary": "把内容包 source root 注册到默认 manual owner scope。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "unregister_source_root",
           "signature": "func unregister_source_root(root_path: String) -> bool",
-          "summary": "注销内容包 source root。",
+          "summary": "从默认 manual owner scope 注销内容包 source root。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "clear_source_roots",
           "signature": "func clear_source_roots() -> void",
-          "summary": "清空内容包 source root。",
+          "summary": "清空默认 manual owner scope 的内容包 source root。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "register_source_root_for_owner",
+          "signature": "func register_source_root_for_owner(owner_id: StringName, root_path: String) -> bool",
+          "summary": "为稳定 owner 注册内容包 source root。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unregister_source_root_for_owner",
+          "signature": "func unregister_source_root_for_owner(owner_id: StringName, root_path: String) -> bool",
+          "summary": "从稳定 owner 注销一个内容包 source root。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "replace_owner_source_roots",
+          "signature": "func replace_owner_source_roots( owner_id: StringName, root_paths: PackedStringArray ) -> GFValidationReport",
+          "summary": "原子替换一个 owner 的全部 source root。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "clear_owner_source_roots",
+          "signature": "func clear_owner_source_roots(owner_id: StringName) -> int",
+          "summary": "释放一个 owner 的全部 source root。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_owner_source_roots",
+          "signature": "func get_owner_source_roots(owner_id: StringName) -> PackedStringArray",
+          "summary": "获取一个 owner 持有的 source root。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_root_owner_ids",
+          "signature": "func get_source_root_owner_ids() -> PackedStringArray",
+          "summary": "获取当前持有 source root 的 owner ID。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFAssetCatalogMount.xml
+++ b/docs/api_catalog/classes/GFAssetCatalogMount.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFAssetCatalogMount" path="addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd" module="standard" extends="RefCounted" classDigest="d496be73856afdf3c7c7138b379d75f1a57e95fef16642b5638b790063938a5e">
+	<description>GFAssetCatalogMount: 资产目录运行时挂载的生命周期句柄。
+句柄保存提交时的目录快照、owner、mount ID、来源和 revision，
+并提供幂等显式卸载入口。失败请求也返回带稳定状态与报告的非活动句柄。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_ACTIVE">
+			<signature>const STATUS_ACTIVE: StringName = &amp;"active"</signature>
+			<description>Mount 已提交且仍活动。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_UNMOUNTED">
+			<signature>const STATUS_UNMOUNTED: StringName = &amp;"unmounted"</signature>
+			<description>Mount 已由调用方或 owner scope 释放。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_CONFLICT">
+			<signature>const STATUS_CONFLICT: StringName = &amp;"conflict"</signature>
+			<description>Mount 与已提交资产 ID 冲突。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_BUILD_FAILED">
+			<signature>const STATUS_BUILD_FAILED: StringName = &amp;"build_failed"</signature>
+			<description>Provider 未能构建目录。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_DUPLICATE_MOUNT">
+			<signature>const STATUS_DUPLICATE_MOUNT: StringName = &amp;"duplicate_mount"</signature>
+			<description>同一 owner 已存在相同 mount ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_REQUEST">
+			<signature>const STATUS_INVALID_REQUEST: StringName = &amp;"invalid_request"</signature>
+			<description>Mount 请求缺少 owner、mount ID 或有效目录。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_DISPOSED">
+			<signature>const STATUS_DISPOSED: StringName = &amp;"disposed"</signature>
+			<description>所属 Runtime 已释放。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="is_active">
+			<signature>func is_active() -&gt; bool:</signature>
+			<description>检查 Mount 是否仍在 Runtime 中活动。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">活动返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; StringName:</signature>
+			<description>获取稳定终态状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATUS_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_owner_id">
+			<signature>func get_owner_id() -&gt; StringName:</signature>
+			<description>获取 owner ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Mount owner ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_mount_id">
+			<signature>func get_mount_id() -&gt; StringName:</signature>
+			<description>获取 owner scope 内稳定 mount ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Mount ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_id">
+			<signature>func get_source_id() -&gt; StringName:</signature>
+			<description>获取来源 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Provider 来源 ID；直接目录 Mount 默认等于 mount ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_priority">
+			<signature>func get_priority() -&gt; int:</signature>
+			<description>获取 Mount 优先级。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">合并优先级。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_revision">
+			<signature>func get_revision() -&gt; int:</signature>
+			<description>获取最近一次提交该 Mount 的 Runtime revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非负 revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_catalog">
+			<signature>func get_catalog() -&gt; GFAssetCatalog:</signature>
+			<description>获取 Mount 自身的资产目录快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">深拷贝目录。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_report">
+			<signature>func get_report() -&gt; Dictionary:</signature>
+			<description>获取 Mount 请求或提交报告。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">GFValidationReport 兼容字典副本。</tag>
+				<tag name="schema">return: GFValidationReport-compatible Dictionary with status, owner_id, mount_id, source_id, priority, and revision.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unmount">
+			<signature>func unmount() -&gt; bool:</signature>
+			<description>从所属 Runtime 卸载当前 Mount。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">本次调用完成卸载返回 true；已终态返回 false。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为 JSON-safe 诊断摘要。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Mount 摘要。</tag>
+				<tag name="schema">return: Dictionary with active, status, owner_id, mount_id, source_id, priority, revision, token, asset_ids, and report.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFAssetCatalogRuntime.xml
+++ b/docs/api_catalog/classes/GFAssetCatalogRuntime.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFAssetCatalogRuntime" path="addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd" module="standard" extends="GFUtility" classDigest="814e37f3521ad847a984ff84fca9895f3777f7555d7a4e2ccd719f33783c73b2">
+	<description>GFAssetCatalogRuntime: owner-scoped 资产目录快照挂载与原子合并服务。
+Runtime 只接收已经构建的目录快照或 Provider 输出，按稳定优先级合并并以 revision 发布。
+任何无效请求、Provider 失败或严格冲突都不会替换上一份已提交目录。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_service</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="catalog_changed">
+			<signature>signal catalog_changed(catalog: GFAssetCatalog, revision: int)</signature>
+			<description>资产目录成功提交新 revision 后发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">catalog: 已提交目录的隔离快照。</tag>
+				<tag name="param">revision: 新 revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums />
+	<constants>
+		<member kind="const" name="CONFLICT_REJECT">
+			<signature>const CONFLICT_REJECT: StringName = &amp;"reject"</signature>
+			<description>任一重复 asset ID 都拒绝整次事务。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="CONFLICT_KEEP_HIGH_PRIORITY">
+			<signature>const CONFLICT_KEEP_HIGH_PRIORITY: StringName = &amp;"keep_high_priority"</signature>
+			<description>重复 asset ID 显式保留高优先级 Mount 的条目。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="configure">
+			<signature>func configure(conflict_policy: StringName = CONFLICT_REJECT) -&gt; GFAssetCatalogRuntime:</signature>
+			<description>配置全局 asset ID 冲突政策。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">conflict_policy: CONFLICT_REJECT 或 CONFLICT_KEEP_HIGH_PRIORITY。</tag>
+				<tag name="return">当前 Runtime；已有 Mount 或政策无效时保持原配置。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="mount_catalog">
+			<signature>func mount_catalog( owner_id: StringName, mount_id: StringName, catalog: GFAssetCatalog, priority: int = 0, source_id: StringName = &amp;"" ) -&gt; GFAssetCatalogMount:</signature>
+			<description>原子挂载一个资产目录快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 非空 owner ID。</tag>
+				<tag name="param">mount_id: owner scope 内非空稳定 ID。</tag>
+				<tag name="param">catalog: 要挂载的目录；Runtime 保存深拷贝。</tag>
+				<tag name="param">priority: 合并优先级，数值越大越先处理。</tag>
+				<tag name="param">source_id: 可选来源 ID；为空时使用 mount_id。</tag>
+				<tag name="return">活动 Mount 或带稳定失败状态的非活动 Mount。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="mount_provider">
+			<signature>func mount_provider( owner_id: StringName, mount_id: StringName, provider: GFAssetCatalogSourceProvider, options: Dictionary = {} ) -&gt; GFAssetCatalogMount:</signature>
+			<description>构建 Provider 快照并原子挂载。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 非空 owner ID。</tag>
+				<tag name="param">mount_id: owner scope 内稳定 ID。</tag>
+				<tag name="param">provider: 资产目录来源 Provider。</tag>
+				<tag name="param">options: 传给 Provider 的构建选项。</tag>
+				<tag name="return">活动 Mount 或带构建失败状态的非活动 Mount。</tag>
+				<tag name="schema">options: Dictionary with provider-defined build options.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="replace_mount_catalog">
+			<signature>func replace_mount_catalog(mount: GFAssetCatalogMount, catalog: GFAssetCatalog) -&gt; bool:</signature>
+			<description>原子替换一个活动 Mount 的目录快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">mount: 当前 Runtime 返回的活动 Mount。</tag>
+				<tag name="param">catalog: 新目录快照。</tag>
+				<tag name="return">完整候选成功提交返回 true；失败时保留原 Mount、目录和 revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unmount_owner">
+			<signature>func unmount_owner(owner_id: StringName) -&gt; int:</signature>
+			<description>批量释放一个 owner 的全部 Mount，并只提交一个新 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 要释放的 owner ID。</tag>
+				<tag name="return">释放的 Mount 数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_catalog">
+			<signature>func get_catalog() -&gt; GFAssetCatalog:</signature>
+			<description>获取当前已提交资产目录快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">深拷贝目录。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_revision">
+			<signature>func get_revision() -&gt; int:</signature>
+			<description>获取当前目录 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">从 0 开始、仅成功提交时递增的 revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_mounts">
+			<signature>func get_mounts() -&gt; Array[GFAssetCatalogMount]:</signature>
+			<description>获取全部活动 Mount。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">按合并顺序排列的 Mount 句柄。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_last_report">
+			<signature>func get_last_report() -&gt; Dictionary:</signature>
+			<description>获取最近一次运行时报告。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">GFValidationReport 兼容字典副本。</tag>
+				<tag name="schema">return: GFValidationReport-compatible Dictionary with conflict_policy, revision, mount_count, asset_count, and issues.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_debug_snapshot">
+			<signature>func get_debug_snapshot() -&gt; Dictionary:</signature>
+			<description>获取 JSON-safe 调试快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Runtime、Mount 和目录摘要。</tag>
+				<tag name="schema">return: Dictionary with conflict_policy, disposed, revision, mount_count, mounts, catalog, and last_report.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFContentPackageAssetCatalogProvider.xml
+++ b/docs/api_catalog/classes/GFContentPackageAssetCatalogProvider.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFContentPackageAssetCatalogProvider" path="addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd" module="extensions/content_package" extends="GFAssetCatalogSourceProvider" classDigest="c8b96e04fabade38cac3bdd9f68fc8445068f901e1eca69361f4f3e25256b296">
+	<description>GFContentPackageAssetCatalogProvider: 内容包目录到通用资产目录的适配器。
+Provider 持有内容包目录快照，通过可选 GFContentPackageQuery 选择 manifest，
+再把资源映射转换为 GFAssetCatalogEntry。它不挂载目录、不下载内容，也不解释业务分类。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">protocol</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="configure_catalog">
+			<signature>func configure_catalog( catalog: GFContentPackageCatalog, p_source_id: StringName = &amp;"content_packages", query: GFContentPackageQuery = null, options: Dictionary = {} ) -&gt; GFContentPackageAssetCatalogProvider:</signature>
+			<description>配置内容包目录快照和可选查询。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">catalog: 内容包目录；Provider 保存其深拷贝。</tag>
+				<tag name="param">p_source_id: 资产来源 ID。</tag>
+				<tag name="param">query: 可选内容包查询；为空时选择全部有效包。</tag>
+				<tag name="param">options: Provider 配置选项，支持 priority。</tag>
+				<tag name="return">当前 Provider。</tag>
+				<tag name="schema">options: Dictionary with optional priority: int.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="build_catalog">
+			<signature>func build_catalog(options: Dictionary = {}) -&gt; GFAssetCatalog:</signature>
+			<description>构建资产目录快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">options: 可选字段映射，支持 title_fields、description_fields、tag_fields、category_fields 和 preview_path_fields。</tag>
+				<tag name="return">转换后的资产目录；内容包目录无效时返回 null。</tag>
+				<tag name="schema">options: Dictionary with optional PackedStringArray field-name lists for title_fields, description_fields, tag_fields, category_fields, and preview_path_fields.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_debug_snapshot">
+			<signature>func get_debug_snapshot() -&gt; Dictionary:</signature>
+			<description>获取 Provider 诊断快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">来源、内容包目录和查询摘要。</tag>
+				<tag name="schema">return: Dictionary with source_id, priority, provider_class, content_catalog, and query.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFContentPackageCatalog.xml
+++ b/docs/api_catalog/classes/GFContentPackageCatalog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFContentPackageCatalog" path="addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd" module="extensions/content_package" extends="RefCounted" classDigest="300e5ca5fe807a1c629424688bf496c19845504c455e6dec02c8a7173d81362f">
+<class name="GFContentPackageCatalog" path="addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd" module="extensions/content_package" extends="RefCounted" classDigest="89ecbcabee3f26256a3017b7aa0525b7fa35e5e1864548f03cdf95896c1fab07">
 	<description>GFContentPackageCatalog: 内容包集合与依赖图诊断。
 管理一组 GFContentPackageManifest，提供包查询、依赖顺序、重复/缺失/循环依赖报告，
 并可把内容包资源键映射注册到 GFResourceResolverUtility。</description>
@@ -90,6 +90,18 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">依赖包先于依赖方出现的内容包 ID 列表。</tag>
+			</tags>
+		</member>
+		<member kind="method" name="query_packages">
+			<signature>func query_packages( query: GFContentPackageQuery, options: Dictionary = {} ) -&gt; GFContentPackageQueryResult:</signature>
+			<description>查询有效内容包并返回隔离结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">query: 通用内容包查询。</tag>
+				<tag name="param">options: manifest 和依赖图校验选项。</tag>
+				<tag name="return">类型化查询终态；目录无效时不返回部分结果。</tag>
+				<tag name="schema">options: Dictionary，可包含 check_resource_exists: bool、check_resource_dependencies: bool 和 dependency_options: Dictionary。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_graph_report">

--- a/docs/api_catalog/classes/GFContentPackageQuery.xml
+++ b/docs/api_catalog/classes/GFContentPackageQuery.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFContentPackageQuery" path="addons/gf/extensions/content_package/resources/gf_content_package_query.gd" module="extensions/content_package" extends="Resource" classDigest="ac49129fe7d8290d2d4f88f94fcda9993d78aefae17ec1f7ad455544cef86e13">
+	<description>GFContentPackageQuery: 内容包目录的确定性通用查询条件。
+查询只描述 package、content type、依赖、资源键、安全分类和 metadata 约束，
+不解释项目业务语义。所有非空条件采用 AND 语义，列表条件要求 manifest 包含全部值。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties>
+		<member kind="property" name="query_id" decorators="@export">
+			<signature>var query_id: StringName = &amp;""</signature>
+			<description>查询稳定标识，仅用于诊断和追踪。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="package_ids" decorators="@export">
+			<signature>var package_ids: PackedStringArray = PackedStringArray()</signature>
+			<description>允许返回的 package ID；为空表示不限制。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="search_text" decorators="@export">
+			<signature>var search_text: String = ""</signature>
+			<description>在 package ID、显示名、版本和 content type 中匹配的大小写无关文本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="required_content_types" decorators="@export">
+			<signature>var required_content_types: PackedStringArray = PackedStringArray()</signature>
+			<description>manifest 必须包含的全部 content type。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="required_dependencies" decorators="@export">
+			<signature>var required_dependencies: PackedStringArray = PackedStringArray()</signature>
+			<description>manifest 必须声明的全部直接依赖 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="required_resource_keys" decorators="@export">
+			<signature>var required_resource_keys: PackedStringArray = PackedStringArray()</signature>
+			<description>manifest 必须声明的全部资源键。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="allowed_safety_kinds" decorators="@export">
+			<signature>var allowed_safety_kinds: PackedStringArray = PackedStringArray()</signature>
+			<description>允许的安全分类；为空表示不限制。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="required_metadata" decorators="@export">
+			<signature>var required_metadata: Dictionary = {}</signature>
+			<description>manifest metadata 必须精确匹配的键值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="schema">required_metadata: Dictionary with exact manifest metadata key/value filters.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="include_dependencies" decorators="@export">
+			<signature>var include_dependencies: bool = false</signature>
+			<description>是否把直接命中包的传递依赖加入结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="max_results" decorators="@export">
+			<signature>var max_results: int = 0</signature>
+			<description>直接命中包的最大数量；小于等于 0 表示不限制。依赖闭包不计入该限制。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="metadata" decorators="@export">
+			<signature>var metadata: Dictionary = {}</signature>
+			<description>调用方自定义查询元数据；GF 只负责复制和序列化。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="schema">metadata: Dictionary with caller-defined query metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</properties>
+	<methods>
+		<member kind="method" name="matches">
+			<signature>func matches(manifest: GFContentPackageManifest) -&gt; bool:</signature>
+			<description>检查 manifest 是否满足全部非空查询条件。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">manifest: 要检查的内容包 manifest。</tag>
+				<tag name="return">满足查询条件返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="apply_dict">
+			<signature>func apply_dict(data: Dictionary) -&gt; void:</signature>
+			<description>从字典应用查询字段并执行集合归一化。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">data: 查询字典。</tag>
+				<tag name="schema">data: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为归一化字典。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">查询字典副本。</tag>
+				<tag name="schema">return: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_query">
+			<signature>func duplicate_query() -&gt; GFContentPackageQuery:</signature>
+			<description>创建查询深拷贝。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新查询。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="from_dict">
+			<signature>static func from_dict(data: Dictionary) -&gt; GFContentPackageQuery:</signature>
+			<description>从字典创建查询。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">data: 查询字典。</tag>
+				<tag name="return">新查询。</tag>
+				<tag name="schema">data: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFContentPackageQueryResult.xml
+++ b/docs/api_catalog/classes/GFContentPackageQueryResult.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFContentPackageQueryResult" path="addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd" module="extensions/content_package" extends="RefCounted" classDigest="74708156aa21f0a0895eeac4c8b6029f15a2aa1ce182989a7d2c31143bdf7385">
+	<description>GFContentPackageQueryResult: 内容包查询的不可变结果快照。
+结果区分直接命中与依赖闭包，并保留隔离的 manifest 和验证报告，
+调用方不需要从空数组推断查询失败或无匹配。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_COMPLETED">
+			<signature>const STATUS_COMPLETED: StringName = &amp;"completed"</signature>
+			<description>查询成功完成。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_QUERY">
+			<signature>const STATUS_INVALID_QUERY: StringName = &amp;"invalid_query"</signature>
+			<description>查询对象为空或无效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_CATALOG">
+			<signature>const STATUS_INVALID_CATALOG: StringName = &amp;"invalid_catalog"</signature>
+			<description>内容包目录依赖图或 manifest 无效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>检查查询是否成功完成。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">查询成功返回 true；零匹配仍属于成功。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; StringName:</signature>
+			<description>获取稳定终态状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATUS_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_query_id">
+			<signature>func get_query_id() -&gt; StringName:</signature>
+			<description>获取查询 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">查询稳定 ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_direct_package_ids">
+			<signature>func get_direct_package_ids() -&gt; PackedStringArray:</signature>
+			<description>获取不含自动依赖扩展的直接命中 package ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">dependency-first 排序的 ID 副本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_package_ids">
+			<signature>func get_package_ids() -&gt; PackedStringArray:</signature>
+			<description>获取最终 package ID，包括请求的依赖闭包。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">dependency-first 排序的 ID 副本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_manifest">
+			<signature>func get_manifest(package_id: StringName) -&gt; GFContentPackageManifest:</signature>
+			<description>获取一个命中 manifest 的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">package_id: 内容包 ID。</tag>
+				<tag name="return">manifest 深拷贝；未命中返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_manifests">
+			<signature>func get_manifests() -&gt; Array[GFContentPackageManifest]:</signature>
+			<description>获取全部命中 manifest 的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">与 get_package_ids() 同序的 manifest 数组。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_report">
+			<signature>func get_report() -&gt; Dictionary:</signature>
+			<description>获取验证报告副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">GFValidationReportDictionary 兼容字典。</tag>
+				<tag name="schema">return: GFValidationReportDictionary-compatible Dictionary with query_id, status, direct_package_ids, and package_ids.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为 JSON-safe 结果摘要。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">不包含 Resource 对象的结果字典。</tag>
+				<tag name="schema">return: Dictionary with successful, status, query_id, direct_package_ids, package_ids, manifests, and report.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFContentPackageUtility.xml
+++ b/docs/api_catalog/classes/GFContentPackageUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFContentPackageUtility" path="addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd" module="extensions/content_package" extends="GFUtility" classDigest="ddd32ec692069cfd910aa73149e7c252d9b0b73c2cf898ebfca2cb9416583c5d">
+<class name="GFContentPackageUtility" path="addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd" module="extensions/content_package" extends="GFUtility" classDigest="93917075f9ac7b16c22f4a049d1ee7ed30345b322eed1c7ab6f1da15e20022af">
 	<description>GFContentPackageUtility: 内容包发现、目录构建和资源解析注册服务。
 维护显式 source root 列表，加载其中的 `gf_content_package.json`，构建 GFContentPackageCatalog，
 并把内容包资源键映射同步到 GFResourceResolverUtility。它不下载内容、不扫描全项目、不决定包启用策略。</description>
@@ -20,12 +20,21 @@
 		</member>
 	</signals>
 	<enums />
-	<constants />
+	<constants>
+		<member kind="const" name="DEFAULT_SOURCE_ROOT_OWNER_ID">
+			<signature>const DEFAULT_SOURCE_ROOT_OWNER_ID: StringName = &amp;"gf.content_package.manual"</signature>
+			<description>register_source_root() 等便捷入口使用的显式 owner scope。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
 	<properties />
 	<methods>
 		<member kind="method" name="register_source_root">
 			<signature>func register_source_root(root_path: String) -&gt; bool:</signature>
-			<description>注册内容包 source root。</description>
+			<description>把内容包 source root 注册到默认 manual owner scope。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">root_path: `res://` 或 `user://` 下的内容包根目录。该目录自身或其直接子目录可包含 `gf_content_package.json`。</tag>
@@ -35,18 +44,82 @@
 		</member>
 		<member kind="method" name="unregister_source_root">
 			<signature>func unregister_source_root(root_path: String) -&gt; bool:</signature>
-			<description>注销内容包 source root。</description>
+			<description>从默认 manual owner scope 注销内容包 source root。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">root_path: 已注册的 source root。</tag>
 				<tag name="return">注销成功返回 true。</tag>
+				<tag name="since">6.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="clear_source_roots">
 			<signature>func clear_source_roots() -&gt; void:</signature>
-			<description>清空内容包 source root。</description>
+			<description>清空默认 manual owner scope 的内容包 source root。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">6.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="register_source_root_for_owner">
+			<signature>func register_source_root_for_owner(owner_id: StringName, root_path: String) -&gt; bool:</signature>
+			<description>为稳定 owner 注册内容包 source root。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 非空 owner ID，用于批量释放来源。</tag>
+				<tag name="param">root_path: `res://` 或 `user://` 根目录。</tag>
+				<tag name="return">owner 首次取得该 root 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unregister_source_root_for_owner">
+			<signature>func unregister_source_root_for_owner(owner_id: StringName, root_path: String) -&gt; bool:</signature>
+			<description>从稳定 owner 注销一个内容包 source root。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 注册时使用的 owner ID。</tag>
+				<tag name="param">root_path: 已注册 root。</tag>
+				<tag name="return">找到并释放时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="replace_owner_source_roots">
+			<signature>func replace_owner_source_roots( owner_id: StringName, root_paths: PackedStringArray ) -&gt; GFValidationReport:</signature>
+			<description>原子替换一个 owner 的全部 source root。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 非空 owner ID。</tag>
+				<tag name="param">root_paths: 新 root 集合；空集合表示释放 owner。</tag>
+				<tag name="return">类型化验证报告；任一 root 无效时不修改现有状态。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="clear_owner_source_roots">
+			<signature>func clear_owner_source_roots(owner_id: StringName) -&gt; int:</signature>
+			<description>释放一个 owner 的全部 source root。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: 要释放的 owner ID。</tag>
+				<tag name="return">释放的 owner-root 关系数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_owner_source_roots">
+			<signature>func get_owner_source_roots(owner_id: StringName) -&gt; PackedStringArray:</signature>
+			<description>获取一个 owner 持有的 source root。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner_id: owner ID。</tag>
+				<tag name="return">排序后的 root 副本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_root_owner_ids">
+			<signature>func get_source_root_owner_ids() -&gt; PackedStringArray:</signature>
+			<description>获取当前持有 source root 的 owner ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">排序后的 owner ID 文本。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_source_roots">
@@ -129,7 +202,8 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">调试快照。</tag>
-				<tag name="schema">return: Dictionary，包含 source_roots 和 catalog。</tag>
+				<tag name="schema">return: Dictionary，包含 source_roots、source_root_owners 和 catalog。</tag>
+				<tag name="since">4.4.0</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="17a79558316bb21fbb2858a336eac49820a65294eb46cdb761efe6ff0e82eb61" classCount="750" methodCount="6701">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="665fd1ec51d513f5f7915bf1172832366c6c8f070e70db1e0383118ad5d7ada2" classCount="755" methodCount="6746">
 	<module id="kernel" label="Kernel" classCount="70" methodCount="715">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -72,13 +72,15 @@
 		<class name="GFTypeEventSystem" path="classes/GFTypeEventSystem.xml" sourcePath="addons/gf/kernel/core/gf_type_event_system.gd" extends="Object" />
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 	</module>
-	<module id="standard" label="Standard" classCount="416" methodCount="4170">
+	<module id="standard" label="Standard" classCount="418" methodCount="4191">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsUtility" path="classes/GFAnalyticsUtility.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_utility.gd" extends="GFUtility" />
 		<class name="GFArtifactFreshnessReport" path="classes/GFArtifactFreshnessReport.xml" sourcePath="addons/gf/standard/foundation/policy/gf_artifact_freshness_report.gd" extends="RefCounted" />
 		<class name="GFAssetCatalog" path="classes/GFAssetCatalog.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_catalog.gd" extends="Resource" />
 		<class name="GFAssetCatalogEntry" path="classes/GFAssetCatalogEntry.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_catalog_entry.gd" extends="Resource" />
+		<class name="GFAssetCatalogMount" path="classes/GFAssetCatalogMount.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd" extends="RefCounted" />
+		<class name="GFAssetCatalogRuntime" path="classes/GFAssetCatalogRuntime.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd" extends="GFUtility" />
 		<class name="GFAssetCatalogSourceProvider" path="classes/GFAssetCatalogSourceProvider.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_catalog_source_provider.gd" extends="RefCounted" />
 		<class name="GFAssetCatalogSourceRegistry" path="classes/GFAssetCatalogSourceRegistry.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_catalog_source_registry.gd" extends="RefCounted" />
 		<class name="GFAssetCollection" path="classes/GFAssetCollection.xml" sourcePath="addons/gf/standard/utilities/assets/gf_asset_collection.gd" extends="Resource" />
@@ -613,10 +615,13 @@
 		<class name="GFSkillTargetingUtility2D" path="classes/GFSkillTargetingUtility2D.xml" sourcePath="addons/gf/extensions/combat/skills/gf_skill_targeting_utility_2d.gd" extends="GFUtility" />
 		<class name="GFTagComponent" path="classes/GFTagComponent.xml" sourcePath="addons/gf/extensions/combat/tags/gf_tag_component.gd" extends="RefCounted" />
 	</module>
-	<module id="extensions/content_package" label="Extensions / Content Package" classCount="4" methodCount="46">
+	<module id="extensions/content_package" label="Extensions / Content Package" classCount="7" methodCount="70">
+		<class name="GFContentPackageAssetCatalogProvider" path="classes/GFContentPackageAssetCatalogProvider.xml" sourcePath="addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd" extends="GFAssetCatalogSourceProvider" />
 		<class name="GFContentPackageCatalog" path="classes/GFContentPackageCatalog.xml" sourcePath="addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd" extends="RefCounted" />
 		<class name="GFContentPackageExportPlan" path="classes/GFContentPackageExportPlan.xml" sourcePath="addons/gf/extensions/content_package/runtime/gf_content_package_export_plan.gd" extends="RefCounted" />
 		<class name="GFContentPackageManifest" path="classes/GFContentPackageManifest.xml" sourcePath="addons/gf/extensions/content_package/resources/gf_content_package_manifest.gd" extends="Resource" />
+		<class name="GFContentPackageQuery" path="classes/GFContentPackageQuery.xml" sourcePath="addons/gf/extensions/content_package/resources/gf_content_package_query.gd" extends="Resource" />
+		<class name="GFContentPackageQueryResult" path="classes/GFContentPackageQueryResult.xml" sourcePath="addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd" extends="RefCounted" />
 		<class name="GFContentPackageUtility" path="classes/GFContentPackageUtility.xml" sourcePath="addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd" extends="GFUtility" />
 	</module>
 	<module id="extensions/decision" label="Decision" classCount="8" methodCount="61">

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -22,12 +22,14 @@
 
 ## [未发布]
 
-**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、存储后端故障转移、运行时会话轨迹、UI 路由预加载规划和轨迹预测数学，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
+**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、内容包查询与运行时目录挂载、存储后端故障转移、运行时会话轨迹、UI 路由预加载规划和轨迹预测数学，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
 
 ### 🚀 新增特性 (Added)
 
 - `GFThumbnailRenderer` 与 `GFThumbnailRenderRequest` 支持 `CanvasItem` 的 `Image` / `ImageTexture` 缩略图请求，统一覆盖 `Node2D` 和 `Control`。调用方可以显式提供内容 `Rect2`，也可以让渲染器保守估算 Sprite、Control、Polygon、Line、AnimatedSprite 和 2D 粒子范围。
 - 新增 `GFAssetCollection`，用稳定 `collection_id` 和有序 `asset_ids` 描述可序列化资源集合，并通过 `GFValidationReport` 报告空 ID、重复 ID 和目录缺失项。
+- 新增 `GFContentPackageQuery`、`GFContentPackageQueryResult` 和 `GFContentPackageAssetCatalogProvider`，提供严格内容包筛选、dependency-first 闭包、类型化失败终态和 qualified 资产 ID 适配。
+- 新增 `GFAssetCatalogRuntime` 与 `GFAssetCatalogMount`，提供 owner-scoped 目录快照、严格或显式高优先级冲突政策、原子 revision 提交和幂等卸载。
 - 新增 `GFStorageFailoverBackend`，按稳定后端 ID 提供有界顺序尝试、`PRIMARY_ONLY` / `FIRST_SUCCESS` 写删语义、暂时性错误冷却和不含业务载荷的结构化操作报告。
 - 新增 `GFSessionTraceUtility`，提供显式通道白名单、事件数与字节双重预算、默认隐私脱敏、同步快照 provider、结构化支持报告快照和可选 `GFLogSink` journal。
 - 新增 `GFUIRoutePreloadUtility`，从 `GFUIRoute.adjacent_route_ids` 做有界、确定性的页面可达性遍历，并生成可直接交给 `GFAssetUtility` 的 `GFAssetPreloadPlan`。
@@ -39,6 +41,7 @@
 ### 🔄 机制更改 (Changed)
 
 - `GFStorageBackend.load_data()` 会为没有显式错误码的后端结果补齐 `error_code`，使组合后端能够区分成功、普通读取失败和明确的暂时性故障。
+- `GFContentPackageUtility` 的 source root 新增稳定 owner 关系和事务式整组替换；既有便捷入口只操作公开 manual owner scope，不再可能清除其他模块来源。
 - `GFStorageUtility` 的异步读写新增请求句柄入口；既有 `save_data_async()`、`load_data_async()` 和全局完成信号保持原行为，并与句柄共用同一调度队列。
 - `GFStorageFailoverBackend.configure_backends()` 对策略、失败阈值和冷却窗口执行事务式 fail-closed 校验，非法配置不会部分替换既有后端或静默改变写入语义。
 - 缩略图渲染改为等待场景树更新后同步强制绘制，避免无持续绘制帧时错过 `frame_post_draw`；dummy 渲染后端现在会安全返回空结果，不再访问无纹理存储的 ViewportTexture。
@@ -67,6 +70,7 @@
 - 新增 `GFThumbnailRenderRequest.for_canvas_item_image()`、`for_canvas_item_texture()` 及相应来源、边界和留白读取入口。
 - 新增 `GFThumbnailRenderer.render_canvas_item()` 与 `render_canvas_item_texture()`。
 - 新增公开类型 `GFAssetCollection` 和 `GFStorageFailoverBackend`；均标记为 `@since unreleased`，不改变既有调用入口默认行为。
+- 新增公开类型 `GFContentPackageQuery`、`GFContentPackageQueryResult`、`GFContentPackageAssetCatalogProvider`、`GFAssetCatalogRuntime` 和 `GFAssetCatalogMount`；`GFContentPackageCatalog` 新增 `query_packages()`，Content Package Utility 新增 owner-scoped root API，Asset Catalog Runtime 支持原子 `replace_mount_catalog()`。
 - 新增公开类型 `GFSessionTraceUtility`、`GFUIRoutePreloadUtility`，以及 `GFUIRoute.adjacent_route_ids`、`get_adjacent_route_ids()` 和 `GFUIRouterUtility.build_preload_plan()`；均标记为 `@since unreleased`。
 - 新增公开类型 `GFTrajectoryMath`，以及运动预测、恒速拦截和有界公式采样入口；均标记为 `@since unreleased`，不改变既有 Steering 行为。
 - 新增公开类型 `GFSaveProfile`、`GFSaveSectionProvider`、`GFSaveRecoveryPolicy`、`GFSaveProfileOperation`、`GFSaveProfileResult`、`GFSaveRollbackFailure` 和 `GFSaveProfileUtility`；Save 扩展安装器会自动注册 Profile Utility，既有 Save Graph 和 Slot API 不变。
@@ -78,6 +82,8 @@
 ### 📘 升级指南 (Migration Guide)
 
 - 既有 3D 缩略图、资产目录、存储后端与同步代码无需迁移。需要 2D 预览、有序资产集合或故障转移时显式采用新入口即可。
+- 既有单调用方 Content Package root 入口继续使用公开 manual owner scope；多模块、热插拔内容或场景生命周期应迁移到 `register_source_root_for_owner()` / `replace_owner_source_roots()`，并在模块退出时调用 `clear_owner_source_roots()`。
+- 运行时资产目录默认拒绝重复 `asset_id`。只有明确设计了覆盖层时，才在首个 Mount 前配置 `CONFLICT_KEEP_HIGH_PRIORITY`；不要依赖 Provider 注册时序决定胜者。
 - 自定义 `_draw()` 或无法可靠推断范围的 2D 节点应传入显式 `content_bounds`；多后端复制与冲突处理继续使用 `GFStorageSyncUtility`，不要把故障转移当作原子双写。
 - 既有 UI 路由无需迁移；只有需要候选页面预热时才声明 `adjacent_route_ids` 并显式执行生成的资产计划。需要发布后问题轨迹时，应由项目定义最小事件 schema、玩家许可和保留策略，再显式采用 `GFSessionTraceUtility`。
 - 既有曲线、Steering、发射体和节点移动逻辑无需迁移。只有需要结构化未来状态、拦截时间或公式点集时才显式采用 `GFTrajectoryMath`；绘制、物理推进、速度继承、重力拦截和业务命中规则继续由项目负责。
@@ -93,6 +99,11 @@
 - `addons/gf/kernel/editor/gf_thumbnail_render_request.gd`
 - `addons/gf/kernel/editor/gf_thumbnail_renderer.gd`
 - `addons/gf/standard/utilities/assets/gf_asset_collection.gd`
+- `addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd`
+- `addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd`
+- `addons/gf/extensions/content_package/resources/gf_content_package_query.gd`
+- `addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd`
+- `addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_backend.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_utility.gd`
@@ -110,31 +121,3 @@
 - `addons/gf/tools/ai_developer/schemas/project_snapshot.schema.json`
 - `.github/workflows/ci.yml`
 - `.github/workflows/release.yml`
-
-## [9.0.1] - 2026-07-20
-
-**版本概述**：修复 Godot 原生 Package Manager 在 Linux 等平台安装含隐藏文件的合法包后无法完整清理事务暂存目录的问题，并保持隐藏链接审计继续 fail closed。
-
-### 🔄 机制更改 (Changed)
-
-- Package Transaction Engine 的树清理与链接审计、Package Manager Backend 的兜底清理现在都会显式枚举隐藏目录项。该行为适用于所有合法 package 载荷，不为特定文件名或业务包增加例外。
-
-### 🐛 Bug 修复 (Fixed)
-
-- 修复合法 package 包含 `.gdignore` 等点号文件时，Linux 上的 `DirAccess` 默认隐藏文件过滤会让 `.gf/t` 保留 staging 副本的问题。该残留此前会被 release 全包 Godot matrix 判定为意外运行时写入，并阻止 GitHub Release 创建。
-- 修复事务树链接审计可能遗漏隐藏目录项的问题；隐藏符号链接或目录链接现在与普通目录项使用同一拒绝策略。
-
-### 🔧 API 变动说明 (API Changes)
-
-- 无公开 API、package schema、lockfile schema、持久化格式、协议或默认配置变化。
-
-### 📘 升级指南 (Migration Guide)
-
-- `9.0.0` 使用方可直接替换为 `9.0.1`。已安装的 package 文件和 `.gf/packages.lock.json` 无需迁移；如果项目残留旧 `.gf/t` 暂存目录，可在确认没有正在运行的 package 操作后删除该临时目录。
-
-### 📁 核心受影响文件 (Affected Files)
-
-- `addons/gf/kernel/package/gf_package_transaction_engine.gd`
-- `addons/gf/kernel/package/gf_package_manager_backend.gd`
-- `tests/gf_core/kernel/package/test_gf_package_manager_backend.gd`
-- `tests/gf_core/maintenance/test_package_transaction_boundary_validation.gd`

--- a/docs/zh/extensions/content-package/index.md
+++ b/docs/zh/extensions/content-package/index.md
@@ -8,7 +8,9 @@ Content Package 扩展用于把项目或插件中的可选内容收束为稳定 
 
 - `GFContentPackageManifest` 描述一个内容包，读取 `gf_content_package.json`，并校验资源路径是否留在包根目录内。
 - `GFContentPackageCatalog` 管理一组 manifest，报告重复包 ID、缺失依赖和循环依赖，并按依赖优先顺序注册资源键。
-- `GFContentPackageUtility` 维护显式 source root，发现 root 或直接子目录中的 manifest，重建 catalog，并把资源映射同步到 `GFResourceResolverUtility`。
+- `GFContentPackageQuery` 与 `GFContentPackageQueryResult` 提供严格 AND 条件、可选依赖闭包和类型化查询终态，不用空数组混淆“零匹配”与“目录无效”。
+- `GFContentPackageUtility` 按稳定 owner 维护显式 source root，发现 root 或直接子目录中的 manifest，重建 catalog，并把资源映射同步到 `GFResourceResolverUtility`。
+- `GFContentPackageAssetCatalogProvider` 把查询后的内容包资源快照适配为通用 `GFAssetCatalog`，不负责运行时挂载或内容启用。
 
 ## Manifest 形态
 
@@ -42,7 +44,9 @@ JSON 字段按稳定 schema 严格读取。字符串、数组、字典、资源�
 
 ## 来源根与安全分类
 
-`GFContentPackageUtility.register_source_root()` 支持 `res://` 与 `user://` 来源根。项目可以把内置内容放在 `res://content_packages`，把运行时下载、编辑器导入或用户生成内容放在 `user://content_packages`，再用同一套 `rebuild_catalog()` 和资源键注册流程处理。
+`GFContentPackageUtility.register_source_root_for_owner()` 支持 `res://` 与 `user://` 来源根。项目可以把内置内容放在 `res://content_packages`，把运行时下载、编辑器导入或用户生成内容放在 `user://content_packages`，再用同一套 `rebuild_catalog()` 和资源键注册流程处理。多个 owner 可以共同持有同一 root；只有最后一个 owner 释放后，该 root 才会从有效来源集合移除。
+
+需要一次切换一组来源时，使用 `replace_owner_source_roots()`。它会先规范化并校验全部路径，任一无效路径都会拒绝整次替换，上一份 owner 快照保持不变。`register_source_root()`、`unregister_source_root()` 和 `clear_source_roots()` 仍可用于手工配置，但只操作公开常量 `DEFAULT_SOURCE_ROOT_OWNER_ID` 对应的 manual scope，不会清除其他模块持有的 root。
 
 `GFContentPackageManifest.safety_kind` 默认是 `data_only`。该分类会拒绝脚本、动态库、shader、shell 脚本等可执行或代码形态扩展名；项目可以通过 `forbidden_resource_extensions` 追加或替换拦截列表。只有确实由开发者控制、并且项目侧已经决定如何加载和审计代码资源时，才应把分类改成 `trusted_developer`。
 
@@ -58,13 +62,31 @@ JSON 字段按稳定 schema 严格读取。字符串、数组、字典、资源�
 
 Catalog 对 manifest 采用深快照语义：`add_manifest()` 不保留调用方对象，`get_manifest()`、`get_catalog()` 和 `catalog_rebuilt` 也不暴露内部可变实例。注册、注销或清空 source root 会立即失效当前 catalog，调用方必须重新 `rebuild_catalog()` 后再同步资源。
 
+## 查询与资产目录适配
+
+`GFContentPackageQuery` 的所有非空条件采用严格 AND 语义。列表条件要求 manifest 包含全部指定值；`package_ids` 和 `allowed_safety_kinds` 是允许集合。`max_results` 只限制直接命中包，`include_dependencies` 会在限制之后补齐传递依赖，并按 dependency-first 顺序返回。查询开始前会验证完整 catalog，依赖图或 manifest 无效时返回 `STATUS_INVALID_CATALOG`，不会泄漏部分匹配。
+
+```gdscript
+var query := GFContentPackageQuery.new()
+query.required_content_types = PackedStringArray(["theme"])
+query.required_metadata = {"channel": "stable"}
+query.include_dependencies = true
+
+var result := packages.get_catalog().query_packages(query)
+if result.is_successful():
+	for manifest in result.get_manifests():
+		print(manifest.package_id)
+```
+
+需要把内容包显示在素材浏览器或交给资产预加载计划时，使用 `GFContentPackageAssetCatalogProvider`。默认 `asset_id` 采用 `package_id/resource_key`，避免不同包中的局部资源键互相覆盖；原始资源键保留在 `resource_entry_ids` 和 metadata 中，可继续交给 Resolver。Provider 只构建隔离快照，项目可以把结果交给 `GFAssetCatalogRuntime` 挂载，或直接用于离线工具。
+
 需要把 manifest 或导出计划交给 JSON 日志、CI 或编辑器面板时，可以使用 `to_report_dictionary()`。它会通过 `GFReportValueCodec` 输出 JSON-safe 结构，避免 Resource、对象引用、非有限浮点或未脱敏路径直接进入公开报告。
 
 ## 典型流程
 
 ```gdscript
 var packages: GFContentPackageUtility = Gf.get_utility(GFContentPackageUtility)
-packages.register_source_root("res://content_packages")
+packages.register_source_root_for_owner(&"project.builtin_content", "res://content_packages")
 
 var report: Dictionary = packages.rebuild_catalog({
 	"check_resource_exists": true,
@@ -108,6 +130,7 @@ var report := plan.get_validation_report()
 
 - Content Package 不内置 `quest`、`item`、`biome`、`npc`、`skin` 等业务字段；这些字段应由项目 schema 或独立插件解释。
 - 内容包之间只声明依赖顺序，不声明启用条件、版本约束求解、下载来源或平台服务账号。
+- 查询只解释稳定 manifest 字段；复杂 OR、版本约束和业务 schema 查询应由项目组合多个查询结果或在独立规则层完成。
 - 资源键冲突时，依赖包先注册，依赖方后注册；项目可以用 resolver priority、owner-scoped 注册或 provider 明确覆盖基础包资源。
 - 需要多扩展组合时，在项目 Installer 或独立插件中组合 `GFContentPackageUtility`、`GFResourceResolverUtility` 和项目 schema，不把组合逻辑写回 GF 内置扩展。
 

--- a/docs/zh/reference/api/classes/GFAssetCatalogMount.md
+++ b/docs/zh/reference/api/classes/GFAssetCatalogMount.md
@@ -1,0 +1,303 @@
+# GFAssetCatalogMount
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+资产目录运行时挂载的生命周期句柄。 句柄保存提交时的目录快照、owner、mount ID、来源和 revision， 并提供幂等显式卸载入口。失败请求也返回带稳定状态与报告的非活动句柄。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_ACTIVE`](#member-gfassetcatalogmount-constants-status_active) | `const STATUS_ACTIVE: StringName = &"active"` |
+| 常量 | [`STATUS_UNMOUNTED`](#member-gfassetcatalogmount-constants-status_unmounted) | `const STATUS_UNMOUNTED: StringName = &"unmounted"` |
+| 常量 | [`STATUS_CONFLICT`](#member-gfassetcatalogmount-constants-status_conflict) | `const STATUS_CONFLICT: StringName = &"conflict"` |
+| 常量 | [`STATUS_BUILD_FAILED`](#member-gfassetcatalogmount-constants-status_build_failed) | `const STATUS_BUILD_FAILED: StringName = &"build_failed"` |
+| 常量 | [`STATUS_DUPLICATE_MOUNT`](#member-gfassetcatalogmount-constants-status_duplicate_mount) | `const STATUS_DUPLICATE_MOUNT: StringName = &"duplicate_mount"` |
+| 常量 | [`STATUS_INVALID_REQUEST`](#member-gfassetcatalogmount-constants-status_invalid_request) | `const STATUS_INVALID_REQUEST: StringName = &"invalid_request"` |
+| 常量 | [`STATUS_DISPOSED`](#member-gfassetcatalogmount-constants-status_disposed) | `const STATUS_DISPOSED: StringName = &"disposed"` |
+| 方法 | [`is_active`](#member-gfassetcatalogmount-methods-is_active) | `func is_active() -> bool:` |
+| 方法 | [`get_status`](#member-gfassetcatalogmount-methods-get_status) | `func get_status() -> StringName:` |
+| 方法 | [`get_owner_id`](#member-gfassetcatalogmount-methods-get_owner_id) | `func get_owner_id() -> StringName:` |
+| 方法 | [`get_mount_id`](#member-gfassetcatalogmount-methods-get_mount_id) | `func get_mount_id() -> StringName:` |
+| 方法 | [`get_source_id`](#member-gfassetcatalogmount-methods-get_source_id) | `func get_source_id() -> StringName:` |
+| 方法 | [`get_priority`](#member-gfassetcatalogmount-methods-get_priority) | `func get_priority() -> int:` |
+| 方法 | [`get_revision`](#member-gfassetcatalogmount-methods-get_revision) | `func get_revision() -> int:` |
+| 方法 | [`get_catalog`](#member-gfassetcatalogmount-methods-get_catalog) | `func get_catalog() -> GFAssetCatalog:` |
+| 方法 | [`get_report`](#member-gfassetcatalogmount-methods-get_report) | `func get_report() -> Dictionary:` |
+| 方法 | [`unmount`](#member-gfassetcatalogmount-methods-unmount) | `func unmount() -> bool:` |
+| 方法 | [`to_dict`](#member-gfassetcatalogmount-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfassetcatalogmount-constants-status_active"></a>
+
+### `STATUS_ACTIVE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ACTIVE: StringName = &"active"
+```
+
+Mount 已提交且仍活动。
+
+<a id="member-gfassetcatalogmount-constants-status_unmounted"></a>
+
+### `STATUS_UNMOUNTED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_UNMOUNTED: StringName = &"unmounted"
+```
+
+Mount 已由调用方或 owner scope 释放。
+
+<a id="member-gfassetcatalogmount-constants-status_conflict"></a>
+
+### `STATUS_CONFLICT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_CONFLICT: StringName = &"conflict"
+```
+
+Mount 与已提交资产 ID 冲突。
+
+<a id="member-gfassetcatalogmount-constants-status_build_failed"></a>
+
+### `STATUS_BUILD_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_BUILD_FAILED: StringName = &"build_failed"
+```
+
+Provider 未能构建目录。
+
+<a id="member-gfassetcatalogmount-constants-status_duplicate_mount"></a>
+
+### `STATUS_DUPLICATE_MOUNT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_DUPLICATE_MOUNT: StringName = &"duplicate_mount"
+```
+
+同一 owner 已存在相同 mount ID。
+
+<a id="member-gfassetcatalogmount-constants-status_invalid_request"></a>
+
+### `STATUS_INVALID_REQUEST`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_REQUEST: StringName = &"invalid_request"
+```
+
+Mount 请求缺少 owner、mount ID 或有效目录。
+
+<a id="member-gfassetcatalogmount-constants-status_disposed"></a>
+
+### `STATUS_DISPOSED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_DISPOSED: StringName = &"disposed"
+```
+
+所属 Runtime 已释放。
+
+## 方法
+
+<a id="member-gfassetcatalogmount-methods-is_active"></a>
+
+### `is_active`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_active() -> bool:
+```
+
+检查 Mount 是否仍在 Runtime 中活动。
+
+返回：活动返回 true。
+
+<a id="member-gfassetcatalogmount-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> StringName:
+```
+
+获取稳定终态状态。
+
+返回：`STATUS_*` 常量之一。
+
+<a id="member-gfassetcatalogmount-methods-get_owner_id"></a>
+
+### `get_owner_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_owner_id() -> StringName:
+```
+
+获取 owner ID。
+
+返回：Mount owner ID。
+
+<a id="member-gfassetcatalogmount-methods-get_mount_id"></a>
+
+### `get_mount_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_mount_id() -> StringName:
+```
+
+获取 owner scope 内稳定 mount ID。
+
+返回：Mount ID。
+
+<a id="member-gfassetcatalogmount-methods-get_source_id"></a>
+
+### `get_source_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_id() -> StringName:
+```
+
+获取来源 ID。
+
+返回：Provider 来源 ID；直接目录 Mount 默认等于 mount ID。
+
+<a id="member-gfassetcatalogmount-methods-get_priority"></a>
+
+### `get_priority`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_priority() -> int:
+```
+
+获取 Mount 优先级。
+
+返回：合并优先级。
+
+<a id="member-gfassetcatalogmount-methods-get_revision"></a>
+
+### `get_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_revision() -> int:
+```
+
+获取最近一次提交该 Mount 的 Runtime revision。
+
+返回：非负 revision。
+
+<a id="member-gfassetcatalogmount-methods-get_catalog"></a>
+
+### `get_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_catalog() -> GFAssetCatalog:
+```
+
+获取 Mount 自身的资产目录快照。
+
+返回：深拷贝目录。
+
+<a id="member-gfassetcatalogmount-methods-get_report"></a>
+
+### `get_report`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_report() -> Dictionary:
+```
+
+获取 Mount 请求或提交报告。
+
+返回：GFValidationReport 兼容字典副本。
+
+结构：
+
+- `return`: GFValidationReport-compatible Dictionary with status, owner_id, mount_id, source_id, priority, and revision.
+
+<a id="member-gfassetcatalogmount-methods-unmount"></a>
+
+### `unmount`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unmount() -> bool:
+```
+
+从所属 Runtime 卸载当前 Mount。
+
+返回：本次调用完成卸载返回 true；已终态返回 false。
+
+<a id="member-gfassetcatalogmount-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为 JSON-safe 诊断摘要。
+
+返回：Mount 摘要。
+
+结构：
+
+- `return`: Dictionary with active, status, owner_id, mount_id, source_id, priority, revision, token, asset_ids, and report.

--- a/docs/zh/reference/api/classes/GFAssetCatalogRuntime.md
+++ b/docs/zh/reference/api/classes/GFAssetCatalogRuntime.md
@@ -1,0 +1,282 @@
+# GFAssetCatalogRuntime
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd`
+- 模块：`Standard`
+- 继承：`GFUtility`
+- API：`public`
+- 类别：运行时服务 (`runtime_service`)
+- 首次版本：`unreleased`
+
+owner-scoped 资产目录快照挂载与原子合并服务。 Runtime 只接收已经构建的目录快照或 Provider 输出，按稳定优先级合并并以 revision 发布。 任何无效请求、Provider 失败或严格冲突都不会替换上一份已提交目录。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`catalog_changed`](#member-gfassetcatalogruntime-signals-catalog_changed) | `signal catalog_changed(catalog: GFAssetCatalog, revision: int)` |
+| 常量 | [`CONFLICT_REJECT`](#member-gfassetcatalogruntime-constants-conflict_reject) | `const CONFLICT_REJECT: StringName = &"reject"` |
+| 常量 | [`CONFLICT_KEEP_HIGH_PRIORITY`](#member-gfassetcatalogruntime-constants-conflict_keep_high_priority) | `const CONFLICT_KEEP_HIGH_PRIORITY: StringName = &"keep_high_priority"` |
+| 方法 | [`configure`](#member-gfassetcatalogruntime-methods-configure) | `func configure(conflict_policy: StringName = CONFLICT_REJECT) -> GFAssetCatalogRuntime:` |
+| 方法 | [`mount_catalog`](#member-gfassetcatalogruntime-methods-mount_catalog) | `func mount_catalog( owner_id: StringName, mount_id: StringName, catalog: GFAssetCatalog, priority: int = 0, source_id: StringName = &"" ) -> GFAssetCatalogMount:` |
+| 方法 | [`mount_provider`](#member-gfassetcatalogruntime-methods-mount_provider) | `func mount_provider( owner_id: StringName, mount_id: StringName, provider: GFAssetCatalogSourceProvider, options: Dictionary = {} ) -> GFAssetCatalogMount:` |
+| 方法 | [`replace_mount_catalog`](#member-gfassetcatalogruntime-methods-replace_mount_catalog) | `func replace_mount_catalog(mount: GFAssetCatalogMount, catalog: GFAssetCatalog) -> bool:` |
+| 方法 | [`unmount_owner`](#member-gfassetcatalogruntime-methods-unmount_owner) | `func unmount_owner(owner_id: StringName) -> int:` |
+| 方法 | [`get_catalog`](#member-gfassetcatalogruntime-methods-get_catalog) | `func get_catalog() -> GFAssetCatalog:` |
+| 方法 | [`get_revision`](#member-gfassetcatalogruntime-methods-get_revision) | `func get_revision() -> int:` |
+| 方法 | [`get_mounts`](#member-gfassetcatalogruntime-methods-get_mounts) | `func get_mounts() -> Array[GFAssetCatalogMount]:` |
+| 方法 | [`get_last_report`](#member-gfassetcatalogruntime-methods-get_last_report) | `func get_last_report() -> Dictionary:` |
+| 方法 | [`get_debug_snapshot`](#member-gfassetcatalogruntime-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
+
+## 信号
+
+<a id="member-gfassetcatalogruntime-signals-catalog_changed"></a>
+
+### `catalog_changed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal catalog_changed(catalog: GFAssetCatalog, revision: int)
+```
+
+资产目录成功提交新 revision 后发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `catalog` | 已提交目录的隔离快照。 |
+| `revision` | 新 revision。 |
+
+## 常量
+
+<a id="member-gfassetcatalogruntime-constants-conflict_reject"></a>
+
+### `CONFLICT_REJECT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const CONFLICT_REJECT: StringName = &"reject"
+```
+
+任一重复 asset ID 都拒绝整次事务。
+
+<a id="member-gfassetcatalogruntime-constants-conflict_keep_high_priority"></a>
+
+### `CONFLICT_KEEP_HIGH_PRIORITY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const CONFLICT_KEEP_HIGH_PRIORITY: StringName = &"keep_high_priority"
+```
+
+重复 asset ID 显式保留高优先级 Mount 的条目。
+
+## 方法
+
+<a id="member-gfassetcatalogruntime-methods-configure"></a>
+
+### `configure`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func configure(conflict_policy: StringName = CONFLICT_REJECT) -> GFAssetCatalogRuntime:
+```
+
+配置全局 asset ID 冲突政策。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `conflict_policy` | CONFLICT_REJECT 或 CONFLICT_KEEP_HIGH_PRIORITY。 |
+
+返回：当前 Runtime；已有 Mount 或政策无效时保持原配置。
+
+<a id="member-gfassetcatalogruntime-methods-mount_catalog"></a>
+
+### `mount_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func mount_catalog( owner_id: StringName, mount_id: StringName, catalog: GFAssetCatalog, priority: int = 0, source_id: StringName = &"" ) -> GFAssetCatalogMount:
+```
+
+原子挂载一个资产目录快照。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 非空 owner ID。 |
+| `mount_id` | owner scope 内非空稳定 ID。 |
+| `catalog` | 要挂载的目录；Runtime 保存深拷贝。 |
+| `priority` | 合并优先级，数值越大越先处理。 |
+| `source_id` | 可选来源 ID；为空时使用 mount_id。 |
+
+返回：活动 Mount 或带稳定失败状态的非活动 Mount。
+
+<a id="member-gfassetcatalogruntime-methods-mount_provider"></a>
+
+### `mount_provider`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func mount_provider( owner_id: StringName, mount_id: StringName, provider: GFAssetCatalogSourceProvider, options: Dictionary = {} ) -> GFAssetCatalogMount:
+```
+
+构建 Provider 快照并原子挂载。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 非空 owner ID。 |
+| `mount_id` | owner scope 内稳定 ID。 |
+| `provider` | 资产目录来源 Provider。 |
+| `options` | 传给 Provider 的构建选项。 |
+
+返回：活动 Mount 或带构建失败状态的非活动 Mount。
+
+结构：
+
+- `options`: Dictionary with provider-defined build options.
+
+<a id="member-gfassetcatalogruntime-methods-replace_mount_catalog"></a>
+
+### `replace_mount_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func replace_mount_catalog(mount: GFAssetCatalogMount, catalog: GFAssetCatalog) -> bool:
+```
+
+原子替换一个活动 Mount 的目录快照。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `mount` | 当前 Runtime 返回的活动 Mount。 |
+| `catalog` | 新目录快照。 |
+
+返回：完整候选成功提交返回 true；失败时保留原 Mount、目录和 revision。
+
+<a id="member-gfassetcatalogruntime-methods-unmount_owner"></a>
+
+### `unmount_owner`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unmount_owner(owner_id: StringName) -> int:
+```
+
+批量释放一个 owner 的全部 Mount，并只提交一个新 revision。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 要释放的 owner ID。 |
+
+返回：释放的 Mount 数量。
+
+<a id="member-gfassetcatalogruntime-methods-get_catalog"></a>
+
+### `get_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_catalog() -> GFAssetCatalog:
+```
+
+获取当前已提交资产目录快照。
+
+返回：深拷贝目录。
+
+<a id="member-gfassetcatalogruntime-methods-get_revision"></a>
+
+### `get_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_revision() -> int:
+```
+
+获取当前目录 revision。
+
+返回：从 0 开始、仅成功提交时递增的 revision。
+
+<a id="member-gfassetcatalogruntime-methods-get_mounts"></a>
+
+### `get_mounts`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_mounts() -> Array[GFAssetCatalogMount]:
+```
+
+获取全部活动 Mount。
+
+返回：按合并顺序排列的 Mount 句柄。
+
+<a id="member-gfassetcatalogruntime-methods-get_last_report"></a>
+
+### `get_last_report`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_last_report() -> Dictionary:
+```
+
+获取最近一次运行时报告。
+
+返回：GFValidationReport 兼容字典副本。
+
+结构：
+
+- `return`: GFValidationReport-compatible Dictionary with conflict_policy, revision, mount_count, asset_count, and issues.
+
+<a id="member-gfassetcatalogruntime-methods-get_debug_snapshot"></a>
+
+### `get_debug_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_debug_snapshot() -> Dictionary:
+```
+
+获取 JSON-safe 调试快照。
+
+返回：Runtime、Mount 和目录摘要。
+
+结构：
+
+- `return`: Dictionary with conflict_policy, disposed, revision, mount_count, mounts, catalog, and last_report.

--- a/docs/zh/reference/api/classes/GFContentPackageAssetCatalogProvider.md
+++ b/docs/zh/reference/api/classes/GFContentPackageAssetCatalogProvider.md
@@ -1,0 +1,94 @@
+# GFContentPackageAssetCatalogProvider
+
+[API Reference](../index.md) / [Extensions / Content Package](../extensions-content-package.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd`
+- 模块：`Extensions / Content Package`
+- 继承：`GFAssetCatalogSourceProvider`
+- API：`public`
+- 类别：协议与扩展点 (`protocol`)
+- 首次版本：`unreleased`
+
+内容包目录到通用资产目录的适配器。 Provider 持有内容包目录快照，通过可选 GFContentPackageQuery 选择 manifest， 再把资源映射转换为 GFAssetCatalogEntry。它不挂载目录、不下载内容，也不解释业务分类。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`configure_catalog`](#member-gfcontentpackageassetcatalogprovider-methods-configure_catalog) | `func configure_catalog( catalog: GFContentPackageCatalog, p_source_id: StringName = &"content_packages", query: GFContentPackageQuery = null, options: Dictionary = {} ) -> GFContentPackageAssetCatalogProvider:` |
+| 方法 | [`build_catalog`](#member-gfcontentpackageassetcatalogprovider-methods-build_catalog) | `func build_catalog(options: Dictionary = {}) -> GFAssetCatalog:` |
+| 方法 | [`get_debug_snapshot`](#member-gfcontentpackageassetcatalogprovider-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
+
+## 方法
+
+<a id="member-gfcontentpackageassetcatalogprovider-methods-configure_catalog"></a>
+
+### `configure_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func configure_catalog( catalog: GFContentPackageCatalog, p_source_id: StringName = &"content_packages", query: GFContentPackageQuery = null, options: Dictionary = {} ) -> GFContentPackageAssetCatalogProvider:
+```
+
+配置内容包目录快照和可选查询。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `catalog` | 内容包目录；Provider 保存其深拷贝。 |
+| `p_source_id` | 资产来源 ID。 |
+| `query` | 可选内容包查询；为空时选择全部有效包。 |
+| `options` | Provider 配置选项，支持 priority。 |
+
+返回：当前 Provider。
+
+结构：
+
+- `options`: Dictionary with optional priority: int.
+
+<a id="member-gfcontentpackageassetcatalogprovider-methods-build_catalog"></a>
+
+### `build_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func build_catalog(options: Dictionary = {}) -> GFAssetCatalog:
+```
+
+构建资产目录快照。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `options` | 可选字段映射，支持 title_fields、description_fields、tag_fields、category_fields 和 preview_path_fields。 |
+
+返回：转换后的资产目录；内容包目录无效时返回 null。
+
+结构：
+
+- `options`: Dictionary with optional PackedStringArray field-name lists for title_fields, description_fields, tag_fields, category_fields, and preview_path_fields.
+
+<a id="member-gfcontentpackageassetcatalogprovider-methods-get_debug_snapshot"></a>
+
+### `get_debug_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_debug_snapshot() -> Dictionary:
+```
+
+获取 Provider 诊断快照。
+
+返回：来源、内容包目录和查询摘要。
+
+结构：
+
+- `return`: Dictionary with source_id, priority, provider_class, content_catalog, and query.

--- a/docs/zh/reference/api/classes/GFContentPackageCatalog.md
+++ b/docs/zh/reference/api/classes/GFContentPackageCatalog.md
@@ -24,6 +24,7 @@
 | 方法 | [`duplicate_catalog`](#member-gfcontentpackagecatalog-methods-duplicate_catalog) | `func duplicate_catalog() -> GFContentPackageCatalog:` |
 | 方法 | [`get_package_ids`](#member-gfcontentpackagecatalog-methods-get_package_ids) | `func get_package_ids() -> PackedStringArray:` |
 | 方法 | [`get_ordered_package_ids`](#member-gfcontentpackagecatalog-methods-get_ordered_package_ids) | `func get_ordered_package_ids() -> PackedStringArray:` |
+| 方法 | [`query_packages`](#member-gfcontentpackagecatalog-methods-query_packages) | `func query_packages( query: GFContentPackageQuery, options: Dictionary = {} ) -> GFContentPackageQueryResult:` |
 | 方法 | [`get_graph_report`](#member-gfcontentpackagecatalog-methods-get_graph_report) | `func get_graph_report(options: Dictionary = {}) -> Dictionary:` |
 | 方法 | [`register_resources`](#member-gfcontentpackagecatalog-methods-register_resources) | `func register_resources(resolver: GFResourceResolverUtility, options: Dictionary = {}) -> Dictionary:` |
 | 方法 | [`get_debug_snapshot`](#member-gfcontentpackagecatalog-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
@@ -189,6 +190,32 @@ func get_ordered_package_ids() -> PackedStringArray:
 获取按依赖优先排序的内容包 ID。
 
 返回：依赖包先于依赖方出现的内容包 ID 列表。
+
+<a id="member-gfcontentpackagecatalog-methods-query_packages"></a>
+
+### `query_packages`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func query_packages( query: GFContentPackageQuery, options: Dictionary = {} ) -> GFContentPackageQueryResult:
+```
+
+查询有效内容包并返回隔离结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `query` | 通用内容包查询。 |
+| `options` | manifest 和依赖图校验选项。 |
+
+返回：类型化查询终态；目录无效时不返回部分结果。
+
+结构：
+
+- `options`: Dictionary，可包含 check_resource_exists: bool、check_resource_dependencies: bool 和 dependency_options: Dictionary。
 
 <a id="member-gfcontentpackagecatalog-methods-get_graph_report"></a>
 

--- a/docs/zh/reference/api/classes/GFContentPackageQuery.md
+++ b/docs/zh/reference/api/classes/GFContentPackageQuery.md
@@ -1,0 +1,291 @@
+# GFContentPackageQuery
+
+[API Reference](../index.md) / [Extensions / Content Package](../extensions-content-package.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/content_package/resources/gf_content_package_query.gd`
+- 模块：`Extensions / Content Package`
+- 继承：`Resource`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+内容包目录的确定性通用查询条件。 查询只描述 package、content type、依赖、资源键、安全分类和 metadata 约束， 不解释项目业务语义。所有非空条件采用 AND 语义，列表条件要求 manifest 包含全部值。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 属性 | [`query_id`](#member-gfcontentpackagequery-properties-query_id) | `var query_id: StringName = &""` |
+| 属性 | [`package_ids`](#member-gfcontentpackagequery-properties-package_ids) | `var package_ids: PackedStringArray = PackedStringArray()` |
+| 属性 | [`search_text`](#member-gfcontentpackagequery-properties-search_text) | `var search_text: String = ""` |
+| 属性 | [`required_content_types`](#member-gfcontentpackagequery-properties-required_content_types) | `var required_content_types: PackedStringArray = PackedStringArray()` |
+| 属性 | [`required_dependencies`](#member-gfcontentpackagequery-properties-required_dependencies) | `var required_dependencies: PackedStringArray = PackedStringArray()` |
+| 属性 | [`required_resource_keys`](#member-gfcontentpackagequery-properties-required_resource_keys) | `var required_resource_keys: PackedStringArray = PackedStringArray()` |
+| 属性 | [`allowed_safety_kinds`](#member-gfcontentpackagequery-properties-allowed_safety_kinds) | `var allowed_safety_kinds: PackedStringArray = PackedStringArray()` |
+| 属性 | [`required_metadata`](#member-gfcontentpackagequery-properties-required_metadata) | `var required_metadata: Dictionary = {}` |
+| 属性 | [`include_dependencies`](#member-gfcontentpackagequery-properties-include_dependencies) | `var include_dependencies: bool = false` |
+| 属性 | [`max_results`](#member-gfcontentpackagequery-properties-max_results) | `var max_results: int = 0` |
+| 属性 | [`metadata`](#member-gfcontentpackagequery-properties-metadata) | `var metadata: Dictionary = {}` |
+| 方法 | [`matches`](#member-gfcontentpackagequery-methods-matches) | `func matches(manifest: GFContentPackageManifest) -> bool:` |
+| 方法 | [`apply_dict`](#member-gfcontentpackagequery-methods-apply_dict) | `func apply_dict(data: Dictionary) -> void:` |
+| 方法 | [`to_dict`](#member-gfcontentpackagequery-methods-to_dict) | `func to_dict() -> Dictionary:` |
+| 方法 | [`duplicate_query`](#member-gfcontentpackagequery-methods-duplicate_query) | `func duplicate_query() -> GFContentPackageQuery:` |
+| 方法 | [`from_dict`](#member-gfcontentpackagequery-methods-from_dict) | `static func from_dict(data: Dictionary) -> GFContentPackageQuery:` |
+
+## 属性
+
+<a id="member-gfcontentpackagequery-properties-query_id"></a>
+
+### `query_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var query_id: StringName = &""
+```
+
+查询稳定标识，仅用于诊断和追踪。
+
+<a id="member-gfcontentpackagequery-properties-package_ids"></a>
+
+### `package_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var package_ids: PackedStringArray = PackedStringArray()
+```
+
+允许返回的 package ID；为空表示不限制。
+
+<a id="member-gfcontentpackagequery-properties-search_text"></a>
+
+### `search_text`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var search_text: String = ""
+```
+
+在 package ID、显示名、版本和 content type 中匹配的大小写无关文本。
+
+<a id="member-gfcontentpackagequery-properties-required_content_types"></a>
+
+### `required_content_types`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var required_content_types: PackedStringArray = PackedStringArray()
+```
+
+manifest 必须包含的全部 content type。
+
+<a id="member-gfcontentpackagequery-properties-required_dependencies"></a>
+
+### `required_dependencies`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var required_dependencies: PackedStringArray = PackedStringArray()
+```
+
+manifest 必须声明的全部直接依赖 ID。
+
+<a id="member-gfcontentpackagequery-properties-required_resource_keys"></a>
+
+### `required_resource_keys`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var required_resource_keys: PackedStringArray = PackedStringArray()
+```
+
+manifest 必须声明的全部资源键。
+
+<a id="member-gfcontentpackagequery-properties-allowed_safety_kinds"></a>
+
+### `allowed_safety_kinds`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var allowed_safety_kinds: PackedStringArray = PackedStringArray()
+```
+
+允许的安全分类；为空表示不限制。
+
+<a id="member-gfcontentpackagequery-properties-required_metadata"></a>
+
+### `required_metadata`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var required_metadata: Dictionary = {}
+```
+
+manifest metadata 必须精确匹配的键值。
+
+结构：
+
+- `required_metadata`: Dictionary with exact manifest metadata key/value filters.
+
+<a id="member-gfcontentpackagequery-properties-include_dependencies"></a>
+
+### `include_dependencies`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var include_dependencies: bool = false
+```
+
+是否把直接命中包的传递依赖加入结果。
+
+<a id="member-gfcontentpackagequery-properties-max_results"></a>
+
+### `max_results`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var max_results: int = 0
+```
+
+直接命中包的最大数量；小于等于 0 表示不限制。依赖闭包不计入该限制。
+
+<a id="member-gfcontentpackagequery-properties-metadata"></a>
+
+### `metadata`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var metadata: Dictionary = {}
+```
+
+调用方自定义查询元数据；GF 只负责复制和序列化。
+
+结构：
+
+- `metadata`: Dictionary with caller-defined query metadata.
+
+## 方法
+
+<a id="member-gfcontentpackagequery-methods-matches"></a>
+
+### `matches`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func matches(manifest: GFContentPackageManifest) -> bool:
+```
+
+检查 manifest 是否满足全部非空查询条件。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `manifest` | 要检查的内容包 manifest。 |
+
+返回：满足查询条件返回 true。
+
+<a id="member-gfcontentpackagequery-methods-apply_dict"></a>
+
+### `apply_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func apply_dict(data: Dictionary) -> void:
+```
+
+从字典应用查询字段并执行集合归一化。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `data` | 查询字典。 |
+
+结构：
+
+- `data`: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.
+
+<a id="member-gfcontentpackagequery-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为归一化字典。
+
+返回：查询字典副本。
+
+结构：
+
+- `return`: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.
+
+<a id="member-gfcontentpackagequery-methods-duplicate_query"></a>
+
+### `duplicate_query`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_query() -> GFContentPackageQuery:
+```
+
+创建查询深拷贝。
+
+返回：新查询。
+
+<a id="member-gfcontentpackagequery-methods-from_dict"></a>
+
+### `from_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func from_dict(data: Dictionary) -> GFContentPackageQuery:
+```
+
+从字典创建查询。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `data` | 查询字典。 |
+
+返回：新查询。
+
+结构：
+
+- `data`: Dictionary with query_id, package_ids, search_text, required_content_types, required_dependencies, required_resource_keys, allowed_safety_kinds, required_metadata, include_dependencies, max_results, and metadata.

--- a/docs/zh/reference/api/classes/GFContentPackageQueryResult.md
+++ b/docs/zh/reference/api/classes/GFContentPackageQueryResult.md
@@ -1,0 +1,221 @@
+# GFContentPackageQueryResult
+
+[API Reference](../index.md) / [Extensions / Content Package](../extensions-content-package.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd`
+- 模块：`Extensions / Content Package`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+内容包查询的不可变结果快照。 结果区分直接命中与依赖闭包，并保留隔离的 manifest 和验证报告， 调用方不需要从空数组推断查询失败或无匹配。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_COMPLETED`](#member-gfcontentpackagequeryresult-constants-status_completed) | `const STATUS_COMPLETED: StringName = &"completed"` |
+| 常量 | [`STATUS_INVALID_QUERY`](#member-gfcontentpackagequeryresult-constants-status_invalid_query) | `const STATUS_INVALID_QUERY: StringName = &"invalid_query"` |
+| 常量 | [`STATUS_INVALID_CATALOG`](#member-gfcontentpackagequeryresult-constants-status_invalid_catalog) | `const STATUS_INVALID_CATALOG: StringName = &"invalid_catalog"` |
+| 方法 | [`is_successful`](#member-gfcontentpackagequeryresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`get_status`](#member-gfcontentpackagequeryresult-methods-get_status) | `func get_status() -> StringName:` |
+| 方法 | [`get_query_id`](#member-gfcontentpackagequeryresult-methods-get_query_id) | `func get_query_id() -> StringName:` |
+| 方法 | [`get_direct_package_ids`](#member-gfcontentpackagequeryresult-methods-get_direct_package_ids) | `func get_direct_package_ids() -> PackedStringArray:` |
+| 方法 | [`get_package_ids`](#member-gfcontentpackagequeryresult-methods-get_package_ids) | `func get_package_ids() -> PackedStringArray:` |
+| 方法 | [`get_manifest`](#member-gfcontentpackagequeryresult-methods-get_manifest) | `func get_manifest(package_id: StringName) -> GFContentPackageManifest:` |
+| 方法 | [`get_manifests`](#member-gfcontentpackagequeryresult-methods-get_manifests) | `func get_manifests() -> Array[GFContentPackageManifest]:` |
+| 方法 | [`get_report`](#member-gfcontentpackagequeryresult-methods-get_report) | `func get_report() -> Dictionary:` |
+| 方法 | [`to_dict`](#member-gfcontentpackagequeryresult-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfcontentpackagequeryresult-constants-status_completed"></a>
+
+### `STATUS_COMPLETED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_COMPLETED: StringName = &"completed"
+```
+
+查询成功完成。
+
+<a id="member-gfcontentpackagequeryresult-constants-status_invalid_query"></a>
+
+### `STATUS_INVALID_QUERY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_QUERY: StringName = &"invalid_query"
+```
+
+查询对象为空或无效。
+
+<a id="member-gfcontentpackagequeryresult-constants-status_invalid_catalog"></a>
+
+### `STATUS_INVALID_CATALOG`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_CATALOG: StringName = &"invalid_catalog"
+```
+
+内容包目录依赖图或 manifest 无效。
+
+## 方法
+
+<a id="member-gfcontentpackagequeryresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+检查查询是否成功完成。
+
+返回：查询成功返回 true；零匹配仍属于成功。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> StringName:
+```
+
+获取稳定终态状态。
+
+返回：`STATUS_*` 常量之一。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_query_id"></a>
+
+### `get_query_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_query_id() -> StringName:
+```
+
+获取查询 ID。
+
+返回：查询稳定 ID。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_direct_package_ids"></a>
+
+### `get_direct_package_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_direct_package_ids() -> PackedStringArray:
+```
+
+获取不含自动依赖扩展的直接命中 package ID。
+
+返回：dependency-first 排序的 ID 副本。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_package_ids"></a>
+
+### `get_package_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_package_ids() -> PackedStringArray:
+```
+
+获取最终 package ID，包括请求的依赖闭包。
+
+返回：dependency-first 排序的 ID 副本。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_manifest"></a>
+
+### `get_manifest`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_manifest(package_id: StringName) -> GFContentPackageManifest:
+```
+
+获取一个命中 manifest 的隔离副本。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `package_id` | 内容包 ID。 |
+
+返回：manifest 深拷贝；未命中返回 null。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_manifests"></a>
+
+### `get_manifests`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_manifests() -> Array[GFContentPackageManifest]:
+```
+
+获取全部命中 manifest 的隔离副本。
+
+返回：与 get_package_ids() 同序的 manifest 数组。
+
+<a id="member-gfcontentpackagequeryresult-methods-get_report"></a>
+
+### `get_report`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_report() -> Dictionary:
+```
+
+获取验证报告副本。
+
+返回：GFValidationReportDictionary 兼容字典。
+
+结构：
+
+- `return`: GFValidationReportDictionary-compatible Dictionary with query_id, status, direct_package_ids, and package_ids.
+
+<a id="member-gfcontentpackagequeryresult-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为 JSON-safe 结果摘要。
+
+返回：不包含 Resource 对象的结果字典。
+
+结构：
+
+- `return`: Dictionary with successful, status, query_id, direct_package_ids, package_ids, manifests, and report.

--- a/docs/zh/reference/api/classes/GFContentPackageUtility.md
+++ b/docs/zh/reference/api/classes/GFContentPackageUtility.md
@@ -16,9 +16,16 @@
 | 类型 | 名称 | 签名 |
 |---|---|---|
 | 信号 | [`catalog_rebuilt`](#member-gfcontentpackageutility-signals-catalog_rebuilt) | `signal catalog_rebuilt(catalog: GFContentPackageCatalog)` |
+| 常量 | [`DEFAULT_SOURCE_ROOT_OWNER_ID`](#member-gfcontentpackageutility-constants-default_source_root_owner_id) | `const DEFAULT_SOURCE_ROOT_OWNER_ID: StringName = &"gf.content_package.manual"` |
 | 方法 | [`register_source_root`](#member-gfcontentpackageutility-methods-register_source_root) | `func register_source_root(root_path: String) -> bool:` |
 | 方法 | [`unregister_source_root`](#member-gfcontentpackageutility-methods-unregister_source_root) | `func unregister_source_root(root_path: String) -> bool:` |
 | 方法 | [`clear_source_roots`](#member-gfcontentpackageutility-methods-clear_source_roots) | `func clear_source_roots() -> void:` |
+| 方法 | [`register_source_root_for_owner`](#member-gfcontentpackageutility-methods-register_source_root_for_owner) | `func register_source_root_for_owner(owner_id: StringName, root_path: String) -> bool:` |
+| 方法 | [`unregister_source_root_for_owner`](#member-gfcontentpackageutility-methods-unregister_source_root_for_owner) | `func unregister_source_root_for_owner(owner_id: StringName, root_path: String) -> bool:` |
+| 方法 | [`replace_owner_source_roots`](#member-gfcontentpackageutility-methods-replace_owner_source_roots) | `func replace_owner_source_roots( owner_id: StringName, root_paths: PackedStringArray ) -> GFValidationReport:` |
+| 方法 | [`clear_owner_source_roots`](#member-gfcontentpackageutility-methods-clear_owner_source_roots) | `func clear_owner_source_roots(owner_id: StringName) -> int:` |
+| 方法 | [`get_owner_source_roots`](#member-gfcontentpackageutility-methods-get_owner_source_roots) | `func get_owner_source_roots(owner_id: StringName) -> PackedStringArray:` |
+| 方法 | [`get_source_root_owner_ids`](#member-gfcontentpackageutility-methods-get_source_root_owner_ids) | `func get_source_root_owner_ids() -> PackedStringArray:` |
 | 方法 | [`get_source_roots`](#member-gfcontentpackageutility-methods-get_source_roots) | `func get_source_roots() -> PackedStringArray:` |
 | 方法 | [`get_catalog`](#member-gfcontentpackageutility-methods-get_catalog) | `func get_catalog() -> GFContentPackageCatalog:` |
 | 方法 | [`discover_manifest_paths`](#member-gfcontentpackageutility-methods-discover_manifest_paths) | `func discover_manifest_paths(root_path: String = "") -> PackedStringArray:` |
@@ -49,6 +56,21 @@ signal catalog_rebuilt(catalog: GFContentPackageCatalog)
 |---|---|
 | `catalog` | 当前内容包目录的隔离快照。 |
 
+## 常量
+
+<a id="member-gfcontentpackageutility-constants-default_source_root_owner_id"></a>
+
+### `DEFAULT_SOURCE_ROOT_OWNER_ID`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DEFAULT_SOURCE_ROOT_OWNER_ID: StringName = &"gf.content_package.manual"
+```
+
+register_source_root() 等便捷入口使用的显式 owner scope。
+
 ## 方法
 
 <a id="member-gfcontentpackageutility-methods-register_source_root"></a>
@@ -62,7 +84,7 @@ signal catalog_rebuilt(catalog: GFContentPackageCatalog)
 func register_source_root(root_path: String) -> bool:
 ```
 
-注册内容包 source root。
+把内容包 source root 注册到默认 manual owner scope。
 
 参数：
 
@@ -77,12 +99,13 @@ func register_source_root(root_path: String) -> bool:
 ### `unregister_source_root`
 
 - API：`public`
+- 首次版本：`6.0.0`
 
 ```gdscript
 func unregister_source_root(root_path: String) -> bool:
 ```
 
-注销内容包 source root。
+从默认 manual owner scope 注销内容包 source root。
 
 参数：
 
@@ -97,12 +120,136 @@ func unregister_source_root(root_path: String) -> bool:
 ### `clear_source_roots`
 
 - API：`public`
+- 首次版本：`6.0.0`
 
 ```gdscript
 func clear_source_roots() -> void:
 ```
 
-清空内容包 source root。
+清空默认 manual owner scope 的内容包 source root。
+
+<a id="member-gfcontentpackageutility-methods-register_source_root_for_owner"></a>
+
+### `register_source_root_for_owner`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func register_source_root_for_owner(owner_id: StringName, root_path: String) -> bool:
+```
+
+为稳定 owner 注册内容包 source root。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 非空 owner ID，用于批量释放来源。 |
+| `root_path` | `res://` 或 `user://` 根目录。 |
+
+返回：owner 首次取得该 root 时返回 true。
+
+<a id="member-gfcontentpackageutility-methods-unregister_source_root_for_owner"></a>
+
+### `unregister_source_root_for_owner`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unregister_source_root_for_owner(owner_id: StringName, root_path: String) -> bool:
+```
+
+从稳定 owner 注销一个内容包 source root。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 注册时使用的 owner ID。 |
+| `root_path` | 已注册 root。 |
+
+返回：找到并释放时返回 true。
+
+<a id="member-gfcontentpackageutility-methods-replace_owner_source_roots"></a>
+
+### `replace_owner_source_roots`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func replace_owner_source_roots( owner_id: StringName, root_paths: PackedStringArray ) -> GFValidationReport:
+```
+
+原子替换一个 owner 的全部 source root。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 非空 owner ID。 |
+| `root_paths` | 新 root 集合；空集合表示释放 owner。 |
+
+返回：类型化验证报告；任一 root 无效时不修改现有状态。
+
+<a id="member-gfcontentpackageutility-methods-clear_owner_source_roots"></a>
+
+### `clear_owner_source_roots`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func clear_owner_source_roots(owner_id: StringName) -> int:
+```
+
+释放一个 owner 的全部 source root。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | 要释放的 owner ID。 |
+
+返回：释放的 owner-root 关系数量。
+
+<a id="member-gfcontentpackageutility-methods-get_owner_source_roots"></a>
+
+### `get_owner_source_roots`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_owner_source_roots(owner_id: StringName) -> PackedStringArray:
+```
+
+获取一个 owner 持有的 source root。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner_id` | owner ID。 |
+
+返回：排序后的 root 副本。
+
+<a id="member-gfcontentpackageutility-methods-get_source_root_owner_ids"></a>
+
+### `get_source_root_owner_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_root_owner_ids() -> PackedStringArray:
+```
+
+获取当前持有 source root 的 owner ID。
+
+返回：排序后的 owner ID 文本。
 
 <a id="member-gfcontentpackageutility-methods-get_source_roots"></a>
 
@@ -259,6 +406,7 @@ func register_resources(resolver: GFResourceResolverUtility, options: Dictionary
 ### `get_debug_snapshot`
 
 - API：`public`
+- 首次版本：`4.4.0`
 
 ```gdscript
 func get_debug_snapshot() -> Dictionary:
@@ -270,4 +418,4 @@ func get_debug_snapshot() -> Dictionary:
 
 结构：
 
-- `return`: Dictionary，包含 source_roots 和 catalog。
+- `return`: Dictionary，包含 source_roots、source_root_owners 和 catalog。

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,14 +7,14 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 70 | 987 | [Kernel](#module-kernel) |
-| Standard | 416 | 6548 | [Standard](#module-standard) |
+| Standard | 418 | 6579 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
 | Camera | 7 | 130 | [Camera](#module-extensions-camera) |
 | Capability | 11 | 148 | [Capability](#module-extensions-capability) |
 | Combat | 51 | 609 | [Combat](#module-extensions-combat) |
-| Extensions / Content Package | 4 | 69 | [Extensions / Content Package](#module-extensions-content_package) |
+| Extensions / Content Package | 7 | 108 | [Extensions / Content Package](#module-extensions-content_package) |
 | Decision | 8 | 110 | [Decision](#module-extensions-decision) |
 | Dialogue | 5 | 75 | [Dialogue](#module-extensions-dialogue) |
 | Domain | 18 | 295 | [Domain](#module-extensions-domain) |
@@ -115,6 +115,7 @@
 | [`GFActivationTransaction`](GFActivationTransaction.md#gfactivationtransaction) | 运行时服务 (`runtime_service`) | `RefCounted` | 18 | `addons/gf/standard/foundation/policy/gf_activation_transaction.gd` |
 | [`GFAnalyticsUtility`](GFAnalyticsUtility.md#gfanalyticsutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 21 | `addons/gf/standard/utilities/analytics/gf_analytics_utility.gd` |
 | [`GFArtifactFreshnessReport`](GFArtifactFreshnessReport.md#gfartifactfreshnessreport) | 运行时服务 (`runtime_service`) | `RefCounted` | 9 | `addons/gf/standard/foundation/policy/gf_artifact_freshness_report.gd` |
+| [`GFAssetCatalogRuntime`](GFAssetCatalogRuntime.md#gfassetcatalogruntime) | 运行时服务 (`runtime_service`) | `GFUtility` | 13 | `addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd` |
 | [`GFAssetCatalogSourceRegistry`](GFAssetCatalogSourceRegistry.md#gfassetcatalogsourceregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/utilities/assets/gf_asset_catalog_source_registry.gd` |
 | [`GFAssetUtility`](GFAssetUtility.md#gfassetutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 39 | `addons/gf/standard/utilities/assets/gf_asset_utility.gd` |
 | [`GFAsyncFlowTools`](GFAsyncFlowTools.md#gfasyncflowtools) | 运行时服务 (`runtime_service`) | `RefCounted` | 8 | `addons/gf/standard/common/gf_async_flow_tools.gd` |
@@ -427,6 +428,7 @@
 | [`GFWaitSequenceStep`](GFWaitSequenceStep.md#gfwaitsequencestep) | 资源定义 (`resource_definition`) | `GFSequenceStep` | 3 | `addons/gf/standard/sequence/gf_wait_sequence_step.gd` |
 | [`GFWeightedEntry`](GFWeightedEntry.md#gfweightedentry) | 资源定义 (`resource_definition`) | `Resource` | 8 | `addons/gf/standard/foundation/math/gf_weighted_entry.gd` |
 | [`GFWeightedTable`](GFWeightedTable.md#gfweightedtable) | 资源定义 (`resource_definition`) | `Resource` | 17 | `addons/gf/standard/foundation/math/gf_weighted_table.gd` |
+| [`GFAssetCatalogMount`](GFAssetCatalogMount.md#gfassetcatalogmount) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 18 | `addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd` |
 | [`GFAssetHandle`](GFAssetHandle.md#gfassethandle) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 9 | `addons/gf/standard/utilities/assets/gf_asset_handle.gd` |
 | [`GFAssetLoadSession`](GFAssetLoadSession.md#gfassetloadsession) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 12 | `addons/gf/standard/utilities/assets/gf_asset_load_session.gd` |
 | [`GFAsyncBatch`](GFAsyncBatch.md#gfasyncbatch) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 31 | `addons/gf/standard/utilities/io/gf_async_batch.gd` |
@@ -688,10 +690,13 @@
 
 | 类 | 类别 | 继承 | 成员 | 源文件 |
 |---|---|---|---:|---|
-| [`GFContentPackageCatalog`](GFContentPackageCatalog.md#gfcontentpackagecatalog) | 运行时服务 (`runtime_service`) | `RefCounted` | 12 | `addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd` |
+| [`GFContentPackageCatalog`](GFContentPackageCatalog.md#gfcontentpackagecatalog) | 运行时服务 (`runtime_service`) | `RefCounted` | 13 | `addons/gf/extensions/content_package/runtime/gf_content_package_catalog.gd` |
 | [`GFContentPackageExportPlan`](GFContentPackageExportPlan.md#gfcontentpackageexportplan) | 运行时服务 (`runtime_service`) | `RefCounted` | 17 | `addons/gf/extensions/content_package/runtime/gf_content_package_export_plan.gd` |
-| [`GFContentPackageUtility`](GFContentPackageUtility.md#gfcontentpackageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 12 | `addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd` |
+| [`GFContentPackageUtility`](GFContentPackageUtility.md#gfcontentpackageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 19 | `addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd` |
+| [`GFContentPackageAssetCatalogProvider`](GFContentPackageAssetCatalogProvider.md#gfcontentpackageassetcatalogprovider) | 协议与扩展点 (`protocol`) | `GFAssetCatalogSourceProvider` | 3 | `addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd` |
 | [`GFContentPackageManifest`](GFContentPackageManifest.md#gfcontentpackagemanifest) | 资源定义 (`resource_definition`) | `Resource` | 28 | `addons/gf/extensions/content_package/resources/gf_content_package_manifest.gd` |
+| [`GFContentPackageQuery`](GFContentPackageQuery.md#gfcontentpackagequery) | 值对象 (`value_object`) | `Resource` | 16 | `addons/gf/extensions/content_package/resources/gf_content_package_query.gd` |
+| [`GFContentPackageQueryResult`](GFContentPackageQueryResult.md#gfcontentpackagequeryresult) | 值对象 (`value_object`) | `RefCounted` | 12 | `addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd` |
 
 <a id="module-extensions-decision"></a>
 

--- a/docs/zh/reference/api/extensions-content-package.md
+++ b/docs/zh/reference/api/extensions-content-package.md
@@ -6,8 +6,10 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 3 | 41 | 34 |
+| [运行时服务](#category-runtime_service) | 3 | 49 | 41 |
+| [协议与扩展点](#category-protocol) | 1 | 3 | 3 |
 | [资源定义](#category-resource_definition) | 1 | 28 | 12 |
+| [值对象](#category-value_object) | 2 | 28 | 14 |
 
 ## 类
 
@@ -21,6 +23,14 @@
 | [`GFContentPackageExportPlan`](classes/GFContentPackageExportPlan.md#gfcontentpackageexportplan) | `RefCounted` | `addons/gf/extensions/content_package/runtime/gf_content_package_export_plan.gd` |
 | [`GFContentPackageUtility`](classes/GFContentPackageUtility.md#gfcontentpackageutility) | `GFUtility` | `addons/gf/extensions/content_package/runtime/gf_content_package_utility.gd` |
 
+<a id="category-protocol"></a>
+
+### 协议与扩展点
+
+| 类 | 继承 | 源文件 |
+|---|---|---|
+| [`GFContentPackageAssetCatalogProvider`](classes/GFContentPackageAssetCatalogProvider.md#gfcontentpackageassetcatalogprovider) | `GFAssetCatalogSourceProvider` | `addons/gf/extensions/content_package/runtime/gf_content_package_asset_catalog_provider.gd` |
+
 <a id="category-resource_definition"></a>
 
 ### 资源定义
@@ -28,3 +38,12 @@
 | 类 | 继承 | 源文件 |
 |---|---|---|
 | [`GFContentPackageManifest`](classes/GFContentPackageManifest.md#gfcontentpackagemanifest) | `Resource` | `addons/gf/extensions/content_package/resources/gf_content_package_manifest.gd` |
+
+<a id="category-value_object"></a>
+
+### 值对象
+
+| 类 | 继承 | 源文件 |
+|---|---|---|
+| [`GFContentPackageQuery`](classes/GFContentPackageQuery.md#gfcontentpackagequery) | `Resource` | `addons/gf/extensions/content_package/resources/gf_content_package_query.gd` |
+| [`GFContentPackageQueryResult`](classes/GFContentPackageQueryResult.md#gfcontentpackagequeryresult) | `RefCounted` | `addons/gf/extensions/content_package/runtime/gf_content_package_query_result.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,23 +5,23 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`750`
-- 公开成员：`10809`
-- 公开方法：`6701`
+- 公开类：`755`
+- 公开成员：`10879`
+- 公开方法：`6746`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 70 | 987 | 715 | [kernel.md](kernel.md) |
-| Standard | 416 | 6548 | 4170 | [standard.md](standard.md) |
+| Standard | 418 | 6579 | 4191 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |
 | Camera | 7 | 130 | 43 | [extensions-camera.md](extensions-camera.md) |
 | Capability | 11 | 148 | 103 | [extensions-capability.md](extensions-capability.md) |
 | Combat | 51 | 609 | 261 | [extensions-combat.md](extensions-combat.md) |
-| Extensions / Content Package | 4 | 69 | 46 | [extensions-content-package.md](extensions-content-package.md) |
+| Extensions / Content Package | 7 | 108 | 70 | [extensions-content-package.md](extensions-content-package.md) |
 | Decision | 8 | 110 | 61 | [extensions-decision.md](extensions-decision.md) |
 | Dialogue | 5 | 75 | 36 | [extensions-dialogue.md](extensions-dialogue.md) |
 | Domain | 18 | 295 | 185 | [extensions-domain.md](extensions-domain.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,10 +6,10 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 182 | 3205 | 2163 |
+| [运行时服务](#category-runtime_service) | 183 | 3218 | 2173 |
 | [协议与扩展点](#category-protocol) | 22 | 309 | 251 |
 | [资源定义](#category-resource_definition) | 111 | 1442 | 747 |
-| [运行时句柄](#category-runtime_handle) | 42 | 713 | 463 |
+| [运行时句柄](#category-runtime_handle) | 43 | 731 | 474 |
 | [值对象](#category-value_object) | 36 | 658 | 416 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |
 | [事件契约](#category-event_contract) | 5 | 47 | 17 |
@@ -27,6 +27,7 @@
 | [`GFActivationTransaction`](classes/GFActivationTransaction.md#gfactivationtransaction) | `RefCounted` | `addons/gf/standard/foundation/policy/gf_activation_transaction.gd` |
 | [`GFAnalyticsUtility`](classes/GFAnalyticsUtility.md#gfanalyticsutility) | `GFUtility` | `addons/gf/standard/utilities/analytics/gf_analytics_utility.gd` |
 | [`GFArtifactFreshnessReport`](classes/GFArtifactFreshnessReport.md#gfartifactfreshnessreport) | `RefCounted` | `addons/gf/standard/foundation/policy/gf_artifact_freshness_report.gd` |
+| [`GFAssetCatalogRuntime`](classes/GFAssetCatalogRuntime.md#gfassetcatalogruntime) | `GFUtility` | `addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd` |
 | [`GFAssetCatalogSourceRegistry`](classes/GFAssetCatalogSourceRegistry.md#gfassetcatalogsourceregistry) | `RefCounted` | `addons/gf/standard/utilities/assets/gf_asset_catalog_source_registry.gd` |
 | [`GFAssetUtility`](classes/GFAssetUtility.md#gfassetutility) | `GFUtility` | `addons/gf/standard/utilities/assets/gf_asset_utility.gd` |
 | [`GFAsyncFlowTools`](classes/GFAsyncFlowTools.md#gfasyncflowtools) | `RefCounted` | `addons/gf/standard/common/gf_async_flow_tools.gd` |
@@ -360,6 +361,7 @@
 
 | 类 | 继承 | 源文件 |
 |---|---|---|
+| [`GFAssetCatalogMount`](classes/GFAssetCatalogMount.md#gfassetcatalogmount) | `RefCounted` | `addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd` |
 | [`GFAssetHandle`](classes/GFAssetHandle.md#gfassethandle) | `RefCounted` | `addons/gf/standard/utilities/assets/gf_asset_handle.gd` |
 | [`GFAssetLoadSession`](classes/GFAssetLoadSession.md#gfassetloadsession) | `RefCounted` | `addons/gf/standard/utilities/assets/gf_asset_load_session.gd` |
 | [`GFAsyncBatch`](classes/GFAsyncBatch.md#gfasyncbatch) | `RefCounted` | `addons/gf/standard/utilities/io/gf_async_batch.gd` |

--- a/docs/zh/standard/utilities/io/assets-jobs-warmup/asset-utility/asset-catalog.md
+++ b/docs/zh/standard/utilities/io/assets-jobs-warmup/asset-utility/asset-catalog.md
@@ -11,6 +11,8 @@
 - `GFAssetCatalogSourceProvider`：资产来源 provider 基类，用于把项目目录、资源注册表、内容包、外部库或项目数据库转换为资产目录。
 - `GFAssetCatalogSourceRegistry`：来源注册表，按优先级汇聚多个 provider，生成可重建的 catalog snapshot 和 JSON-safe 报告。
 - `GFResourceRegistryAssetSourceProvider`：把现有 `GFResourceRegistry` 适配为资产目录来源。
+- `GFAssetCatalogRuntime`：按 owner 和 mount ID 原子组合已构建目录快照，只在完整候选成功时推进 revision。
+- `GFAssetCatalogMount`：活动挂载或失败请求的类型化生命周期句柄，提供状态、报告、来源快照和幂等卸载。
 - `GFAssetCollection`：只保存稳定、有序的 `asset_id` 集合以及展示信息和调用方 metadata，不持有资源实例。
 - `GFAssetPreloadPlan`：稳定 ID 解析后的不可变加载计划；缺失 ID 会保留为无效计划项，而不是静默缩小请求集合。
 - `GFAssetLoadSession` / `GFAssetLoadSessionResult`：把加载、提交和回滚组成一次明确终态的事务会话。
@@ -119,9 +121,34 @@ if result == null or not result.is_successful():
 
 默认合并时，高优先级 provider 先写入，同 `asset_id` 的低优先级条目会被跳过。需要诊断重复 ID 时调用 `build_catalog_report()`，报告会返回 `sources`、`entry_count`、`catalog_data` 和 `issues`。
 
+`GFAssetCatalogSourceRegistry` 适合一次性构建或编辑器预览。需要让场景、功能模块、内容包或可选插件在运行时贡献并释放目录时，使用 `GFAssetCatalogRuntime`。Provider 在 Mount 前只执行一次，其输出立即复制为快照；后续修改 Provider 或源目录不会暗中改变已提交 catalog。
+
+```gdscript
+var runtime := GFAssetCatalogRuntime.new()
+runtime.configure(GFAssetCatalogRuntime.CONFLICT_REJECT)
+runtime.init()
+
+var mount := runtime.mount_provider(
+	&"feature.inventory",
+	&"inventory_assets",
+	provider
+)
+if not mount.is_active():
+	push_error(JSON.stringify(mount.get_report()))
+
+var live_catalog := runtime.get_catalog()
+# feature 退出时显式释放；重复调用安全返回 false。
+mount.unmount()
+```
+
+默认 `CONFLICT_REJECT` 会把任一重复 `asset_id` 视为事务错误，上一份目录和 revision 保持不变。确实需要覆盖层时，必须在首个 Mount 前显式配置 `CONFLICT_KEEP_HIGH_PRIORITY`；Runtime 会按 priority 降序，再按 owner ID 与 mount ID 稳定排序，同优先级结果不依赖注册时序。`unmount_owner()` 会批量释放 owner 的全部 Mount，并只提交一个新 revision。
+
+Provider 或内容包目录更新后，使用 `replace_mount_catalog()` 原子替换现有 Mount。Runtime 会先在候选集合中完成冲突检查与合并，成功后才同时更新 Mount 快照、聚合目录和 revision；失败时旧快照保持可用。不要用“先 `unmount()`、再重新 mount”模拟更新，因为两次提交之间会暴露不必要的空目录或降级目录。
+
 ## 使用边界
 
 - `GFAssetCatalog` 是索引，不是资源缓存；加载和生命周期仍交给 `GFAssetUtility`、`GFResourceResolverUtility` 或项目自己的加载流程。项目若已有业务资源目录，应把它适配成 catalog/provider，不要复制一套缓存所有权。
+- `GFAssetCatalogRuntime` 挂载的是隔离索引快照，不持有已加载资源；Mount 释放不会直接卸载 `GFAssetHandle`，资源生命周期仍需独立 owner 或 group。
 - `asset_id` 应作为长期稳定 ID，不应直接等同资源路径。
 - `GFAssetCollection` 是有序引用集合，不是调色板 UI、收藏夹数据库或资源缓存；项目可以在它之上实现任意编辑器交互，但不能假设 GF 会解释集合用途。
 - 标签、分类、备注和 metadata 只作为通用字段保存和索引；GF 不解释 `character`、`weapon`、`quest`、`license` 等项目语义。

--- a/tests/gf_core/extensions/content_package/test_gf_content_package_query.gd
+++ b/tests/gf_core/extensions/content_package/test_gf_content_package_query.gd
@@ -1,0 +1,231 @@
+## 测试内容包查询、资产目录适配和 source root 所有权契约。
+extends GutTest
+
+
+# --- 测试用例 ---
+
+func test_query_returns_dependency_first_snapshot_without_leaking_manifest_mutation() -> void:
+	var base_manifest: GFContentPackageManifest = _make_manifest(
+		&"author.base",
+		PackedStringArray(),
+		PackedStringArray(["theme"]),
+		{"channel": "stable"},
+		[{
+			"key": "base.palette",
+			"path": "assets/palette.tres",
+		}]
+	)
+	var ui_manifest: GFContentPackageManifest = _make_manifest(
+		&"author.ui",
+		PackedStringArray(["author.base"]),
+		PackedStringArray(["ui", "theme"]),
+		{"channel": "stable"},
+		[{
+			"key": "ui.save",
+			"path": "assets/save.png",
+		}]
+	)
+	var catalog: GFContentPackageCatalog = GFContentPackageCatalog.new().set_manifests([
+		ui_manifest,
+		base_manifest,
+	])
+	var query: GFContentPackageQuery = GFContentPackageQuery.new()
+	query.required_content_types = PackedStringArray(["ui"])
+	query.required_metadata = {"channel": "stable"}
+	query.include_dependencies = true
+
+	var result: GFContentPackageQueryResult = catalog.query_packages(query)
+	ui_manifest.display_name = "mutated outside catalog"
+	var result_manifest: GFContentPackageManifest = result.get_manifest(&"author.ui")
+
+	assert_true(result.is_successful(), "有效查询应返回成功终态。")
+	assert_eq(result.get_direct_package_ids(), PackedStringArray(["author.ui"]))
+	assert_eq(
+		result.get_package_ids(),
+		PackedStringArray(["author.base", "author.ui"]),
+		"依赖闭包应按 dependency-first 顺序返回。"
+	)
+	assert_not_null(result_manifest)
+	if result_manifest != null:
+		assert_ne(result_manifest.display_name, "mutated outside catalog", "结果必须持有隔离的 manifest 快照。")
+
+
+func test_query_applies_strict_filters_and_limit_before_dependency_expansion() -> void:
+	var base_manifest: GFContentPackageManifest = _make_manifest(
+		&"author.base",
+		PackedStringArray(),
+		PackedStringArray(["shared"]),
+		{},
+		[{"key": "base", "path": "base.tres"}]
+	)
+	var first_manifest: GFContentPackageManifest = _make_manifest(
+		&"author.first",
+		PackedStringArray(["author.base"]),
+		PackedStringArray(["ui"]),
+		{"channel": "stable"},
+		[{"key": "first", "path": "first.tres"}]
+	)
+	var second_manifest: GFContentPackageManifest = _make_manifest(
+		&"author.second",
+		PackedStringArray(["author.base"]),
+		PackedStringArray(["ui"]),
+		{"channel": "stable"},
+		[{"key": "second", "path": "second.tres"}]
+	)
+	var catalog: GFContentPackageCatalog = GFContentPackageCatalog.new().set_manifests([
+		second_manifest,
+		first_manifest,
+		base_manifest,
+	])
+	var query: GFContentPackageQuery = GFContentPackageQuery.new()
+	query.package_ids = PackedStringArray(["author.first", "author.second"])
+	query.required_content_types = PackedStringArray(["ui"])
+	query.required_resource_keys = PackedStringArray(["first"])
+	query.required_metadata = {"channel": "stable"}
+	query.max_results = 1
+	query.include_dependencies = true
+
+	var result: GFContentPackageQueryResult = catalog.query_packages(query)
+
+	assert_true(result.is_successful())
+	assert_eq(result.get_direct_package_ids(), PackedStringArray(["author.first"]))
+	assert_eq(result.get_package_ids(), PackedStringArray(["author.base", "author.first"]))
+
+
+func test_query_fails_closed_for_null_query_and_invalid_catalog_graph() -> void:
+	var catalog: GFContentPackageCatalog = GFContentPackageCatalog.new()
+	var invalid_manifest: GFContentPackageManifest = _make_manifest(
+		&"author.invalid",
+		PackedStringArray(["author.missing"]),
+		PackedStringArray(),
+		{},
+		[]
+	)
+	var _manifest_added: bool = catalog.add_manifest(invalid_manifest)
+
+	var null_result: GFContentPackageQueryResult = catalog.query_packages(null)
+	var graph_result: GFContentPackageQueryResult = catalog.query_packages(GFContentPackageQuery.new())
+
+	assert_false(null_result.is_successful(), "空 query 必须返回可诊断失败结果。")
+	assert_eq(null_result.get_status(), GFContentPackageQueryResult.STATUS_INVALID_QUERY)
+	assert_false(graph_result.is_successful(), "无效依赖图不应产出部分查询结果。")
+	assert_eq(graph_result.get_status(), GFContentPackageQueryResult.STATUS_INVALID_CATALOG)
+	assert_eq(graph_result.get_package_ids(), PackedStringArray())
+
+
+func test_content_package_provider_builds_qualified_generic_asset_entries() -> void:
+	var manifest: GFContentPackageManifest = _make_manifest(
+		&"author.ui",
+		PackedStringArray(),
+		PackedStringArray(["ui"]),
+		{"channel": "stable"},
+		[{
+			"key": "save",
+			"path": "icons/save.png",
+			"type_hint": "Texture2D",
+			"metadata": {
+				"title": "Save",
+				"description": "Toolbar icon",
+				"tags": PackedStringArray(["ui", "icon"]),
+				"category": "interface",
+				"preview_path": "icons/save_preview.png",
+			},
+		}]
+	)
+	var content_catalog: GFContentPackageCatalog = GFContentPackageCatalog.new().set_manifests([manifest])
+	var provider: GFContentPackageAssetCatalogProvider = GFContentPackageAssetCatalogProvider.new()
+	var configured_provider: GFContentPackageAssetCatalogProvider = provider.configure_catalog(
+		content_catalog,
+		&"content_packages"
+	)
+
+	var asset_catalog: GFAssetCatalog = configured_provider.build_catalog()
+	var entry: GFAssetCatalogEntry = asset_catalog.get_entry(&"author.ui/save")
+
+	assert_not_null(entry, "默认 qualified asset ID 应避免不同内容包的资源键碰撞。")
+	if entry == null:
+		return
+	assert_eq(entry.title, "Save")
+	assert_eq(entry.description, "Toolbar icon")
+	assert_eq(entry.tags, PackedStringArray(["icon", "ui"]))
+	assert_eq(entry.category, &"interface")
+	assert_eq(entry.type_hint, "Texture2D")
+	assert_eq(entry.resource_entry_ids, PackedStringArray(["save"]))
+	assert_eq(entry.source_id, &"content_packages")
+	assert_eq(
+		GFVariantData.get_option_string_name(entry.metadata, "content_package_id"),
+		&"author.ui"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(entry.metadata, "content_package_resource_key"),
+		&"save"
+	)
+
+
+func test_owner_scoped_roots_preserve_shared_roots_until_last_owner_releases() -> void:
+	var utility: GFContentPackageUtility = GFContentPackageUtility.new()
+	utility.init()
+
+	assert_true(utility.register_source_root_for_owner(&"feature.a", "res://content/shared"))
+	assert_true(utility.register_source_root_for_owner(&"feature.b", "res://content/shared/"))
+	assert_eq(utility.get_source_roots(), PackedStringArray(["res://content/shared"]))
+
+	assert_eq(utility.clear_owner_source_roots(&"feature.a"), 1)
+	assert_eq(
+		utility.get_source_roots(),
+		PackedStringArray(["res://content/shared"]),
+		"另一个 owner 仍持有根目录时不应移除有效来源。"
+	)
+	assert_eq(utility.clear_owner_source_roots(&"feature.b"), 1)
+	assert_eq(utility.get_source_roots(), PackedStringArray())
+
+
+func test_owner_root_replacement_is_transactional_and_legacy_scope_is_explicit() -> void:
+	var utility: GFContentPackageUtility = GFContentPackageUtility.new()
+	utility.init()
+	var initial_report: GFValidationReport = utility.replace_owner_source_roots(
+		&"feature.a",
+		PackedStringArray(["res://content/a", "user://content/b"])
+	)
+	var rejected_report: GFValidationReport = utility.replace_owner_source_roots(
+		&"feature.a",
+		PackedStringArray(["res://content/new", "C:/outside"])
+	)
+
+	assert_true(initial_report.is_ok())
+	assert_false(rejected_report.is_ok(), "任一无效 root 都必须拒绝整次替换。")
+	assert_eq(
+		utility.get_owner_source_roots(&"feature.a"),
+		PackedStringArray(["res://content/a", "user://content/b"]),
+		"失败替换不得破坏上一份 owner 快照。"
+	)
+
+	assert_true(utility.register_source_root("res://content/manual"))
+	assert_eq(
+		utility.get_owner_source_roots(GFContentPackageUtility.DEFAULT_SOURCE_ROOT_OWNER_ID),
+		PackedStringArray(["res://content/manual"]),
+		"旧入口只能写入明确的 manual owner scope。"
+	)
+	utility.clear_source_roots()
+	assert_eq(utility.get_owner_source_roots(&"feature.a").size(), 2)
+
+
+# --- 私有/辅助方法 ---
+
+func _make_manifest(
+	package_id: StringName,
+	dependencies: PackedStringArray,
+	content_types: PackedStringArray,
+	metadata: Dictionary,
+	resources: Array[Dictionary]
+) -> GFContentPackageManifest:
+	return GFContentPackageManifest.new().configure(
+		package_id,
+		"1.0.0",
+		resources,
+		String(package_id),
+		content_types,
+		dependencies,
+		metadata,
+		"res://content/%s" % String(package_id).replace(".", "_")
+	)

--- a/tests/gf_core/extensions/content_package/test_gf_content_package_query.gd.uid
+++ b/tests/gf_core/extensions/content_package/test_gf_content_package_query.gd.uid
@@ -1,0 +1,1 @@
+uid://c5w16grga6px6

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -27,7 +27,8 @@
       "res://tests/gf_core/extensions/combat/test_gf_projectiles.gd"
     ],
     "gf.extension.content_package": [
-      "res://tests/gf_core/extensions/content_package/test_gf_content_package.gd"
+      "res://tests/gf_core/extensions/content_package/test_gf_content_package.gd",
+      "res://tests/gf_core/extensions/content_package/test_gf_content_package_query.gd"
     ],
     "gf.extension.decision": [
       "res://tests/gf_core/extensions/decision/test_gf_decision_utility.gd"
@@ -91,6 +92,7 @@
       "res://tests/gf_core/standard/utilities/assets/test_gf_resource_registry.gd",
       "res://tests/gf_core/standard/utilities/assets/test_gf_resource_registry_tools.gd",
       "res://tests/gf_core/standard/utilities/assets/test_gf_resource_resolver_utility.gd",
+      "res://tests/gf_core/standard/utilities/assets/test_gf_asset_catalog_runtime.gd",
       "res://tests/gf_core/standard/utilities/io/test_gf_remote_cache_utility.gd",
       "res://tests/gf_core/standard/utilities/io/test_gf_async_batch.gd",
       "res://tests/gf_core/standard/utilities/io/test_gf_path_enumeration_tools.gd",

--- a/tests/gf_core/standard/utilities/assets/test_gf_asset_catalog_runtime.gd
+++ b/tests/gf_core/standard/utilities/assets/test_gf_asset_catalog_runtime.gd
@@ -1,0 +1,256 @@
+## 测试资产目录运行时的事务挂载、所有权和快照隔离契约。
+extends GutTest
+
+
+# --- 测试用例 ---
+
+func test_mount_provider_commits_snapshot_and_unmount_is_idempotent() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var source_catalog: GFAssetCatalog = _make_catalog(&"ui.save", "res://ui/save.png", &"provider")
+	var provider: StaticCatalogProvider = StaticCatalogProvider.new()
+	provider.setup(&"provider", source_catalog)
+
+	var mount: GFAssetCatalogMount = runtime.mount_provider(&"feature.ui", &"toolbar", provider)
+	var revision_after_mount: int = runtime.get_revision()
+	var _mutated_source: bool = source_catalog.set_entry(
+		_make_entry(&"ui.load", "res://ui/load.png", &"provider")
+	)
+
+	assert_true(mount.is_active(), "成功 mount 应返回活动句柄。")
+	assert_eq(mount.get_owner_id(), &"feature.ui")
+	assert_eq(mount.get_mount_id(), &"toolbar")
+	assert_eq(runtime.get_catalog().get_all_ids(), PackedStringArray(["ui.save"]))
+	assert_eq(revision_after_mount, 1)
+	assert_true(mount.unmount())
+	assert_false(mount.unmount(), "重复 unmount 必须无副作用。")
+	assert_false(mount.is_active())
+	assert_eq(runtime.get_catalog().get_all_ids(), PackedStringArray())
+	assert_eq(runtime.get_revision(), revision_after_mount + 1)
+
+
+func test_mount_rejects_duplicate_assets_without_mutating_committed_state() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var first_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.a",
+		&"first",
+		_make_catalog(&"shared.icon", "res://first.png", &"first"),
+		10
+	)
+	var revision_before_failure: int = runtime.get_revision()
+	var failed_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.b",
+		&"second",
+		_make_catalog(&"shared.icon", "res://second.png", &"second"),
+		100
+	)
+	var committed_entry: GFAssetCatalogEntry = runtime.get_catalog().get_entry(&"shared.icon")
+
+	assert_true(first_mount.is_active())
+	assert_false(failed_mount.is_active(), "默认冲突策略必须 fail-closed。")
+	assert_eq(failed_mount.get_status(), GFAssetCatalogMount.STATUS_CONFLICT)
+	assert_eq(runtime.get_revision(), revision_before_failure, "失败 mount 不得推进 revision。")
+	assert_false(GFVariantData.get_option_bool(runtime.get_last_report(), "ok"))
+	assert_eq(runtime.get_mounts().size(), 1)
+	assert_not_null(committed_entry)
+	if committed_entry != null:
+		assert_eq(committed_entry.primary_path, "res://first.png")
+
+
+func test_explicit_high_priority_conflict_policy_is_deterministic() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	var configured_runtime: GFAssetCatalogRuntime = runtime.configure(
+		GFAssetCatalogRuntime.CONFLICT_KEEP_HIGH_PRIORITY
+	)
+	configured_runtime.init()
+
+	var low_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.low",
+		&"low",
+		_make_catalog(&"shared.icon", "res://low.png", &"low"),
+		1
+	)
+	var high_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.high",
+		&"high",
+		_make_catalog(&"shared.icon", "res://high.png", &"high"),
+		100
+	)
+	var entry: GFAssetCatalogEntry = runtime.get_catalog().get_entry(&"shared.icon")
+
+	assert_true(low_mount.is_active())
+	assert_true(high_mount.is_active())
+	assert_not_null(entry)
+	if entry != null:
+		assert_eq(entry.primary_path, "res://high.png", "显式覆盖策略应稳定选择高优先级 mount。")
+
+
+func test_owner_unmount_and_dispose_deactivate_all_handles() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var first_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.ui",
+		&"first",
+		_make_catalog(&"ui.first", "res://first.png", &"first")
+	)
+	var second_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.ui",
+		&"second",
+		_make_catalog(&"ui.second", "res://second.png", &"second")
+	)
+	var other_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.other",
+		&"other",
+		_make_catalog(&"other", "res://other.png", &"other")
+	)
+
+	assert_eq(runtime.unmount_owner(&"feature.ui"), 2)
+	assert_false(first_mount.is_active())
+	assert_false(second_mount.is_active())
+	assert_true(other_mount.is_active())
+	assert_eq(runtime.get_catalog().get_all_ids(), PackedStringArray(["other"]))
+
+	runtime.dispose()
+	assert_false(other_mount.is_active(), "runtime dispose 必须使外部 handle 进入终态。")
+	assert_eq(other_mount.get_status(), GFAssetCatalogMount.STATUS_DISPOSED)
+	assert_eq(runtime.get_catalog().get_all_ids(), PackedStringArray())
+
+
+func test_runtime_retains_active_mount_handle_until_owner_unmounts() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.retained",
+		&"retained",
+		_make_catalog(&"retained", "res://retained.tres", &"retained")
+	)
+	var weak_mount: WeakRef = weakref(mount)
+	mount = null
+	var retained_value: Variant = weak_mount.get_ref()
+
+	assert_true(retained_value is GFAssetCatalogMount, "Runtime 必须强持有活动 Mount，避免不可管理的存活目录。")
+	assert_eq(runtime.get_mounts().size(), 1)
+	assert_eq(runtime.unmount_owner(&"feature.retained"), 1)
+	assert_eq(runtime.get_mounts().size(), 0)
+
+
+func test_mount_catalog_replacement_is_atomic_and_preserves_handle_identity() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.a",
+		&"primary",
+		_make_catalog(&"first", "res://first.tres", &"primary")
+	)
+	var first_revision: int = runtime.get_revision()
+
+	assert_true(runtime.replace_mount_catalog(
+		mount,
+		_make_catalog(&"replacement", "res://replacement.tres", &"primary")
+	))
+	assert_true(mount.is_active())
+	assert_eq(mount.get_catalog().get_all_ids(), PackedStringArray(["replacement"]))
+	assert_eq(runtime.get_revision(), first_revision + 1)
+
+	var other_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.b",
+		&"other",
+		_make_catalog(&"other", "res://other.tres", &"other")
+	)
+	var revision_before_conflict: int = runtime.get_revision()
+	assert_false(runtime.replace_mount_catalog(
+		mount,
+		_make_catalog(&"other", "res://conflict.tres", &"primary")
+	), "冲突替换必须保留上一份 Mount 和聚合目录。")
+	assert_true(other_mount.is_active())
+	assert_eq(runtime.get_revision(), revision_before_conflict)
+	assert_eq(mount.get_catalog().get_all_ids(), PackedStringArray(["replacement"]))
+	assert_eq(runtime.get_catalog().get_all_ids(), PackedStringArray(["other", "replacement"]))
+
+
+func test_null_provider_and_duplicate_mount_key_fail_without_partial_commit() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var null_provider: NullCatalogProvider = NullCatalogProvider.new()
+	var _null_provider_configured: GFAssetCatalogSourceProvider = null_provider.configure(&"null")
+	var provider_failure: GFAssetCatalogMount = runtime.mount_provider(
+		&"feature.a",
+		&"null",
+		null_provider
+	)
+	var active_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.a",
+		&"stable",
+		_make_catalog(&"stable", "res://stable.tres", &"stable")
+	)
+	var duplicate_mount: GFAssetCatalogMount = runtime.mount_catalog(
+		&"feature.a",
+		&"stable",
+		_make_catalog(&"replacement", "res://replacement.tres", &"replacement")
+	)
+
+	assert_false(provider_failure.is_active())
+	assert_eq(provider_failure.get_status(), GFAssetCatalogMount.STATUS_BUILD_FAILED)
+	assert_true(active_mount.is_active())
+	assert_false(duplicate_mount.is_active())
+	assert_eq(duplicate_mount.get_status(), GFAssetCatalogMount.STATUS_DUPLICATE_MOUNT)
+	assert_eq(runtime.get_catalog().get_all_ids(), PackedStringArray(["stable"]))
+
+
+func test_rejected_provider_request_does_not_invoke_provider() -> void:
+	var runtime: GFAssetCatalogRuntime = GFAssetCatalogRuntime.new()
+	runtime.init()
+	var provider: CountingCatalogProvider = CountingCatalogProvider.new()
+	provider.setup(&"counting", _make_catalog(&"asset", "res://asset.tres", &"counting"))
+	var first_mount: GFAssetCatalogMount = runtime.mount_provider(&"feature.a", &"stable", provider)
+	var duplicate_mount: GFAssetCatalogMount = runtime.mount_provider(&"feature.a", &"stable", provider)
+	runtime.dispose()
+	var disposed_mount: GFAssetCatalogMount = runtime.mount_provider(&"feature.b", &"late", provider)
+
+	assert_true(first_mount.get_status() == GFAssetCatalogMount.STATUS_DISPOSED)
+	assert_eq(duplicate_mount.get_status(), GFAssetCatalogMount.STATUS_DUPLICATE_MOUNT)
+	assert_eq(disposed_mount.get_status(), GFAssetCatalogMount.STATUS_DISPOSED)
+	assert_eq(provider.build_count, 1, "Runtime 已知拒绝请求时不得执行 Provider。")
+
+
+# --- 私有/辅助方法 ---
+
+func _make_catalog(asset_id: StringName, path: String, source_id: StringName) -> GFAssetCatalog:
+	var catalog: GFAssetCatalog = GFAssetCatalog.new()
+	var _entry_set: bool = catalog.set_entry(_make_entry(asset_id, path, source_id))
+	return catalog
+
+
+func _make_entry(asset_id: StringName, path: String, source_id: StringName) -> GFAssetCatalogEntry:
+	return GFAssetCatalogEntry.new().configure(asset_id, path, {"source_id": source_id})
+
+
+class StaticCatalogProvider:
+	extends GFAssetCatalogSourceProvider
+
+	var _catalog: GFAssetCatalog = GFAssetCatalog.new()
+
+	func setup(p_source_id: StringName, catalog: GFAssetCatalog) -> void:
+		var _provider_configured: GFAssetCatalogSourceProvider = configure(p_source_id)
+		_catalog = GFAssetCatalog.from_dict(catalog.to_dict())
+
+	func build_catalog(_options: Dictionary = {}) -> GFAssetCatalog:
+		return GFAssetCatalog.from_dict(_catalog.to_dict())
+
+
+class NullCatalogProvider:
+	extends GFAssetCatalogSourceProvider
+
+	func build_catalog(_options: Dictionary = {}) -> GFAssetCatalog:
+		return null
+
+
+class CountingCatalogProvider:
+	extends StaticCatalogProvider
+
+	var build_count: int = 0
+
+	func build_catalog(options: Dictionary = {}) -> GFAssetCatalog:
+		build_count += 1
+		return super.build_catalog(options)

--- a/tests/gf_core/standard/utilities/assets/test_gf_asset_catalog_runtime.gd.uid
+++ b/tests/gf_core/standard/utilities/assets/test_gf_asset_catalog_runtime.gd.uid
@@ -1,0 +1,1 @@
+uid://c3u6visuny87


### PR DESCRIPTION
## Summary

- add typed, deterministic content package queries and dependency-closed results
- adapt content package resources into generic asset catalogs
- add owner-scoped content roots plus transactional asset catalog runtime/mount lifecycles
- update focused tests, package mappings, API references, guides, and changelog

## Review scope

Rebased directly onto `main@f061b547` after #23 was squash-merged. The PR now contains one reviewable commit, `bb215c09`, and 41 files; the former #23 commit is no longer part of this PR.

## Contract and boundaries

- queries are bounded, deterministic, dependency-first, and fail closed on invalid graphs
- catalog mounts use explicit owner-scoped lifetimes, atomic replacement, stable revisions, and deterministic conflict policies
- the framework exposes reusable catalog/query mechanisms only; it does not define project download, CDN, hot-update, or gameplay policy
- new public API is documented as `@since unreleased`; generated Catalog, Reference, and AI knowledge output are current
- no release tag or stable version is created by this PR

## Verification

- focused Content Package and Asset Catalog Runtime GUT: 14/14 tests, 89 assertions
- quick suite: 22/22 checks
- GDScript reload warning gate: passed
- strict LSP gate: 1,168 files, 0 diagnostics, 0 timeouts, verified against this workspace
- full GUT in isolation: 4,499/4,499 tests, 34,659 assertions
- package CLI local smoke: 12/12 scenarios, 0 issues
- package editor wizard smoke: 11/11 scenarios, 0 issues
- the aggregate local full run passed 31/34 checks; its three process-level failures were a GUT wall-clock timeout and Windows log-file locks after otherwise successful package scenarios. All three checks passed when rerun serially in isolation at the same `bb215c09` head. Ready PR CI remains the authoritative merge gate.
