### PR TITLE
Fix closed review regressions

### DIFF
--- a/addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd
+++ b/addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd
@@ -1334,9 +1334,19 @@ func collect_snapshot(options: Dictionary = {}) -> Dictionary:
 		"diagnostic_provider_ids"
 	)
 	if not diagnostic_provider_ids.is_empty():
+		var _legacy_provider_section_removed: bool = snapshot.erase(&"diagnostic_providers")
+		var _provider_section_removed: bool = snapshot.erase("diagnostic_providers")
+		var diagnostic_provider_request_value: Variant = GFVariantData.get_option_value(
+			options,
+			"diagnostic_provider_request",
+			{}
+		)
+		var diagnostic_provider_request: Dictionary = GFVariantData.as_dictionary(
+			diagnostic_provider_request_value
+		)
 		snapshot["diagnostic_providers"] = collect_diagnostic_providers(
 			diagnostic_provider_ids,
-			GFVariantData.get_option_dictionary(options, "diagnostic_provider_request")
+			diagnostic_provider_request
 		)
 
 	snapshot_collected.emit(snapshot)
@@ -1634,7 +1644,7 @@ func _index_signal_graph(graph: Dictionary) -> Dictionary:
 
 func _is_reserved_snapshot_section_id(section_id: StringName) -> bool:
 	match section_id:
-		&"timestamp_unix", &"engine", &"build", &"architecture", &"event_system", &"performance", &"logs", &"tools", &"scene_tree", &"signal_graph", &"monitors", &"diagnostic_providers":
+		&"timestamp_unix", &"engine", &"build", &"architecture", &"event_system", &"performance", &"logs", &"tools", &"scene_tree", &"signal_graph", &"monitors":
 			return true
 		_:
 			return false

--- a/addons/gf/standard/utilities/debug/gf_session_trace_utility.gd
+++ b/addons/gf/standard/utilities/debug/gf_session_trace_utility.gd
@@ -951,6 +951,7 @@ func capture_snapshot_provider(provider_id: StringName, options: Dictionary = {}
 	_provider_capture_active = false
 	var record_options: Dictionary = _duplicate_dictionary(options)
 	var _metadata_removed: bool = record_options.erase("metadata")
+	var _metadata_name_removed: bool = record_options.erase(&"metadata")
 	var metadata: Dictionary = GFVariantData.get_option_dictionary(provider_entry, "metadata").duplicate(true)
 	var capture_metadata: Dictionary = _sanitize_dictionary(
 		_get_dictionary(options, "metadata"),
@@ -1629,7 +1630,7 @@ func _get_sorted_provider_ids() -> PackedStringArray:
 
 
 func _get_dictionary(source: Dictionary, key: Variant) -> Dictionary:
-	var value: Variant = source.get(key)
+	var value: Variant = GFVariantData.get_option_value(source, key)
 	if value is Dictionary:
 		var dictionary_value: Dictionary = value
 		return dictionary_value

--- a/addons/gf/tools/ai_developer/gf_ai/cli.py
+++ b/addons/gf/tools/ai_developer/gf_ai/cli.py
@@ -120,8 +120,14 @@ def _dispatch(args: argparse.Namespace, project_root: Path) -> dict[str, Any]:
 		return migration.plan_contract_migration(project_root, args.contract)
 	if args.command == "contract-migrate":
 		plan = migration.plan_contract_migration(project_root, args.contract)
-		if not plan.get("ok") or plan.get("status") != "ready":
+		if not plan.get("ok"):
 			return plan
+		if plan.get("status") != "ready":
+			return migration.apply_contract_migration(
+				project_root,
+				args.expected_plan_sha256,
+				args.contract,
+			)
 		if args.expected_plan_sha256 != plan.get("plan_sha256"):
 			return migration.apply_contract_migration(
 				project_root,

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -72,6 +72,10 @@
 - 修复 `GFStorageUtility` 读取旧版本数据时绕过派生类 `migrate_data()` 覆写的问题；自定义迁移继续经过公开扩展点，未覆写时仍保留注册迁移链的类型化失败结果。
 - 修复 Save Profile 持续收到更新保存请求时，generation 屏障已经满足的最老读取仍可能长期饥饿的问题；就绪读取与等待保存现在采用有界轮转，未满足屏障的读取仍会等待覆盖它的保存终态。
 - 修复超时写入在重试期间晚到成功后，逻辑保存仍可能被后续重试失败错误翻转的问题；已确认成功的 generation 会立即完成受覆盖请求，尚未终态的物理重试继续保留路径所有权直至结束。
+- 修复 Session Trace 的通道、Provider、直接事件与 Provider capture 读取 `metadata` 时依赖原生字典键比较的问题；这些入口现在通过 GF 的 String/StringName 等价键规则读取原引用，并在转发 capture 选项前移除两种键形态，继续保持循环 metadata 的有界处理。
+- 修复惰性诊断 Provider 引入后会拒绝历史 `diagnostic_providers` 自定义快照分区的问题；普通快照继续保留既有分区，只有显式提交非空 `diagnostic_provider_ids` 的当次快照由内置批次结果占用该顶层键，且不会注销已发布缓存。
+- 修复总快照入口会在结构与循环预检前深复制 `diagnostic_provider_request`、从而可能触发递归上限的问题；请求现在先按原引用 fail closed 校验，失败时不执行任何项目 Provider。
+- 修复当前契约已经是 schema v2 时，CLI `contract-migrate` 会把 `up_to_date` 计划当作成功应用并退出 0 的问题；没有待执行迁移时现在返回 `no_pending_contract_migration` 和非零退出码。
 
 ### 🔧 API 变动说明 (API Changes)
 
@@ -97,7 +101,7 @@
 - 自定义 `_draw()` 或无法可靠推断范围的 2D 节点应传入显式 `content_bounds`；多后端复制与冲突处理继续使用 `GFStorageSyncUtility`，不要把故障转移当作原子双写。
 - 既有 UI 路由无需迁移；只有需要候选页面预热时才声明 `adjacent_route_ids` 并显式执行生成的资产计划。需要发布后问题轨迹时，应由项目定义最小事件 schema、玩家许可和保留策略，再显式采用 `GFSessionTraceUtility`。
 - 既有诊断快照无需迁移。只有无法安全长期缓存的状态才实现 `GFDiagnosticSnapshotProvider`，并由故障点或支持报告入口显式请求；需要跨系统固定轨迹预算和检查点时，在首次会话前应用 `GFSessionTraceRecipe`，不要把上传、许可或业务恢复逻辑写进配方。
-- 历史代码若通过 `publish_snapshot_section()` 使用了 `diagnostic_providers` 分区 ID，必须迁移为项目自有稳定名称；该 ID 现为惰性 Provider 批量结果的内建保留字段，继续注册会被明确拒绝。
+- 历史代码通过 `publish_snapshot_section()` 使用 `diagnostic_providers` 分区 ID 时无需迁移：普通快照继续返回该缓存；只有当次显式请求惰性 Provider 时，同名顶层键才由内置批次结果确定性覆盖，后续普通快照仍恢复既有分区。
 - 既有曲线、Steering、发射体和节点移动逻辑无需迁移。只有需要结构化未来状态、拦截时间或公式点集时才显式采用 `GFTrajectoryMath`；绘制、物理推进、速度继承、重力拦截和业务命中规则继续由项目负责。
 - 既有 Save Graph、Slot 和直接 Storage 调用无需迁移。需要跨模块自动保存时，为每个稳定数据边界实现一个可回滚 `GFSaveSectionProvider`，注册 Profile 和完整迁移链；不要把缺失、损坏或未来版本统一重置为空存档。
 - 历史配置若有意使用带首尾空白的 route ID，需迁移为去除空白后的稳定 ID；规范化后重复的 ID 会指向同一注册身份，不应再依赖空白区分页面。
@@ -122,6 +126,7 @@
 - `addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_utility.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_async_operation.gd`
+- `addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd`
 - `addons/gf/standard/utilities/debug/gf_session_trace_utility.gd`
 - `addons/gf/standard/utilities/debug/gf_diagnostic_snapshot_provider.gd`
 - `addons/gf/standard/utilities/debug/gf_diagnostic_provider_result.gd`
@@ -137,6 +142,7 @@
 - `addons/gf/extensions/save/profile/`
 - `docs/zh/extensions/save-graph/save-profile-runtime.md`
 - `docs/zh/extensions/save-graph/save-profile-adr.md`
+- `addons/gf/tools/ai_developer/gf_ai/cli.py`
 - `addons/gf/tools/ai_developer/gf_ai/dependencies.py`
 - `addons/gf/tools/ai_developer/schemas/project_contract.schema.json`
 - `addons/gf/tools/ai_developer/schemas/project_snapshot.schema.json`

--- a/docs/zh/editor/tools/ai-developer.md
+++ b/docs/zh/editor/tools/ai-developer.md
@@ -59,7 +59,7 @@ python addons/gf/tools/ai_developer/gf_ai_project.py contract-migration-plan --p
 python addons/gf/tools/ai_developer/gf_ai_project.py contract-migrate --project-root . --expected-plan-sha256 <plan-sha256>
 ```
 
-CLI 会再次展示完整候选，并要求原样输入 `MIGRATE <plan-sha256>`。契约源或目标在审阅后发生变化、路径经过符号链接/junction/重解析点、迁移锁冲突、旧字段非法、目标契约不满足 Schema/语义约束或版本没有显式迁移路径时，compare-and-swap 写入会被拒绝。工具不会同时维护 v1/v2 两套运行格式，也不会从源码或 Snapshot 自动生成业务验收条件。应用后先把每项 `pending_review` 改成经过确认的 owner、Recipe 和验收条件，再执行 `validate` 和 `snapshot`；Snapshot 是可重建证据，禁止迁移旧 Snapshot 或手工补字段。
+CLI 会再次展示完整候选，并要求原样输入 `MIGRATE <plan-sha256>`。契约已经是当前 schema、契约源或目标在审阅后发生变化、路径经过符号链接/junction/重解析点、迁移锁冲突、旧字段非法、目标契约不满足 Schema/语义约束或版本没有显式迁移路径时，compare-and-swap 写入会被拒绝；当前契约没有待执行迁移时返回 `no_pending_contract_migration` 和非零退出码。工具不会同时维护 v1/v2 两套运行格式，也不会从源码或 Snapshot 自动生成业务验收条件。应用后先把每项 `pending_review` 改成经过确认的 owner、Recipe 和验收条件，再执行 `validate` 和 `snapshot`；Snapshot 是可重建证据，禁止迁移旧 Snapshot 或手工补字段。
 
 ## 为 Agent 安装项目规则
 

--- a/docs/zh/standard/utilities/runtime/debug-observability/runtime-telemetry/build-diagnostics/diagnostics-commands/lazy-providers.md
+++ b/docs/zh/standard/utilities/runtime/debug-observability/runtime-telemetry/build-diagnostics/diagnostics-commands/lazy-providers.md
@@ -53,9 +53,11 @@ var snapshot: Dictionary = diagnostics.collect_snapshot({
 })
 ```
 
+总快照把内置批次写入顶层 `diagnostic_providers`。为兼容历史项目，普通快照仍允许同名的已发布自定义分区；只有显式提交非空 `diagnostic_provider_ids` 时，内置批次才在当次结果中确定性优先，且不会注销自定义缓存。
+
 结果按 Provider ID 隔离。不存在、重入、owner 释放、注册表变化、超时或非法输出只会让对应项失败，后续 Provider 仍会执行。批次会分别报告 `requested_count`、`unique_request_count`、`duplicate_count`、`invalid_count` 和真正因上限未执行的 `omitted_count`；重复 ID 只执行一次但不算容量丢失，非法 ID 和超过 `max_diagnostic_providers` 的唯一 ID 则使批次 fail closed。为限制去重本身的工作量，原始 ID 列表最多 1024 项；超限返回 `provider_request_size_exceeded`，且不会执行任何 Provider。
 
-共享 request 会在任何项目回调执行前通过同一套深度、节点数、集合项数和估算字节预算。预检失败时批次返回 `provider_request_rejected`、`executed_count = 0`，避免为每个 Provider 重复复制一个无界输入。
+共享 request 会在深复制和任何项目回调执行前，以原始引用通过同一套循环、深度、节点数、集合项数和估算字节预算。预检失败时批次返回 `provider_request_rejected`、`executed_count = 0`，避免递归复制或为每个 Provider 重复复制一个无界输入。
 
 `max_duration_usec` 是同步回调返回后的验收预算，不是可抢占 timeout。GDScript 回调一旦开始就无法被 GF 安全中止，因此 Provider 自身仍必须保证最坏执行时间；超时结果会被拒绝并记录 `duration_usec`，但已经消耗的主线程时间无法追回。`0` 只用于显式关闭返回后时长拒绝，负数不会被静默归一为 `0`，而会让 Provider 定义校验与注册失败。
 

--- a/docs/zh/standard/utilities/runtime/debug-observability/runtime-telemetry/build-diagnostics/signals-monitors.md
+++ b/docs/zh/standard/utilities/runtime/debug-observability/runtime-telemetry/build-diagnostics/signals-monitors.md
@@ -43,4 +43,6 @@ var text: String = diagnostics.export_monitor_snapshot(monitor_snapshot, &"text"
 
 外部分区和工具快照必须通过 `publish_snapshot_section()` / `publish_tool_snapshot()` 提交 `Dictionary`。监控值则先用 `register_monitor()` 声明 owner 和显示元数据，再用 `publish_monitor_sample()` 更新。发布时会检查 `max_contribution_collection_items`、`max_contribution_nodes`、`max_contribution_depth` 和 `max_contribution_bytes`，并立即转换为 report-safe 缓存；无效或超预算的新值会被拒绝，监控项继续保留上一份有效采样。
 
+为兼容既有集成，项目仍可发布名为 `diagnostic_providers` 的自定义分区。普通 `collect_snapshot()` 会返回这份缓存；只有调用方显式提交非空 `diagnostic_provider_ids` 时，当次快照的同名顶层键才由内置惰性 Provider 批次结果占用。这个临时覆盖不会注销自定义分区，后续普通快照仍会返回原缓存。
+
 同名贡献只允许当前 owner 更新或移除，owner 释放后会自动剪枝。`collect_snapshot()` 和 Overlay 刷新只读取缓存，不执行外部 `Callable`，因此观察行为不能重入业务逻辑或阻塞诊断 UI。框架内置采样仍可保留进程内 native Variant；把完整快照写入文件、Debugger 通道或支持报告时，继续通过 `GFReportValueCodec` 处理最终导出策略。

--- a/tests/gf_core/standard/utilities/debug/test_gf_diagnostics_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_diagnostics_utility.gd
@@ -334,6 +334,72 @@ func test_diagnostics_collects_external_published_snapshots() -> void:
 	assert_true(tool_monitors.has(&"runtime.pending"), "追加到 tools 预设的外部监控项应可采样。")
 
 
+func test_diagnostics_preserves_existing_diagnostic_providers_snapshot_section() -> void:
+	var diagnostics: GFDiagnosticsUtility = GFDiagnosticsUtility.new()
+	diagnostics.init()
+	var provider: CountingDiagnosticProvider = CountingDiagnosticProvider.new()
+	var _configured_provider: GFDiagnosticSnapshotProvider = provider.configure(&"game.compatibility")
+
+	assert_true(
+		diagnostics.publish_snapshot_section(
+			self,
+			&"diagnostic_providers",
+			{ "legacy_value": 7 }
+		),
+		"既有 diagnostic_providers 自定义分区应继续允许发布。"
+	)
+	var snapshot: Dictionary = diagnostics.collect_snapshot({
+		"include_monitors": false,
+		"include_recent_logs": false,
+	})
+	var section: Dictionary = GFVariantData.get_option_dictionary(
+		snapshot,
+		"diagnostic_providers"
+	)
+
+	assert_eq(
+		GFVariantData.get_option_int(section, "legacy_value"),
+		7,
+		"未显式请求惰性 Provider 时应保留既有自定义分区。"
+	)
+	assert_true(
+		diagnostics.register_diagnostic_provider(self, provider),
+		"兼容测试 Provider 应注册成功。"
+	)
+	var requested_snapshot: Dictionary = diagnostics.collect_snapshot({
+		"include_monitors": false,
+		"include_recent_logs": false,
+		"diagnostic_provider_ids": PackedStringArray(["game.compatibility"]),
+	})
+	var requested_batch: Dictionary = GFVariantData.get_option_dictionary(
+		requested_snapshot,
+		"diagnostic_providers"
+	)
+	var equivalent_key_count: int = 0
+	for key: Variant in requested_snapshot.keys():
+		if GFVariantData.to_text(key) == "diagnostic_providers":
+			equivalent_key_count += 1
+
+	assert_true(GFVariantData.get_option_bool(requested_batch, "ok"), "显式请求时内置 Provider 批次应优先。")
+	assert_eq(provider.call_count, 1, "显式请求应执行一次 Provider。")
+	assert_eq(equivalent_key_count, 1, "显式请求不得留下文本等价的双重顶层键。")
+	assert_true(diagnostics.has_snapshot_section(&"diagnostic_providers"), "内置批次覆盖不应注销既有分区。")
+	var later_snapshot: Dictionary = diagnostics.collect_snapshot({
+		"include_monitors": false,
+		"include_recent_logs": false,
+	})
+	var later_section: Dictionary = GFVariantData.get_option_dictionary(
+		later_snapshot,
+		"diagnostic_providers"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(later_section, "legacy_value"),
+		7,
+		"后续普通快照应继续恢复既有自定义分区。"
+	)
+	diagnostics.dispose()
+
+
 func test_diagnostics_rejects_external_contributions_for_reserved_snapshot_keys() -> void:
 	var diagnostics: GFDiagnosticsUtility = GFDiagnosticsUtility.new()
 	diagnostics.init()
@@ -773,6 +839,36 @@ func test_lazy_diagnostic_provider_rejects_unbounded_shared_request_before_callb
 	)
 	assert_eq(GFVariantData.get_option_int(batch, "executed_count"), 0, "非法 request 不得执行任何 Provider。")
 	assert_eq(provider.call_count, 0, "预算预检必须早于项目回调。")
+	diagnostics.dispose()
+
+
+func test_collect_snapshot_rejects_circular_provider_request_before_callbacks() -> void:
+	var diagnostics: GFDiagnosticsUtility = GFDiagnosticsUtility.new()
+	var provider: CountingDiagnosticProvider = CountingDiagnosticProvider.new()
+	var _configured_provider: GFDiagnosticSnapshotProvider = provider.configure(&"game.circular_request")
+	assert_true(diagnostics.register_diagnostic_provider(self, provider), "循环请求测试 Provider 应注册成功。")
+	var circular_request: Dictionary = {}
+	circular_request["self"] = circular_request
+
+	var snapshot: Dictionary = diagnostics.collect_snapshot({
+		"include_monitors": false,
+		"include_recent_logs": false,
+		"diagnostic_provider_ids": PackedStringArray(["game.circular_request"]),
+		&"diagnostic_provider_request": circular_request,
+	})
+	var batch: Dictionary = GFVariantData.get_option_dictionary(
+		snapshot,
+		"diagnostic_providers"
+	)
+
+	assert_false(GFVariantData.get_option_bool(batch, "ok", true), "循环 request 必须 fail closed。")
+	assert_eq(
+		GFVariantData.get_option_string_name(batch, "error_code"),
+		&"provider_request_rejected",
+		"循环 request 应返回稳定批次错误码。"
+	)
+	assert_eq(GFVariantData.get_option_int(batch, "executed_count"), 0, "循环 request 不得执行 Provider。")
+	assert_eq(provider.call_count, 0, "循环检测必须早于项目回调。")
 	diagnostics.dispose()
 
 

--- a/tests/gf_core/standard/utilities/debug/test_gf_session_trace_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_session_trace_utility.gd
@@ -213,6 +213,71 @@ func test_session_trace_bounds_circular_metadata_at_every_public_recording_bound
 	trace.dispose()
 
 
+func test_session_trace_accepts_string_name_metadata_option_keys() -> void:
+	var trace: GFSessionTraceUtility = GFSessionTraceUtility.new()
+	assert_true(
+		trace.register_channel(
+			&"state",
+			{ &"metadata": { "channel_value": 1 } }
+		),
+		"通道注册应接受 StringName metadata 选项键。"
+	)
+	assert_true(
+		trace.register_snapshot_provider(
+			&"state_provider",
+			&"state",
+			func() -> Dictionary:
+				return { "ready": true },
+			{ &"metadata": { "provider_value": 2 } }
+		),
+		"Provider 注册应接受 StringName metadata 选项键。"
+	)
+	var _session_id: StringName = trace.start_session(&"string-name-metadata")
+	var direct_result: Dictionary = trace.record_event(
+		&"state",
+		&"direct",
+		{},
+		{ &"metadata": { "direct_value": 3 } }
+	)
+	var capture_result: Dictionary = trace.capture_snapshot_provider(
+		&"state_provider",
+		{ &"metadata": { "capture_value": 4 } }
+	)
+	var direct_event: Dictionary = GFVariantData.get_option_dictionary(direct_result, "event")
+	var capture_event: Dictionary = GFVariantData.get_option_dictionary(capture_result, "event")
+	var direct_metadata: Dictionary = GFVariantData.get_option_dictionary(direct_event, "metadata")
+	var capture_metadata: Dictionary = GFVariantData.get_option_dictionary(capture_event, "metadata")
+
+	assert_true(GFVariantData.get_option_bool(direct_result, "ok"), "直接事件应成功记录。")
+	assert_true(GFVariantData.get_option_bool(capture_result, "ok"), "Provider capture 应成功记录。")
+	assert_eq(
+		GFVariantData.get_option_int(direct_metadata, "channel_value"),
+		1,
+		"直接事件应保留通道 metadata。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(direct_metadata, "direct_value"),
+		3,
+		"直接事件应保留 StringName 键读取的调用 metadata。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(capture_metadata, "channel_value"),
+		1,
+		"Provider capture 应保留通道 metadata。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(capture_metadata, "provider_value"),
+		2,
+		"Provider capture 应保留注册 metadata。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(capture_metadata, "capture_value"),
+		4,
+		"Provider capture 应保留 StringName 键读取的调用 metadata。"
+	)
+	trace.dispose()
+
+
 func test_session_trace_snapshot_provider_is_explicit_and_bounded() -> void:
 	var trace: GFSessionTraceUtility = GFSessionTraceUtility.new()
 	assert_true(trace.register_channel(&"model"), "模型通道应注册成功。")

--- a/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
+++ b/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
@@ -393,6 +393,31 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 		self.assertTrue(core_applied["ok"], core_applied)
 		self.assertEqual(json.loads(contract_path.read_text(encoding="utf-8"))["schema_version"], CONTRACT_SCHEMA_VERSION)
 
+	def test_cli_contract_migrate_rejects_when_contract_is_current(self) -> None:
+		cli = ADDON_ROOT / "gf_ai_project.py"
+
+		completed = subprocess.run(
+			[
+				sys.executable,
+				str(cli),
+				"contract-migrate",
+				"--project-root",
+				str(self.project_root),
+				"--expected-plan-sha256",
+				"0" * 64,
+			],
+			capture_output=True,
+			text=True,
+			encoding="utf-8",
+			timeout=30,
+			check=False,
+		)
+
+		result = json.loads(completed.stdout)
+		self.assertEqual(completed.returncode, 1, completed.stderr)
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["issues"][0]["code"], "no_pending_contract_migration")
+
 	def test_cli_contract_migration_requires_the_exact_interactive_phrase(self) -> None:
 		plan_sha256 = "a" * 64
 		plan = {"plan_sha256": plan_sha256, "candidate": {"schema_version": CONTRACT_SCHEMA_VERSION}}


### PR DESCRIPTION
## Summary

- restore compatibility for projects that already publish a custom top-level `diagnostic_providers` snapshot section; a non-empty explicit provider request deterministically owns that key only for the requested snapshot
- validate `diagnostic_provider_request` by reference before any deep copy, so circular or over-budget requests fail closed without invoking project providers
- make Session Trace metadata option lookup explicitly follow GF's String/StringName alias contract while preserving cycle-safe handling
- make `contract-migrate` reject an already-current contract with `no_pending_contract_migration` and a non-zero exit code instead of reporting a successful no-op
- add focused regressions and update compatibility/migration documentation and the unreleased changelog

No public signatures or generated API contracts changed.

## Validation

- Session Trace focused GUT: 30/30
- Diagnostics focused GUT: 38/38
- AI Developer CLI tests: 62/62
- AI Developer Kit source generation/freshness, package-focused mapping, warning scan, and focused editor LSP: passed
- Quick Suite: 22/22
- Full Suite (`--jobs 3`): 34/34
- MkDocs strict build, docs quality, public docs boundary, project settings drift, log hygiene, and `git diff --check`: passed
- independent standards/docs, API/compatibility, and verification audits: no blocking findings; two low-risk documentation precision findings were fixed and revalidated

## Review context

This follows up unresolved review feedback left on merged PRs #26 and #27. Historical unresolved threads on #21 were already fixed by #22 and will be closed with that evidence.