### PR TITLE
Add secure Runtime Agent Environment

### DIFF
--- a/addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd
+++ b/addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd
@@ -1,0 +1,2003 @@
+## GFRuntimeAgentEnvironment: 传输无关的受限运行时 Agent 调用环境。
+##
+## 受信宿主显式注册严格 endpoint，再为调用方签发仅授权指定 endpoint 的短期 session。
+## 环境负责协议版本、bearer token、TTL、限流、防重放、结构预算、策略检查和无载荷审计；
+## 它不提供网络传输、模型客户端、文件或命令执行，也不是进程或脚本沙箱。
+## 实例绑定创建线程；所有公开入口与公开策略对象的原地修改都必须在该线程串行执行，
+## 外层 transport 应先编排回拥有线程。跨线程公开入口会 fail closed 且不写共享审计状态。
+## [br]
+## @api public
+## [br]
+## @category runtime_service
+## [br]
+## @since unreleased
+class_name GFRuntimeAgentEnvironment
+extends GFUtility
+
+
+# --- 信号 ---
+
+## 追加安全审计事件时触发。
+## [br]
+## 事件只包含固定协议字段、稳定标识和 request id 摘要，不包含 token、payload、
+## handler 输出或策略返回数据。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event: 固定字段、无业务载荷的 Runtime Agent 审计事件。
+## [br]
+## @schema event: Dictionary { schema_version: int, protocol_version: int, sequence: int, timestamp_msec: int, action: String, outcome: String, reason: String, session_id: String, endpoint_id: String, request_id_digest: String }.
+signal audit_event_recorded(event: Dictionary)
+
+
+# --- 常量 ---
+
+## Runtime Agent 请求协议版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const PROTOCOL_VERSION: int = 1
+
+## Runtime Agent 结果与审计结构版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const SCHEMA_VERSION: int = 1
+
+const _SESSION_POLICY_KIND: String = "gf.runtime_agent.session"
+const _REQUEST_POLICY_KIND: String = "gf.runtime_agent.request"
+const _TOKEN_BYTE_COUNT: int = 32
+const _TOKEN_TEXT_LENGTH: int = _TOKEN_BYTE_COUNT * 2
+const _MAX_IDENTIFIER_LENGTH: int = 128
+const _MAX_ENDPOINTS: int = 128
+const _MAX_ACTIVE_SESSIONS: int = 32
+const _MAX_SCHEMA_DEPTH: int = 16
+const _MAX_SCHEMA_NODES: int = 512
+const _MAX_SCHEMA_FIELDS: int = 64
+const _MAX_VALUE_DEPTH: int = 32
+const _MAX_VALUE_NODES: int = 2048
+const _MAX_VALUE_BYTES: int = 64 * 1024
+const _MAX_AUDIT_EVENTS: int = 256
+const _DEFAULT_SESSION_TTL_MSEC: int = 60_000
+const _MAX_SESSION_TTL_MSEC: int = 15 * 60_000
+const _DEFAULT_RATE_WINDOW_MSEC: int = 60_000
+const _MAX_RATE_WINDOW_MSEC: int = 5 * 60_000
+const _DEFAULT_MAX_REQUESTS_PER_WINDOW: int = 60
+const _MAX_REQUESTS_PER_WINDOW: int = 256
+const _DEFAULT_MAX_REQUEST_IDS: int = 256
+const _MAX_REQUEST_IDS: int = 512
+const _JSON_SAFE_INTEGER_MAX: int = 9_007_199_254_740_991
+const _JSON_SAFE_INTEGER_MIN: int = -9_007_199_254_740_991
+const _REPORT_MARKER_KEY: String = "__gf_report_value__"
+const _VARIANT_MARKER_KEY: String = "__gf_variant__"
+
+const _REQUEST_KEYS: Array[String] = [
+	"protocol_version",
+	"session_id",
+	"endpoint_id",
+	"request_id",
+	"payload",
+]
+const _SESSION_OPTION_KEYS: Array[String] = [
+	"ttl_msec",
+	"max_requests_per_window",
+	"rate_window_msec",
+	"max_request_ids",
+]
+const _ALLOWED_SCHEMA_TYPES: Array[int] = [
+	GFSchemaField.ValueType.BOOL,
+	GFSchemaField.ValueType.INT,
+	GFSchemaField.ValueType.FLOAT,
+	GFSchemaField.ValueType.STRING,
+	GFSchemaField.ValueType.DICTIONARY,
+	GFSchemaField.ValueType.ARRAY,
+]
+
+
+# --- 公共变量 ---
+
+## 是否接受新 session 和请求。
+##
+## 默认 false。由 true 切换为 false 会立即撤销全部 session；再次启用不会恢复旧凭据。
+## endpoint 注册会保留，便于宿主先完成声明再显式开放环境。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var enabled: bool = false:
+	set(value):
+		if not _is_owner_thread():
+			return
+		if enabled == value:
+			return
+		enabled = value
+		_security_context_epoch += 1
+		if not enabled:
+			_sessions.clear()
+			if not _disposing:
+				_append_audit("set_enabled", "succeeded", "sessions_revoked", "", "", "")
+
+## session 签发与请求执行使用的策略注册表。
+##
+## 空注册表表示没有项目附加策略；null 会 fail closed。策略 Provider 属于受信宿主，
+## 可以读取当次策略 artifact，但其结果和 artifact 不会复制到 Runtime Agent 响应或审计。
+## registry、providers 数组及 Provider 字段的原地修改也必须由环境拥有线程串行完成。
+## 原地修改前必须调用 invalidate_policy_context()，以覆盖调用间发生并恢复的 ABA 变化；
+## 当前公开配置摘要仍会对未通知但持续存在的配置漂移 fail closed。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var policy_registry: GFPolicyRegistry = GFPolicyRegistry.new():
+	set(value):
+		if not _is_owner_thread():
+			return
+		if is_same(policy_registry, value):
+			return
+		policy_registry = value
+		_security_context_epoch += 1
+
+
+# --- 私有变量 ---
+
+var _owner_thread_id: int = 0
+var _security_context_epoch: int = 0
+var _endpoints: Dictionary = {}
+var _sessions: Dictionary = {}
+var _audit_events: Array[Dictionary] = []
+var _next_endpoint_generation: int = 0
+var _next_audit_sequence: int = 0
+var _handler_active: bool = false
+var _policy_evaluation_active: bool = false
+var _disposing: bool = false
+
+
+# --- Godot 生命周期方法 ---
+
+func _init() -> void:
+	_owner_thread_id = OS.get_thread_caller_id()
+
+
+# --- GF 生命周期方法 ---
+
+## 释放 endpoint、session、凭据摘要与内存审计。
+## [br]
+## 跨拥有线程调用不会改变环境；transport 必须先把控制流编排回拥有线程。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func dispose() -> void:
+	if not _is_owner_thread():
+		return
+	_disposing = true
+	enabled = false
+	_endpoints.clear()
+	_sessions.clear()
+	_audit_events.clear()
+	policy_registry = null
+	_handler_active = false
+	_policy_evaluation_active = false
+	_disposing = false
+
+
+# --- 公共方法 ---
+
+## 注册一个受信 endpoint。
+##
+## request_schema 与 response_schema 必须是 closed、无 coercion、无 metadata/default/rule，
+## 且只使用 JSON 原生字段类型的有限非循环结构。环境保存 schema 副本，注册后调用方修改
+## 原 Resource 不会改变 endpoint 契约。重复 ID 必须先显式注销，不会隐式替换 handler。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param endpoint_id: 稳定 endpoint 标识。
+## [br]
+## @param request_schema: 严格请求 payload schema。
+## [br]
+## @param response_schema: 严格响应 schema。
+## [br]
+## @param handler: 同步受信回调；接收不含 token 的请求 Dictionary，返回 Dictionary。
+## [br]
+## @return 版本化注册结果。
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_id?: String }.
+func register_endpoint(
+	endpoint_id: String,
+	request_schema: GFDictionarySchema,
+	response_schema: GFDictionarySchema,
+	handler: Callable
+) -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	if not _is_valid_identifier(endpoint_id):
+		return _audit_result(
+			_make_result(false, "rejected", "invalid_endpoint_id"),
+			"register_endpoint",
+			"",
+			"",
+			""
+		)
+	if _endpoints.has(endpoint_id):
+		return _audit_result(
+			_make_result(false, "rejected", "endpoint_already_registered", {
+				"endpoint_id": endpoint_id,
+			}),
+			"register_endpoint",
+			"",
+			endpoint_id,
+			""
+		)
+	if _endpoints.size() >= _MAX_ENDPOINTS:
+		return _audit_result(
+			_make_result(false, "rejected", "endpoint_limit_reached"),
+			"register_endpoint",
+			"",
+			endpoint_id,
+			""
+		)
+	if not handler.is_valid():
+		return _audit_result(
+			_make_result(false, "rejected", "invalid_handler"),
+			"register_endpoint",
+			"",
+			endpoint_id,
+			""
+		)
+	if not _is_safe_schema(request_schema):
+		return _audit_result(
+			_make_result(false, "rejected", "unsafe_request_schema"),
+			"register_endpoint",
+			"",
+			endpoint_id,
+			""
+		)
+	if not _is_safe_schema(response_schema):
+		return _audit_result(
+			_make_result(false, "rejected", "unsafe_response_schema"),
+			"register_endpoint",
+			"",
+			endpoint_id,
+			""
+		)
+
+	_next_endpoint_generation += 1
+	_endpoints[endpoint_id] = {
+		"generation": _next_endpoint_generation,
+		"request_schema": request_schema.duplicate_schema(),
+		"response_schema": response_schema.duplicate_schema(),
+		"handler": handler,
+	}
+	return _audit_result(
+		_make_result(true, "registered", "", {
+			"endpoint_id": endpoint_id,
+		}),
+		"register_endpoint",
+		"",
+		endpoint_id,
+		""
+	)
+
+
+## 注销 endpoint。
+##
+## 已签发 session 中的旧 grant 不会绑定到后续同名注册；旧请求会以
+## endpoint_grant_stale 失败，避免注销/重注册的 ABA 权限恢复。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param endpoint_id: endpoint 标识。
+## [br]
+## @return 版本化注销结果。
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_id?: String }.
+func unregister_endpoint(endpoint_id: String) -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	if not _is_valid_identifier(endpoint_id):
+		return _audit_result(
+			_make_result(false, "rejected", "invalid_endpoint_id"),
+			"unregister_endpoint",
+			"",
+			"",
+			""
+		)
+	if not _endpoints.has(endpoint_id):
+		return _audit_result(
+			_make_result(false, "rejected", "endpoint_not_registered", {
+				"endpoint_id": endpoint_id,
+			}),
+			"unregister_endpoint",
+			"",
+			endpoint_id,
+			""
+		)
+	var _endpoint_erased: bool = _endpoints.erase(endpoint_id)
+	return _audit_result(
+		_make_result(true, "unregistered", "", {
+			"endpoint_id": endpoint_id,
+		}),
+		"unregister_endpoint",
+		"",
+		endpoint_id,
+		""
+	)
+
+
+## 获取不含 handler、token、metadata 和默认值的 endpoint 目录。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 版本化安全目录。
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_count?: int, endpoints?: Array[Dictionary { endpoint_id: String, request_schema: Dictionary { schema_id: String, allow_extra_fields: bool, fields: Array[Dictionary] }, response_schema: Dictionary { schema_id: String, allow_extra_fields: bool, fields: Array[Dictionary] } }] }.
+func get_endpoint_catalog() -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	var endpoint_ids: Array[String] = []
+	for endpoint_key: Variant in _endpoints.keys():
+		if not (endpoint_key is String):
+			continue
+		var endpoint_id: String = endpoint_key
+		endpoint_ids.append(endpoint_id)
+	endpoint_ids.sort()
+	var descriptions: Array[Dictionary] = []
+	for endpoint_id: String in endpoint_ids:
+		var endpoint: Dictionary = _as_dictionary(_endpoints[endpoint_id])
+		var current_request_schema: GFDictionarySchema = _as_schema(endpoint.get("request_schema"))
+		var current_response_schema: GFDictionarySchema = _as_schema(endpoint.get("response_schema"))
+		descriptions.append({
+			"endpoint_id": endpoint_id,
+			"request_schema": _describe_safe_schema(current_request_schema),
+			"response_schema": _describe_safe_schema(current_response_schema),
+		})
+	return _make_result(true, "catalog", "", {
+		"endpoint_count": descriptions.size(),
+		"endpoints": descriptions,
+	})
+
+
+## 为一组精确 endpoint grant 创建短期 session。
+##
+## 此方法属于受信宿主控制面，不是无需认证的远程 endpoint。返回的 token 只出现一次；
+## 环境仅保存与 session id 绑定后的 SHA-256。时间字段使用环境单调毫秒时钟，不是 Unix 时间。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param endpoint_ids: session 唯一允许调用的 endpoint ID。
+## [br]
+## @param options: 严格选项；支持 ttl_msec、max_requests_per_window、rate_window_msec 和 max_request_ids。
+## [br]
+## @return 成功时包含一次性 token 的版本化 session 凭据；失败时不含 token 字段。
+## [br]
+## @schema endpoint_ids: PackedStringArray exact endpoint grants.
+## [br]
+## @schema options: Dictionary { ttl_msec?: int, max_requests_per_window?: int, rate_window_msec?: int, max_request_ids?: int }; no other keys are accepted.
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, session_id?: String, token?: String, endpoint_ids?: Array[String], issued_at_msec?: int, expires_at_msec?: int }; credential fields exist only on success.
+func open_session(
+	endpoint_ids: PackedStringArray,
+	options: Dictionary = {}
+) -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	if _policy_evaluation_active:
+		return _audit_result(
+			_make_result(false, "rejected", "reentrant_policy_evaluation"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	if not enabled:
+		return _audit_result(
+			_make_result(false, "rejected", "environment_disabled"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	if policy_registry == null:
+		return _audit_result(
+			_make_result(false, "rejected", "policy_registry_unavailable"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	var opening_security_context_epoch: int = _security_context_epoch
+	var opening_registry: GFPolicyRegistry = policy_registry
+	var opening_registry_signature: String = _make_policy_registry_signature(opening_registry)
+	if opening_registry_signature.is_empty():
+		return _audit_result(
+			_make_result(false, "rejected", "policy_configuration_invalid"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	if endpoint_ids.size() > _MAX_ENDPOINTS:
+		return _audit_result(
+			_make_result(false, "rejected", "endpoint_grant_limit_exceeded"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	if options.size() > _SESSION_OPTION_KEYS.size():
+		return _audit_result(
+			_make_result(false, "rejected", "invalid_session_options"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	for endpoint_id: String in endpoint_ids:
+		if not _is_valid_identifier(endpoint_id):
+			return _audit_result(
+				_make_result(false, "rejected", "invalid_endpoint_grant"),
+				"open_session",
+				"",
+				"",
+				""
+			)
+	var now_msec: int = _get_current_time_msec()
+	var _pruned_session_count: int = _prune_expired_sessions_internal(now_msec)
+	if _sessions.size() >= _MAX_ACTIVE_SESSIONS:
+		return _audit_result(
+			_make_result(false, "rejected", "session_limit_reached"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+
+	var parsed_options: Dictionary = _parse_session_options(options)
+	if not GFVariantData.get_option_bool(parsed_options, "ok"):
+		return _audit_result(
+			_make_result(false, "rejected", "invalid_session_options"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	var normalized_endpoint_ids: Array[String] = _normalize_endpoint_ids(endpoint_ids)
+	if normalized_endpoint_ids.is_empty():
+		return _audit_result(
+			_make_result(false, "rejected", "empty_endpoint_grants"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+
+	var grants: Dictionary = {}
+	for endpoint_id: String in normalized_endpoint_ids:
+		if not _is_valid_identifier(endpoint_id) or not _endpoints.has(endpoint_id):
+			return _audit_result(
+				_make_result(false, "rejected", "unknown_endpoint_grant"),
+				"open_session",
+				"",
+				endpoint_id if _is_valid_identifier(endpoint_id) else "",
+				""
+			)
+		var endpoint: Dictionary = _as_dictionary(_endpoints[endpoint_id])
+		grants[endpoint_id] = GFVariantData.get_option_int(endpoint, "generation")
+
+	var session_id: String = _make_unique_session_id()
+	if session_id.is_empty():
+		return _audit_result(
+			_make_result(false, "failed", "session_id_generation_failed"),
+			"open_session",
+			"",
+			"",
+			""
+		)
+	var ttl_msec: int = GFVariantData.get_option_int(parsed_options, "ttl_msec")
+	var expires_at_msec: int = now_msec + ttl_msec
+	var session_policy_artifact: Dictionary = {
+		"kind": _SESSION_POLICY_KIND,
+		"protocol_version": PROTOCOL_VERSION,
+		"session_id": session_id,
+		"endpoint_ids": normalized_endpoint_ids.duplicate(),
+		"issued_at_msec": now_msec,
+		"expires_at_msec": expires_at_msec,
+		"limits": {
+			"max_requests_per_window": GFVariantData.get_option_int(
+				parsed_options,
+				"max_requests_per_window"
+			),
+			"rate_window_msec": GFVariantData.get_option_int(
+				parsed_options,
+				"rate_window_msec"
+			),
+			"max_request_ids": GFVariantData.get_option_int(
+				parsed_options,
+				"max_request_ids"
+			),
+		},
+	}
+	var policy_decision: Dictionary = _evaluate_policy(session_policy_artifact, {
+		"operation": "open_session",
+	})
+	if not GFVariantData.get_option_bool(policy_decision, "ok"):
+		return _audit_result(
+			_make_result(
+				false,
+				"rejected",
+				GFVariantData.get_option_string(policy_decision, "reason", "policy_denied")
+			),
+			"open_session",
+			session_id,
+			"",
+			""
+		)
+	if (
+		not enabled
+		or _security_context_epoch != opening_security_context_epoch
+		or not is_same(policy_registry, opening_registry)
+		or _make_policy_registry_signature(opening_registry) != opening_registry_signature
+		or not _are_grants_current(grants)
+	):
+		return _audit_result(
+			_make_result(false, "rejected", "execution_context_changed"),
+			"open_session",
+			session_id,
+			"",
+			""
+		)
+	if _get_current_time_msec() >= expires_at_msec:
+		return _audit_result(
+			_make_result(false, "rejected", "session_creation_expired"),
+			"open_session",
+			session_id,
+			"",
+			""
+		)
+
+	var token: String = _generate_token()
+	if token.length() != _TOKEN_TEXT_LENGTH:
+		return _audit_result(
+			_make_result(false, "failed", "token_generation_failed"),
+			"open_session",
+			session_id,
+			"",
+			""
+		)
+	_sessions[session_id] = {
+		"token_hash": _hash_token(session_id, token),
+		"grants": grants,
+		"issued_at_msec": now_msec,
+		"expires_at_msec": expires_at_msec,
+		"last_seen_msec": now_msec,
+		"max_requests_per_window": GFVariantData.get_option_int(
+			parsed_options,
+			"max_requests_per_window"
+		),
+		"rate_window_msec": GFVariantData.get_option_int(
+			parsed_options,
+			"rate_window_msec"
+		),
+		"rate_window_started_at_msec": now_msec,
+		"requests_in_window": 0,
+		"max_request_ids": GFVariantData.get_option_int(parsed_options, "max_request_ids"),
+		"request_id_hashes": {},
+		"policy_registry_signature": opening_registry_signature,
+	}
+	var result: Dictionary = _make_result(true, "session_opened", "", {
+		"session_id": session_id,
+		"token": token,
+		"endpoint_ids": normalized_endpoint_ids.duplicate(),
+		"issued_at_msec": now_msec,
+		"expires_at_msec": expires_at_msec,
+	})
+	_append_audit("open_session", "succeeded", "", session_id, "", "")
+	return result
+
+
+## 使用凭据关闭 session。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param session_id: session 标识。
+## [br]
+## @param bearer_token: open_session() 一次返回的 token。
+## [br]
+## @return 版本化关闭结果。
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String }.
+func close_session(session_id: String, bearer_token: String) -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	var authentication: Dictionary = _authenticate_session(
+		session_id,
+		bearer_token,
+		_get_current_time_msec()
+	)
+	if not GFVariantData.get_option_bool(authentication, "ok"):
+		return _audit_result(
+			_make_result(
+				false,
+				"rejected",
+				GFVariantData.get_option_string(authentication, "reason", "invalid_credentials")
+			),
+			"close_session",
+			session_id if _is_valid_identifier(session_id) else "",
+			"",
+			""
+		)
+	var _closed_session_erased: bool = _sessions.erase(session_id)
+	return _audit_result(
+		_make_result(true, "session_closed"),
+		"close_session",
+		session_id,
+		"",
+		""
+	)
+
+
+## 由受信宿主按 session id 撤销凭据。
+##
+## 此入口不要求 bearer token，因此只能放在宿主控制面，不能直接映射为未鉴权远程 endpoint。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param session_id: 待撤销 session 标识。
+## [br]
+## @return 找到并撤销 session 时返回 true。
+func revoke_session(session_id: String) -> bool:
+	if not _is_owner_thread():
+		return false
+	if not _is_valid_identifier(session_id) or not _sessions.has(session_id):
+		return false
+	var _revoked_session_erased: bool = _sessions.erase(session_id)
+	_append_audit("revoke_session", "succeeded", "", session_id, "", "")
+	return true
+
+
+## 使策略上下文的任意原地或外部变化立即失效。
+##
+## 修改 registry/provider 公开可变对象，或改变无法由环境观察的自定义字段、外部服务状态
+## 与闭包捕获值之前，受信宿主必须调用本入口。调用会撤销全部 session，并使正在进行的
+## session 签发或请求在回调后的上下文复核中失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 本次撤销的 session 数量；跨拥有线程调用返回 0。
+func invalidate_policy_context() -> int:
+	if not _is_owner_thread():
+		return 0
+	var revoked_count: int = _sessions.size()
+	_security_context_epoch += 1
+	_sessions.clear()
+	_append_audit(
+		"invalidate_policy_context",
+		"succeeded",
+		"sessions_revoked",
+		"",
+		"",
+		""
+	)
+	return revoked_count
+
+
+## 执行一个版本化 Runtime Agent 请求。
+##
+## bearer token 与协议请求分离，不会进入 handler、策略响应、目录、调试快照或审计。
+## 通过身份和精确 grant 校验后，request id 会在策略与 handler 前被消费；失败请求不能
+## 以同一 request id 重试。handler 返回后会复核 session、endpoint generation 和策略注册表
+## 身份，发生同步撤销或替换时丢弃输出。handler 已产生的副作用无法回滚。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param request: closed 请求 envelope。
+## [br]
+## @param bearer_token: session bearer token；不会写入 request 副本。
+## [br]
+## @return 版本化执行结果；仅成功结果包含 response。
+## [br]
+## @schema request: Dictionary { protocol_version: int, session_id: String, endpoint_id: String, request_id: String, payload: Dictionary }; exactly these five keys are accepted.
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, response?: Dictionary }; response exists only on success and matches the endpoint response schema.
+func execute_request(request: Dictionary, bearer_token: String) -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	if _handler_active:
+		return _make_result(false, "rejected", "reentrant_execution")
+	if _policy_evaluation_active:
+		return _make_result(false, "rejected", "reentrant_policy_evaluation")
+	if not enabled:
+		return _audit_result(
+			_make_result(false, "rejected", "environment_disabled"),
+			"execute_request",
+			"",
+			"",
+			""
+		)
+	var envelope_check: Dictionary = _validate_request_envelope(request)
+	if not GFVariantData.get_option_bool(envelope_check, "ok"):
+		var envelope_reason: String = GFVariantData.get_option_string(
+			envelope_check,
+			"reason",
+			"invalid_request_envelope"
+		)
+		return _audit_result(
+			_make_result(false, "rejected", envelope_reason),
+			"execute_request",
+			"",
+			"",
+			""
+		)
+
+	var session_id: String = GFVariantData.get_option_string(request, "session_id")
+	var endpoint_id: String = GFVariantData.get_option_string(request, "endpoint_id")
+	var request_id: String = GFVariantData.get_option_string(request, "request_id")
+	var request_id_hash: String = request_id.sha256_text()
+	var now_msec: int = _get_current_time_msec()
+	var authentication: Dictionary = _authenticate_session(session_id, bearer_token, now_msec)
+	if not GFVariantData.get_option_bool(authentication, "ok"):
+		return _audit_result(
+			_make_result(
+				false,
+				"rejected",
+				GFVariantData.get_option_string(authentication, "reason", "invalid_credentials")
+			),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	var session: Dictionary = _as_dictionary(authentication.get("session"))
+	var rate_check: Dictionary = _consume_rate_budget(session, now_msec)
+	if not GFVariantData.get_option_bool(rate_check, "ok"):
+		return _audit_result(
+			_make_result(false, "rejected", "rate_limited"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	var grant_check: Dictionary = _validate_session_grant(session, endpoint_id)
+	if not GFVariantData.get_option_bool(grant_check, "ok"):
+		return _audit_result(
+			_make_result(
+				false,
+				"rejected",
+				GFVariantData.get_option_string(grant_check, "reason", "endpoint_not_granted")
+			),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+
+	var request_id_hashes: Dictionary = _get_session_dictionary(session, "request_id_hashes")
+	if request_id_hashes.has(request_id_hash):
+		return _audit_result(
+			_make_result(false, "rejected", "request_replayed"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	if request_id_hashes.size() >= GFVariantData.get_option_int(session, "max_request_ids"):
+		return _audit_result(
+			_make_result(false, "rejected", "request_id_budget_exhausted"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	request_id_hashes[request_id_hash] = true
+	session["request_id_hashes"] = request_id_hashes
+
+	var payload_value: Variant = request["payload"]
+	var payload: Dictionary = payload_value
+	var payload_check: Dictionary = _validate_plain_json_value(payload)
+	if not GFVariantData.get_option_bool(payload_check, "ok"):
+		var payload_error: String = GFVariantData.get_option_string(payload_check, "error")
+		var payload_reason: String = (
+			"request_budget_exceeded"
+			if _is_budget_error(payload_error)
+			else "invalid_payload"
+		)
+		return _audit_result(
+			_make_result(false, "rejected", payload_reason),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+
+	var endpoint: Dictionary = _as_dictionary(_endpoints.get(endpoint_id))
+	var current_request_schema: GFDictionarySchema = _as_schema(endpoint.get("request_schema"))
+	if (
+		current_request_schema == null
+		or not _matches_safe_schema(payload, current_request_schema)
+		or not current_request_schema.validate_dictionary(payload).is_ok()
+	):
+		return _audit_result(
+			_make_result(false, "rejected", "request_schema_rejected"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	if policy_registry == null:
+		return _audit_result(
+			_make_result(false, "rejected", "policy_registry_unavailable"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+
+	var endpoint_generation: int = GFVariantData.get_option_int(endpoint, "generation")
+	var handler: Callable = _as_callable(endpoint.get("handler"))
+	var registry_snapshot: GFPolicyRegistry = policy_registry
+	var registry_signature: String = _make_policy_registry_signature(registry_snapshot)
+	var safe_payload: Dictionary = payload.duplicate(true)
+	var policy_artifact: Dictionary = {
+		"kind": _REQUEST_POLICY_KIND,
+		"protocol_version": PROTOCOL_VERSION,
+		"session_id": session_id,
+		"endpoint_id": endpoint_id,
+		"request_id_digest": request_id_hash.substr(0, 16),
+		"payload": safe_payload.duplicate(true),
+	}
+	var policy_decision: Dictionary = _evaluate_policy(policy_artifact, {
+		"operation": "execute_request",
+	})
+	if not GFVariantData.get_option_bool(policy_decision, "ok"):
+		return _audit_result(
+			_make_result(
+				false,
+				"rejected",
+				GFVariantData.get_option_string(policy_decision, "reason", "policy_denied")
+			),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	if not _is_execution_context_current(
+		session_id,
+		endpoint_id,
+		endpoint_generation,
+		registry_snapshot,
+		registry_signature
+	):
+		return _audit_result(
+			_make_result(false, "rejected", "execution_context_changed"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	if not handler.is_valid():
+		return _audit_result(
+			_make_result(false, "failed", "handler_unavailable"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+
+	var handler_request: Dictionary = {
+		"protocol_version": PROTOCOL_VERSION,
+		"session_id": session_id,
+		"endpoint_id": endpoint_id,
+		"request_id": request_id,
+		"payload": safe_payload.duplicate(true),
+	}
+	_handler_active = true
+	var raw_response: Variant = handler.call(handler_request)
+	_handler_active = false
+	if not _is_execution_context_current(
+		session_id,
+		endpoint_id,
+		endpoint_generation,
+		registry_snapshot,
+		registry_signature
+	):
+		return _audit_result(
+			_make_result(false, "rejected", "execution_context_changed"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	if not (raw_response is Dictionary):
+		return _audit_result(
+			_make_result(false, "failed", "invalid_handler_response"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	var response: Dictionary = raw_response
+	var response_check: Dictionary = _validate_plain_json_value(response)
+	if not GFVariantData.get_option_bool(response_check, "ok"):
+		var response_error: String = GFVariantData.get_option_string(response_check, "error")
+		var response_reason: String = (
+			"response_budget_exceeded"
+			if _is_budget_error(response_error)
+			else "invalid_handler_response"
+		)
+		return _audit_result(
+			_make_result(false, "failed", response_reason),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+	var current_response_schema: GFDictionarySchema = _as_schema(endpoint.get("response_schema"))
+	if (
+		current_response_schema == null
+		or not _matches_safe_schema(response, current_response_schema)
+		or not current_response_schema.validate_dictionary(response).is_ok()
+	):
+		return _audit_result(
+			_make_result(false, "failed", "response_schema_rejected"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+
+	var encoded_response: Dictionary = GFReportValueCodec.to_report_dictionary(
+		response,
+		GFReportValueCodec.make_redaction_options(
+			GFReportValueCodec.REDACTION_PROFILE_PRIVACY,
+			{
+				"max_depth": _MAX_VALUE_DEPTH,
+				"max_string_length": _MAX_VALUE_BYTES,
+				"max_collection_items": _MAX_VALUE_NODES,
+				"max_packed_length": 0,
+				"max_total_nodes": _MAX_VALUE_NODES,
+				"max_total_bytes": _MAX_VALUE_BYTES,
+				"encode_dictionary_keys": false,
+				"path_redaction": "none",
+			}
+		)
+	)
+	var encoded_check: Dictionary = _validate_plain_json_value(encoded_response)
+	if (
+		not GFVariantData.get_option_bool(encoded_check, "ok")
+		or _contains_report_marker(encoded_response)
+		or not _json_values_are_identical(response, encoded_response)
+		or not _matches_safe_schema(encoded_response, current_response_schema)
+	):
+		return _audit_result(
+			_make_result(false, "failed", "response_budget_exceeded"),
+			"execute_request",
+			session_id,
+			endpoint_id,
+			request_id
+		)
+
+	var success_result: Dictionary = _make_result(true, "succeeded", "", {
+		"response": encoded_response,
+	})
+	_append_audit("execute_request", "succeeded", "", session_id, endpoint_id, request_id)
+	return success_result
+
+
+## 删除所有已过期 session。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 本次删除数量。
+func prune_expired_sessions() -> int:
+	if not _is_owner_thread():
+		return 0
+	return _prune_expired_sessions_internal(_get_current_time_msec())
+
+
+## 获取最近的无载荷安全审计事件。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param limit: 最多返回数量；钳制到 0..256。
+## [br]
+## @return 版本化审计结果。
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, event_count?: int, retained_event_count?: int, events?: Array[Dictionary { schema_version: int, protocol_version: int, sequence: int, timestamp_msec: int, action: String, outcome: String, reason: String, session_id: String, endpoint_id: String, request_id_digest: String }] }.
+func get_audit_events(limit: int = 64) -> Dictionary:
+	if not _is_owner_thread():
+		return _make_result(false, "rejected", "owner_thread_required")
+	var effective_limit: int = mini(maxi(limit, 0), _MAX_AUDIT_EVENTS)
+	var start_index: int = maxi(_audit_events.size() - effective_limit, 0)
+	var events: Array[Dictionary] = []
+	for index: int in range(start_index, _audit_events.size()):
+		events.append(_audit_events[index].duplicate(true))
+	return _make_result(true, "audit", "", {
+		"event_count": events.size(),
+		"retained_event_count": _audit_events.size(),
+		"events": events,
+	})
+
+
+## 清空环境内存审计环形缓冲。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func clear_audit_events() -> void:
+	if not _is_owner_thread():
+		return
+	_audit_events.clear()
+
+
+## 获取不含凭据、请求 ID 与业务值的调试快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 固定形态调试快照。
+## [br]
+## @schema return: Dictionary { schema_version: int, protocol_version: int, enabled: bool, endpoint_count: int, active_session_count: int, audit_event_count: int, policy_provider_count: int, handler_active: bool, secrets_stored_as_hashes: bool, owner_thread_access: bool }.
+func get_debug_snapshot() -> Dictionary:
+	if not _is_owner_thread():
+		return {
+			"schema_version": SCHEMA_VERSION,
+			"protocol_version": PROTOCOL_VERSION,
+			"enabled": false,
+			"endpoint_count": 0,
+			"active_session_count": 0,
+			"audit_event_count": 0,
+			"policy_provider_count": 0,
+			"handler_active": false,
+			"secrets_stored_as_hashes": true,
+			"owner_thread_access": false,
+		}
+	var provider_count: int = 0
+	if policy_registry != null:
+		provider_count = policy_registry.providers.size()
+	return {
+		"schema_version": SCHEMA_VERSION,
+		"protocol_version": PROTOCOL_VERSION,
+		"enabled": enabled,
+		"endpoint_count": _endpoints.size(),
+		"active_session_count": _sessions.size(),
+		"audit_event_count": _audit_events.size(),
+		"policy_provider_count": provider_count,
+		"handler_active": _handler_active,
+		"secrets_stored_as_hashes": true,
+		"owner_thread_access": true,
+	}
+
+
+# --- 可重写钩子 / 虚方法 ---
+
+## 获取环境单调毫秒时钟。
+##
+## 测试实现可覆写此入口；生产实现使用 Time.get_ticks_msec()，不受系统墙钟回拨影响。
+## [br]
+## @api protected
+## [br]
+## @since unreleased
+## [br]
+## @return 单调毫秒值。
+func _get_current_time_msec() -> int:
+	return Time.get_ticks_msec()
+
+
+# --- 私有/辅助方法 ---
+
+func _is_owner_thread() -> bool:
+	return (
+		_owner_thread_id == 0
+		or OS.get_thread_caller_id() == _owner_thread_id
+	)
+
+
+func _validate_request_envelope(request: Dictionary) -> Dictionary:
+	if request.size() != _REQUEST_KEYS.size():
+		return {
+			"ok": false,
+			"reason": "invalid_request_envelope",
+		}
+	for key: Variant in request.keys():
+		if not (key is String) or not _REQUEST_KEYS.has(key):
+			return {
+				"ok": false,
+				"reason": "invalid_request_envelope",
+			}
+	for required_key: String in _REQUEST_KEYS:
+		if not request.has(required_key):
+			return {
+				"ok": false,
+				"reason": "invalid_request_envelope",
+			}
+	if not (request["protocol_version"] is int):
+		return {
+			"ok": false,
+			"reason": "invalid_request_envelope",
+		}
+	if GFVariantData.get_option_int(request, "protocol_version") != PROTOCOL_VERSION:
+		return {
+			"ok": false,
+			"reason": "unsupported_protocol_version",
+		}
+	if (
+		not (request["session_id"] is String)
+		or not (request["endpoint_id"] is String)
+		or not (request["request_id"] is String)
+		or not (request["payload"] is Dictionary)
+	):
+		return {
+			"ok": false,
+			"reason": "invalid_request_envelope",
+		}
+	if (
+		not _is_valid_identifier(GFVariantData.get_option_string(request, "session_id"))
+		or not _is_valid_identifier(GFVariantData.get_option_string(request, "endpoint_id"))
+		or not _is_valid_identifier(GFVariantData.get_option_string(request, "request_id"))
+	):
+		return {
+			"ok": false,
+			"reason": "invalid_request_envelope",
+		}
+	return { "ok": true }
+
+
+func _parse_session_options(options: Dictionary) -> Dictionary:
+	for key: Variant in options.keys():
+		if (
+			not (key is String)
+			or not _SESSION_OPTION_KEYS.has(key)
+			or not (options[key] is int)
+		):
+			return { "ok": false }
+	var ttl_msec: int = _strict_option_int(options, "ttl_msec", _DEFAULT_SESSION_TTL_MSEC)
+	var max_requests_per_window: int = _strict_option_int(
+		options,
+		"max_requests_per_window",
+		_DEFAULT_MAX_REQUESTS_PER_WINDOW
+	)
+	var rate_window_msec: int = _strict_option_int(
+		options,
+		"rate_window_msec",
+		_DEFAULT_RATE_WINDOW_MSEC
+	)
+	var max_request_ids: int = _strict_option_int(
+		options,
+		"max_request_ids",
+		_DEFAULT_MAX_REQUEST_IDS
+	)
+	if ttl_msec < 1 or ttl_msec > _MAX_SESSION_TTL_MSEC:
+		return { "ok": false }
+	if rate_window_msec < 1 or rate_window_msec > _MAX_RATE_WINDOW_MSEC:
+		return { "ok": false }
+	if (
+		max_requests_per_window < 1
+		or max_requests_per_window > _MAX_REQUESTS_PER_WINDOW
+	):
+		return { "ok": false }
+	if max_request_ids < max_requests_per_window or max_request_ids > _MAX_REQUEST_IDS:
+		return { "ok": false }
+	return {
+		"ok": true,
+		"ttl_msec": ttl_msec,
+		"max_requests_per_window": max_requests_per_window,
+		"rate_window_msec": rate_window_msec,
+		"max_request_ids": max_request_ids,
+	}
+
+
+func _normalize_endpoint_ids(endpoint_ids: PackedStringArray) -> Array[String]:
+	var seen: Dictionary = {}
+	var result: Array[String] = []
+	for endpoint_id: String in endpoint_ids:
+		if seen.has(endpoint_id):
+			continue
+		seen[endpoint_id] = true
+		result.append(endpoint_id)
+	result.sort()
+	return result
+
+
+func _authenticate_session(
+	session_id: String,
+	bearer_token: String,
+	now_msec: int
+) -> Dictionary:
+	if (
+		not _is_valid_identifier(session_id)
+		or not _is_valid_token_text(bearer_token)
+		or not _sessions.has(session_id)
+	):
+		return {
+			"ok": false,
+			"reason": "invalid_credentials",
+		}
+	var session: Dictionary = _as_dictionary(_sessions[session_id])
+	var expected_hash: String = GFVariantData.get_option_string(session, "token_hash")
+	var candidate_hash: String = _hash_token(session_id, bearer_token)
+	if not _constant_time_hash_equal(expected_hash, candidate_hash):
+		return {
+			"ok": false,
+			"reason": "invalid_credentials",
+		}
+	if policy_registry == null:
+		var _unavailable_policy_session_erased: bool = _sessions.erase(session_id)
+		return {
+			"ok": false,
+			"reason": "policy_registry_unavailable",
+		}
+	var current_policy_signature: String = _make_policy_registry_signature(policy_registry)
+	if current_policy_signature.is_empty():
+		var _invalid_policy_session_erased: bool = _sessions.erase(session_id)
+		return {
+			"ok": false,
+			"reason": "policy_configuration_invalid",
+		}
+	if (
+		current_policy_signature
+		!= GFVariantData.get_option_string(session, "policy_registry_signature")
+	):
+		var _changed_policy_session_erased: bool = _sessions.erase(session_id)
+		return {
+			"ok": false,
+			"reason": "policy_context_changed",
+		}
+	if now_msec >= GFVariantData.get_option_int(session, "expires_at_msec"):
+		var _expired_session_erased: bool = _sessions.erase(session_id)
+		return {
+			"ok": false,
+			"reason": "session_expired",
+		}
+	if now_msec < GFVariantData.get_option_int(session, "last_seen_msec"):
+		var _regressed_session_erased: bool = _sessions.erase(session_id)
+		return {
+			"ok": false,
+			"reason": "session_clock_regressed",
+		}
+	session["last_seen_msec"] = now_msec
+	return {
+		"ok": true,
+		"session": session,
+	}
+
+
+func _validate_session_grant(session: Dictionary, endpoint_id: String) -> Dictionary:
+	var grants: Dictionary = _get_session_dictionary(session, "grants")
+	if not grants.has(endpoint_id):
+		return {
+			"ok": false,
+			"reason": "endpoint_not_granted",
+		}
+	if not _endpoints.has(endpoint_id):
+		return {
+			"ok": false,
+			"reason": "endpoint_grant_stale",
+		}
+	var endpoint: Dictionary = _as_dictionary(_endpoints[endpoint_id])
+	if (
+		GFVariantData.get_option_int(endpoint, "generation")
+		!= GFVariantData.get_option_int(grants, endpoint_id)
+	):
+		return {
+			"ok": false,
+			"reason": "endpoint_grant_stale",
+		}
+	return { "ok": true }
+
+
+func _consume_rate_budget(session: Dictionary, now_msec: int) -> Dictionary:
+	var window_started_at_msec: int = GFVariantData.get_option_int(
+		session,
+		"rate_window_started_at_msec"
+	)
+	var window_msec: int = GFVariantData.get_option_int(session, "rate_window_msec")
+	if (
+		now_msec < window_started_at_msec
+		or now_msec - window_started_at_msec >= window_msec
+	):
+		session["rate_window_started_at_msec"] = now_msec
+		session["requests_in_window"] = 0
+	var request_count: int = GFVariantData.get_option_int(session, "requests_in_window")
+	if request_count >= GFVariantData.get_option_int(session, "max_requests_per_window"):
+		return { "ok": false }
+	session["requests_in_window"] = request_count + 1
+	return { "ok": true }
+
+
+func _evaluate_policy(artifact: Dictionary, context: Dictionary) -> Dictionary:
+	if policy_registry == null:
+		return {
+			"ok": false,
+			"reason": "policy_registry_unavailable",
+		}
+	if _policy_evaluation_active:
+		return {
+			"ok": false,
+			"reason": "reentrant_policy_evaluation",
+		}
+	var registry_snapshot: GFPolicyRegistry = policy_registry
+	var registry_signature: String = _make_policy_registry_signature(registry_snapshot)
+	if registry_signature.is_empty():
+		return {
+			"ok": false,
+			"reason": "policy_configuration_invalid",
+		}
+	_policy_evaluation_active = true
+	var result: Dictionary = registry_snapshot.evaluate_artifact(
+		artifact.duplicate(true),
+		context.duplicate(true)
+	)
+	_policy_evaluation_active = false
+	if (
+		not is_same(policy_registry, registry_snapshot)
+		or _make_policy_registry_signature(registry_snapshot) != registry_signature
+	):
+		return {
+			"ok": false,
+			"reason": "policy_context_changed",
+		}
+	if not GFVariantData.get_option_bool(result, "ok", false):
+		return {
+			"ok": false,
+			"reason": "policy_denied",
+		}
+	return { "ok": true }
+
+
+func _make_policy_registry_signature(registry: GFPolicyRegistry) -> String:
+	if registry == null:
+		return ""
+	var provider_snapshots: Array = []
+	for provider: GFPolicyProvider in registry.providers:
+		if provider == null:
+			provider_snapshots.append(null)
+			continue
+		var supported_artifact_kinds: Array[String] = []
+		for artifact_kind: String in provider.supported_artifact_kinds:
+			supported_artifact_kinds.append(artifact_kind)
+		provider_snapshots.append({
+			"instance_id": str(provider.get_instance_id()),
+			"provider_id": String(provider.provider_id),
+			"display_name": provider.display_name,
+			"supported_artifact_kinds": supported_artifact_kinds,
+			"priority": str(provider.priority),
+			"input_schema": provider.input_schema,
+			"output_schema": provider.output_schema,
+			"deterministic": provider.deterministic,
+			"metadata": provider.metadata,
+		})
+	var signature_snapshot: Dictionary = {
+		"security_context_epoch": str(_security_context_epoch),
+		"providers": provider_snapshots,
+	}
+	if not GFVariantData.get_option_bool(
+		_validate_plain_json_value(signature_snapshot),
+		"ok"
+	):
+		return ""
+	return JSON.stringify(signature_snapshot, "", true).sha256_text()
+
+
+func _is_execution_context_current(
+	session_id: String,
+	endpoint_id: String,
+	endpoint_generation: int,
+	registry_snapshot: GFPolicyRegistry,
+	registry_signature: String
+) -> bool:
+	if not enabled or not _sessions.has(session_id) or not _endpoints.has(endpoint_id):
+		return false
+	var session: Dictionary = _as_dictionary(_sessions[session_id])
+	if _get_current_time_msec() >= GFVariantData.get_option_int(session, "expires_at_msec"):
+		var _context_session_erased: bool = _sessions.erase(session_id)
+		return false
+	if (
+		GFVariantData.get_option_string(session, "policy_registry_signature")
+		!= registry_signature
+	):
+		return false
+	var endpoint: Dictionary = _as_dictionary(_endpoints[endpoint_id])
+	if GFVariantData.get_option_int(endpoint, "generation") != endpoint_generation:
+		return false
+	if policy_registry == null or not is_same(policy_registry, registry_snapshot):
+		return false
+	return _make_policy_registry_signature(registry_snapshot) == registry_signature
+
+
+func _are_grants_current(grants: Dictionary) -> bool:
+	for endpoint_key: Variant in grants.keys():
+		if not (endpoint_key is String):
+			return false
+		var endpoint_id: String = endpoint_key
+		if not _endpoints.has(endpoint_id):
+			return false
+		var endpoint: Dictionary = _as_dictionary(_endpoints[endpoint_id])
+		if (
+			GFVariantData.get_option_int(endpoint, "generation")
+			!= GFVariantData.get_option_int(grants, endpoint_id)
+		):
+			return false
+	return true
+
+
+func _is_safe_schema(schema: GFDictionarySchema) -> bool:
+	if schema == null:
+		return false
+	var state: Dictionary = {
+		"schema_nodes": 0,
+		"active_schemas": [],
+		"active_fields": [],
+	}
+	if not _validate_safe_schema_node(schema, state, 0):
+		return false
+	return schema.validate_definition().is_ok()
+
+
+func _validate_safe_schema_node(
+	schema: GFDictionarySchema,
+	state: Dictionary,
+	depth: int
+) -> bool:
+	if schema == null or depth > _MAX_SCHEMA_DEPTH:
+		return false
+	if _visited_contains(_state_array(state, "active_schemas"), schema):
+		return false
+	state["schema_nodes"] = GFVariantData.get_option_int(state, "schema_nodes") + 1
+	if GFVariantData.get_option_int(state, "schema_nodes") > _MAX_SCHEMA_NODES:
+		return false
+	if (
+		not _is_valid_identifier(String(schema.schema_id))
+		or schema.allow_extra_fields
+		or schema.coerce_values
+		or not schema.fail_on_coerce_error
+		or not schema.metadata.is_empty()
+		or schema.fields.size() > _MAX_SCHEMA_FIELDS
+	):
+		return false
+	_state_array(state, "active_schemas").append(schema)
+	var seen_names: Dictionary = {}
+	for field: GFSchemaField in schema.fields:
+		if (
+			field == null
+			or not _validate_safe_field_node(field, state, depth + 1, false)
+			or seen_names.has(String(field.field_name))
+		):
+			var _removed_failed_schema: Variant = _state_array(
+				state,
+				"active_schemas"
+			).pop_back()
+			return false
+		seen_names[String(field.field_name)] = true
+	var _removed_schema: Variant = _state_array(state, "active_schemas").pop_back()
+	return true
+
+
+func _validate_safe_field_node(
+	field: GFSchemaField,
+	state: Dictionary,
+	depth: int,
+	is_array_item: bool
+) -> bool:
+	if field == null or depth > _MAX_SCHEMA_DEPTH:
+		return false
+	if _visited_contains(_state_array(state, "active_fields"), field):
+		return false
+	state["schema_nodes"] = GFVariantData.get_option_int(state, "schema_nodes") + 1
+	if GFVariantData.get_option_int(state, "schema_nodes") > _MAX_SCHEMA_NODES:
+		return false
+	if not _ALLOWED_SCHEMA_TYPES.has(field.value_type):
+		return false
+	if (
+		not field.metadata.is_empty()
+		or not field.validation_rules.is_empty()
+		or field.default_value != null
+	):
+		return false
+	if is_array_item:
+		if field.field_name != &"" or field.required:
+			return false
+	elif not _is_valid_identifier(String(field.field_name)):
+		return false
+
+	_state_array(state, "active_fields").append(field)
+	var valid: bool = true
+	match field.value_type:
+		GFSchemaField.ValueType.DICTIONARY:
+			valid = (
+				field.array_item_schema == null
+				and _validate_safe_schema_node(field.dictionary_schema, state, depth + 1)
+			)
+		GFSchemaField.ValueType.ARRAY:
+			valid = (
+				field.dictionary_schema == null
+				and _validate_safe_field_node(field.array_item_schema, state, depth + 1, true)
+			)
+		_:
+			valid = field.dictionary_schema == null and field.array_item_schema == null
+	var _removed_field: Variant = _state_array(state, "active_fields").pop_back()
+	return valid
+
+
+func _describe_safe_schema(schema: GFDictionarySchema) -> Dictionary:
+	var fields: Array[Dictionary] = []
+	if schema != null:
+		for field: GFSchemaField in schema.fields:
+			fields.append(_describe_safe_field(field))
+	return {
+		"schema_id": String(schema.schema_id) if schema != null else "",
+		"allow_extra_fields": false,
+		"fields": fields,
+	}
+
+
+func _describe_safe_field(field: GFSchemaField) -> Dictionary:
+	var result: Dictionary = {
+		"name": String(field.field_name),
+		"type": _schema_type_name(field.value_type),
+		"required": field.required,
+		"allow_null": field.allow_null,
+	}
+	if field.value_type == GFSchemaField.ValueType.DICTIONARY:
+		result["dictionary_schema"] = _describe_safe_schema(field.dictionary_schema)
+	elif field.value_type == GFSchemaField.ValueType.ARRAY:
+		result["array_item_schema"] = _describe_safe_field(field.array_item_schema)
+	return result
+
+
+func _schema_type_name(value_type: GFSchemaField.ValueType) -> String:
+	match value_type:
+		GFSchemaField.ValueType.BOOL:
+			return "bool"
+		GFSchemaField.ValueType.INT:
+			return "int"
+		GFSchemaField.ValueType.FLOAT:
+			return "float"
+		GFSchemaField.ValueType.STRING:
+			return "string"
+		GFSchemaField.ValueType.DICTIONARY:
+			return "dictionary"
+		GFSchemaField.ValueType.ARRAY:
+			return "array"
+	return "unsupported"
+
+
+func _matches_safe_schema(values: Dictionary, schema: GFDictionarySchema) -> bool:
+	if schema == null or values.size() > schema.fields.size():
+		return false
+	var fields_by_name: Dictionary = {}
+	for field: GFSchemaField in schema.fields:
+		if field == null:
+			return false
+		var field_name: String = String(field.field_name)
+		fields_by_name[field_name] = field
+		if field.required and not values.has(field_name):
+			return false
+	for key: Variant in values.keys():
+		if not (key is String) or not fields_by_name.has(key):
+			return false
+		var field: GFSchemaField = fields_by_name[key]
+		if not _matches_safe_field(values[key], field):
+			return false
+	return true
+
+
+func _matches_safe_field(value: Variant, field: GFSchemaField) -> bool:
+	if field == null:
+		return false
+	if value == null:
+		return field.allow_null
+	match field.value_type:
+		GFSchemaField.ValueType.BOOL:
+			return value is bool
+		GFSchemaField.ValueType.INT:
+			return value is int
+		GFSchemaField.ValueType.FLOAT:
+			return value is int or value is float
+		GFSchemaField.ValueType.STRING:
+			return value is String
+		GFSchemaField.ValueType.DICTIONARY:
+			if not (value is Dictionary):
+				return false
+			var dictionary_value: Dictionary = value
+			return _matches_safe_schema(dictionary_value, field.dictionary_schema)
+		GFSchemaField.ValueType.ARRAY:
+			if not (value is Array):
+				return false
+			var array_value: Array = value
+			for item: Variant in array_value:
+				if not _matches_safe_field(item, field.array_item_schema):
+					return false
+			return true
+	return false
+
+
+func _validate_plain_json_value(value: Variant) -> Dictionary:
+	var state: Dictionary = {
+		"node_count": 0,
+		"work_bytes": 0,
+		"visited": [],
+	}
+	var error: String = _validate_plain_json_node(value, state, 0)
+	if not error.is_empty():
+		return {
+			"ok": false,
+			"error": error,
+		}
+	var json_text: String = JSON.stringify(value)
+	var byte_count: int = json_text.to_utf8_buffer().size()
+	if byte_count > _MAX_VALUE_BYTES:
+		return {
+			"ok": false,
+			"error": "max_bytes_exceeded",
+		}
+	return {
+		"ok": true,
+		"node_count": GFVariantData.get_option_int(state, "node_count"),
+		"byte_count": byte_count,
+	}
+
+
+func _validate_plain_json_node(
+	value: Variant,
+	state: Dictionary,
+	depth: int
+) -> String:
+	if depth > _MAX_VALUE_DEPTH:
+		return "max_depth_exceeded"
+	state["node_count"] = GFVariantData.get_option_int(state, "node_count") + 1
+	if GFVariantData.get_option_int(state, "node_count") > _MAX_VALUE_NODES:
+		return "max_nodes_exceeded"
+
+	match typeof(value):
+		TYPE_NIL:
+			return _consume_json_work_bytes(state, 4)
+		TYPE_BOOL:
+			return _consume_json_work_bytes(state, 5)
+		TYPE_INT:
+			var integer_value: int = value
+			if integer_value < _JSON_SAFE_INTEGER_MIN or integer_value > _JSON_SAFE_INTEGER_MAX:
+				return "unsafe_integer"
+			return _consume_json_work_bytes(state, 24)
+		TYPE_FLOAT:
+			var float_value: float = value
+			if is_nan(float_value) or is_inf(float_value):
+				return "non_finite_number"
+			return _consume_json_work_bytes(state, 32)
+		TYPE_STRING:
+			var string_value: String = value
+			if string_value.length() > _MAX_VALUE_BYTES:
+				return "max_bytes_exceeded"
+			return _consume_json_work_bytes(state, string_value.to_utf8_buffer().size() + 2)
+		TYPE_DICTIONARY:
+			var dictionary_value: Dictionary = value
+			if _visited_contains(_state_array(state, "visited"), dictionary_value):
+				return "circular_reference"
+			_state_array(state, "visited").append(dictionary_value)
+			var dictionary_budget_error: String = _consume_json_work_bytes(state, 2)
+			if not dictionary_budget_error.is_empty():
+				var _removed_budget_dictionary: Variant = _state_array(
+					state,
+					"visited"
+				).pop_back()
+				return dictionary_budget_error
+			for key: Variant in dictionary_value:
+				if not (key is String):
+					var _removed_invalid_key_dictionary: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return "invalid_dictionary_key"
+				var key_text: String = key
+				if key_text == _REPORT_MARKER_KEY or key_text == _VARIANT_MARKER_KEY:
+					var _removed_reserved_key_dictionary: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return "reserved_marker"
+				if key_text.length() > _MAX_VALUE_BYTES:
+					var _removed_oversized_key_dictionary: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return "max_bytes_exceeded"
+				state["node_count"] = GFVariantData.get_option_int(state, "node_count") + 1
+				if GFVariantData.get_option_int(state, "node_count") > _MAX_VALUE_NODES:
+					var _removed_node_budget_dictionary: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return "max_nodes_exceeded"
+				var key_budget_error: String = _consume_json_work_bytes(
+					state,
+					key_text.to_utf8_buffer().size() + 3
+				)
+				if not key_budget_error.is_empty():
+					var _removed_key_budget_dictionary: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return key_budget_error
+				var child_error: String = _validate_plain_json_node(
+					dictionary_value[key],
+					state,
+					depth + 1
+				)
+				if not child_error.is_empty():
+					var _removed_child_dictionary: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return child_error
+			var _removed_dictionary: Variant = _state_array(state, "visited").pop_back()
+			return ""
+		TYPE_ARRAY:
+			var array_value: Array = value
+			if _visited_contains(_state_array(state, "visited"), array_value):
+				return "circular_reference"
+			_state_array(state, "visited").append(array_value)
+			var array_budget_error: String = _consume_json_work_bytes(state, 2)
+			if not array_budget_error.is_empty():
+				var _removed_budget_array: Variant = _state_array(state, "visited").pop_back()
+				return array_budget_error
+			for item: Variant in array_value:
+				var child_error: String = _validate_plain_json_node(item, state, depth + 1)
+				if not child_error.is_empty():
+					var _removed_child_array: Variant = _state_array(
+						state,
+						"visited"
+					).pop_back()
+					return child_error
+			var _removed_array: Variant = _state_array(state, "visited").pop_back()
+			return ""
+		_:
+			return "non_json_value"
+
+
+func _consume_json_work_bytes(state: Dictionary, amount: int) -> String:
+	state["work_bytes"] = GFVariantData.get_option_int(state, "work_bytes") + maxi(amount, 0)
+	if GFVariantData.get_option_int(state, "work_bytes") > _MAX_VALUE_BYTES:
+		return "max_bytes_exceeded"
+	return ""
+
+
+func _contains_report_marker(value: Variant) -> bool:
+	if value is Dictionary:
+		var dictionary_value: Dictionary = value
+		if dictionary_value.has(_REPORT_MARKER_KEY) or dictionary_value.has(_VARIANT_MARKER_KEY):
+			return true
+		for child: Variant in dictionary_value.values():
+			if _contains_report_marker(child):
+				return true
+	elif value is Array:
+		var array_value: Array = value
+		for child: Variant in array_value:
+			if _contains_report_marker(child):
+				return true
+	return false
+
+
+func _json_values_are_identical(left: Variant, right: Variant) -> bool:
+	return JSON.stringify(left, "", true) == JSON.stringify(right, "", true)
+
+
+func _is_budget_error(error: String) -> bool:
+	return error in [
+		"max_depth_exceeded",
+		"max_nodes_exceeded",
+		"max_bytes_exceeded",
+	]
+
+
+func _prune_expired_sessions_internal(now_msec: int) -> int:
+	var expired_ids: Array[String] = []
+	for session_key: Variant in _sessions.keys():
+		if not (session_key is String):
+			continue
+		var session_id: String = session_key
+		var session: Dictionary = _as_dictionary(_sessions[session_id])
+		if now_msec >= GFVariantData.get_option_int(session, "expires_at_msec"):
+			expired_ids.append(session_id)
+	for session_id: String in expired_ids:
+		var _pruned_session_erased: bool = _sessions.erase(session_id)
+		_append_audit("prune_session", "succeeded", "session_expired", session_id, "", "")
+	return expired_ids.size()
+
+
+func _make_unique_session_id() -> String:
+	for _attempt: int in range(4):
+		var candidate: String = GFUuid.generate_v4()
+		if _is_valid_identifier(candidate) and not _sessions.has(candidate):
+			return candidate
+	return ""
+
+
+func _generate_token() -> String:
+	var crypto: Crypto = Crypto.new()
+	return crypto.generate_random_bytes(_TOKEN_BYTE_COUNT).hex_encode()
+
+
+func _hash_token(session_id: String, token: String) -> String:
+	return ("%s:%s" % [session_id, token]).sha256_text()
+
+
+func _constant_time_hash_equal(left: String, right: String) -> bool:
+	if left.length() != 64 or right.length() != 64:
+		return false
+	var mismatch: int = 0
+	for index: int in range(64):
+		mismatch |= left.unicode_at(index) ^ right.unicode_at(index)
+	return mismatch == 0
+
+
+func _is_valid_token_text(token: String) -> bool:
+	if token.length() != _TOKEN_TEXT_LENGTH:
+		return false
+	for index: int in range(token.length()):
+		var character_code: int = token.unicode_at(index)
+		if not (
+			(character_code >= 48 and character_code <= 57)
+			or (character_code >= 97 and character_code <= 102)
+		):
+			return false
+	return true
+
+
+func _is_valid_identifier(value: String) -> bool:
+	if value.is_empty() or value.length() > _MAX_IDENTIFIER_LENGTH:
+		return false
+	for index: int in range(value.length()):
+		var character_code: int = value.unicode_at(index)
+		var allowed: bool = (
+			(character_code >= 48 and character_code <= 57)
+			or (character_code >= 65 and character_code <= 90)
+			or (character_code >= 97 and character_code <= 122)
+			or character_code in [45, 46, 47, 58, 95]
+		)
+		if not allowed:
+			return false
+	return true
+
+
+func _append_audit(
+	action: String,
+	outcome: String,
+	reason: String,
+	session_id: String,
+	endpoint_id: String,
+	request_id: String
+) -> void:
+	_next_audit_sequence += 1
+	var event: Dictionary = {
+		"schema_version": SCHEMA_VERSION,
+		"protocol_version": PROTOCOL_VERSION,
+		"sequence": _next_audit_sequence,
+		"timestamp_msec": _get_current_time_msec(),
+		"action": action,
+		"outcome": outcome,
+		"reason": reason,
+		"session_id": session_id,
+		"endpoint_id": endpoint_id,
+		"request_id_digest": request_id.sha256_text().substr(0, 16) if not request_id.is_empty() else "",
+	}
+	_audit_events.append(event)
+	while _audit_events.size() > _MAX_AUDIT_EVENTS:
+		_audit_events.remove_at(0)
+	audit_event_recorded.emit(event.duplicate(true))
+
+
+func _audit_result(
+	result: Dictionary,
+	action: String,
+	session_id: String,
+	endpoint_id: String,
+	request_id: String
+) -> Dictionary:
+	var outcome: String = (
+		"succeeded"
+		if GFVariantData.get_option_bool(result, "ok")
+		else GFVariantData.get_option_string(result, "status", "rejected")
+	)
+	_append_audit(
+		action,
+		outcome,
+		GFVariantData.get_option_string(result, "reason"),
+		session_id,
+		endpoint_id,
+		request_id
+	)
+	return result
+
+
+func _make_result(
+	ok: bool,
+	status: String,
+	reason: String = "",
+	extra: Dictionary = {}
+) -> Dictionary:
+	var result: Dictionary = {
+		"schema_version": SCHEMA_VERSION,
+		"protocol_version": PROTOCOL_VERSION,
+		"ok": ok,
+		"status": status,
+		"reason": reason,
+	}
+	for key: Variant in extra.keys():
+		result[key] = extra[key]
+	return result
+
+
+func _strict_option_int(options: Dictionary, key: String, default_value: int) -> int:
+	if options.has(key):
+		var value: Variant = options[key]
+		if value is int:
+			return value
+	return default_value
+
+
+func _get_session_dictionary(session: Dictionary, key: String) -> Dictionary:
+	var value: Variant = session.get(key)
+	if value is Dictionary:
+		var dictionary_value: Dictionary = value
+		return dictionary_value
+	return {}
+
+
+func _state_array(state: Dictionary, key: String) -> Array:
+	var value: Variant = state.get(key)
+	if value is Array:
+		var array_value: Array = value
+		return array_value
+	return []
+
+
+func _visited_contains(visited: Array, value: Variant) -> bool:
+	for existing: Variant in visited:
+		if is_same(existing, value):
+			return true
+	return false
+
+
+func _as_dictionary(value: Variant) -> Dictionary:
+	if value is Dictionary:
+		var dictionary_value: Dictionary = value
+		return dictionary_value
+	return {}
+
+
+func _as_schema(value: Variant) -> GFDictionarySchema:
+	if value is GFDictionarySchema:
+		var schema: GFDictionarySchema = value
+		return schema
+	return null
+
+
+func _as_callable(value: Variant) -> Callable:
+	if value is Callable:
+		var callable_value: Callable = value
+		return callable_value
+	return Callable()

--- a/addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd.uid
+++ b/addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd.uid
@@ -1,0 +1,1 @@
+uid://pe5qospil3tp

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,9 +2,9 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "6e7b31919ecb9dc1f35018fbed0fe05a8d9f2cabd0ca29cfdefaee58acbb70dd",
-  "class_count": 738,
-  "package_count": 50,
+  "source_digest": "d4200026bc81cf70d262aefeae934e7e9e463f5dbbc6b48f91115fd598cb974a",
+  "class_count": 739,
+  "package_count": 51,
   "packages": [
     {
       "id": "gf.extension.action_queue",
@@ -194,6 +194,16 @@
       "dependencies": [],
       "description": "Minimal GF framework core, plugin entry, lifecycle, extension manager, and Godot-native package management base.",
       "representative_path": "addons/gf/kernel/base/gf_clock.gd"
+    },
+    {
+      "id": "gf.standard.agent_environment",
+      "kind": "standard",
+      "dependencies": [
+        "gf.kernel",
+        "gf.standard.base"
+      ],
+      "description": "Transport-neutral, default-closed runtime Agent endpoint sessions with strict JSON schemas, exact grants, short-lived hashed credentials, replay and rate controls, policy checks, bounded results, and payload-free audit events.",
+      "representative_path": "addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd"
     },
     {
       "id": "gf.standard.assets",
@@ -61554,6 +61564,151 @@
           "signature": "func validate() -> bool",
           "summary": "校验规则的配置数据是否合法。",
           "visibility": "public"
+        }
+      ]
+    },
+    "GFRuntimeAgentEnvironment": {
+      "extends": "GFUtility",
+      "module": "standard",
+      "package_id": "gf.standard.agent_environment",
+      "path": "addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd",
+      "summary": "GFRuntimeAgentEnvironment: 传输无关的受限运行时 Agent 调用环境。 受信宿主显式注册严格 endpoint，再为调用方签发仅授权指定 endpoint 的短期 session。 环境负责协议版本、bearer token、TTL、限流、防重放、结构预算、策略检查和无载荷审计；",
+      "visibility": "public",
+      "category": "runtime_service",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "audit_event_recorded",
+          "signature": "signal audit_event_recorded(event: Dictionary)",
+          "summary": "追加安全审计事件时触发。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "PROTOCOL_VERSION",
+          "signature": "const PROTOCOL_VERSION: int = 1",
+          "summary": "Runtime Agent 请求协议版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "SCHEMA_VERSION",
+          "signature": "const SCHEMA_VERSION: int = 1",
+          "summary": "Runtime Agent 结果与审计结构版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "enabled",
+          "signature": "var enabled: bool = false",
+          "summary": "是否接受新 session 和请求。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "policy_registry",
+          "signature": "var policy_registry: GFPolicyRegistry = GFPolicyRegistry.new()",
+          "summary": "session 签发与请求执行使用的策略注册表。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "dispose",
+          "signature": "func dispose() -> void",
+          "summary": "释放 endpoint、session、凭据摘要与内存审计。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "register_endpoint",
+          "signature": "func register_endpoint( endpoint_id: String, request_schema: GFDictionarySchema, response_schema: GFDictionarySchema, handler: Callable ) -> Dictionary",
+          "summary": "注册一个受信 endpoint。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unregister_endpoint",
+          "signature": "func unregister_endpoint(endpoint_id: String) -> Dictionary",
+          "summary": "注销 endpoint。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_endpoint_catalog",
+          "signature": "func get_endpoint_catalog() -> Dictionary",
+          "summary": "获取不含 handler、token、metadata 和默认值的 endpoint 目录。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "open_session",
+          "signature": "func open_session( endpoint_ids: PackedStringArray, options: Dictionary = {} ) -> Dictionary",
+          "summary": "为一组精确 endpoint grant 创建短期 session。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "close_session",
+          "signature": "func close_session(session_id: String, bearer_token: String) -> Dictionary",
+          "summary": "使用凭据关闭 session。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "revoke_session",
+          "signature": "func revoke_session(session_id: String) -> bool",
+          "summary": "由受信宿主按 session id 撤销凭据。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "invalidate_policy_context",
+          "signature": "func invalidate_policy_context() -> int",
+          "summary": "使策略上下文的任意原地或外部变化立即失效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "execute_request",
+          "signature": "func execute_request(request: Dictionary, bearer_token: String) -> Dictionary",
+          "summary": "执行一个版本化 Runtime Agent 请求。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "prune_expired_sessions",
+          "signature": "func prune_expired_sessions() -> int",
+          "summary": "删除所有已过期 session。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_audit_events",
+          "signature": "func get_audit_events(limit: int = 64) -> Dictionary",
+          "summary": "获取最近的无载荷安全审计事件。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "clear_audit_events",
+          "signature": "func clear_audit_events() -> void",
+          "summary": "清空环境内存审计环形缓冲。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_debug_snapshot",
+          "signature": "func get_debug_snapshot() -> Dictionary",
+          "summary": "获取不含凭据、请求 ID 与业务值的调试快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "_get_current_time_msec",
+          "signature": "func _get_current_time_msec() -> int",
+          "summary": "获取环境单调毫秒时钟。",
+          "visibility": "protected"
         }
       ]
     },

--- a/addons/gf/tools/ai_developer/knowledge/capabilities.json
+++ b/addons/gf/tools/ai_developer/knowledge/capabilities.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.1.0",
+  "catalog_version": "1.2.0",
   "capabilities": [
     {
       "id": "architecture",
@@ -101,6 +101,16 @@
       "primary_classes": ["GFDiagnosticsUtility", "GFDiagnosticSnapshotProvider", "GFDiagnosticProviderResult", "GFSessionTraceUtility", "GFSessionTraceRecipe", "GFOperationDiagnosticsUtility", "GFSupportReportUtility"],
       "recipes": ["diagnostic-contribution", "session-trace", "feedback-candidate"],
       "boundary": "Collect the minimum needed data, bound all histories, and require explicit consent for precise or private diagnostics."
+    },
+    {
+      "id": "runtime-agent-environment",
+      "title": "Runtime Agent endpoint environment",
+      "summary": "Default-closed, transport-neutral runtime endpoints with strict JSON schemas, exact short-lived grants, replay and rate controls, policy checks, bounded responses, and payload-free audit.",
+      "keywords": ["runtime agent", "automation", "endpoint", "session", "grant", "bearer token", "replay", "rate limit", "policy", "audit"],
+      "packages": ["gf.standard.agent_environment"],
+      "primary_classes": ["GFRuntimeAgentEnvironment"],
+      "recipes": ["runtime-agent-endpoint"],
+      "boundary": "GF protects untrusted request data entering trusted synchronous handlers. Create the environment on its long-lived owner thread, marshal every transport call back to that thread, and call invalidate_policy_context before mutating registry, provider, or external policy state. Projects still own pre-decode body limits, transport authentication and throttling, user approval, business authorization, side-effect rollback, and process isolation."
     },
     {
       "id": "determinism",

--- a/addons/gf/tools/ai_developer/knowledge/recipes.json
+++ b/addons/gf/tools/ai_developer/knowledge/recipes.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.1.0",
+  "catalog_version": "1.2.0",
   "recipes": [
     {
       "id": "project-feature",
@@ -268,6 +268,23 @@
         "Test disabled consent, budget exhaustion, invalid recipes, provider failure, redaction, repeated sessions, and teardown."
       ],
       "avoid": ["Always-on precise telemetry", "Unbounded arbitrary Variant payloads", "Embedding upload or gameplay recovery policy in the trace recipe"]
+    },
+    {
+      "id": "runtime-agent-endpoint",
+      "title": "Expose a bounded runtime Agent endpoint",
+      "package_requirements": {"all_of": ["gf.standard.agent_environment"], "any_of": []},
+      "primary_classes": ["GFRuntimeAgentEnvironment", "GFDictionarySchema", "GFPolicyRegistry"],
+      "steps": [
+        "Define the smallest project-owned synchronous operation and closed JSON request/response schemas; do not expose arbitrary reflection or generic command dispatch.",
+        "Register endpoints while the environment is disabled, then install project policy providers for business authorization or approval requirements.",
+        "Create the environment on a long-lived owner thread; make transport workers enforce pre-decode body and connection limits, then marshal every environment call back to the owner thread.",
+        "Enable the environment only after the outer transport is authenticated, and issue a short-lived session with exact endpoint grants and finite rate/replay budgets.",
+        "Before mutating the registry, a Provider, or external policy state in place, call invalidate_policy_context on the owner thread so every earlier credential is revoked.",
+        "Keep the bearer token out of the request envelope, logs, URLs, snapshots, and persistence; use a unique request ID for every authenticated attempt.",
+        "Observe typed results and payload-free audit events, revoke sessions on ownership changes, and disable or dispose the environment during teardown.",
+        "Test invalid credentials, expiry, replay, rate exhaustion, schema and byte budgets, policy denial, policy-context invalidation, cross-thread rejection, endpoint re-registration, callback revocation, and secret absence."
+      ],
+      "avoid": ["Calling the environment or mutating policy objects directly from transport workers", "Generic reflection, file, shell, screenshot, or diagnostics bridges", "Treating an in-process callback boundary as an OS sandbox", "Persisting bearer tokens or copying business payloads into audit"]
     },
     {
       "id": "deterministic-scope",

--- a/docs/api_catalog/classes/GFRuntimeAgentEnvironment.xml
+++ b/docs/api_catalog/classes/GFRuntimeAgentEnvironment.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFRuntimeAgentEnvironment" path="addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd" module="standard" extends="GFUtility" classDigest="e17ae3ce2c4a7c60204d3c588c2bbb41dc2ed651997ecfccf0a3f0e1d07f680c">
+	<description>GFRuntimeAgentEnvironment: 传输无关的受限运行时 Agent 调用环境。
+受信宿主显式注册严格 endpoint，再为调用方签发仅授权指定 endpoint 的短期 session。
+环境负责协议版本、bearer token、TTL、限流、防重放、结构预算、策略检查和无载荷审计；
+它不提供网络传输、模型客户端、文件或命令执行，也不是进程或脚本沙箱。
+实例绑定创建线程；所有公开入口与公开策略对象的原地修改都必须在该线程串行执行，
+外层 transport 应先编排回拥有线程。跨线程公开入口会 fail closed 且不写共享审计状态。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_service</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="audit_event_recorded">
+			<signature>signal audit_event_recorded(event: Dictionary)</signature>
+			<description>追加安全审计事件时触发。
+事件只包含固定协议字段、稳定标识和 request id 摘要，不包含 token、payload、
+handler 输出或策略返回数据。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">event: 固定字段、无业务载荷的 Runtime Agent 审计事件。</tag>
+				<tag name="schema">event: Dictionary { schema_version: int, protocol_version: int, sequence: int, timestamp_msec: int, action: String, outcome: String, reason: String, session_id: String, endpoint_id: String, request_id_digest: String }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums />
+	<constants>
+		<member kind="const" name="PROTOCOL_VERSION">
+			<signature>const PROTOCOL_VERSION: int = 1</signature>
+			<description>Runtime Agent 请求协议版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="SCHEMA_VERSION">
+			<signature>const SCHEMA_VERSION: int = 1</signature>
+			<description>Runtime Agent 结果与审计结构版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties>
+		<member kind="property" name="enabled">
+			<signature>var enabled: bool = false:</signature>
+			<description>是否接受新 session 和请求。
+默认 false。由 true 切换为 false 会立即撤销全部 session；再次启用不会恢复旧凭据。
+endpoint 注册会保留，便于宿主先完成声明再显式开放环境。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="policy_registry">
+			<signature>var policy_registry: GFPolicyRegistry = GFPolicyRegistry.new():</signature>
+			<description>session 签发与请求执行使用的策略注册表。
+空注册表表示没有项目附加策略；null 会 fail closed。策略 Provider 属于受信宿主，
+可以读取当次策略 artifact，但其结果和 artifact 不会复制到 Runtime Agent 响应或审计。
+registry、providers 数组及 Provider 字段的原地修改也必须由环境拥有线程串行完成。
+原地修改前必须调用 invalidate_policy_context()，以覆盖调用间发生并恢复的 ABA 变化；
+当前公开配置摘要仍会对未通知但持续存在的配置漂移 fail closed。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</properties>
+	<methods>
+		<member kind="method" name="dispose">
+			<signature>func dispose() -&gt; void:</signature>
+			<description>释放 endpoint、session、凭据摘要与内存审计。
+跨拥有线程调用不会改变环境；transport 必须先把控制流编排回拥有线程。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="register_endpoint">
+			<signature>func register_endpoint( endpoint_id: String, request_schema: GFDictionarySchema, response_schema: GFDictionarySchema, handler: Callable ) -&gt; Dictionary:</signature>
+			<description>注册一个受信 endpoint。
+request_schema 与 response_schema 必须是 closed、无 coercion、无 metadata/default/rule，
+且只使用 JSON 原生字段类型的有限非循环结构。环境保存 schema 副本，注册后调用方修改
+原 Resource 不会改变 endpoint 契约。重复 ID 必须先显式注销，不会隐式替换 handler。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">endpoint_id: 稳定 endpoint 标识。</tag>
+				<tag name="param">request_schema: 严格请求 payload schema。</tag>
+				<tag name="param">response_schema: 严格响应 schema。</tag>
+				<tag name="param">handler: 同步受信回调；接收不含 token 的请求 Dictionary，返回 Dictionary。</tag>
+				<tag name="return">版本化注册结果。</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_id?: String }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unregister_endpoint">
+			<signature>func unregister_endpoint(endpoint_id: String) -&gt; Dictionary:</signature>
+			<description>注销 endpoint。
+已签发 session 中的旧 grant 不会绑定到后续同名注册；旧请求会以
+endpoint_grant_stale 失败，避免注销/重注册的 ABA 权限恢复。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">endpoint_id: endpoint 标识。</tag>
+				<tag name="return">版本化注销结果。</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_id?: String }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_endpoint_catalog">
+			<signature>func get_endpoint_catalog() -&gt; Dictionary:</signature>
+			<description>获取不含 handler、token、metadata 和默认值的 endpoint 目录。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">版本化安全目录。</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_count?: int, endpoints?: Array[Dictionary { endpoint_id: String, request_schema: Dictionary { schema_id: String, allow_extra_fields: bool, fields: Array[Dictionary] }, response_schema: Dictionary { schema_id: String, allow_extra_fields: bool, fields: Array[Dictionary] } }] }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="open_session">
+			<signature>func open_session( endpoint_ids: PackedStringArray, options: Dictionary = {} ) -&gt; Dictionary:</signature>
+			<description>为一组精确 endpoint grant 创建短期 session。
+此方法属于受信宿主控制面，不是无需认证的远程 endpoint。返回的 token 只出现一次；
+环境仅保存与 session id 绑定后的 SHA-256。时间字段使用环境单调毫秒时钟，不是 Unix 时间。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">endpoint_ids: session 唯一允许调用的 endpoint ID。</tag>
+				<tag name="param">options: 严格选项；支持 ttl_msec、max_requests_per_window、rate_window_msec 和 max_request_ids。</tag>
+				<tag name="return">成功时包含一次性 token 的版本化 session 凭据；失败时不含 token 字段。</tag>
+				<tag name="schema">endpoint_ids: PackedStringArray exact endpoint grants.</tag>
+				<tag name="schema">options: Dictionary { ttl_msec?: int, max_requests_per_window?: int, rate_window_msec?: int, max_request_ids?: int }; no other keys are accepted.</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, session_id?: String, token?: String, endpoint_ids?: Array[String], issued_at_msec?: int, expires_at_msec?: int }; credential fields exist only on success.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="close_session">
+			<signature>func close_session(session_id: String, bearer_token: String) -&gt; Dictionary:</signature>
+			<description>使用凭据关闭 session。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">session_id: session 标识。</tag>
+				<tag name="param">bearer_token: open_session() 一次返回的 token。</tag>
+				<tag name="return">版本化关闭结果。</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="revoke_session">
+			<signature>func revoke_session(session_id: String) -&gt; bool:</signature>
+			<description>由受信宿主按 session id 撤销凭据。
+此入口不要求 bearer token，因此只能放在宿主控制面，不能直接映射为未鉴权远程 endpoint。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">session_id: 待撤销 session 标识。</tag>
+				<tag name="return">找到并撤销 session 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="invalidate_policy_context">
+			<signature>func invalidate_policy_context() -&gt; int:</signature>
+			<description>使策略上下文的任意原地或外部变化立即失效。
+修改 registry/provider 公开可变对象，或改变无法由环境观察的自定义字段、外部服务状态
+与闭包捕获值之前，受信宿主必须调用本入口。调用会撤销全部 session，并使正在进行的
+session 签发或请求在回调后的上下文复核中失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">本次撤销的 session 数量；跨拥有线程调用返回 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="execute_request">
+			<signature>func execute_request(request: Dictionary, bearer_token: String) -&gt; Dictionary:</signature>
+			<description>执行一个版本化 Runtime Agent 请求。
+bearer token 与协议请求分离，不会进入 handler、策略响应、目录、调试快照或审计。
+通过身份和精确 grant 校验后，request id 会在策略与 handler 前被消费；失败请求不能
+以同一 request id 重试。handler 返回后会复核 session、endpoint generation 和策略注册表
+身份，发生同步撤销或替换时丢弃输出。handler 已产生的副作用无法回滚。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">request: closed 请求 envelope。</tag>
+				<tag name="param">bearer_token: session bearer token；不会写入 request 副本。</tag>
+				<tag name="return">版本化执行结果；仅成功结果包含 response。</tag>
+				<tag name="schema">request: Dictionary { protocol_version: int, session_id: String, endpoint_id: String, request_id: String, payload: Dictionary }; exactly these five keys are accepted.</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, response?: Dictionary }; response exists only on success and matches the endpoint response schema.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="prune_expired_sessions">
+			<signature>func prune_expired_sessions() -&gt; int:</signature>
+			<description>删除所有已过期 session。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">本次删除数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_audit_events">
+			<signature>func get_audit_events(limit: int = 64) -&gt; Dictionary:</signature>
+			<description>获取最近的无载荷安全审计事件。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">limit: 最多返回数量；钳制到 0..256。</tag>
+				<tag name="return">版本化审计结果。</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, event_count?: int, retained_event_count?: int, events?: Array[Dictionary { schema_version: int, protocol_version: int, sequence: int, timestamp_msec: int, action: String, outcome: String, reason: String, session_id: String, endpoint_id: String, request_id_digest: String }] }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="clear_audit_events">
+			<signature>func clear_audit_events() -&gt; void:</signature>
+			<description>清空环境内存审计环形缓冲。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_debug_snapshot">
+			<signature>func get_debug_snapshot() -&gt; Dictionary:</signature>
+			<description>获取不含凭据、请求 ID 与业务值的调试快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">固定形态调试快照。</tag>
+				<tag name="schema">return: Dictionary { schema_version: int, protocol_version: int, enabled: bool, endpoint_count: int, active_session_count: int, audit_event_count: int, policy_provider_count: int, handler_active: bool, secrets_stored_as_hashes: bool, owner_thread_access: bool }.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="_get_current_time_msec">
+			<signature>func _get_current_time_msec() -&gt; int:</signature>
+			<description>获取环境单调毫秒时钟。
+测试实现可覆写此入口；生产实现使用 Time.get_ticks_msec()，不受系统墙钟回拨影响。</description>
+			<tags>
+				<tag name="api">protected</tag>
+				<tag name="return">单调毫秒值。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="9cf06649ff763e608ba9f0f8f4bcefc73dea81904dad973814bb239650cc1195" classCount="762" methodCount="6802">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="5af573605f40ac877167ff708b9971fe6fdef309ddb29bfeb4f9c89e8886b299" classCount="763" methodCount="6816">
 	<module id="kernel" label="Kernel" classCount="70" methodCount="715">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -72,7 +72,7 @@
 		<class name="GFTypeEventSystem" path="classes/GFTypeEventSystem.xml" sourcePath="addons/gf/kernel/core/gf_type_event_system.gd" extends="Object" />
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 	</module>
-	<module id="standard" label="Standard" classCount="425" methodCount="4247">
+	<module id="standard" label="Standard" classCount="426" methodCount="4261">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsUtility" path="classes/GFAnalyticsUtility.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_utility.gd" extends="GFUtility" />
@@ -366,6 +366,7 @@
 		<class name="GFResourceVariantProvider" path="classes/GFResourceVariantProvider.xml" sourcePath="addons/gf/standard/utilities/assets/gf_resource_variant_provider.gd" extends="RefCounted" />
 		<class name="GFResultDictionary" path="classes/GFResultDictionary.xml" sourcePath="addons/gf/standard/foundation/validation/gf_result_dictionary.gd" extends="RefCounted" />
 		<class name="GFRichTextFormatter" path="classes/GFRichTextFormatter.xml" sourcePath="addons/gf/standard/utilities/ui/gf_rich_text_formatter.gd" extends="RefCounted" />
+		<class name="GFRuntimeAgentEnvironment" path="classes/GFRuntimeAgentEnvironment.xml" sourcePath="addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd" extends="GFUtility" />
 		<class name="GFRuntimeCleanupScope" path="classes/GFRuntimeCleanupScope.xml" sourcePath="addons/gf/standard/common/gf_runtime_cleanup_scope.gd" extends="RefCounted" />
 		<class name="GFRuntimeDebuggerPlugin" path="classes/GFRuntimeDebuggerPlugin.xml" sourcePath="addons/gf/standard/utilities/debug/editor/gf_runtime_debugger_plugin.gd" extends="EditorDebuggerPlugin" />
 		<class name="GFRuntimeDebuggerTab" path="classes/GFRuntimeDebuggerTab.xml" sourcePath="addons/gf/standard/utilities/debug/editor/gf_runtime_debugger_tab.gd" extends="Control" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -22,7 +22,7 @@
 
 ## [未发布]
 
-**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、内容包查询与运行时目录挂载、存储后端故障转移、惰性诊断采集、配方化运行时会话轨迹、UI 路由预加载规划和轨迹预测数学，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
+**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、有序资产集合、内容包查询与运行时目录挂载、存储后端故障转移、惰性诊断采集、配方化运行时会话轨迹、UI 路由预加载规划、轨迹预测数学和默认关闭的 Runtime Agent Environment，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
 
 ### 🚀 新增特性 (Added)
 
@@ -36,6 +36,7 @@
 - 新增 `GFUIRoutePreloadUtility`，从 `GFUIRoute.adjacent_route_ids` 做有界、确定性的页面可达性遍历，并生成可直接交给 `GFAssetUtility` 的 `GFAssetPreloadPlan`。
 - 新增 `GFUIRouteOperation` 与 `GFUIRouteResult`，把异步路由的输入拒绝、预加载、面板打开、取消、释放和未知结果统一为单终态请求契约。
 - 新增 `GFTrajectoryMath`，提供 2D/3D 恒加速度未来状态、恒速发射体对匀速目标的最早拦截解，以及带绝对点数上限的同步公式轨迹采样。
+- 新增可选包 `gf.standard.agent_environment` 与 `GFRuntimeAgentEnvironment`：受信宿主可声明严格 JSON endpoint，为调用方签发精确授权的短期 session，并统一执行创建线程绑定、token 摘要校验、TTL、固定窗口限流、防重放、策略上下文失效、输入输出硬预算和无业务载荷审计；环境默认关闭，不内置网络、模型 SDK、文件/命令执行、截图或任意反射。
 - 新增 Save Profile 运行时：`GFSaveProfile`、`GFSaveSectionProvider`、`GFSaveRecoveryPolicy`、`GFSaveProfileUtility`、异步操作句柄和类型化终态结果共同提供多 section 所有权、generation 合并、flush 屏障、迁移校验和事务回滚。
 - 新增 `GFStorageAsyncOperation` 与 `GFStorageAsyncResult`，让并发调用方按唯一 request ID 观察单次读写终态；`GFStorageReadResult.FailureKind` 结构化区分非法请求、缺失、IO、损坏、未来格式、迁移失败和不可用。
 - AI Developer 项目契约新增可选 `architecture.owned_resources`，用于精确声明 `project.godot`、`export_presets.cfg` 等不属于业务模块的项目级治理文件。
@@ -87,6 +88,7 @@
 - 新增公开类型 `GFDiagnosticProviderResult`、`GFDiagnosticSnapshotProvider`、`GFSessionTraceUtility`、`GFSessionTraceRecipe`、`GFSessionTraceChannelDefinition`、`GFSessionTraceCheckpoint` 与 `GFUIRoutePreloadUtility`，以及 `GFDiagnosticsUtility` 的惰性 Provider 注册/采集 API、`GFUIRoute.adjacent_route_ids`、`get_adjacent_route_ids()` 和 `GFUIRouterUtility.build_preload_plan()`；均标记为 `@since unreleased`。
 - 新增公开类型 `GFUIRouteOperation`、`GFUIRouteResult`、`GFUIRouterUtility.route_operation_completed` 和 `PRELOAD_*` 常量；`push_route_async()`、`replace_route_async()` 新增 `async_options` 并从 `void` 改为返回句柄。
 - 新增公开类型 `GFTrajectoryMath`，以及运动预测、恒速拦截和有界公式采样入口；均标记为 `@since unreleased`，不改变既有 Steering 行为。
+- 新增公开类型 `GFRuntimeAgentEnvironment`，以及 endpoint 注册/目录、session 签发/撤销、`invalidate_policy_context()`、版本化请求执行、安全审计和调试快照入口；均标记为 `@since unreleased`。该类型绑定创建线程，只保护不可信请求进入受信同步 handler 的协议边界，不是 OS sandbox。
 - 新增公开类型 `GFSaveProfile`、`GFSaveSectionProvider`、`GFSaveRecoveryPolicy`、`GFSaveProfileOperation`、`GFSaveProfileResult`、`GFSaveRollbackFailure` 和 `GFSaveProfileUtility`；Save 扩展安装器会自动注册 Profile Utility，既有 Save Graph 和 Slot API 不变。
 - 新增公开类型 `GFStorageAsyncOperation`、`GFStorageAsyncResult`，以及 `GFStorageUtility.save_data_request_async()`、`load_data_request_async()`、`canonicalize_data_file_name()`；`GFStorageReadResult` 新增只追加的 `FailureKind` 与 `failure_kind`。
 - `GFUIRoute.get_route_id()` 以及 Router 的注册、查询、打开信号和异步 pending 身份统一去除 route ID 首尾空白。
@@ -103,6 +105,7 @@
 - 既有诊断快照无需迁移。只有无法安全长期缓存的状态才实现 `GFDiagnosticSnapshotProvider`，并由故障点或支持报告入口显式请求；需要跨系统固定轨迹预算和检查点时，在首次会话前应用 `GFSessionTraceRecipe`，不要把上传、许可或业务恢复逻辑写进配方。
 - 历史代码通过 `publish_snapshot_section()` 使用 `diagnostic_providers` 分区 ID 时无需迁移：普通快照继续返回该缓存；只有当次显式请求惰性 Provider 时，同名顶层键才由内置批次结果确定性覆盖，后续普通快照仍恢复既有分区。
 - 既有曲线、Steering、发射体和节点移动逻辑无需迁移。只有需要结构化未来状态、拦截时间或公式点集时才显式采用 `GFTrajectoryMath`；绘制、物理推进、速度继承、重力拦截和业务命中规则继续由项目负责。
+- 既有诊断命令、开发者控制台与 AI Developer 工具无需迁移，也不得直接当作 Runtime Agent 权限入口。只有明确需要运行时自动化时才安装 `gf.standard.agent_environment`，在禁用态注册最小 endpoint 与 closed Schema，由项目策略负责业务授权/批准，并由外层传输负责身份认证和凭据保护。
 - 既有 Save Graph、Slot 和直接 Storage 调用无需迁移。需要跨模块自动保存时，为每个稳定数据边界实现一个可回滚 `GFSaveSectionProvider`，注册 Profile 和完整迁移链；不要把缺失、损坏或未来版本统一重置为空存档。
 - 历史配置若有意使用带首尾空白的 route ID，需迁移为去除空白后的稳定 ID；规范化后重复的 ID 会指向同一注册身份，不应再依赖空白区分页面。
 - 严格 warning 项目必须接收 `push_route_async()` / `replace_route_async()` 的新返回值；需要结果时保存 `GFUIRouteOperation`，只需 fire-and-observe 全局信号时也应赋给带下划线的局部变量。打开前预加载必须显式选择策略，默认仍为 `PRELOAD_NONE`。
@@ -139,6 +142,8 @@
 - `addons/gf/standard/utilities/ui/gf_ui_route_result.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd`
 - `addons/gf/standard/foundation/math/gf_trajectory_math.gd`
+- `addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd`
+- `docs/zh/standard/utilities/runtime/agent-environment.md`
 - `addons/gf/extensions/save/profile/`
 - `docs/zh/extensions/save-graph/save-profile-runtime.md`
 - `docs/zh/extensions/save-graph/save-profile-adr.md`

--- a/docs/zh/reference/api/classes/GFRuntimeAgentEnvironment.md
+++ b/docs/zh/reference/api/classes/GFRuntimeAgentEnvironment.md
@@ -1,0 +1,408 @@
+# GFRuntimeAgentEnvironment
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd`
+- 模块：`Standard`
+- 继承：`GFUtility`
+- API：`public`
+- 类别：运行时服务 (`runtime_service`)
+- 首次版本：`unreleased`
+
+传输无关的受限运行时 Agent 调用环境。 受信宿主显式注册严格 endpoint，再为调用方签发仅授权指定 endpoint 的短期 session。 环境负责协议版本、bearer token、TTL、限流、防重放、结构预算、策略检查和无载荷审计； 它不提供网络传输、模型客户端、文件或命令执行，也不是进程或脚本沙箱。 实例绑定创建线程；所有公开入口与公开策略对象的原地修改都必须在该线程串行执行， 外层 transport 应先编排回拥有线程。跨线程公开入口会 fail closed 且不写共享审计状态。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`audit_event_recorded`](#member-gfruntimeagentenvironment-signals-audit_event_recorded) | `signal audit_event_recorded(event: Dictionary)` |
+| 常量 | [`PROTOCOL_VERSION`](#member-gfruntimeagentenvironment-constants-protocol_version) | `const PROTOCOL_VERSION: int = 1` |
+| 常量 | [`SCHEMA_VERSION`](#member-gfruntimeagentenvironment-constants-schema_version) | `const SCHEMA_VERSION: int = 1` |
+| 属性 | [`enabled`](#member-gfruntimeagentenvironment-properties-enabled) | `var enabled: bool = false:` |
+| 属性 | [`policy_registry`](#member-gfruntimeagentenvironment-properties-policy_registry) | `var policy_registry: GFPolicyRegistry = GFPolicyRegistry.new():` |
+| 方法 | [`dispose`](#member-gfruntimeagentenvironment-methods-dispose) | `func dispose() -> void:` |
+| 方法 | [`register_endpoint`](#member-gfruntimeagentenvironment-methods-register_endpoint) | `func register_endpoint( endpoint_id: String, request_schema: GFDictionarySchema, response_schema: GFDictionarySchema, handler: Callable ) -> Dictionary:` |
+| 方法 | [`unregister_endpoint`](#member-gfruntimeagentenvironment-methods-unregister_endpoint) | `func unregister_endpoint(endpoint_id: String) -> Dictionary:` |
+| 方法 | [`get_endpoint_catalog`](#member-gfruntimeagentenvironment-methods-get_endpoint_catalog) | `func get_endpoint_catalog() -> Dictionary:` |
+| 方法 | [`open_session`](#member-gfruntimeagentenvironment-methods-open_session) | `func open_session( endpoint_ids: PackedStringArray, options: Dictionary = {} ) -> Dictionary:` |
+| 方法 | [`close_session`](#member-gfruntimeagentenvironment-methods-close_session) | `func close_session(session_id: String, bearer_token: String) -> Dictionary:` |
+| 方法 | [`revoke_session`](#member-gfruntimeagentenvironment-methods-revoke_session) | `func revoke_session(session_id: String) -> bool:` |
+| 方法 | [`invalidate_policy_context`](#member-gfruntimeagentenvironment-methods-invalidate_policy_context) | `func invalidate_policy_context() -> int:` |
+| 方法 | [`execute_request`](#member-gfruntimeagentenvironment-methods-execute_request) | `func execute_request(request: Dictionary, bearer_token: String) -> Dictionary:` |
+| 方法 | [`prune_expired_sessions`](#member-gfruntimeagentenvironment-methods-prune_expired_sessions) | `func prune_expired_sessions() -> int:` |
+| 方法 | [`get_audit_events`](#member-gfruntimeagentenvironment-methods-get_audit_events) | `func get_audit_events(limit: int = 64) -> Dictionary:` |
+| 方法 | [`clear_audit_events`](#member-gfruntimeagentenvironment-methods-clear_audit_events) | `func clear_audit_events() -> void:` |
+| 方法 | [`get_debug_snapshot`](#member-gfruntimeagentenvironment-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
+| 方法 | [`_get_current_time_msec`](#member-gfruntimeagentenvironment-methods-_get_current_time_msec) | `func _get_current_time_msec() -> int:` |
+
+## 信号
+
+<a id="member-gfruntimeagentenvironment-signals-audit_event_recorded"></a>
+
+### `audit_event_recorded`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal audit_event_recorded(event: Dictionary)
+```
+
+追加安全审计事件时触发。 事件只包含固定协议字段、稳定标识和 request id 摘要，不包含 token、payload、 handler 输出或策略返回数据。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `event` | 固定字段、无业务载荷的 Runtime Agent 审计事件。 |
+
+结构：
+
+- `event`: Dictionary { schema_version: int, protocol_version: int, sequence: int, timestamp_msec: int, action: String, outcome: String, reason: String, session_id: String, endpoint_id: String, request_id_digest: String }.
+
+## 常量
+
+<a id="member-gfruntimeagentenvironment-constants-protocol_version"></a>
+
+### `PROTOCOL_VERSION`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const PROTOCOL_VERSION: int = 1
+```
+
+Runtime Agent 请求协议版本。
+
+<a id="member-gfruntimeagentenvironment-constants-schema_version"></a>
+
+### `SCHEMA_VERSION`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const SCHEMA_VERSION: int = 1
+```
+
+Runtime Agent 结果与审计结构版本。
+
+## 属性
+
+<a id="member-gfruntimeagentenvironment-properties-enabled"></a>
+
+### `enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var enabled: bool = false:
+```
+
+是否接受新 session 和请求。 默认 false。由 true 切换为 false 会立即撤销全部 session；再次启用不会恢复旧凭据。 endpoint 注册会保留，便于宿主先完成声明再显式开放环境。
+
+<a id="member-gfruntimeagentenvironment-properties-policy_registry"></a>
+
+### `policy_registry`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var policy_registry: GFPolicyRegistry = GFPolicyRegistry.new():
+```
+
+session 签发与请求执行使用的策略注册表。 空注册表表示没有项目附加策略；null 会 fail closed。策略 Provider 属于受信宿主， 可以读取当次策略 artifact，但其结果和 artifact 不会复制到 Runtime Agent 响应或审计。 registry、providers 数组及 Provider 字段的原地修改也必须由环境拥有线程串行完成。 原地修改前必须调用 invalidate_policy_context()，以覆盖调用间发生并恢复的 ABA 变化； 当前公开配置摘要仍会对未通知但持续存在的配置漂移 fail closed。
+
+## 方法
+
+<a id="member-gfruntimeagentenvironment-methods-dispose"></a>
+
+### `dispose`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func dispose() -> void:
+```
+
+释放 endpoint、session、凭据摘要与内存审计。 跨拥有线程调用不会改变环境；transport 必须先把控制流编排回拥有线程。
+
+<a id="member-gfruntimeagentenvironment-methods-register_endpoint"></a>
+
+### `register_endpoint`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func register_endpoint( endpoint_id: String, request_schema: GFDictionarySchema, response_schema: GFDictionarySchema, handler: Callable ) -> Dictionary:
+```
+
+注册一个受信 endpoint。 request_schema 与 response_schema 必须是 closed、无 coercion、无 metadata/default/rule， 且只使用 JSON 原生字段类型的有限非循环结构。环境保存 schema 副本，注册后调用方修改 原 Resource 不会改变 endpoint 契约。重复 ID 必须先显式注销，不会隐式替换 handler。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `endpoint_id` | 稳定 endpoint 标识。 |
+| `request_schema` | 严格请求 payload schema。 |
+| `response_schema` | 严格响应 schema。 |
+| `handler` | 同步受信回调；接收不含 token 的请求 Dictionary，返回 Dictionary。 |
+
+返回：版本化注册结果。
+
+结构：
+
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_id?: String }.
+
+<a id="member-gfruntimeagentenvironment-methods-unregister_endpoint"></a>
+
+### `unregister_endpoint`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unregister_endpoint(endpoint_id: String) -> Dictionary:
+```
+
+注销 endpoint。 已签发 session 中的旧 grant 不会绑定到后续同名注册；旧请求会以 endpoint_grant_stale 失败，避免注销/重注册的 ABA 权限恢复。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `endpoint_id` | endpoint 标识。 |
+
+返回：版本化注销结果。
+
+结构：
+
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_id?: String }.
+
+<a id="member-gfruntimeagentenvironment-methods-get_endpoint_catalog"></a>
+
+### `get_endpoint_catalog`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_endpoint_catalog() -> Dictionary:
+```
+
+获取不含 handler、token、metadata 和默认值的 endpoint 目录。
+
+返回：版本化安全目录。
+
+结构：
+
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, endpoint_count?: int, endpoints?: Array[Dictionary { endpoint_id: String, request_schema: Dictionary { schema_id: String, allow_extra_fields: bool, fields: Array[Dictionary] }, response_schema: Dictionary { schema_id: String, allow_extra_fields: bool, fields: Array[Dictionary] } }] }.
+
+<a id="member-gfruntimeagentenvironment-methods-open_session"></a>
+
+### `open_session`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func open_session( endpoint_ids: PackedStringArray, options: Dictionary = {} ) -> Dictionary:
+```
+
+为一组精确 endpoint grant 创建短期 session。 此方法属于受信宿主控制面，不是无需认证的远程 endpoint。返回的 token 只出现一次； 环境仅保存与 session id 绑定后的 SHA-256。时间字段使用环境单调毫秒时钟，不是 Unix 时间。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `endpoint_ids` | session 唯一允许调用的 endpoint ID。 |
+| `options` | 严格选项；支持 ttl_msec、max_requests_per_window、rate_window_msec 和 max_request_ids。 |
+
+返回：成功时包含一次性 token 的版本化 session 凭据；失败时不含 token 字段。
+
+结构：
+
+- `endpoint_ids`: PackedStringArray exact endpoint grants.
+- `options`: Dictionary { ttl_msec?: int, max_requests_per_window?: int, rate_window_msec?: int, max_request_ids?: int }; no other keys are accepted.
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, session_id?: String, token?: String, endpoint_ids?: Array[String], issued_at_msec?: int, expires_at_msec?: int }; credential fields exist only on success.
+
+<a id="member-gfruntimeagentenvironment-methods-close_session"></a>
+
+### `close_session`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func close_session(session_id: String, bearer_token: String) -> Dictionary:
+```
+
+使用凭据关闭 session。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `session_id` | session 标识。 |
+| `bearer_token` | open_session() 一次返回的 token。 |
+
+返回：版本化关闭结果。
+
+结构：
+
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String }.
+
+<a id="member-gfruntimeagentenvironment-methods-revoke_session"></a>
+
+### `revoke_session`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func revoke_session(session_id: String) -> bool:
+```
+
+由受信宿主按 session id 撤销凭据。 此入口不要求 bearer token，因此只能放在宿主控制面，不能直接映射为未鉴权远程 endpoint。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `session_id` | 待撤销 session 标识。 |
+
+返回：找到并撤销 session 时返回 true。
+
+<a id="member-gfruntimeagentenvironment-methods-invalidate_policy_context"></a>
+
+### `invalidate_policy_context`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func invalidate_policy_context() -> int:
+```
+
+使策略上下文的任意原地或外部变化立即失效。 修改 registry/provider 公开可变对象，或改变无法由环境观察的自定义字段、外部服务状态 与闭包捕获值之前，受信宿主必须调用本入口。调用会撤销全部 session，并使正在进行的 session 签发或请求在回调后的上下文复核中失败。
+
+返回：本次撤销的 session 数量；跨拥有线程调用返回 0。
+
+<a id="member-gfruntimeagentenvironment-methods-execute_request"></a>
+
+### `execute_request`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func execute_request(request: Dictionary, bearer_token: String) -> Dictionary:
+```
+
+执行一个版本化 Runtime Agent 请求。 bearer token 与协议请求分离，不会进入 handler、策略响应、目录、调试快照或审计。 通过身份和精确 grant 校验后，request id 会在策略与 handler 前被消费；失败请求不能 以同一 request id 重试。handler 返回后会复核 session、endpoint generation 和策略注册表 身份，发生同步撤销或替换时丢弃输出。handler 已产生的副作用无法回滚。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `request` | closed 请求 envelope。 |
+| `bearer_token` | session bearer token；不会写入 request 副本。 |
+
+返回：版本化执行结果；仅成功结果包含 response。
+
+结构：
+
+- `request`: Dictionary { protocol_version: int, session_id: String, endpoint_id: String, request_id: String, payload: Dictionary }; exactly these five keys are accepted.
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, response?: Dictionary }; response exists only on success and matches the endpoint response schema.
+
+<a id="member-gfruntimeagentenvironment-methods-prune_expired_sessions"></a>
+
+### `prune_expired_sessions`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func prune_expired_sessions() -> int:
+```
+
+删除所有已过期 session。
+
+返回：本次删除数量。
+
+<a id="member-gfruntimeagentenvironment-methods-get_audit_events"></a>
+
+### `get_audit_events`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_audit_events(limit: int = 64) -> Dictionary:
+```
+
+获取最近的无载荷安全审计事件。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `limit` | 最多返回数量；钳制到 0..256。 |
+
+返回：版本化审计结果。
+
+结构：
+
+- `return`: Dictionary { schema_version: int, protocol_version: int, ok: bool, status: String, reason: String, event_count?: int, retained_event_count?: int, events?: Array[Dictionary { schema_version: int, protocol_version: int, sequence: int, timestamp_msec: int, action: String, outcome: String, reason: String, session_id: String, endpoint_id: String, request_id_digest: String }] }.
+
+<a id="member-gfruntimeagentenvironment-methods-clear_audit_events"></a>
+
+### `clear_audit_events`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func clear_audit_events() -> void:
+```
+
+清空环境内存审计环形缓冲。
+
+<a id="member-gfruntimeagentenvironment-methods-get_debug_snapshot"></a>
+
+### `get_debug_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_debug_snapshot() -> Dictionary:
+```
+
+获取不含凭据、请求 ID 与业务值的调试快照。
+
+返回：固定形态调试快照。
+
+结构：
+
+- `return`: Dictionary { schema_version: int, protocol_version: int, enabled: bool, endpoint_count: int, active_session_count: int, audit_event_count: int, policy_provider_count: int, handler_active: bool, secrets_stored_as_hashes: bool, owner_thread_access: bool }.
+
+<a id="member-gfruntimeagentenvironment-methods-_get_current_time_msec"></a>
+
+### `_get_current_time_msec`
+
+- API：`protected`
+- 首次版本：`unreleased`
+
+```gdscript
+func _get_current_time_msec() -> int:
+```
+
+获取环境单调毫秒时钟。 测试实现可覆写此入口；生产实现使用 Time.get_ticks_msec()，不受系统墙钟回拨影响。
+
+返回：单调毫秒值。

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 70 | 987 | [Kernel](#module-kernel) |
-| Standard | 425 | 6683 | [Standard](#module-standard) |
+| Standard | 426 | 6702 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -232,6 +232,7 @@
 | [`GFResourceResolverUtility`](GFResourceResolverUtility.md#gfresourceresolverutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 21 | `addons/gf/standard/utilities/assets/gf_resource_resolver_utility.gd` |
 | [`GFResourceVariantProvider`](GFResourceVariantProvider.md#gfresourcevariantprovider) | 运行时服务 (`runtime_service`) | `RefCounted` | 10 | `addons/gf/standard/utilities/assets/gf_resource_variant_provider.gd` |
 | [`GFRichTextFormatter`](GFRichTextFormatter.md#gfrichtextformatter) | 运行时服务 (`runtime_service`) | `RefCounted` | 9 | `addons/gf/standard/utilities/ui/gf_rich_text_formatter.gd` |
+| [`GFRuntimeAgentEnvironment`](GFRuntimeAgentEnvironment.md#gfruntimeagentenvironment) | 运行时服务 (`runtime_service`) | `GFUtility` | 19 | `addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd` |
 | [`GFRuntimeCleanupScope`](GFRuntimeCleanupScope.md#gfruntimecleanupscope) | 运行时服务 (`runtime_service`) | `RefCounted` | 8 | `addons/gf/standard/common/gf_runtime_cleanup_scope.gd` |
 | [`GFRuntimeInspectorUtility`](GFRuntimeInspectorUtility.md#gfruntimeinspectorutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 20 | `addons/gf/standard/utilities/debug/gf_runtime_inspector_utility.gd` |
 | [`GFRuntimeTaskScheduler`](GFRuntimeTaskScheduler.md#gfruntimetaskscheduler) | 运行时服务 (`runtime_service`) | `GFUtility` | 21 | `addons/gf/standard/sequence/gf_runtime_task_scheduler.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,16 +5,16 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`762`
-- 公开成员：`10983`
-- 公开方法：`6802`
+- 公开类：`763`
+- 公开成员：`11002`
+- 公开方法：`6816`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 70 | 987 | 715 | [kernel.md](kernel.md) |
-| Standard | 425 | 6683 | 4247 | [standard.md](standard.md) |
+| Standard | 426 | 6702 | 4261 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 183 | 3231 | 2181 |
+| [运行时服务](#category-runtime_service) | 184 | 3250 | 2195 |
 | [协议与扩展点](#category-protocol) | 23 | 317 | 255 |
 | [资源定义](#category-resource_definition) | 114 | 1472 | 755 |
 | [运行时句柄](#category-runtime_handle) | 44 | 744 | 484 |
@@ -144,6 +144,7 @@
 | [`GFResourceResolverUtility`](classes/GFResourceResolverUtility.md#gfresourceresolverutility) | `GFUtility` | `addons/gf/standard/utilities/assets/gf_resource_resolver_utility.gd` |
 | [`GFResourceVariantProvider`](classes/GFResourceVariantProvider.md#gfresourcevariantprovider) | `RefCounted` | `addons/gf/standard/utilities/assets/gf_resource_variant_provider.gd` |
 | [`GFRichTextFormatter`](classes/GFRichTextFormatter.md#gfrichtextformatter) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_rich_text_formatter.gd` |
+| [`GFRuntimeAgentEnvironment`](classes/GFRuntimeAgentEnvironment.md#gfruntimeagentenvironment) | `GFUtility` | `addons/gf/standard/utilities/agent/gf_runtime_agent_environment.gd` |
 | [`GFRuntimeCleanupScope`](classes/GFRuntimeCleanupScope.md#gfruntimecleanupscope) | `RefCounted` | `addons/gf/standard/common/gf_runtime_cleanup_scope.gd` |
 | [`GFRuntimeInspectorUtility`](classes/GFRuntimeInspectorUtility.md#gfruntimeinspectorutility) | `GFUtility` | `addons/gf/standard/utilities/debug/gf_runtime_inspector_utility.gd` |
 | [`GFRuntimeTaskScheduler`](classes/GFRuntimeTaskScheduler.md#gfruntimetaskscheduler) | `GFUtility` | `addons/gf/standard/sequence/gf_runtime_task_scheduler.gd` |

--- a/docs/zh/standard/utilities/runtime/agent-environment.md
+++ b/docs/zh/standard/utilities/runtime/agent-environment.md
@@ -1,0 +1,252 @@
+# Runtime Agent Environment
+
+`GFRuntimeAgentEnvironment` 为运行时自动化、受控本地工具或项目自有 Agent 适配器提供一条传输无关的最小调用边界。宿主只注册明确命名、明确输入输出 Schema 的 endpoint；调用方只能使用短期 session 中被精确授权的 endpoint。
+
+该能力属于可选包 `gf.standard.agent_environment`，依赖 `gf.kernel` 与 `gf.standard.base`。它默认关闭，不会自行监听端口、连接模型服务、扫描项目对象或暴露诊断命令。
+
+## 适用边界
+
+适合：
+
+- 把少量、明确、可审计的项目运行时操作开放给受控自动化；
+- 由项目自有传输层在认证后转发版本化请求；
+- 为每个调用会话限制 endpoint、有效期、速率和请求总量；
+- 在不保存 payload、token 或 handler 输出的前提下记录安全决策事实。
+
+不适合：
+
+- 把任意方法名、反射、`Gf.send_command()` 或开发者控制台直接暴露给外部调用方；
+- 直接执行文件、Shell、脚本、资源写入、截图或模型 SDK；
+- 代替网络认证、TLS、账号权限、用户确认、操作回滚或操作系统沙箱；
+- 防御恶意的同进程 GDScript、GDExtension、策略 Provider 或 endpoint handler。
+
+## 拥有线程与传输边界
+
+每个环境实例在创建时绑定当前线程，不支持转移 ownership。所有公开方法、`enabled` /
+`policy_registry` setter，以及 `policy_registry.providers` 和 Provider 字段的原地修改，都必须在
+该拥有线程串行执行。项目通常应在主线程创建环境；网络或 IPC worker 只负责解析传输，
+再通过 `GFMainThreadDispatchQueue.post()` 或项目等价队列把请求编排回拥有线程，并在该线程
+调用 `dispatch()`。
+
+除 `get_debug_snapshot()` 外，跨线程调用 Dictionary 返回入口会以 `owner_thread_required`
+fail closed；snapshot 返回带 `owner_thread_access == false` 的固定零值视图。bool/int/void
+入口分别返回 false、0 或不执行，setter 也不改变状态。拒绝路径不会触碰 endpoint、session、
+限流、防重放或审计 Dictionary，也不会发出审计 signal。直接从 worker 原地修改公开
+registry/provider Resource 绕过了环境入口，属于受信宿主违反线程契约；环境不把同进程对象
+伪装成线程安全或恶意代码沙箱。
+
+## 最小接入
+
+先在禁用态声明 closed Schema 和 endpoint：
+
+```gdscript
+var environment := GFRuntimeAgentEnvironment.new()
+
+var message_field := GFSchemaField.new().configure(
+	&"message",
+	GFSchemaField.ValueType.STRING,
+	{
+		"required": true,
+		"allow_null": false,
+	}
+)
+var request_schema := GFDictionarySchema.new().configure(
+	&"project.agent.echo.request",
+	[message_field],
+	{
+		"allow_extra_fields": false,
+		"coerce_values": false,
+		"fail_on_coerce_error": true,
+	}
+)
+
+var accepted_field := GFSchemaField.new().configure(
+	&"accepted",
+	GFSchemaField.ValueType.BOOL,
+	{
+		"required": true,
+		"allow_null": false,
+	}
+)
+var response_schema := GFDictionarySchema.new().configure(
+	&"project.agent.echo.response",
+	[accepted_field],
+	{
+		"allow_extra_fields": false,
+		"coerce_values": false,
+		"fail_on_coerce_error": true,
+	}
+)
+
+var registration := environment.register_endpoint(
+	"project.echo",
+	request_schema,
+	response_schema,
+	func(request: Dictionary) -> Dictionary:
+		var payload: Dictionary = request["payload"]
+		print(payload["message"])
+		return { "accepted": true }
+)
+if not registration["ok"]:
+	push_error(registration["reason"])
+```
+
+环境会保存 Schema 的深副本。注册成功后修改原 Resource 或修改 `get_endpoint_catalog()` 的返回值，都不会改变已注册契约。重复 endpoint ID 不会隐式替换 handler；需要先调用 `unregister_endpoint()`。
+
+由受信宿主显式启用并签发 session：
+
+```gdscript
+environment.enabled = true
+
+var opened := environment.open_session(
+	PackedStringArray(["project.echo"]),
+	{
+		"ttl_msec": 60_000,
+		"max_requests_per_window": 20,
+		"rate_window_msec": 60_000,
+		"max_request_ids": 64,
+	}
+)
+if not opened["ok"]:
+	push_error(opened["reason"])
+	return
+
+var session_id: String = opened["session_id"]
+var bearer_token: String = opened["token"]
+```
+
+`open_session()` 是受信宿主控制面，不应直接映射为未鉴权的远程接口。token 由 32 个随机字节生成，只在成功结果中返回一次；环境只保存与 session ID 绑定后的完整 SHA-256。调用方和传输层仍必须保护 bearer token，不能写入日志、URL、审计事件或持久化快照。
+
+请求 envelope 与 token 分离：
+
+```gdscript
+var result := environment.execute_request(
+	{
+		"protocol_version": GFRuntimeAgentEnvironment.PROTOCOL_VERSION,
+		"session_id": session_id,
+		"endpoint_id": "project.echo",
+		"request_id": "request-0001",
+		"payload": {
+			"message": "hello",
+		},
+	},
+	bearer_token
+)
+```
+
+handler 收到 `protocol_version`、`session_id`、`endpoint_id`、`request_id` 和 `payload`，但永远收不到 token。成功结果才包含 `response`；失败结果只返回版本、状态和稳定原因。
+
+## 严格 Schema 子集
+
+endpoint Schema 不是普通 `GFDictionarySchema` 的全部能力。环境只接受：
+
+- `allow_extra_fields == false`；
+- `coerce_values == false`；
+- `fail_on_coerce_error == true`；
+- 非空、ASCII 稳定的 schema ID 与字段名；
+- `BOOL`、`INT`、`FLOAT`、`STRING`、`DICTIONARY`、`ARRAY`；
+- `DICTIONARY` 的显式 nested Schema；
+- `ARRAY` 的显式 item field；
+- 无循环，最大 16 层、512 个 Schema 节点、每个 Dictionary 最多 64 个字段；
+- 空 metadata、空 validation rules、null default。
+
+`ANY`、未知枚举、`Object`、`Resource`、`NodePath`、`StringName`、Vector/Color、缺失 nested Schema、开放嵌套结构和 coercion 都会在注册时 fail closed。目录只公开字段名、类型、required/null 规则和嵌套结构，不公开 handler、metadata 或默认值。
+
+请求和响应还必须是 plain JSON tree：
+
+- Dictionary key 只能是 `String`；
+- 值只能是 null、bool、JSON 安全整数、有限 float、String、Dictionary 或 Array；
+- 拒绝 NaN/INF、超出 `±9_007_199_254_740_991` 的整数、循环引用和 Godot Object；
+- 递归拒绝 `__gf_report_value__`、`__gf_variant__`，调用方不能伪造报告 marker；
+- 单值最大深度 32、节点数 2048、UTF-8 JSON 64 KiB。
+
+环境在调用 `GFDictionarySchema` 前完成上述原引用预检，避免非 String key 归一化、循环深复制或开放类型的隐式放行。响应只有在 plain JSON、Schema 和精确预算全部通过后才会发布；不会把脱敏、截断或预算 marker 冒充成功业务响应。
+
+## Session、安全顺序与重放
+
+每个 session 保存 endpoint ID 到注册 generation 的精确映射。注销后再注册同名 endpoint 不会恢复旧权限，旧 session 会返回 `endpoint_grant_stale`。
+
+一次执行按以下顺序收敛：
+
+1. 检查环境启用态和 closed envelope；
+2. 检查 token 形态，以固定长度摘要比较认证 session；
+3. 检查单调时钟 TTL；
+4. 对所有已认证尝试计入固定窗口限流，包括越权、重放和 Schema 拒绝；
+5. 检查 endpoint grant 与注册 generation；
+6. 检查 session 全局 request ID 摘要；
+7. 在 payload、策略或 handler 执行前消费 request ID；
+8. 校验 plain JSON、硬预算和请求 Schema；
+9. 执行项目策略；
+10. 复核环境、session、TTL、endpoint generation 和策略注册表；
+11. 同步调用受信 handler；
+12. 再次复核执行上下文，随后校验并发布响应。
+
+request ID 在整个 session 内唯一，不按 endpoint 分区。`max_request_ids` 达到上限后不会淘汰旧摘要并重新允许重放，而是 fail closed，调用方应关闭旧 session 并由宿主重新签发。
+
+`max_request_ids` 必须大于等于 `max_requests_per_window`。它是 session 生命周期总上限，不会随固定限流窗口重置。
+
+默认与硬上限：
+
+| 项目 | 默认 | 硬上限 |
+| --- | ---: | ---: |
+| session TTL | 60 秒 | 15 分钟 |
+| 固定限流窗口 | 60 秒 | 5 分钟 |
+| 每窗口请求 | 60 | 256 |
+| session request ID | 256 | 512 |
+| 活动 session | — | 32 |
+| endpoint | — | 128 |
+| 审计事件 | — | 256 |
+
+时间字段来自单调毫秒时钟，不是 Unix 时间；检测到时钟回退会撤销该 session，而不会刷新限流窗口或延长 TTL。把 `enabled` 从 true 切换到 false 会立即清空全部 session；重新启用不会恢复旧凭据。`revoke_session()` 不要求 token，只能由受信宿主控制面调用。
+
+## 策略模型
+
+环境默认持有一个空 `GFPolicyRegistry`。空注册表是明确的中性允许：安全边界仍由“默认关闭 + 显式 endpoint + 精确 session grant + token/TTL/限流/Schema/预算”组成。将 `policy_registry` 设为 null 会 fail closed。session 会绑定签发时的安全上下文 epoch、Provider 顺序/实例，以及 Provider 的 `provider_id`、`display_name`、`supported_artifact_kinds`、`priority`、`input_schema`、`output_schema`、`deterministic` 和 `metadata`。摘要使用排序后的结构化 JSON，不使用可碰撞的分隔符拼接；这些 Dictionary 配置必须是前述预算内的 plain JSON，否则 session 签发以 `policy_configuration_invalid` fail closed。把 `environment.policy_registry` 替换为另一对象会递增 epoch；未通知但持续存在的公开配置漂移也会因摘要不匹配而 fail closed。
+
+`GFPolicyRegistry` 与 Provider 是公开可变 Resource，环境无法观察两次环境调用之间完整发生并恢复的 S1→S2→S1 原地变化。拥有线程在调用 `register_provider()`、`unregister_provider()`、`clear()`，修改 Provider 公开字段，或改变自定义 Provider 的非公开字段、闭包捕获值、外部服务授权状态之前，必须先调用 `invalidate_policy_context()`。该入口递增安全上下文并立即撤销全部 session，因此既覆盖公开配置 ABA，也覆盖无法反射的自定义状态。只改可变策略对象而不通知环境属于 Provider 集成错误。
+
+项目可分别注册支持以下 artifact kind 的 Provider：
+
+- `gf.runtime_agent.session`：在签发 token 前检查 endpoint 集、有效期和请求限制；
+- `gf.runtime_agent.request`：在 handler 前检查 session、endpoint、request ID 摘要和 payload。
+
+请求策略可以读取 payload，因此 Provider 也是受信代码，项目必须自行控制其日志、遥测和外部调用。环境只读取汇总 `ok`，不会把策略的 artifact、issues、data 或 metadata 写入响应和审计。需要一次性人工批准、高风险分级、账号身份或业务授权时，应由项目策略和控制面实现；不要把这些决策伪装成通用 endpoint metadata。
+
+## 审计与可观察面
+
+`audit_event_recorded` 与 `get_audit_events()` 只包含固定字段：
+
+- schema/protocol version、单调 sequence 和 timestamp；
+- action、outcome、reason；
+- session ID、endpoint ID；
+- 原始 request ID 的截断 SHA-256 摘要。
+
+`request_id_digest` 只用于同一部署内的相关性，不是匿名化机制；无密钥截断摘要无法抵抗
+对低熵、可枚举 ID 的字典猜测。`request_id` 应是 opaque 协议标识，不得编码用户资料、
+业务秘密或其他需要保密的语义。
+
+不包含：
+
+- token 或 token hash；
+- payload、handler 请求或响应；
+- 策略 artifact、issue、data 或 metadata；
+- Schema metadata/default；
+- 任意对象、路径或业务日志。
+
+`get_debug_snapshot()` 只返回启用态、endpoint/session/audit/provider 数量、执行状态和
+`owner_thread_access`。跨线程快照是固定的零值拒绝视图，不读取共享 Dictionary。调用方仍应
+把 session ID、endpoint ID 和时间视作可能敏感的运行信息，并按项目保留策略处理。
+
+## 威胁模型与同步限制
+
+该环境保护的是“不可信协议数据进入受信同步 handler”这一层边界，不是 OS sandbox：
+
+- handler、策略 Provider 和审计 signal 监听者均为同进程受信代码，可以访问引擎、读取其他秘密、阻塞主线程或产生副作用；
+- 同步回调无法被抢占。回调后 TTL/revision 复核只能阻止发布过时结果，不能回滚已经发生的副作用；
+- 默认拒绝 handler 重入另一个 handler，但不能阻止恶意同进程代码绕开环境直接调用项目 API；
+- 网络传输、连接认证、加密、来源身份、跨进程隔离和用户批准均由项目或外层适配器负责；
+  外层还必须在解码 Dictionary 前限制 frame/body 大小，并对 malformed envelope 与无效凭据
+  做连接级限流；64 KiB plain-JSON 预算和 session limiter 不是网络入口的全局 DoS 防线；
+- endpoint 应保持小、同步、确定终态和可独立授权。长任务应由 endpoint 创建项目自有的有界操作句柄，而不是在 handler 内阻塞。
+
+关闭服务时调用 `dispose()`，清除 endpoint、session、凭据摘要和内存审计；如果由 `GFArchitecture` 持有，架构释放阶段会调用该生命周期入口。

--- a/docs/zh/standard/utilities/runtime/index.md
+++ b/docs/zh/standard/utilities/runtime/index.md
@@ -20,6 +20,7 @@
 - [随机种子、日志、构建信息与诊断总览](debug-observability/runtime-telemetry/index.md)：随机流复现、结构化日志、构建信息和诊断快照的分层边界。
 - [随机种子与可复现随机流](debug-observability/runtime-telemetry/seed-utility.md)：全局种子、主 RNG 状态和按标签派生的分支随机流。
 - [响应式状态与控件绑定](reactive-state.md)：状态树、路径订阅、dirty queue、控件双向绑定和自动解绑。
+- [Runtime Agent Environment](agent-environment.md)：默认关闭的 endpoint/session 协议、严格 Schema、短期凭据、限流、防重放、策略检查与无载荷审计。
 - [结构化日志与日志 Sink](debug-observability/runtime-telemetry/log-utility/index.md)：分级日志、本地文件、内存缓存、JSONL sink 和批量 sink。
 - [构建信息与诊断快照](debug-observability/runtime-telemetry/build-diagnostics/index.md)：构建信息、诊断命令、信号图、监控预设和工具快照。
 - [支持报告与通知队列](debug-observability/support-notifications/index.md)：支持报告数据聚合和通用通知队列。

--- a/packages/standard/gf.standard.agent_environment.json
+++ b/packages/standard/gf.standard.agent_environment.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "gf.standard.agent_environment",
+  "kind": "standard",
+  "version": "unreleased",
+  "display_name": "GF Standard Runtime Agent Environment",
+  "description": "Transport-neutral, default-closed runtime Agent endpoint sessions with strict JSON schemas, exact grants, short-lived hashed credentials, replay and rate controls, policy checks, bounded results, and payload-free audit events.",
+  "dependencies": [
+    "gf.kernel",
+    "gf.standard.base"
+  ],
+  "paths": [
+    "addons/gf/standard/utilities/agent/**"
+  ],
+  "metadata": {
+    "stage": "standard-split-v1"
+  }
+}

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -80,6 +80,9 @@
       "res://tests/gf_core/kernel/extension/test_gf_extension_manifest.gd",
       "res://tests/gf_core/kernel/package/test_gf_package_manager_backend.gd"
     ],
+    "gf.standard.agent_environment": [
+      "res://tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd"
+    ],
     "gf.standard.assets": [
       "res://tests/gf_core/standard/utilities/assets/test_gf_asset_utility.gd",
       "res://tests/gf_core/standard/utilities/assets/test_gf_threaded_resource_coordinator.gd",

--- a/tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd
+++ b/tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd
@@ -1,0 +1,1596 @@
+## 测试 Runtime Agent Environment 的传输无关协议与默认拒绝安全边界。
+extends GutTest
+
+
+var environment: ManualClockEnvironment
+var handler: RecordingHandler
+var request_schema: GFDictionarySchema
+var response_schema: GFDictionarySchema
+
+
+func before_each() -> void:
+	environment = ManualClockEnvironment.new()
+	environment.current_time_msec = 10_000
+	handler = RecordingHandler.new()
+	request_schema = _make_schema(&"agent.echo.request", [
+		_make_field(&"message", GFSchemaField.ValueType.STRING, {
+			"required": true,
+			"allow_null": false,
+		}),
+	])
+	response_schema = _make_schema(&"agent.echo.response", [
+		_make_field(&"accepted", GFSchemaField.ValueType.BOOL, {
+			"required": true,
+			"allow_null": false,
+		}),
+		_make_field(&"echo", GFSchemaField.ValueType.STRING, {
+			"required": true,
+			"allow_null": false,
+		}),
+	])
+
+
+func after_each() -> void:
+	environment.dispose()
+
+
+func test_environment_is_disabled_by_default_and_does_not_issue_credentials() -> void:
+	var registration: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	var opened: Dictionary = environment.open_session(PackedStringArray(["echo"]))
+
+	assert_true(GFVariantData.get_option_bool(registration, "ok"), "禁用态应允许受信宿主预注册 endpoint。")
+	assert_false(environment.enabled, "Runtime Agent Environment 必须默认关闭。")
+	assert_false(GFVariantData.get_option_bool(opened, "ok"), "禁用态不得签发 session。")
+	assert_eq(GFVariantData.get_option_string(opened, "reason"), "environment_disabled")
+	assert_false(opened.has("token"), "拒绝结果不得包含 token 字段。")
+
+
+func test_registration_requires_closed_json_only_schema_and_rejects_duplicates() -> void:
+	var open_schema: GFDictionarySchema = request_schema.duplicate_schema()
+	open_schema.allow_extra_fields = true
+	var unsafe_schema: GFDictionarySchema = _make_schema(&"agent.unsafe.request", [
+		_make_field(&"value", GFSchemaField.ValueType.ANY),
+	])
+	var recursive_schema: GFDictionarySchema = _make_schema(&"agent.recursive.request")
+	var recursive_field: GFSchemaField = _make_field(
+		&"child",
+		GFSchemaField.ValueType.DICTIONARY,
+		{ "dictionary_schema": recursive_schema }
+	)
+	var _recursive_field_added: bool = recursive_schema.add_field(recursive_field)
+
+	var open_result: Dictionary = environment.register_endpoint(
+		"open",
+		open_schema,
+		response_schema,
+		handler.handle
+	)
+	var unsafe_result: Dictionary = environment.register_endpoint(
+		"unsafe",
+		unsafe_schema,
+		response_schema,
+		handler.handle
+	)
+	var recursive_result: Dictionary = environment.register_endpoint(
+		"recursive",
+		recursive_schema,
+		response_schema,
+		handler.handle
+	)
+	var first: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	var duplicate_result: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+
+	assert_false(GFVariantData.get_option_bool(open_result, "ok"), "允许额外字段的 schema 必须被拒绝。")
+	assert_eq(GFVariantData.get_option_string(open_result, "reason"), "unsafe_request_schema")
+	assert_false(GFVariantData.get_option_bool(unsafe_result, "ok"), "ANY 等非 JSON 严格类型必须被拒绝。")
+	assert_false(GFVariantData.get_option_bool(recursive_result, "ok"), "循环 schema 必须 fail closed。")
+	assert_true(GFVariantData.get_option_bool(first, "ok"), "严格 schema 应可注册。")
+	assert_false(GFVariantData.get_option_bool(duplicate_result, "ok"), "重复 endpoint 不得隐式替换 handler。")
+	assert_eq(GFVariantData.get_option_string(duplicate_result, "reason"), "endpoint_already_registered")
+
+
+func test_catalog_exposes_only_structural_schema_without_handler_metadata_or_defaults() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+
+	var catalog: Dictionary = environment.get_endpoint_catalog()
+	var endpoints: Array = GFVariantData.get_option_array(catalog, "endpoints")
+	var endpoint: Dictionary = GFVariantData.as_dictionary(endpoints[0])
+	var described_request: Dictionary = GFVariantData.get_option_dictionary(endpoint, "request_schema")
+	var fields: Array = GFVariantData.get_option_array(described_request, "fields")
+	var field: Dictionary = GFVariantData.as_dictionary(fields[0])
+
+	assert_eq(GFVariantData.get_option_int(catalog, "protocol_version"), 1)
+	assert_eq(GFVariantData.get_option_string(endpoint, "endpoint_id"), "echo")
+	assert_false(endpoint.has("handler"), "目录不得暴露 Callable。")
+	assert_false(described_request.has("metadata"), "目录不得暴露 schema metadata。")
+	assert_false(field.has("metadata"), "目录不得暴露字段 metadata。")
+	assert_false(field.has("default_value"), "目录不得暴露默认值。")
+	assert_eq(GFVariantData.get_option_string(field, "type"), "string")
+
+
+func test_session_uses_exact_grants_and_token_is_absent_from_public_observability() -> void:
+	var secondary_handler: RecordingHandler = RecordingHandler.new()
+	var _echo_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	var _secondary_registered: Dictionary = environment.register_endpoint(
+		"secondary",
+		request_schema,
+		response_schema,
+		secondary_handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+
+	var denied: Dictionary = environment.execute_request(
+		_make_request(session_id, "secondary", "request-1", { "message": "private-payload" }),
+		token
+	)
+	var observable_text: String = JSON.stringify({
+		"catalog": environment.get_endpoint_catalog(),
+		"debug": environment.get_debug_snapshot(),
+		"audit": environment.get_audit_events(),
+	})
+	var token_hash: String = ("%s:%s" % [session_id, token]).sha256_text()
+	var internal_session_text: String = JSON.stringify(environment._sessions)
+
+	assert_eq(token.length(), 64, "token 应由 32 个随机字节编码。")
+	assert_false(GFVariantData.get_option_bool(denied, "ok"), "session 不得调用未授权 endpoint。")
+	assert_eq(GFVariantData.get_option_string(denied, "reason"), "endpoint_not_granted")
+	assert_eq(secondary_handler.call_count, 0, "越权请求不得触发 handler。")
+	assert_eq(observable_text.find(token), -1, "目录、快照与审计不得包含明文 token。")
+	assert_eq(observable_text.find(token_hash), -1, "公开可观察面也不得包含 token hash。")
+	assert_eq(observable_text.find("private-payload"), -1, "审计不得复制业务载荷。")
+	assert_eq(internal_session_text.find(token), -1, "session 内部状态不得保存明文 token。")
+	assert_true(internal_session_text.find(token_hash) >= 0, "session 内部只保存绑定 session id 的 token hash。")
+
+
+func test_valid_request_calls_handler_once_without_forwarding_token() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+
+	var result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "request-1", { "message": "hello" }),
+		token
+	)
+	var response: Dictionary = GFVariantData.get_option_dictionary(result, "response")
+	var callback_text: String = JSON.stringify(handler.last_request)
+
+	assert_true(GFVariantData.get_option_bool(result, "ok"), "合法请求应成功。")
+	assert_eq(GFVariantData.get_option_string(result, "status"), "succeeded")
+	assert_eq(GFVariantData.get_option_string(response, "echo"), "hello")
+	assert_eq(handler.call_count, 1, "每个 request id 最多调用一次 handler。")
+	assert_eq(callback_text.find(token), -1, "handler request 不得包含 bearer token。")
+	assert_eq(GFVariantData.get_option_int(handler.last_request, "protocol_version"), 1)
+
+
+func test_envelope_payload_and_protocol_are_strictly_validated_before_callback() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"max_requests_per_window": 12,
+		"max_request_ids": 12,
+	})
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var extra_envelope: Dictionary = _make_request(
+		session_id,
+		"echo",
+		"request-extra-envelope",
+		{ "message": "hello" }
+	)
+	extra_envelope["unexpected"] = true
+	var wrong_version: Dictionary = _make_request(
+		session_id,
+		"echo",
+		"request-version",
+		{ "message": "hello" }
+	)
+	wrong_version["protocol_version"] = 2
+	var cyclic_payload: Dictionary = {}
+	cyclic_payload["message"] = cyclic_payload
+	var results: Array[Dictionary] = [
+		environment.execute_request(extra_envelope, token),
+		environment.execute_request(wrong_version, token),
+		environment.execute_request(
+			_make_request(session_id, "echo", "request-extra-payload", {
+				"message": "hello",
+				"extra": true,
+			}),
+			token
+		),
+		environment.execute_request(
+			_make_request(session_id, "echo", "request-object", {
+				"message": RefCounted.new(),
+			}),
+			token
+		),
+		environment.execute_request(
+			_make_request(session_id, "echo", "request-cycle", cyclic_payload),
+			token
+		),
+		environment.execute_request(
+			_make_request(session_id, "echo", "request-bytes", {
+				"message": "x".repeat(70_000),
+			}),
+			token
+		),
+	]
+
+	for result: Dictionary in results:
+		assert_false(GFVariantData.get_option_bool(result, "ok"), "非法 envelope 或 payload 必须拒绝。")
+	assert_eq(handler.call_count, 0, "任何协议、结构或预算错误都不得调用 handler。")
+	assert_eq(GFVariantData.get_option_string(results[0], "reason"), "invalid_request_envelope")
+	assert_eq(GFVariantData.get_option_string(results[1], "reason"), "unsupported_protocol_version")
+	assert_eq(GFVariantData.get_option_string(results[2], "reason"), "request_schema_rejected")
+	assert_eq(GFVariantData.get_option_string(results[3], "reason"), "invalid_payload")
+	assert_eq(GFVariantData.get_option_string(results[4], "reason"), "invalid_payload")
+	assert_eq(GFVariantData.get_option_string(results[5], "reason"), "request_budget_exceeded")
+
+
+func test_invalid_token_and_replayed_request_never_call_handler_twice() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var request: Dictionary = _make_request(
+		session_id,
+		"echo",
+		"request-replay",
+		{ "message": "hello" }
+	)
+
+	var invalid_token_result: Dictionary = environment.execute_request(request, "0".repeat(64))
+	var first: Dictionary = environment.execute_request(request, token)
+	var replay: Dictionary = environment.execute_request(request, token)
+
+	assert_false(GFVariantData.get_option_bool(invalid_token_result, "ok"), "错误凭据必须拒绝。")
+	assert_eq(GFVariantData.get_option_string(invalid_token_result, "reason"), "invalid_credentials")
+	assert_true(GFVariantData.get_option_bool(first, "ok"), "首次合法请求应成功。")
+	assert_false(GFVariantData.get_option_bool(replay, "ok"), "相同 request id 不得重放。")
+	assert_eq(GFVariantData.get_option_string(replay, "reason"), "request_replayed")
+	assert_eq(handler.call_count, 1, "错误凭据与重放都不得增加 handler 调用。")
+
+
+func test_session_ttl_and_fixed_window_rate_limit_fail_closed() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var rate_session: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"ttl_msec": 1_000,
+		"max_requests_per_window": 2,
+		"rate_window_msec": 100,
+		"max_request_ids": 8,
+	})
+	var rate_token: String = GFVariantData.get_option_string(rate_session, "token")
+	var rate_session_id: String = GFVariantData.get_option_string(rate_session, "session_id")
+
+	var first: Dictionary = environment.execute_request(
+		_make_request(rate_session_id, "echo", "rate-1", { "message": "one" }),
+		rate_token
+	)
+	var second: Dictionary = environment.execute_request(
+		_make_request(rate_session_id, "echo", "rate-2", { "message": "two" }),
+		rate_token
+	)
+	var limited: Dictionary = environment.execute_request(
+		_make_request(rate_session_id, "echo", "rate-3", { "message": "three" }),
+		rate_token
+	)
+	environment.current_time_msec += 101
+	var reset: Dictionary = environment.execute_request(
+		_make_request(rate_session_id, "echo", "rate-4", { "message": "four" }),
+		rate_token
+	)
+	environment.current_time_msec += 900
+	var expired: Dictionary = environment.execute_request(
+		_make_request(rate_session_id, "echo", "rate-5", { "message": "five" }),
+		rate_token
+	)
+
+	assert_true(GFVariantData.get_option_bool(first, "ok"))
+	assert_true(GFVariantData.get_option_bool(second, "ok"))
+	assert_false(GFVariantData.get_option_bool(limited, "ok"), "固定窗口超限必须拒绝。")
+	assert_eq(GFVariantData.get_option_string(limited, "reason"), "rate_limited")
+	assert_true(GFVariantData.get_option_bool(reset, "ok"), "新窗口应恢复请求额度。")
+	assert_false(GFVariantData.get_option_bool(expired, "ok"), "过期 session 必须拒绝。")
+	assert_eq(GFVariantData.get_option_string(expired, "reason"), "session_expired")
+	assert_eq(handler.call_count, 3, "限流与过期请求不得触发 handler。")
+
+
+func test_request_policy_denial_consumes_request_id_without_exposing_policy_payload() -> void:
+	var denying_provider: DenyingPolicyProvider = DenyingPolicyProvider.new()
+	var _configured_provider: GFPolicyProvider = denying_provider.configure(
+		&"deny_runtime_agent",
+		PackedStringArray(["gf.runtime_agent.request"])
+	)
+	var _provider_registered: bool = environment.policy_registry.register_provider(denying_provider)
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var request: Dictionary = _make_request(
+		session_id,
+		"echo",
+		"policy-request",
+		{ "message": "policy-secret" }
+	)
+
+	var denied: Dictionary = environment.execute_request(request, token)
+	var replay: Dictionary = environment.execute_request(request, token)
+	var observable_text: String = JSON.stringify({
+		"denied": denied,
+		"audit": environment.get_audit_events(),
+	})
+
+	assert_false(GFVariantData.get_option_bool(denied, "ok"), "策略拒绝必须阻断请求。")
+	assert_eq(GFVariantData.get_option_string(denied, "reason"), "policy_denied")
+	assert_eq(handler.call_count, 0, "策略拒绝不得调用 handler。")
+	assert_eq(GFVariantData.get_option_string(replay, "reason"), "request_replayed", "已决策的 request id 不得复用。")
+	assert_eq(observable_text.find("policy-secret"), -1, "策略输入 payload 不得复制到结果或审计。")
+
+
+func test_response_schema_and_budget_failures_do_not_escape_handler_output() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+
+	handler.response_override = {
+		"accepted": true,
+		"echo": 42,
+	}
+	var schema_rejected: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "response-schema", { "message": "hello" }),
+		token
+	)
+	handler.response_override = {
+		"accepted": true,
+		"echo": "x".repeat(70_000),
+	}
+	var budget_rejected: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "response-budget", { "message": "hello" }),
+		token
+	)
+
+	assert_false(GFVariantData.get_option_bool(schema_rejected, "ok"))
+	assert_eq(GFVariantData.get_option_string(schema_rejected, "reason"), "response_schema_rejected")
+	assert_false(schema_rejected.has("response"), "失败结果不得带出非法 handler 输出。")
+	assert_false(GFVariantData.get_option_bool(budget_rejected, "ok"))
+	assert_eq(GFVariantData.get_option_string(budget_rejected, "reason"), "response_budget_exceeded")
+	assert_false(budget_rejected.has("response"), "超预算输出不得截断后冒充成功。")
+	assert_eq(handler.call_count, 2, "输出失败发生在受信 handler 返回后。")
+
+
+func test_handler_output_plain_json_failures_never_escape() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"max_requests_per_window": 12,
+		"max_request_ids": 12,
+	})
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var circular_response: Dictionary = {}
+	circular_response["self"] = circular_response
+	var deep_response: Variant = "leaf"
+	for _index: int in range(40):
+		deep_response = { "child": deep_response }
+	var many_response_nodes: Array = []
+	for index: int in range(2_100):
+		many_response_nodes.append(index)
+	var raw_responses: Array = [
+		"not-a-dictionary",
+		{ "accepted": true, "echo": NAN },
+		{ "accepted": true, "echo": RefCounted.new() },
+		{ "accepted": true, "echo": "ok", "__gf_variant__": {} },
+		circular_response,
+		{ "accepted": true, "echo": "ok", "deep": deep_response },
+		{ "accepted": true, "echo": "ok", "nodes": many_response_nodes },
+	]
+	var expected_reasons: Array[String] = [
+		"invalid_handler_response",
+		"invalid_handler_response",
+		"invalid_handler_response",
+		"invalid_handler_response",
+		"invalid_handler_response",
+		"response_budget_exceeded",
+		"response_budget_exceeded",
+	]
+	var results: Array[Dictionary] = []
+	handler.use_raw_response_override = true
+	for index: int in range(raw_responses.size()):
+		handler.raw_response_override = raw_responses[index]
+		results.append(environment.execute_request(
+			_make_request(
+				session_id,
+				"echo",
+				"unsafe-response-%d" % index,
+				{ "message": "hello" }
+			),
+			token
+		))
+
+	for index: int in range(results.size()):
+		assert_false(GFVariantData.get_option_bool(results[index], "ok"))
+		assert_eq(
+			GFVariantData.get_option_string(results[index], "reason"),
+			expected_reasons[index]
+		)
+		assert_false(results[index].has("response"), "非法 handler 输出不得进入失败结果。")
+	assert_eq(handler.call_count, raw_responses.size())
+
+
+func test_unregister_reregister_does_not_resurrect_old_session_grant() -> void:
+	var replacement_handler: RecordingHandler = RecordingHandler.new()
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var _unregistered: Dictionary = environment.unregister_endpoint("echo")
+	var _reregistered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		replacement_handler.handle
+	)
+
+	var result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "request-stale", { "message": "hello" }),
+		token
+	)
+
+	assert_false(GFVariantData.get_option_bool(result, "ok"), "同名重注册不得恢复旧 grant。")
+	assert_eq(GFVariantData.get_option_string(result, "reason"), "endpoint_grant_stale")
+	assert_eq(handler.call_count, 0)
+	assert_eq(replacement_handler.call_count, 0, "旧 session 不得触发 replacement handler。")
+
+
+func test_callback_context_revocation_discards_result_and_reentrant_execution_is_rejected() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	handler.on_call = func() -> void:
+		handler.nested_result = environment.execute_request(
+			_make_request(session_id, "echo", "nested-request", { "message": "nested" }),
+			token
+		)
+		var _revoked: bool = environment.revoke_session(session_id)
+
+	var result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "outer-request", { "message": "outer" }),
+		token
+	)
+
+	assert_eq(handler.call_count, 1, "同步 handler 执行期间不得重入另一个 handler。")
+	assert_eq(GFVariantData.get_option_string(handler.nested_result, "reason"), "reentrant_execution")
+	assert_false(GFVariantData.get_option_bool(result, "ok"), "回调期间 session 被撤销时不得发布输出。")
+	assert_eq(GFVariantData.get_option_string(result, "reason"), "execution_context_changed")
+	assert_false(result.has("response"))
+
+
+func test_disabling_environment_revokes_existing_sessions() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+
+	environment.enabled = false
+	environment.enabled = true
+	var result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "request-after-disable", { "message": "hello" }),
+		token
+	)
+
+	assert_false(GFVariantData.get_option_bool(result, "ok"), "关闭环境必须立即撤销所有 session。")
+	assert_eq(GFVariantData.get_option_string(result, "reason"), "invalid_credentials")
+	assert_eq(handler.call_count, 0)
+
+
+func test_audit_uses_request_digest_and_never_keeps_raw_request_id() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var request_id: String = "request.audit.raw-id"
+	var _result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", request_id, { "message": "audit-payload-secret" }),
+		token
+	)
+
+	var audit: Dictionary = environment.get_audit_events()
+	var events: Array = GFVariantData.get_option_array(audit, "events")
+	var last_event: Dictionary = GFVariantData.as_dictionary(events.back())
+	var audit_text: String = JSON.stringify(audit)
+
+	assert_eq(GFVariantData.get_option_string(last_event, "action"), "execute_request")
+	assert_eq(last_event.size(), 10, "审计事件必须保持固定字段集。")
+	assert_true(GFVariantData.get_option_string(last_event, "request_id_digest").length() >= 16)
+	assert_eq(audit_text.find(request_id), -1, "审计不得保存原始 request id。")
+	assert_eq(audit_text.find("audit-payload-secret"), -1, "审计不得保存业务 payload。")
+	assert_eq(audit_text.find(token), -1, "审计不得保存 token。")
+
+
+func test_audit_ring_is_bounded_returns_deep_copies_and_can_be_cleared() -> void:
+	for _index: int in range(300):
+		var _rejected: Dictionary = environment.register_endpoint(
+			"",
+			request_schema,
+			response_schema,
+			handler.handle
+		)
+	var audit: Dictionary = environment.get_audit_events(999)
+	var events: Array = GFVariantData.get_option_array(audit, "events")
+	var first_event: Dictionary = GFVariantData.as_dictionary(events.front())
+	var last_event: Dictionary = GFVariantData.as_dictionary(events.back())
+	first_event["action"] = "tampered"
+	var fresh_audit: Dictionary = environment.get_audit_events(999)
+	var fresh_events: Array = GFVariantData.get_option_array(fresh_audit, "events")
+	var fresh_first_event: Dictionary = GFVariantData.as_dictionary(fresh_events.front())
+
+	assert_eq(GFVariantData.get_option_int(audit, "retained_event_count"), 256)
+	assert_eq(events.size(), 256)
+	assert_eq(GFVariantData.get_option_int(last_event, "sequence"), 300)
+	assert_eq(GFVariantData.get_option_string(fresh_first_event, "action"), "register_endpoint")
+	environment.clear_audit_events()
+	var cleared: Dictionary = environment.get_audit_events()
+	assert_eq(GFVariantData.get_option_int(cleared, "event_count"), 0)
+	assert_eq(GFVariantData.get_option_int(cleared, "retained_event_count"), 0)
+
+
+func test_prune_and_dispose_leave_no_runtime_state() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var _opened: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"ttl_msec": 100,
+	})
+	environment.current_time_msec += 100
+
+	var pruned_count: int = environment.prune_expired_sessions()
+	var after_prune: Dictionary = environment.get_debug_snapshot()
+	environment.dispose()
+	var after_dispose: Dictionary = environment.get_debug_snapshot()
+
+	assert_eq(pruned_count, 1)
+	assert_eq(GFVariantData.get_option_int(after_prune, "active_session_count"), 0)
+	assert_false(GFVariantData.get_option_bool(after_dispose, "enabled"))
+	assert_eq(GFVariantData.get_option_int(after_dispose, "endpoint_count"), 0)
+	assert_eq(GFVariantData.get_option_int(after_dispose, "active_session_count"), 0)
+	assert_eq(GFVariantData.get_option_int(after_dispose, "audit_event_count"), 0)
+	assert_eq(GFVariantData.get_option_int(after_dispose, "policy_provider_count"), 0)
+	assert_true(GFVariantData.get_option_bool(after_dispose, "owner_thread_access"))
+
+
+func test_nested_schema_contract_is_closed_and_registration_uses_an_immutable_copy() -> void:
+	var open_nested_schema: GFDictionarySchema = _make_schema(&"agent.nested.open")
+	open_nested_schema.allow_extra_fields = true
+	var outer_schema: GFDictionarySchema = _make_schema(&"agent.outer.request", [
+		_make_field(&"nested", GFSchemaField.ValueType.DICTIONARY, {
+			"dictionary_schema": open_nested_schema,
+		}),
+	])
+	var missing_nested_schema: GFDictionarySchema = _make_schema(&"agent.missing.request", [
+		_make_field(&"nested", GFSchemaField.ValueType.DICTIONARY),
+	])
+	var metadata_schema: GFDictionarySchema = request_schema.duplicate_schema()
+	metadata_schema.metadata = { "private": RefCounted.new() }
+
+	var open_nested_result: Dictionary = environment.register_endpoint(
+		"nested-open",
+		outer_schema,
+		response_schema,
+		handler.handle
+	)
+	var missing_nested_result: Dictionary = environment.register_endpoint(
+		"nested-missing",
+		missing_nested_schema,
+		response_schema,
+		handler.handle
+	)
+	var metadata_result: Dictionary = environment.register_endpoint(
+		"metadata",
+		metadata_schema,
+		response_schema,
+		handler.handle
+	)
+	var registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	request_schema.allow_extra_fields = true
+	request_schema.fields[0].value_type = GFSchemaField.ValueType.INT
+	var first_catalog: Dictionary = environment.get_endpoint_catalog()
+	var first_endpoints: Array = GFVariantData.get_option_array(first_catalog, "endpoints")
+	var first_endpoint: Dictionary = GFVariantData.as_dictionary(first_endpoints[0])
+	first_endpoint["request_schema"] = {}
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var result: Dictionary = environment.execute_request(
+		_make_request(
+			GFVariantData.get_option_string(opened, "session_id"),
+			"echo",
+			"immutable-schema",
+			{ "message": "hello" }
+		),
+		GFVariantData.get_option_string(opened, "token")
+	)
+
+	assert_false(GFVariantData.get_option_bool(open_nested_result, "ok"), "嵌套开放 schema 必须拒绝。")
+	assert_false(GFVariantData.get_option_bool(missing_nested_result, "ok"), "缺失嵌套 schema 必须拒绝。")
+	assert_false(GFVariantData.get_option_bool(metadata_result, "ok"), "schema metadata 不得进入安全契约。")
+	assert_true(GFVariantData.get_option_bool(registered, "ok"))
+	assert_true(GFVariantData.get_option_bool(result, "ok"), "原 schema 或目录副本修改不得改变已注册契约。")
+	assert_eq(GFVariantData.get_option_string(
+		GFVariantData.get_option_dictionary(result, "response"),
+		"echo"
+	), "hello")
+
+
+func test_nested_array_schema_executes_and_registration_deep_copies_all_children() -> void:
+	var item_dictionary_schema: GFDictionarySchema = _make_schema(&"agent.items.item", [
+		_make_field(&"value", GFSchemaField.ValueType.STRING, {
+			"required": true,
+			"allow_null": false,
+		}),
+	])
+	var item_field: GFSchemaField = _make_field(
+		&"",
+		GFSchemaField.ValueType.DICTIONARY,
+		{
+			"allow_null": false,
+			"dictionary_schema": item_dictionary_schema,
+		}
+	)
+	var array_field: GFSchemaField = _make_field(
+		&"items",
+		GFSchemaField.ValueType.ARRAY,
+		{
+			"required": true,
+			"allow_null": false,
+			"array_item_schema": item_field,
+		}
+	)
+	var array_schema: GFDictionarySchema = _make_schema(
+		&"agent.items.request",
+		[array_field]
+	)
+	var registered: Dictionary = environment.register_endpoint(
+		"items",
+		array_schema,
+		response_schema,
+		handler.handle
+	)
+	array_field.array_item_schema.value_type = GFSchemaField.ValueType.INT
+	item_dictionary_schema.fields[0].value_type = GFSchemaField.ValueType.INT
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["items"]))
+	var result: Dictionary = environment.execute_request(
+		_make_request(
+			GFVariantData.get_option_string(opened, "session_id"),
+			"items",
+			"nested-array",
+			{
+				"items": [
+					{ "value": "one" },
+					{ "value": "two" },
+				],
+			}
+		),
+		GFVariantData.get_option_string(opened, "token")
+	)
+
+	assert_true(GFVariantData.get_option_bool(registered, "ok"))
+	assert_true(
+		GFVariantData.get_option_bool(result, "ok"),
+		"注册后修改数组 item 与 nested schema 不得改变保存的深副本。"
+	)
+	assert_eq(handler.call_count, 1)
+
+
+func test_plain_json_preflight_rejects_non_string_keys_markers_and_unsafe_numbers() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"max_requests_per_window": 8,
+		"max_request_ids": 8,
+	})
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var non_string_key_payload: Dictionary = {}
+	non_string_key_payload[&"message"] = "hello"
+	var results: Array[Dictionary] = [
+		environment.execute_request(
+			_make_request(session_id, "echo", "json-key", non_string_key_payload),
+			token
+		),
+		environment.execute_request(
+			_make_request(session_id, "echo", "json-marker", {
+				"message": "hello",
+				"__gf_report_value__": {},
+			}),
+			token
+		),
+		environment.execute_request(
+			_make_request(session_id, "echo", "json-nan", { "message": NAN }),
+			token
+		),
+		environment.execute_request(
+			_make_request(session_id, "echo", "json-int", {
+				"message": 9_007_199_254_740_992,
+			}),
+			token
+		),
+	]
+
+	for result: Dictionary in results:
+		assert_false(GFVariantData.get_option_bool(result, "ok"))
+		assert_eq(GFVariantData.get_option_string(result, "reason"), "invalid_payload")
+	assert_eq(handler.call_count, 0, "JSON 预检失败不得进入 schema 或 handler。")
+
+
+func test_empty_policy_registry_is_neutral_while_null_and_session_policy_denial_fail_closed() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	environment.policy_registry = null
+	var null_open: Dictionary = environment.open_session(PackedStringArray(["echo"]))
+	environment.policy_registry = GFPolicyRegistry.new()
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	environment.policy_registry = null
+	var null_execute: Dictionary = environment.execute_request(
+		_make_request(
+			GFVariantData.get_option_string(opened, "session_id"),
+			"echo",
+			"null-policy",
+			{ "message": "hello" }
+		),
+		GFVariantData.get_option_string(opened, "token")
+	)
+	var session_deny_registry: GFPolicyRegistry = GFPolicyRegistry.new()
+	var session_denier: DenyingPolicyProvider = DenyingPolicyProvider.new()
+	var _configured_denier: GFPolicyProvider = session_denier.configure(
+		&"deny_runtime_agent_session",
+		PackedStringArray(["gf.runtime_agent.session"])
+	)
+	var _denier_registered: bool = session_deny_registry.register_provider(session_denier)
+	environment.policy_registry = session_deny_registry
+	var denied_open: Dictionary = environment.open_session(PackedStringArray(["echo"]))
+
+	assert_eq(GFVariantData.get_option_string(null_open, "reason"), "policy_registry_unavailable")
+	assert_false(null_open.has("token"), "null registry 拒绝不得签发 token。")
+	assert_false(GFVariantData.get_option_bool(null_execute, "ok"), "执行时 null registry 必须 fail closed。")
+	assert_eq(GFVariantData.get_option_string(null_execute, "reason"), "policy_registry_unavailable")
+	assert_false(GFVariantData.get_option_bool(denied_open, "ok"), "session 策略拒绝不得签发凭据。")
+	assert_eq(GFVariantData.get_option_string(denied_open, "reason"), "policy_denied")
+	assert_false(denied_open.has("token"))
+	assert_eq(handler.call_count, 0)
+
+
+func test_session_policy_cannot_issue_credentials_after_disabling_environment() -> void:
+	var disabling_provider: DisablingSessionPolicyProvider = DisablingSessionPolicyProvider.new()
+	disabling_provider.environment = environment
+	var _configured_provider: GFPolicyProvider = disabling_provider.configure(
+		&"disable_during_runtime_agent_session",
+		PackedStringArray(["gf.runtime_agent.session"])
+	)
+	var _provider_registered: bool = environment.policy_registry.register_provider(
+		disabling_provider
+	)
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+
+	var opened: Dictionary = environment.open_session(PackedStringArray(["echo"]))
+	var snapshot: Dictionary = environment.get_debug_snapshot()
+
+	assert_false(GFVariantData.get_option_bool(opened, "ok"))
+	assert_eq(GFVariantData.get_option_string(opened, "reason"), "policy_context_changed")
+	assert_false(opened.has("token"), "策略回调改变启用上下文后不得签发 token。")
+	assert_false(environment.enabled)
+	assert_eq(GFVariantData.get_option_int(snapshot, "active_session_count"), 0)
+
+
+func test_policy_receives_a_copy_and_policy_revocation_prevents_handler_execution() -> void:
+	var mutating_provider: MutatingPolicyProvider = MutatingPolicyProvider.new()
+	var _configured_provider: GFPolicyProvider = mutating_provider.configure(
+		&"mutating_runtime_agent_policy",
+		PackedStringArray(["gf.runtime_agent.request"])
+	)
+	var _provider_registered: bool = environment.policy_registry.register_provider(mutating_provider)
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	mutating_provider.environment = environment
+	mutating_provider.session_id = session_id
+
+	var copied_payload_result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "policy-copy", { "message": "original" }),
+		token
+	)
+	mutating_provider.revoke_session = true
+	var revoked_result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "policy-revoke", { "message": "second" }),
+		token
+	)
+
+	assert_true(GFVariantData.get_option_bool(copied_payload_result, "ok"))
+	assert_eq(GFVariantData.get_option_string(
+		GFVariantData.get_option_dictionary(copied_payload_result, "response"),
+		"echo"
+	), "original", "策略对 artifact 的修改不得污染 handler payload。")
+	assert_false(GFVariantData.get_option_bool(revoked_result, "ok"))
+	assert_eq(GFVariantData.get_option_string(revoked_result, "reason"), "execution_context_changed")
+	assert_eq(handler.call_count, 1, "策略期间撤销 session 后不得调用 handler。")
+
+
+func test_policy_registry_definition_change_invalidates_existing_session() -> void:
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var added_provider: DenyingPolicyProvider = DenyingPolicyProvider.new()
+	var _configured_provider: GFPolicyProvider = added_provider.configure(
+		&"added_after_session",
+		PackedStringArray(["gf.runtime_agent.request"])
+	)
+	var _provider_registered: bool = environment.policy_registry.register_provider(added_provider)
+
+	var changed: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "policy-changed", { "message": "hello" }),
+		token
+	)
+	var revoked: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "policy-revoked", { "message": "hello" }),
+		token
+	)
+
+	assert_eq(GFVariantData.get_option_string(changed, "reason"), "policy_context_changed")
+	assert_eq(GFVariantData.get_option_string(revoked, "reason"), "invalid_credentials")
+	assert_eq(handler.call_count, 0, "策略集合改变后旧 session 不得继续执行。")
+
+
+func test_policy_signature_is_structured_and_covers_public_provider_configuration() -> void:
+	var delimiter_provider: DenyingPolicyProvider = DenyingPolicyProvider.new()
+	var _delimiter_configured: GFPolicyProvider = delimiter_provider.configure(
+		&"delimiter_sensitive_policy",
+		PackedStringArray(["gf.runtime_agent.request", "other"])
+	)
+	var _delimiter_registered: bool = environment.policy_registry.register_provider(
+		delimiter_provider
+	)
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var delimiter_session: Dictionary = _open_session(PackedStringArray(["echo"]))
+	delimiter_provider.supported_artifact_kinds = PackedStringArray([
+		"gf.runtime_agent.request,other",
+	])
+	var delimiter_result: Dictionary = environment.execute_request(
+		_make_request(
+			GFVariantData.get_option_string(delimiter_session, "session_id"),
+			"echo",
+			"policy-delimiter",
+			{ "message": "hello" }
+		),
+		GFVariantData.get_option_string(delimiter_session, "token")
+	)
+
+	var _cleared_policy_sessions: int = environment.invalidate_policy_context()
+	environment.policy_registry.clear()
+	var metadata_provider: MetadataPolicyProvider = MetadataPolicyProvider.new()
+	var _metadata_configured: GFPolicyProvider = metadata_provider.configure(
+		&"metadata_policy",
+		PackedStringArray(["gf.runtime_agent.request"]),
+		{ "allow": false }
+	)
+	var _metadata_registered: bool = environment.policy_registry.register_provider(
+		metadata_provider
+	)
+	var metadata_session: Dictionary = _open_session(PackedStringArray(["echo"]))
+	metadata_provider.metadata["allow"] = true
+	var metadata_result: Dictionary = environment.execute_request(
+		_make_request(
+			GFVariantData.get_option_string(metadata_session, "session_id"),
+			"echo",
+			"policy-metadata",
+			{ "message": "hello" }
+		),
+		GFVariantData.get_option_string(metadata_session, "token")
+	)
+	var _invalidated_public_policy: int = environment.invalidate_policy_context()
+	metadata_provider.metadata = { "unsafe": RefCounted.new() }
+	var invalid_configuration: Dictionary = environment.open_session(
+		PackedStringArray(["echo"])
+	)
+
+	assert_eq(
+		GFVariantData.get_option_string(delimiter_result, "reason"),
+		"policy_context_changed",
+		"结构化签名必须区分 kind 数组与包含逗号的单个 kind。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(metadata_result, "reason"),
+		"policy_context_changed",
+		"公开 Provider 配置改变后旧 session 不得沿用。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(invalid_configuration, "reason"),
+		"policy_configuration_invalid",
+		"非 plain-JSON Provider 配置不得参与 session 签发。"
+	)
+	assert_eq(handler.call_count, 0)
+
+
+func test_custom_policy_state_requires_explicit_context_invalidation() -> void:
+	var toggle_provider: TogglePolicyProvider = TogglePolicyProvider.new()
+	var _configured_provider: GFPolicyProvider = toggle_provider.configure(
+		&"custom_state_policy",
+		PackedStringArray(["gf.runtime_agent.request"])
+	)
+	var _provider_registered: bool = environment.policy_registry.register_provider(toggle_provider)
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var revoked_count: int = environment.invalidate_policy_context()
+	toggle_provider.allow_requests = true
+
+	var stale_result: Dictionary = environment.execute_request(
+		_make_request(
+			GFVariantData.get_option_string(opened, "session_id"),
+			"echo",
+			"custom-policy-state",
+			{ "message": "hello" }
+		),
+		GFVariantData.get_option_string(opened, "token")
+	)
+
+	assert_eq(revoked_count, 1)
+	assert_eq(GFVariantData.get_option_string(stale_result, "reason"), "invalid_credentials")
+	assert_eq(handler.call_count, 0)
+
+
+func test_non_owner_thread_cannot_mutate_or_execute_environment() -> void:
+	var _endpoint_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var target_environment: GFRuntimeAgentEnvironment = environment
+	var request: Dictionary = _make_request(
+		GFVariantData.get_option_string(opened, "session_id"),
+		"echo",
+		"worker-request",
+		{ "message": "hello" }
+	)
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var audit_before: int = GFVariantData.get_option_int(
+		environment.get_audit_events(),
+		"retained_event_count"
+	)
+	var worker: Thread = Thread.new()
+	var start_error: Error = worker.start(func() -> Dictionary:
+		target_environment.enabled = false
+		return {
+			"unregister": target_environment.unregister_endpoint("echo"),
+			"execute": target_environment.execute_request(request, token),
+			"snapshot": target_environment.get_debug_snapshot(),
+		}
+	)
+	assert_eq(start_error, OK, "跨线程拒绝测试 worker 应启动成功。")
+	if start_error != OK:
+		return
+	var worker_value: Variant = worker.wait_to_finish()
+	var worker_record: Dictionary = (
+		worker_value
+		if worker_value is Dictionary
+		else {}
+	)
+	var unregister_result: Dictionary = GFVariantData.get_option_dictionary(
+		worker_record,
+		"unregister"
+	)
+	var execute_result: Dictionary = GFVariantData.get_option_dictionary(
+		worker_record,
+		"execute"
+	)
+	var worker_snapshot: Dictionary = GFVariantData.get_option_dictionary(
+		worker_record,
+		"snapshot"
+	)
+	var audit_after: int = GFVariantData.get_option_int(
+		environment.get_audit_events(),
+		"retained_event_count"
+	)
+
+	assert_eq(
+		GFVariantData.get_option_string(unregister_result, "reason"),
+		"owner_thread_required"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(execute_result, "reason"),
+		"owner_thread_required"
+	)
+	assert_false(GFVariantData.get_option_bool(worker_snapshot, "owner_thread_access", true))
+	assert_true(environment.enabled, "跨线程 setter 不得改变启用态。")
+	assert_eq(
+		GFVariantData.get_option_int(environment.get_endpoint_catalog(), "endpoint_count"),
+		1
+	)
+	assert_eq(audit_after, audit_before, "跨线程拒绝不得写共享审计缓冲。")
+	assert_eq(handler.call_count, 0)
+
+
+func test_valid_large_and_path_like_response_strings_are_not_truncated_or_redacted() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var path_like_text: String = "C:/private/data/session.json"
+	handler.response_override = {
+		"accepted": true,
+		"echo": path_like_text,
+	}
+	var path_result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "response-path", { "message": "hello" }),
+		token
+	)
+	var large_text: String = "x".repeat(10_000)
+	handler.response_override = {
+		"accepted": true,
+		"echo": large_text,
+	}
+	var large_result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "response-large", { "message": "hello" }),
+		token
+	)
+
+	assert_eq(GFVariantData.get_option_string(
+		GFVariantData.get_option_dictionary(path_result, "response"),
+		"echo"
+	), path_like_text, "合法业务字符串不得被报告 codec 路径脱敏。")
+	assert_eq(GFVariantData.get_option_string(
+		GFVariantData.get_option_dictionary(large_result, "response"),
+		"echo"
+	).length(), large_text.length(), "预算内字符串不得被静默截断。")
+
+
+func test_handler_result_is_discarded_when_ttl_expires_during_callback() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"ttl_msec": 100,
+	})
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	handler.on_call = func() -> void:
+		environment.current_time_msec += 100
+
+	var result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "expires-in-handler", { "message": "hello" }),
+		token
+	)
+
+	assert_eq(handler.call_count, 1)
+	assert_false(GFVariantData.get_option_bool(result, "ok"))
+	assert_eq(GFVariantData.get_option_string(result, "reason"), "execution_context_changed")
+	assert_false(result.has("response"), "回调期间过期时不得发布 handler 输出。")
+
+
+func test_monotonic_clock_regression_revokes_session() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	environment.current_time_msec -= 1
+
+	var regressed: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "clock-regressed", { "message": "hello" }),
+		token
+	)
+	var revoked: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "clock-revoked", { "message": "hello" }),
+		token
+	)
+
+	assert_eq(GFVariantData.get_option_string(regressed, "reason"), "session_clock_regressed")
+	assert_eq(GFVariantData.get_option_string(revoked, "reason"), "invalid_credentials")
+	assert_eq(handler.call_count, 0, "时钟回退不得刷新窗口或延长 session。")
+
+
+func test_schema_depth_and_payload_depth_node_budgets_are_hard() -> void:
+	var nested_schema: GFDictionarySchema = _make_schema(&"agent.depth.leaf", [
+		_make_field(&"value", GFSchemaField.ValueType.STRING),
+	])
+	for index: int in range(10):
+		nested_schema = _make_schema(StringName("agent.depth.%d" % index), [
+			_make_field(&"child", GFSchemaField.ValueType.DICTIONARY, {
+				"dictionary_schema": nested_schema,
+			}),
+		])
+	var schema_result: Dictionary = environment.register_endpoint(
+		"too-deep",
+		nested_schema,
+		response_schema,
+		handler.handle
+	)
+	var _echo_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var deep_value: Variant = "leaf"
+	for index: int in range(40):
+		deep_value = { "child": deep_value }
+	var deep_result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "payload-depth", { "message": deep_value }),
+		token
+	)
+	var many_nodes: Array = []
+	for index: int in range(2_100):
+		many_nodes.append(index)
+	var node_result: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "payload-nodes", { "message": many_nodes }),
+		token
+	)
+
+	assert_false(GFVariantData.get_option_bool(schema_result, "ok"), "超深 schema 必须在注册时拒绝。")
+	assert_eq(GFVariantData.get_option_string(schema_result, "reason"), "unsafe_request_schema")
+	assert_eq(GFVariantData.get_option_string(deep_result, "reason"), "request_budget_exceeded")
+	assert_eq(GFVariantData.get_option_string(node_result, "reason"), "request_budget_exceeded")
+	assert_eq(handler.call_count, 0)
+
+
+func test_session_options_grants_and_capacity_limits_are_closed() -> void:
+	var _echo_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var empty_grants: Dictionary = environment.open_session(PackedStringArray())
+	var invalid_grant: Dictionary = environment.open_session(PackedStringArray(["bad grant"]))
+	var unknown_grant: Dictionary = environment.open_session(PackedStringArray(["missing"]))
+	var unknown_option: Dictionary = environment.open_session(
+		PackedStringArray(["echo"]),
+		{ "unknown": 1 }
+	)
+	var wrong_option_type: Dictionary = environment.open_session(
+		PackedStringArray(["echo"]),
+		{ "ttl_msec": "100" }
+	)
+	var inconsistent_limits: Dictionary = environment.open_session(
+		PackedStringArray(["echo"]),
+		{
+			"max_requests_per_window": 2,
+			"max_request_ids": 1,
+		}
+	)
+	var duplicate_grants: Dictionary = environment.open_session(
+		PackedStringArray(["echo", "echo"])
+	)
+
+	var registered_count: int = 1
+	for index: int in range(127):
+		var registration: Dictionary = environment.register_endpoint(
+			"limit-%03d" % index,
+			request_schema,
+			response_schema,
+			handler.handle
+		)
+		if GFVariantData.get_option_bool(registration, "ok"):
+			registered_count += 1
+	var endpoint_overflow: Dictionary = environment.register_endpoint(
+		"limit-overflow",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	var opened_count: int = 1
+	for _index: int in range(31):
+		var opened: Dictionary = environment.open_session(PackedStringArray(["echo"]))
+		if GFVariantData.get_option_bool(opened, "ok"):
+			opened_count += 1
+	var session_overflow: Dictionary = environment.open_session(PackedStringArray(["echo"]))
+
+	assert_eq(GFVariantData.get_option_string(empty_grants, "reason"), "empty_endpoint_grants")
+	assert_eq(GFVariantData.get_option_string(invalid_grant, "reason"), "invalid_endpoint_grant")
+	assert_eq(GFVariantData.get_option_string(unknown_grant, "reason"), "unknown_endpoint_grant")
+	assert_eq(GFVariantData.get_option_string(unknown_option, "reason"), "invalid_session_options")
+	assert_eq(GFVariantData.get_option_string(wrong_option_type, "reason"), "invalid_session_options")
+	assert_eq(GFVariantData.get_option_string(inconsistent_limits, "reason"), "invalid_session_options")
+	assert_true(GFVariantData.get_option_bool(duplicate_grants, "ok"))
+	assert_eq(
+		GFVariantData.get_option_array(duplicate_grants, "endpoint_ids").size(),
+		1,
+		"重复 grant 应规范化为唯一的精确授权。"
+	)
+	assert_eq(registered_count, 128)
+	assert_eq(GFVariantData.get_option_string(endpoint_overflow, "reason"), "endpoint_limit_reached")
+	assert_eq(opened_count, 32)
+	assert_eq(GFVariantData.get_option_string(session_overflow, "reason"), "session_limit_reached")
+
+
+func test_close_session_requires_the_token_and_removes_credentials() -> void:
+	var _registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	environment.enabled = true
+	var first_opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var second_opened: Dictionary = _open_session(PackedStringArray(["echo"]))
+	var token: String = GFVariantData.get_option_string(first_opened, "token")
+	var session_id: String = GFVariantData.get_option_string(first_opened, "session_id")
+
+	var wrong_token: Dictionary = environment.close_session(session_id, "0".repeat(64))
+	var closed: Dictionary = environment.close_session(session_id, token)
+	var after_close: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "after-close", { "message": "hello" }),
+		token
+	)
+
+	assert_ne(
+		GFVariantData.get_option_string(first_opened, "token"),
+		GFVariantData.get_option_string(second_opened, "token"),
+		"独立 session 不得复用 bearer token。"
+	)
+	assert_eq(GFVariantData.get_option_string(wrong_token, "reason"), "invalid_credentials")
+	assert_true(GFVariantData.get_option_bool(closed, "ok"))
+	assert_eq(GFVariantData.get_option_string(after_close, "reason"), "invalid_credentials")
+	assert_eq(handler.call_count, 0)
+
+
+func test_authenticated_rejections_consume_rate_budget_and_replay_cache_never_evicts() -> void:
+	var secondary_handler: RecordingHandler = RecordingHandler.new()
+	var _echo_registered: Dictionary = environment.register_endpoint(
+		"echo",
+		request_schema,
+		response_schema,
+		handler.handle
+	)
+	var _secondary_registered: Dictionary = environment.register_endpoint(
+		"secondary",
+		request_schema,
+		response_schema,
+		secondary_handler.handle
+	)
+	environment.enabled = true
+	var opened: Dictionary = _open_session(PackedStringArray(["echo"]), {
+		"ttl_msec": 1_000,
+		"max_requests_per_window": 3,
+		"rate_window_msec": 100,
+		"max_request_ids": 3,
+	})
+	var token: String = GFVariantData.get_option_string(opened, "token")
+	var session_id: String = GFVariantData.get_option_string(opened, "session_id")
+	var unauthorized: Dictionary = environment.execute_request(
+		_make_request(session_id, "secondary", "rate-unauthorized", { "message": "hello" }),
+		token
+	)
+	var invalid_schema_request: Dictionary = _make_request(
+		session_id,
+		"echo",
+		"rate-invalid",
+		{
+			"message": "hello",
+			"extra": true,
+		}
+	)
+	var invalid_schema: Dictionary = environment.execute_request(invalid_schema_request, token)
+	var replay: Dictionary = environment.execute_request(invalid_schema_request, token)
+	var limited: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "rate-valid", { "message": "hello" }),
+		token
+	)
+	environment.current_time_msec += 101
+	var first: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "cache-1", { "message": "one" }),
+		token
+	)
+	var second: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "cache-2", { "message": "two" }),
+		token
+	)
+	var exhausted: Dictionary = environment.execute_request(
+		_make_request(session_id, "echo", "cache-3", { "message": "three" }),
+		token
+	)
+	environment.current_time_msec += 101
+	var old_replay: Dictionary = environment.execute_request(invalid_schema_request, token)
+
+	assert_eq(GFVariantData.get_option_string(unauthorized, "reason"), "endpoint_not_granted")
+	assert_eq(GFVariantData.get_option_string(invalid_schema, "reason"), "request_schema_rejected")
+	assert_eq(GFVariantData.get_option_string(replay, "reason"), "request_replayed")
+	assert_eq(GFVariantData.get_option_string(limited, "reason"), "rate_limited", "已认证拒绝也应消耗限流预算。")
+	assert_true(GFVariantData.get_option_bool(first, "ok"))
+	assert_true(GFVariantData.get_option_bool(second, "ok"))
+	assert_eq(GFVariantData.get_option_string(exhausted, "reason"), "request_id_budget_exhausted")
+	assert_eq(GFVariantData.get_option_string(old_replay, "reason"), "request_replayed", "满载后旧 request id 仍不得重放。")
+	assert_eq(handler.call_count, 2)
+
+
+func _open_session(endpoint_ids: PackedStringArray, options: Dictionary = {}) -> Dictionary:
+	var result: Dictionary = environment.open_session(endpoint_ids, options)
+	assert_true(GFVariantData.get_option_bool(result, "ok"), "测试前置 session 应成功创建。")
+	return result
+
+
+func _make_request(
+	session_id: String,
+	endpoint_id: String,
+	request_id: String,
+	payload: Dictionary
+) -> Dictionary:
+	return {
+		"protocol_version": GFRuntimeAgentEnvironment.PROTOCOL_VERSION,
+		"session_id": session_id,
+		"endpoint_id": endpoint_id,
+		"request_id": request_id,
+		"payload": payload,
+	}
+
+
+func _make_schema(
+	schema_id: StringName,
+	fields: Array[GFSchemaField] = []
+) -> GFDictionarySchema:
+	var schema: GFDictionarySchema = GFDictionarySchema.new()
+	return schema.configure(schema_id, fields, {
+		"allow_extra_fields": false,
+		"coerce_values": false,
+		"fail_on_coerce_error": true,
+	})
+
+
+func _make_field(
+	field_name: StringName,
+	value_type: GFSchemaField.ValueType,
+	options: Dictionary = {}
+) -> GFSchemaField:
+	var field: GFSchemaField = GFSchemaField.new()
+	return field.configure(field_name, value_type, options)
+
+
+class ManualClockEnvironment extends GFRuntimeAgentEnvironment:
+	var current_time_msec: int = 0
+
+
+	func _get_current_time_msec() -> int:
+		return current_time_msec
+
+
+class RecordingHandler extends RefCounted:
+	var call_count: int = 0
+	var last_request: Dictionary = {}
+	var response_override: Dictionary = {}
+	var raw_response_override: Variant = null
+	var use_raw_response_override: bool = false
+	var on_call: Callable = Callable()
+	var nested_result: Dictionary = {}
+
+
+	func handle(request: Dictionary) -> Variant:
+		call_count += 1
+		last_request = request.duplicate(true)
+		if on_call.is_valid():
+			on_call.call()
+		if use_raw_response_override:
+			return raw_response_override
+		if not response_override.is_empty():
+			return response_override.duplicate(true)
+		var payload: Dictionary = GFVariantData.get_option_dictionary(request, "payload")
+		return {
+			"accepted": true,
+			"echo": GFVariantData.get_option_string(payload, "message"),
+		}
+
+
+class DenyingPolicyProvider extends GFPolicyProvider:
+	func _evaluate_policy(artifact: Dictionary, _context: Dictionary) -> Dictionary:
+		return make_result(false, &"failed", artifact, [
+			{
+				"kind": "denied",
+				"message": "Denied by test policy.",
+			},
+		])
+
+
+class DisablingSessionPolicyProvider extends GFPolicyProvider:
+	var environment: GFRuntimeAgentEnvironment = null
+
+
+	func _evaluate_policy(artifact: Dictionary, _context: Dictionary) -> Dictionary:
+		if environment != null:
+			environment.enabled = false
+		return make_result(true, &"passed", artifact)
+
+
+class MetadataPolicyProvider extends GFPolicyProvider:
+	func _evaluate_policy(artifact: Dictionary, _context: Dictionary) -> Dictionary:
+		var allowed: bool = GFVariantData.get_option_bool(metadata, "allow")
+		return make_result(allowed, &"passed" if allowed else &"denied", artifact)
+
+
+class TogglePolicyProvider extends GFPolicyProvider:
+	var allow_requests: bool = false
+
+
+	func _evaluate_policy(artifact: Dictionary, _context: Dictionary) -> Dictionary:
+		return make_result(
+			allow_requests,
+			&"passed" if allow_requests else &"denied",
+			artifact
+		)
+
+
+class MutatingPolicyProvider extends GFPolicyProvider:
+	var environment: GFRuntimeAgentEnvironment = null
+	var session_id: String = ""
+	var revoke_session: bool = false
+
+
+	func _evaluate_policy(artifact: Dictionary, _context: Dictionary) -> Dictionary:
+		var payload: Dictionary = GFVariantData.get_option_dictionary(artifact, "payload")
+		payload["message"] = "mutated-by-policy"
+		if revoke_session and environment != null:
+			var _revoked: bool = environment.revoke_session(session_id)
+		return make_result(true, &"passed", artifact)

--- a/tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd.uid
+++ b/tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd.uid
@@ -1,0 +1,1 @@
+uid://v8ymwn3vdqwj


### PR DESCRIPTION
## Summary

- add the optional `gf.standard.agent_environment` package and `GFRuntimeAgentEnvironment`
- expose only explicitly registered, closed-schema synchronous endpoints through exact short-lived session grants
- enforce hashed bearer credentials, TTL, fixed-window rate limits, session-wide replay protection, endpoint generations, bounded plain-JSON input/output, policy checks, and payload-free audit events
- bind each environment to its creation thread and fail closed for cross-thread calls; provide `invalidate_policy_context()` for mutable or external policy state
- add package mapping, AI Developer Kit capability/recipe entries, Chinese integration guidance, changelog coverage, and generated API reference

## Security boundary

This is a transport-neutral in-process protocol boundary, not an OS sandbox. It does not provide networking, model SDK integration, arbitrary reflection, file/shell execution, screenshots, transport authentication, or business authorization. Transport adapters must enforce pre-decode body and connection limits and marshal calls back to the environment owner thread.

## Validation

- Runtime Agent focused GUT: 34/34 tests, 251 assertions
- API Surface focused GUT: 26/26 tests, 4,223 assertions
- Quick suite: 22/22 checks
- Framework static suite: 17/17 checks
- Full suite (`--jobs 3`): 34/34 checks
- full-project Godot import, warnings, and strict LSP: 1,177 files, 0 diagnostics
- selected package Godot smoke: 2/2 scenarios, 0 issues, 0 exit-leak warnings
- MkDocs strict, API/AI generated-source freshness, project-settings drift, diff check, path hygiene, and log hygiene
- independent standards, security, and verification audits completed with no remaining blocking findings