### PR TITLE
Add shared weak method invocation primitive

### DIFF
--- a/addons/gf/kernel/core/gf_weak_method_invocation.gd
+++ b/addons/gf/kernel/core/gf_weak_method_invocation.gd
@@ -1,0 +1,171 @@
+## GFWeakMethodInvocation: 不强持有目标对象的方法调用记录。
+##
+## 记录只保留目标的 WeakRef、创建时实例 ID 与方法名，并在调用时接收参数。
+## 它不会保存 Callable，因此目标为 RefCounted 时不会被绑定回调意外延长生命周期。
+## `invoked` 只表示方法通过定义与参数数量预检且 Object.callv() 已返回；GDScript
+## 无法捕获 callv 期间的类型错误或被调方法内部错误，因此这类错误不会转换为 `failed`。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+## [br]
+## @layer kernel/core
+class_name GFWeakMethodInvocation
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 方法已被调用并返回。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVOKED: StringName = &"invoked"
+
+## 目标对象已释放。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_OWNER_RELEASED: StringName = &"owner_released"
+
+## 目标对象不再提供记录的方法。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_METHOD_MISSING: StringName = &"method_missing"
+
+## 调用记录或参数未通过显式预检。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_FAILED: StringName = &"failed"
+
+
+# --- 私有变量 ---
+
+var _owner_ref: WeakRef = null
+var _initial_owner_instance_id: int = 0
+var _method_name: StringName = &""
+
+
+# --- Godot 生命周期方法 ---
+
+## 创建弱方法调用记录。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner: 调用目标；无效目标会构造一个始终返回 failed 的记录。
+## [br]
+## @param method_name: 调用时解析的方法名；空名称会构造一个始终返回 failed 的记录。
+func _init(owner: Object = null, method_name: StringName = &"") -> void:
+	_method_name = method_name
+	if owner == null or not is_instance_valid(owner):
+		return
+	_owner_ref = weakref(owner)
+	_initial_owner_instance_id = owner.get_instance_id()
+
+
+# --- 公共方法 ---
+
+## 调用仍存活目标上的记录方法。
+## [br]
+## 参数只在本次调用期间使用，不会保存到调用记录。返回 `invoked` 只代表定义与参数
+## 数量预检通过且 callv 已返回，不代表 callv 期间没有类型错误或被调方法内部错误。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param arguments: 传给 Object.callv() 的调用时参数数组。
+## [br]
+## @schema arguments: Array of invocation-time arguments; values are never retained by this record.
+## [br]
+## @return 调用状态、返回值与稳定目标身份。
+## [br]
+## @schema return: Dictionary with status, invoked, value, error_code, initial_owner_instance_id, and method_name.
+func invoke(arguments: Array = []) -> Dictionary:
+	if not _has_valid_definition():
+		return _make_result(STATUS_FAILED, null, ERR_INVALID_PARAMETER)
+
+	var owner_value: Variant = _owner_ref.get_ref()
+	if not (owner_value is Object):
+		return _make_result(STATUS_OWNER_RELEASED, null, ERR_DOES_NOT_EXIST)
+	var owner: Object = owner_value
+	if not is_instance_valid(owner):
+		return _make_result(STATUS_OWNER_RELEASED, null, ERR_DOES_NOT_EXIST)
+	if owner.get_instance_id() != _initial_owner_instance_id:
+		return _make_result(STATUS_OWNER_RELEASED, null, ERR_DOES_NOT_EXIST)
+	if not owner.has_method(_method_name):
+		return _make_result(STATUS_METHOD_MISSING, null, ERR_DOES_NOT_EXIST)
+	var argument_validation_error: Error = _validate_argument_count(owner, arguments.size())
+	if argument_validation_error != OK:
+		return _make_result(STATUS_FAILED, null, argument_validation_error)
+
+	var value: Variant = owner.callv(_method_name, arguments)
+	return _make_result(STATUS_INVOKED, value, OK)
+
+
+# --- 私有/辅助方法 ---
+
+func _has_valid_definition() -> bool:
+	return (
+		_owner_ref != null
+		and _initial_owner_instance_id != 0
+		and not _method_name.is_empty()
+	)
+
+
+func _make_result(status: StringName, value: Variant, error_code: Error) -> Dictionary:
+	return {
+		"status": status,
+		"invoked": status == STATUS_INVOKED,
+		"value": value,
+		"error_code": error_code,
+		"initial_owner_instance_id": _initial_owner_instance_id,
+		"method_name": _method_name,
+	}
+
+
+func _validate_argument_count(owner: Object, argument_count: int) -> Error:
+	var found_valid_signature: bool = false
+	for method_record: Dictionary in owner.get_method_list():
+		var raw_method_name: Variant = method_record.get("name", &"")
+		var candidate_method_name: StringName = &""
+		if raw_method_name is StringName:
+			candidate_method_name = raw_method_name
+		elif raw_method_name is String:
+			var method_name_text: String = raw_method_name
+			candidate_method_name = StringName(method_name_text)
+		if candidate_method_name != _method_name:
+			continue
+
+		var raw_method_arguments: Variant = method_record.get("args", [])
+		var raw_default_arguments: Variant = method_record.get("default_args", [])
+		if not (raw_method_arguments is Array) or not (raw_default_arguments is Array):
+			continue
+		var method_arguments: Array = raw_method_arguments
+		var default_arguments: Array = raw_default_arguments
+		if default_arguments.size() > method_arguments.size():
+			continue
+
+		var required_count: int = method_arguments.size() - default_arguments.size()
+		var raw_method_flags: Variant = method_record.get("flags", 0)
+		if not (raw_method_flags is int):
+			continue
+		var method_flags: int = raw_method_flags
+		var accepts_varargs: bool = (method_flags & METHOD_FLAG_VARARG) != 0
+		found_valid_signature = true
+		if argument_count < required_count:
+			continue
+		if not accepts_varargs and argument_count > method_arguments.size():
+			continue
+		return OK
+	return ERR_INVALID_PARAMETER if found_valid_signature else ERR_INVALID_DATA

--- a/addons/gf/kernel/core/gf_weak_method_invocation.gd.uid
+++ b/addons/gf/kernel/core/gf_weak_method_invocation.gd.uid
@@ -1,0 +1,1 @@
+uid://bj8gxlbp76ts1

--- a/addons/gf/standard/common/gf_deferred_mutation_queue.gd
+++ b/addons/gf/standard/common/gf_deferred_mutation_queue.gd
@@ -1,8 +1,8 @@
 ## GFDeferredMutationQueue: 确定性延迟变更队列。
 ##
 ## 用于把运行时或工具流程中收集到的状态变更延迟到显式 playback 点执行。
-## 队列只保存 Callable、排序信息和诊断 metadata，不解释调用方的实体、组件、
-## 节点或资源语义。
+## record() 保存无 owner 的强 Callable；record_method() 通过弱 owner 和方法名
+## 保存生命周期调用。队列不解释调用方的实体、组件、节点或资源语义。
 ## [br]
 ## @api public
 ## [br]
@@ -21,6 +21,9 @@ extends GFUtility
 ## [br]
 ## @since 7.0.0
 const DEFAULT_PHASE: StringName = &"default"
+
+const _RECORD_KIND_CALLABLE: StringName = &"callable"
+const _RECORD_KIND_WEAK_METHOD: StringName = &"weak_method"
 
 
 # --- 公共变量 ---
@@ -79,35 +82,12 @@ func dispose() -> void:
 
 # --- 公共方法 ---
 
-## 记录一条延迟变更。
+## 记录一条无 owner 的延迟变更。
+## 该入口会强持有 mutation；需要绑定 owner 生命周期时使用 record_method()。
 ## [br]
 ## @api public
 ## [br]
 ## @since 7.0.0
-## [br]
-## @param mutation: playback() 时执行的回调。
-## [br]
-## @param options: 记录选项，支持 phase、sort_key、order、label、metadata 和 owner。
-## [br]
-## @schema options: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary、owner: Object。
-## [br]
-## @return 变更句柄；mutation 无效时返回 0。
-func record(mutation: Callable, options: Dictionary = {}) -> int:
-	if not mutation.is_valid():
-		push_error("[GFDeferredMutationQueue] record 失败：mutation 无效。")
-		return 0
-
-	var owner: Object = _variant_to_object(GFVariantData.get_option_value(options, "owner"))
-	return _enqueue(mutation, owner, options)
-
-
-## 记录一条绑定 owner 的延迟变更。owner 释放后变更会在 playback() 时跳过。
-## [br]
-## @api public
-## [br]
-## @since 7.0.0
-## [br]
-## @param owner: 变更拥有者。
 ## [br]
 ## @param mutation: playback() 时执行的回调。
 ## [br]
@@ -115,16 +95,49 @@ func record(mutation: Callable, options: Dictionary = {}) -> int:
 ## [br]
 ## @schema options: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary。
 ## [br]
-## @return 变更句柄；参数无效时返回 0。
-func record_owned(owner: Object, mutation: Callable, options: Dictionary = {}) -> int:
-	if owner == null:
-		push_error("[GFDeferredMutationQueue] record_owned 失败：owner 为空。")
-		return 0
+## @return 变更句柄；mutation 无效时返回 0。
+func record(mutation: Callable, options: Dictionary = {}) -> int:
 	if not mutation.is_valid():
-		push_error("[GFDeferredMutationQueue] record_owned 失败：mutation 无效。")
+		push_error("[GFDeferredMutationQueue] record 失败：mutation 无效。")
+		return 0
+	if options.has("owner") or options.has(&"owner"):
+		push_error("[GFDeferredMutationQueue] record 失败：owner 选项已移除，请使用 record_method()。")
 		return 0
 
-	return _enqueue(mutation, owner, options)
+	return _enqueue(mutation, options)
+
+
+## 通过弱引用 owner 与方法名记录延迟变更。
+## 队列不会保存 owner、Callable 或任意持久调用参数的强引用。为避免 metadata
+## 间接保活 owner，安全入口只保存 phase、sort_key、order 和 label 选项。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner: 变更拥有者。
+## [br]
+## @param method_name: playback() 时调用的 owner 方法名。
+## [br]
+## @param options: 记录选项，支持 phase、sort_key、order 和 label。
+## [br]
+## @schema options: Dictionary，可包含 phase: StringName、sort_key: int、order: int 和 label: String；不会保存 metadata。
+## [br]
+## @return 变更句柄；参数无效时返回 0。
+func record_method(
+	owner: Object,
+	method_name: StringName,
+	options: Dictionary = {}
+) -> int:
+	if owner == null or not is_instance_valid(owner):
+		push_error("[GFDeferredMutationQueue] record_method 失败：owner 无效。")
+		return 0
+	if method_name == &"":
+		push_error("[GFDeferredMutationQueue] record_method 失败：method_name 为空。")
+		return 0
+
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(owner, method_name)
+	return _enqueue_method(invocation, owner.get_instance_id(), options)
 
 
 ## 按 phase、sort_key、order 和记录句柄的稳定顺序应用延迟变更。
@@ -162,9 +175,33 @@ func playback(options: Dictionary = {}) -> Dictionary:
 		if mutation_record.is_empty():
 			break
 
-		if _record_owner_is_released(mutation_record):
-			skipped_owner_now += 1
-			_skipped_owner_count += 1
+		if _record_uses_weak_method(mutation_record):
+			var invocation: GFWeakMethodInvocation = _get_record_weak_method_invocation(mutation_record)
+			if invocation == null:
+				failed_now += 1
+				_failed_count += 1
+				processed_records.append(_record_to_snapshot(mutation_record))
+				continue
+
+			var invocation_result: Dictionary = invocation.invoke()
+			var invocation_status: StringName = GFVariantData.get_option_string_name(
+				invocation_result,
+				"status"
+			)
+			if invocation_status == GFWeakMethodInvocation.STATUS_OWNER_RELEASED:
+				skipped_owner_now += 1
+				_skipped_owner_count += 1
+			elif invocation_status != GFWeakMethodInvocation.STATUS_INVOKED:
+				failed_now += 1
+				_failed_count += 1
+			elif _mutation_result_is_failure(
+				GFVariantData.get_option_value(invocation_result, "value")
+			):
+				failed_now += 1
+				_failed_count += 1
+			else:
+				applied_now += 1
+				_applied_count += 1
 			processed_records.append(_record_to_snapshot(mutation_record))
 			continue
 
@@ -237,7 +274,7 @@ func preview(options: Dictionary = {}) -> Array[Dictionary]:
 ## [br]
 ## @since 7.0.0
 ## [br]
-## @param handle: record() 返回的变更句柄。
+## @param handle: record() 或 record_method() 返回的变更句柄。
 ## [br]
 ## @return 找到并取消时返回 true。
 func cancel(handle: int) -> bool:
@@ -255,7 +292,7 @@ func cancel(handle: int) -> bool:
 	return false
 
 
-## 取消指定 owner 绑定的全部待应用变更。
+## 取消指定 owner 的全部待应用弱方法调用。
 ## [br]
 ## @api public
 ## [br]
@@ -265,7 +302,7 @@ func cancel(handle: int) -> bool:
 ## [br]
 ## @return 取消数量。
 func cancel_owner(owner: Object) -> int:
-	if owner == null:
+	if owner == null or not is_instance_valid(owner):
 		return 0
 
 	var owner_id: int = owner.get_instance_id()
@@ -362,25 +399,51 @@ func get_debug_snapshot() -> Dictionary:
 
 # --- 私有/辅助方法 ---
 
-func _enqueue(mutation: Callable, owner: Object, options: Dictionary) -> int:
+func _enqueue(mutation: Callable, options: Dictionary) -> int:
+	return _enqueue_record({
+		"record_kind": _RECORD_KIND_CALLABLE,
+		"mutation": mutation,
+	}, 0, options, true)
+
+
+func _enqueue_method(
+	invocation: GFWeakMethodInvocation,
+	owner_id: int,
+	options: Dictionary
+) -> int:
+	return _enqueue_record({
+		"record_kind": _RECORD_KIND_WEAK_METHOD,
+		"weak_method_invocation": invocation,
+	}, owner_id, options, false)
+
+
+func _enqueue_record(
+	execution_record: Dictionary,
+	owner_id: int,
+	options: Dictionary,
+	persist_metadata: bool
+) -> int:
 	_mutex.lock()
 	var handle: int = _next_handle
 	_next_handle += 1
 	var order: int = GFVariantData.get_option_int(options, "order", _next_order)
 	if not options.has("order"):
 		_next_order += 1
+	var metadata: Dictionary = {}
+	if persist_metadata:
+		metadata = GFVariantData.get_option_dictionary(options, "metadata").duplicate(true)
 	var mutation_record: Dictionary = {
 		"handle": handle,
-		"mutation": mutation,
-		"owner_ref": weakref(owner) if owner != null else null,
-		"owner_id": owner.get_instance_id() if owner != null else 0,
+		"owner_id": owner_id,
 		"phase": GFVariantData.get_option_string_name(options, "phase", DEFAULT_PHASE),
 		"sort_key": GFVariantData.get_option_int(options, "sort_key"),
 		"order": order,
 		"label": GFVariantData.get_option_string(options, "label"),
-		"metadata": GFVariantData.get_option_dictionary(options, "metadata").duplicate(true),
+		"metadata": metadata,
 		"recorded_msec": Time.get_ticks_msec(),
 	}
+	for execution_key: Variant in execution_record:
+		mutation_record[execution_key] = execution_record[execution_key]
 	_insert_record_sorted(mutation_record)
 	_recorded_count += 1
 	_mutex.unlock()
@@ -423,11 +486,6 @@ func _is_playback_budget_exhausted(started_usec: int, max_seconds: float, proces
 	return elapsed_seconds >= max_seconds
 
 
-func _record_owner_is_released(mutation_record: Dictionary) -> bool:
-	var owner_ref: WeakRef = _get_record_owner_ref(mutation_record)
-	return owner_ref != null and owner_ref.get_ref() == null
-
-
 func _mutation_result_is_failure(result: Variant) -> bool:
 	if result is bool:
 		var bool_result: bool = result
@@ -436,6 +494,13 @@ func _mutation_result_is_failure(result: Variant) -> bool:
 		var dictionary_result: Dictionary = result
 		return not GFVariantData.get_option_bool(dictionary_result, "ok", true)
 	return false
+
+
+func _record_uses_weak_method(mutation_record: Dictionary) -> bool:
+	return (
+		GFVariantData.get_option_string_name(mutation_record, "record_kind")
+		== _RECORD_KIND_WEAK_METHOD
+	)
 
 
 func _record_to_snapshot(mutation_record: Dictionary) -> Dictionary:
@@ -503,16 +568,14 @@ func _get_record_mutation(mutation_record: Dictionary) -> Callable:
 	return Callable()
 
 
-func _get_record_owner_ref(mutation_record: Dictionary) -> WeakRef:
-	var value: Variant = GFVariantData.get_option_value(mutation_record, "owner_ref")
-	if value is WeakRef:
-		var owner_ref: WeakRef = value
-		return owner_ref
-	return null
-
-
-func _variant_to_object(value: Variant) -> Object:
-	if value is Object:
-		var object_value: Object = value
-		return object_value
+func _get_record_weak_method_invocation(
+	mutation_record: Dictionary
+) -> GFWeakMethodInvocation:
+	var value: Variant = GFVariantData.get_option_value(
+		mutation_record,
+		"weak_method_invocation"
+	)
+	if value is GFWeakMethodInvocation:
+		var invocation: GFWeakMethodInvocation = value
+		return invocation
 	return null

--- a/addons/gf/standard/common/gf_main_thread_dispatch_queue.gd
+++ b/addons/gf/standard/common/gf_main_thread_dispatch_queue.gd
@@ -1,7 +1,8 @@
 ## GFMainThreadDispatchQueue: 主线程回调派发队列。
 ##
 ## 用于让后台线程、资源加载回调或项目侧异步流程把最终应用逻辑排回主线程。
-## 队列只保存和派发 Callable，不创建线程、不校验线程身份，也不解释调用方的业务语义。
+## post() 保存无 owner 的强 Callable；post_method() 通过弱 owner 和方法名保存生命周期调用。
+## 队列不创建线程、不校验线程身份，也不解释调用方的业务语义。
 ## [br]
 ## @api public
 ## [br]
@@ -80,35 +81,12 @@ func dispose() -> void:
 
 # --- 公共方法 ---
 
-## 把回调加入主线程派发队列。
+## 把无 owner 的回调加入主线程派发队列。
+## 该入口会强持有 callback；需要绑定 owner 生命周期时使用 post_method()。
 ## [br]
 ## @api public
 ## [br]
 ## @since 7.0.0
-## [br]
-## @param callback: 需要在显式派发点执行的回调。
-## [br]
-## @param options: 队列选项，支持 owner、metadata、label 和 front。
-## [br]
-## @schema options: Dictionary，可包含 owner: Object、metadata: Dictionary、label: String、front: bool。
-## [br]
-## @return 派发句柄；callback 无效时返回 0。
-func post(callback: Callable, options: Dictionary = {}) -> int:
-	if not callback.is_valid():
-		push_error("[GFMainThreadDispatchQueue] post 失败：callback 无效。")
-		return 0
-
-	var owner: Object = _variant_to_object(GFVariantData.get_option_value(options, "owner"))
-	return _enqueue(callback, owner, options)
-
-
-## 把 owner 绑定回调加入主线程派发队列。owner 释放后回调会被跳过。
-## [br]
-## @api public
-## [br]
-## @since 7.0.0
-## [br]
-## @param owner: 回调拥有者。
 ## [br]
 ## @param callback: 需要在显式派发点执行的回调。
 ## [br]
@@ -116,16 +94,44 @@ func post(callback: Callable, options: Dictionary = {}) -> int:
 ## [br]
 ## @schema options: Dictionary，可包含 metadata: Dictionary、label: String、front: bool。
 ## [br]
-## @return 派发句柄；参数无效时返回 0。
-func post_owned(owner: Object, callback: Callable, options: Dictionary = {}) -> int:
-	if owner == null:
-		push_error("[GFMainThreadDispatchQueue] post_owned 失败：owner 为空。")
-		return 0
+## @return 派发句柄；callback 无效时返回 0。
+func post(callback: Callable, options: Dictionary = {}) -> int:
 	if not callback.is_valid():
-		push_error("[GFMainThreadDispatchQueue] post_owned 失败：callback 无效。")
+		push_error("[GFMainThreadDispatchQueue] post 失败：callback 无效。")
+		return 0
+	if options.has("owner") or options.has(&"owner"):
+		push_error("[GFMainThreadDispatchQueue] post 失败：owner 选项已移除，请使用 post_method()。")
 		return 0
 
-	return _enqueue(callback, owner, options)
+	return _enqueue(callback, options)
+
+
+## 把弱 owner 方法调用加入主线程派发队列。
+## 队列只保存 owner 的弱引用与方法名，不保存绑定 Callable、调用参数或 owner 强引用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner: 方法调用拥有者。
+## [br]
+## @param method_name: 派发时调用的方法名。
+## [br]
+## @param options: 队列选项，支持 label 和 front。
+## [br]
+## @schema options: Dictionary，可包含 label: String、front: bool。
+## [br]
+## @return 派发句柄；owner 或 method_name 无效时返回 0。
+func post_method(owner: Object, method_name: StringName, options: Dictionary = {}) -> int:
+	if owner == null or not is_instance_valid(owner):
+		push_error("[GFMainThreadDispatchQueue] post_method 失败：owner 为空或已释放。")
+		return 0
+	if method_name == &"":
+		push_error("[GFMainThreadDispatchQueue] post_method 失败：method_name 为空。")
+		return 0
+
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(owner, method_name)
+	return _enqueue_method(invocation, owner.get_instance_id(), options)
 
 
 ## 派发队列中的回调。
@@ -159,9 +165,28 @@ func dispatch(max_count: int = 0, max_seconds: float = 0.0) -> Dictionary:
 		if record.is_empty():
 			break
 
-		if _record_owner_is_released(record):
-			skipped_owner_now += 1
-			_skipped_owner_count += 1
+		var invocation: GFWeakMethodInvocation = _get_record_method_invocation(record)
+		if invocation != null:
+			var invocation_report: Dictionary = invocation.invoke()
+			var invocation_status: StringName = GFVariantData.get_option_string_name(
+				invocation_report,
+				"status",
+				GFWeakMethodInvocation.STATUS_FAILED
+			)
+			if invocation_status == GFWeakMethodInvocation.STATUS_OWNER_RELEASED:
+				skipped_owner_now += 1
+				_skipped_owner_count += 1
+			elif invocation_status != GFWeakMethodInvocation.STATUS_INVOKED:
+				failed_now += 1
+				_failed_count += 1
+			elif _callback_result_is_failure(
+				GFVariantData.get_option_value(invocation_report, "value")
+			):
+				failed_now += 1
+				_failed_count += 1
+			else:
+				dispatched_now += 1
+				_dispatched_count += 1
 			continue
 
 		var callback: Callable = _get_record_callback(record)
@@ -194,7 +219,7 @@ func dispatch(max_count: int = 0, max_seconds: float = 0.0) -> Dictionary:
 ## [br]
 ## @since 7.0.0
 ## [br]
-## @param handle: post() 返回的派发句柄。
+## @param handle: post() 或 post_method() 返回的派发句柄。
 ## [br]
 ## @return 找到并取消时返回 true。
 func cancel(handle: int) -> bool:
@@ -212,7 +237,7 @@ func cancel(handle: int) -> bool:
 	return false
 
 
-## 取消指定 owner 绑定的全部待派发回调。
+## 取消指定 owner 的全部待派发弱方法调用。
 ## [br]
 ## @api public
 ## [br]
@@ -222,7 +247,7 @@ func cancel(handle: int) -> bool:
 ## [br]
 ## @return 取消数量。
 func cancel_owner(owner: Object) -> int:
-	if owner == null:
+	if owner == null or not is_instance_valid(owner):
 		return 0
 
 	var owner_id: int = owner.get_instance_id()
@@ -340,17 +365,40 @@ func get_debug_snapshot() -> Dictionary:
 
 # --- 私有/辅助方法 ---
 
-func _enqueue(callback: Callable, owner: Object, options: Dictionary) -> int:
+func _enqueue(callback: Callable, options: Dictionary) -> int:
 	_mutex.lock()
 	var handle: int = _next_handle
 	_next_handle += 1
 	var record: Dictionary = {
 		"handle": handle,
 		"callback": callback,
-		"owner_ref": weakref(owner) if owner != null else null,
-		"owner_id": owner.get_instance_id() if owner != null else 0,
+		"owner_id": 0,
 		"label": GFVariantData.get_option_string(options, "label"),
 		"metadata": GFVariantData.get_option_dictionary(options, "metadata"),
+		"posted_msec": Time.get_ticks_msec(),
+	}
+	if GFVariantData.get_option_bool(options, "front", false):
+		_queue.push_front(record)
+	else:
+		_queue.append(record)
+	_posted_count += 1
+	_mutex.unlock()
+	return handle
+
+
+func _enqueue_method(
+	invocation: GFWeakMethodInvocation,
+	owner_id: int,
+	options: Dictionary
+) -> int:
+	_mutex.lock()
+	var handle: int = _next_handle
+	_next_handle += 1
+	var record: Dictionary = {
+		"handle": handle,
+		"invocation": invocation,
+		"owner_id": owner_id,
+		"label": GFVariantData.get_option_string(options, "label"),
 		"posted_msec": Time.get_ticks_msec(),
 	}
 	if GFVariantData.get_option_bool(options, "front", false):
@@ -379,11 +427,6 @@ func _is_dispatch_budget_exhausted(started_usec: int, max_seconds: float, proces
 	return elapsed_seconds >= max_seconds
 
 
-func _record_owner_is_released(record: Dictionary) -> bool:
-	var owner_ref: WeakRef = _get_record_owner_ref(record)
-	return owner_ref != null and owner_ref.get_ref() == null
-
-
 func _callback_result_is_failure(result: Variant) -> bool:
 	if result is bool:
 		var bool_result: bool = result
@@ -410,16 +453,9 @@ func _get_record_callback(record: Dictionary) -> Callable:
 	return Callable()
 
 
-func _get_record_owner_ref(record: Dictionary) -> WeakRef:
-	var value: Variant = GFVariantData.get_option_value(record, "owner_ref")
-	if value is WeakRef:
-		var owner_ref: WeakRef = value
-		return owner_ref
-	return null
-
-
-func _variant_to_object(value: Variant) -> Object:
-	if value is Object:
-		var object_value: Object = value
-		return object_value
+func _get_record_method_invocation(record: Dictionary) -> GFWeakMethodInvocation:
+	var value: Variant = GFVariantData.get_option_value(record, "invocation")
+	if value is GFWeakMethodInvocation:
+		var invocation: GFWeakMethodInvocation = value
+		return invocation
 	return null

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "17494b7a571932682fc9733fda14eef6ea4c2b09d43709367da74095bb1c3b70",
-  "class_count": 754,
+  "source_digest": "a1b5758e4dcb654df9a361dfb6d3be50040dc2b7712fe45c95ac89a7f07b0c42",
+  "class_count": 755,
   "package_count": 52,
   "packages": [
     {
@@ -22642,7 +22642,7 @@
       "module": "standard",
       "package_id": "gf.standard.base",
       "path": "addons/gf/standard/common/gf_deferred_mutation_queue.gd",
-      "summary": "GFDeferredMutationQueue: 确定性延迟变更队列。 用于把运行时或工具流程中收集到的状态变更延迟到显式 playback 点执行。 队列只保存 Callable、排序信息和诊断 metadata，不解释调用方的实体、组件、",
+      "summary": "GFDeferredMutationQueue: 确定性延迟变更队列。 用于把运行时或工具流程中收集到的状态变更延迟到显式 playback 点执行。 record() 保存无 owner 的强 Callable；record_method() 通过弱 owner 和方法名",
       "visibility": "public",
       "category": "runtime_service",
       "since": "7.0.0",
@@ -22686,14 +22686,14 @@
           "kind": "func",
           "name": "record",
           "signature": "func record(mutation: Callable, options: Dictionary = {}) -> int",
-          "summary": "记录一条延迟变更。",
+          "summary": "记录一条无 owner 的延迟变更。",
           "visibility": "public"
         },
         {
           "kind": "func",
-          "name": "record_owned",
-          "signature": "func record_owned(owner: Object, mutation: Callable, options: Dictionary = {}) -> int",
-          "summary": "记录一条绑定 owner 的延迟变更。owner 释放后变更会在 playback() 时跳过。",
+          "name": "record_method",
+          "signature": "func record_method( owner: Object, method_name: StringName, options: Dictionary = {} ) -> int",
+          "summary": "通过弱引用 owner 与方法名记录延迟变更。",
           "visibility": "public"
         },
         {
@@ -22721,7 +22721,7 @@
           "kind": "func",
           "name": "cancel_owner",
           "signature": "func cancel_owner(owner: Object) -> int",
-          "summary": "取消指定 owner 绑定的全部待应用变更。",
+          "summary": "取消指定 owner 的全部待应用弱方法调用。",
           "visibility": "public"
         },
         {
@@ -43373,7 +43373,7 @@
       "module": "standard",
       "package_id": "gf.standard.base",
       "path": "addons/gf/standard/common/gf_main_thread_dispatch_queue.gd",
-      "summary": "GFMainThreadDispatchQueue: 主线程回调派发队列。 用于让后台线程、资源加载回调或项目侧异步流程把最终应用逻辑排回主线程。 队列只保存和派发 Callable，不创建线程、不校验线程身份，也不解释调用方的业务语义。",
+      "summary": "GFMainThreadDispatchQueue: 主线程回调派发队列。 用于让后台线程、资源加载回调或项目侧异步流程把最终应用逻辑排回主线程。 post() 保存无 owner 的强 Callable；post_method() 通过弱 owner 和方法名保存生命周期调用。",
       "visibility": "public",
       "category": "runtime_service",
       "since": "7.0.0",
@@ -43417,14 +43417,14 @@
           "kind": "func",
           "name": "post",
           "signature": "func post(callback: Callable, options: Dictionary = {}) -> int",
-          "summary": "把回调加入主线程派发队列。",
+          "summary": "把无 owner 的回调加入主线程派发队列。",
           "visibility": "public"
         },
         {
           "kind": "func",
-          "name": "post_owned",
-          "signature": "func post_owned(owner: Object, callback: Callable, options: Dictionary = {}) -> int",
-          "summary": "把 owner 绑定回调加入主线程派发队列。owner 释放后回调会被跳过。",
+          "name": "post_method",
+          "signature": "func post_method(owner: Object, method_name: StringName, options: Dictionary = {}) -> int",
+          "summary": "把弱 owner 方法调用加入主线程派发队列。",
           "visibility": "public"
         },
         {
@@ -43445,7 +43445,7 @@
           "kind": "func",
           "name": "cancel_owner",
           "signature": "func cancel_owner(owner: Object) -> int",
-          "summary": "取消指定 owner 绑定的全部待派发回调。",
+          "summary": "取消指定 owner 的全部待派发弱方法调用。",
           "visibility": "public"
         },
         {
@@ -87687,6 +87687,60 @@
           "name": "expand_transformed_adjacency_rules",
           "signature": "static func expand_transformed_adjacency_rules( adjacency_rules: Array[Dictionary], transform_specs: Array[Dictionary], options: Dictionary = {} ) -> Dictionary",
           "summary": "按 2D 网格变换和 tile id 重映射展开邻接规则。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFWeakMethodInvocation": {
+      "extends": "RefCounted",
+      "module": "kernel",
+      "package_id": "gf.kernel",
+      "path": "addons/gf/kernel/core/gf_weak_method_invocation.gd",
+      "summary": "GFWeakMethodInvocation: 不强持有目标对象的方法调用记录。 记录只保留目标的 WeakRef、创建时实例 ID 与方法名，并在调用时接收参数。 它不会保存 Callable，因此目标为 RefCounted 时不会被绑定回调意外延长生命周期。",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_INVOKED",
+          "signature": "const STATUS_INVOKED: StringName = &\"invoked\"",
+          "summary": "方法已被调用并返回。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_OWNER_RELEASED",
+          "signature": "const STATUS_OWNER_RELEASED: StringName = &\"owner_released\"",
+          "summary": "目标对象已释放。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_METHOD_MISSING",
+          "signature": "const STATUS_METHOD_MISSING: StringName = &\"method_missing\"",
+          "summary": "目标对象不再提供记录的方法。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_FAILED",
+          "signature": "const STATUS_FAILED: StringName = &\"failed\"",
+          "summary": "调用记录或参数未通过显式预检。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "_init",
+          "signature": "func _init(owner: Object = null, method_name: StringName = &\"\") -> void",
+          "summary": "创建弱方法调用记录。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "invoke",
+          "signature": "func invoke(arguments: Array = []) -> Dictionary",
+          "summary": "调用仍存活目标上的记录方法。",
           "visibility": "public"
         }
       ]

--- a/docs/api_catalog/classes/GFDeferredMutationQueue.xml
+++ b/docs/api_catalog/classes/GFDeferredMutationQueue.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFDeferredMutationQueue" path="addons/gf/standard/common/gf_deferred_mutation_queue.gd" module="standard" extends="GFUtility" classDigest="ea9d257d66eaab1a1930995b05ead0d0c02b03a2c9e77ea6d297c8ac8eafce7b">
+<class name="GFDeferredMutationQueue" path="addons/gf/standard/common/gf_deferred_mutation_queue.gd" module="standard" extends="GFUtility" classDigest="93e7fca44b5c4c42567696ec8416fb5cd01660725a6d5587abefa18e1a36469e">
 	<description>GFDeferredMutationQueue: 确定性延迟变更队列。
 用于把运行时或工具流程中收集到的状态变更延迟到显式 playback 点执行。
-队列只保存 Callable、排序信息和诊断 metadata，不解释调用方的实体、组件、
-节点或资源语义。</description>
+record() 保存无 owner 的强 Callable；record_method() 通过弱 owner 和方法名
+保存生命周期调用。队列不解释调用方的实体、组件、节点或资源语义。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -58,27 +58,30 @@
 		</member>
 		<member kind="method" name="record">
 			<signature>func record(mutation: Callable, options: Dictionary = {}) -&gt; int:</signature>
-			<description>记录一条延迟变更。</description>
+			<description>记录一条无 owner 的延迟变更。
+该入口会强持有 mutation；需要绑定 owner 生命周期时使用 record_method()。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">mutation: playback() 时执行的回调。</tag>
-				<tag name="param">options: 记录选项，支持 phase、sort_key、order、label、metadata 和 owner。</tag>
+				<tag name="param">options: 记录选项，支持 phase、sort_key、order、label 和 metadata。</tag>
 				<tag name="return">变更句柄；mutation 无效时返回 0。</tag>
-				<tag name="schema">options: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary、owner: Object。</tag>
+				<tag name="schema">options: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary。</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>
-		<member kind="method" name="record_owned">
-			<signature>func record_owned(owner: Object, mutation: Callable, options: Dictionary = {}) -&gt; int:</signature>
-			<description>记录一条绑定 owner 的延迟变更。owner 释放后变更会在 playback() 时跳过。</description>
+		<member kind="method" name="record_method">
+			<signature>func record_method( owner: Object, method_name: StringName, options: Dictionary = {} ) -&gt; int:</signature>
+			<description>通过弱引用 owner 与方法名记录延迟变更。
+队列不会保存 owner、Callable 或任意持久调用参数的强引用。为避免 metadata
+间接保活 owner，安全入口只保存 phase、sort_key、order 和 label 选项。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">owner: 变更拥有者。</tag>
-				<tag name="param">mutation: playback() 时执行的回调。</tag>
-				<tag name="param">options: 记录选项，支持 phase、sort_key、order、label 和 metadata。</tag>
+				<tag name="param">method_name: playback() 时调用的 owner 方法名。</tag>
+				<tag name="param">options: 记录选项，支持 phase、sort_key、order 和 label。</tag>
 				<tag name="return">变更句柄；参数无效时返回 0。</tag>
-				<tag name="schema">options: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary。</tag>
-				<tag name="since">7.0.0</tag>
+				<tag name="schema">options: Dictionary，可包含 phase: StringName、sort_key: int、order: int 和 label: String；不会保存 metadata。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="playback">
@@ -110,14 +113,14 @@
 			<description>取消一条尚未应用的变更。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">handle: record() 返回的变更句柄。</tag>
+				<tag name="param">handle: record() 或 record_method() 返回的变更句柄。</tag>
 				<tag name="return">找到并取消时返回 true。</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="cancel_owner">
 			<signature>func cancel_owner(owner: Object) -&gt; int:</signature>
-			<description>取消指定 owner 绑定的全部待应用变更。</description>
+			<description>取消指定 owner 的全部待应用弱方法调用。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">owner: 变更拥有者。</tag>

--- a/docs/api_catalog/classes/GFMainThreadDispatchQueue.xml
+++ b/docs/api_catalog/classes/GFMainThreadDispatchQueue.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFMainThreadDispatchQueue" path="addons/gf/standard/common/gf_main_thread_dispatch_queue.gd" module="standard" extends="GFUtility" classDigest="30641dbea05e83b0414a1f1a5be90412dff7503343d78c024ce7b968e9346b6c">
+<class name="GFMainThreadDispatchQueue" path="addons/gf/standard/common/gf_main_thread_dispatch_queue.gd" module="standard" extends="GFUtility" classDigest="4d941d9a09784f0cb572c856378489e2683ade0394f55fcf3b4a9c5ef4b337ca">
 	<description>GFMainThreadDispatchQueue: 主线程回调派发队列。
 用于让后台线程、资源加载回调或项目侧异步流程把最终应用逻辑排回主线程。
-队列只保存和派发 Callable，不创建线程、不校验线程身份，也不解释调用方的业务语义。</description>
+post() 保存无 owner 的强 Callable；post_method() 通过弱 owner 和方法名保存生命周期调用。
+队列不创建线程、不校验线程身份，也不解释调用方的业务语义。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -57,27 +58,29 @@
 		</member>
 		<member kind="method" name="post">
 			<signature>func post(callback: Callable, options: Dictionary = {}) -&gt; int:</signature>
-			<description>把回调加入主线程派发队列。</description>
+			<description>把无 owner 的回调加入主线程派发队列。
+该入口会强持有 callback；需要绑定 owner 生命周期时使用 post_method()。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">callback: 需要在显式派发点执行的回调。</tag>
-				<tag name="param">options: 队列选项，支持 owner、metadata、label 和 front。</tag>
+				<tag name="param">options: 队列选项，支持 metadata、label 和 front。</tag>
 				<tag name="return">派发句柄；callback 无效时返回 0。</tag>
-				<tag name="schema">options: Dictionary，可包含 owner: Object、metadata: Dictionary、label: String、front: bool。</tag>
+				<tag name="schema">options: Dictionary，可包含 metadata: Dictionary、label: String、front: bool。</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>
-		<member kind="method" name="post_owned">
-			<signature>func post_owned(owner: Object, callback: Callable, options: Dictionary = {}) -&gt; int:</signature>
-			<description>把 owner 绑定回调加入主线程派发队列。owner 释放后回调会被跳过。</description>
+		<member kind="method" name="post_method">
+			<signature>func post_method(owner: Object, method_name: StringName, options: Dictionary = {}) -&gt; int:</signature>
+			<description>把弱 owner 方法调用加入主线程派发队列。
+队列只保存 owner 的弱引用与方法名，不保存绑定 Callable、调用参数或 owner 强引用。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">owner: 回调拥有者。</tag>
-				<tag name="param">callback: 需要在显式派发点执行的回调。</tag>
-				<tag name="param">options: 队列选项，支持 metadata、label 和 front。</tag>
-				<tag name="return">派发句柄；参数无效时返回 0。</tag>
-				<tag name="schema">options: Dictionary，可包含 metadata: Dictionary、label: String、front: bool。</tag>
-				<tag name="since">7.0.0</tag>
+				<tag name="param">owner: 方法调用拥有者。</tag>
+				<tag name="param">method_name: 派发时调用的方法名。</tag>
+				<tag name="param">options: 队列选项，支持 label 和 front。</tag>
+				<tag name="return">派发句柄；owner 或 method_name 无效时返回 0。</tag>
+				<tag name="schema">options: Dictionary，可包含 label: String、front: bool。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="dispatch">
@@ -97,14 +100,14 @@
 			<description>取消一个尚未派发的回调。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">handle: post() 返回的派发句柄。</tag>
+				<tag name="param">handle: post() 或 post_method() 返回的派发句柄。</tag>
 				<tag name="return">找到并取消时返回 true。</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="cancel_owner">
 			<signature>func cancel_owner(owner: Object) -&gt; int:</signature>
-			<description>取消指定 owner 绑定的全部待派发回调。</description>
+			<description>取消指定 owner 的全部待派发弱方法调用。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">owner: 回调拥有者。</tag>

--- a/docs/api_catalog/classes/GFWeakMethodInvocation.xml
+++ b/docs/api_catalog/classes/GFWeakMethodInvocation.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFWeakMethodInvocation" path="addons/gf/kernel/core/gf_weak_method_invocation.gd" module="kernel" extends="RefCounted" classDigest="3554b40203f1020ffca5699b3543ddde90448ee9c9523a04d240d440e8ed9aa5">
+	<description>GFWeakMethodInvocation: 不强持有目标对象的方法调用记录。
+记录只保留目标的 WeakRef、创建时实例 ID 与方法名，并在调用时接收参数。
+它不会保存 Callable，因此目标为 RefCounted 时不会被绑定回调意外延长生命周期。
+`invoked` 只表示方法通过定义与参数数量预检且 Object.callv() 已返回；GDScript
+无法捕获 callv 期间的类型错误或被调方法内部错误，因此这类错误不会转换为 `failed`。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="layer">kernel/core</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_INVOKED">
+			<signature>const STATUS_INVOKED: StringName = &amp;"invoked"</signature>
+			<description>方法已被调用并返回。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_OWNER_RELEASED">
+			<signature>const STATUS_OWNER_RELEASED: StringName = &amp;"owner_released"</signature>
+			<description>目标对象已释放。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_METHOD_MISSING">
+			<signature>const STATUS_METHOD_MISSING: StringName = &amp;"method_missing"</signature>
+			<description>目标对象不再提供记录的方法。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_FAILED">
+			<signature>const STATUS_FAILED: StringName = &amp;"failed"</signature>
+			<description>调用记录或参数未通过显式预检。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="_init">
+			<signature>func _init(owner: Object = null, method_name: StringName = &amp;"") -&gt; void:</signature>
+			<description>创建弱方法调用记录。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner: 调用目标；无效目标会构造一个始终返回 failed 的记录。</tag>
+				<tag name="param">method_name: 调用时解析的方法名；空名称会构造一个始终返回 failed 的记录。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="invoke">
+			<signature>func invoke(arguments: Array = []) -&gt; Dictionary:</signature>
+			<description>调用仍存活目标上的记录方法。
+参数只在本次调用期间使用，不会保存到调用记录。返回 `invoked` 只代表定义与参数
+数量预检通过且 callv 已返回，不代表 callv 期间没有类型错误或被调方法内部错误。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">arguments: 传给 Object.callv() 的调用时参数数组。</tag>
+				<tag name="return">调用状态、返回值与稳定目标身份。</tag>
+				<tag name="schema">arguments: Array of invocation-time arguments; values are never retained by this record.</tag>
+				<tag name="schema">return: Dictionary with status, invoked, value, error_code, initial_owner_instance_id, and method_name.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="a5bf02a213ef9a83c1e087d880e0640a909b8c9b853faf188fc238cfb7353edb" classCount="778" methodCount="6981">
-	<module id="kernel" label="Kernel" classCount="70" methodCount="715">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="5119bbdcd17c5ab66ab5b25228c0cd2017d397ac27f912b11530ede6d56b6a6e" classCount="779" methodCount="6983">
+	<module id="kernel" label="Kernel" classCount="71" methodCount="717">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
 		<class name="GFAsyncCompletion" path="classes/GFAsyncCompletion.xml" sourcePath="addons/gf/kernel/core/gf_async_completion.gd" extends="RefCounted" />
@@ -71,6 +71,7 @@
 		<class name="GFTimeProvider" path="classes/GFTimeProvider.xml" sourcePath="addons/gf/kernel/base/gf_time_provider.gd" extends="GFUtility" />
 		<class name="GFTypeEventSystem" path="classes/GFTypeEventSystem.xml" sourcePath="addons/gf/kernel/core/gf_type_event_system.gd" extends="Object" />
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
+		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
 	<module id="standard" label="Standard" classCount="434" methodCount="4353">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -26,6 +26,7 @@
 
 ### 🚀 新增特性 (Added)
 
+- 新增 `GFWeakMethodInvocation` 框架级弱方法调用原语，以及 `GFMainThreadDispatchQueue.post_method()` 和 `GFDeferredMutationQueue.record_method()`：长期记录只保存 owner 的弱引用、初始实例 ID 和方法名，调用参数只在执行时传入；队列安全入口不持久化任意参数或 metadata，并把 owner 释放、方法缺失、预检失败与真实业务返回值明确分离。
 - 新增平台 Contract Descriptor、Activation Intent 有界去重队列与 `GFPlatformAdapterConformance`，让外部 SDK Adapter 可以声明请求/结果 Schema、字节预算、能力、并发、取消和敏感字段，并在不调用 SDK 时完成静态覆盖审查。
 - Network Lobby 升级为带唯一请求关联、单终态、取消、单调超时和迟到 callback 防护的类型化操作模型；新增可显式接管 owned/borrowed `MultiplayerPeer` 的通用 Backend，以及区分未知值的传输指标快照与有界采样历史。
 - AI Developer Kit 新增 Platform Adapter、Lobby Backend、契约测试、兼容性 Profile 和故障矩阵模板，并更新 Network / Platform capability 与 Recipe，使 AI 默认生成 Provider 中立且可验证的 Adapter 边界。
@@ -95,8 +96,13 @@
 - 修复当前契约已经是 schema v2 时，CLI `contract-migrate` 会把 `up_to_date` 计划当作成功应用并退出 0 的问题；没有待执行迁移时现在返回 `no_pending_contract_migration` 和非零退出码。
 - 修复有限 `Projection` 已通过 Network transport 值校验、却无法进入确定性规范指纹而导致同步消息在接收端失败的问题；`GFDeterministicVariantSerializer` 现在以 16 个浮点分量稳定编码 `Projection`。
 
+### ⚠️ 废弃与移除 (Deprecated/Removed)
+
+- 移除 `GFMainThreadDispatchQueue.post_owned()`、`GFDeferredMutationQueue.record_owned()`，并移除 `post()` / `record()` 的 `options.owner`。旧设计同时保存弱 owner 与完整 Callable，Callable 指向或捕获同一个 `RefCounted` owner 时会破坏弱生命周期语义；动态 options 继续传入 `owner` 会 fail closed，不会静默退化为无条件执行。
+
 ### 🔧 API 变动说明 (API Changes)
 
+- 新增公开类型 `GFWeakMethodInvocation`，提供 `invoked`、`owner_released`、`method_missing`、`failed` 四种稳定调用状态；`GFMainThreadDispatchQueue` 新增 `post_method()`，`GFDeferredMutationQueue` 新增 `record_method()`，均标记为 `@since unreleased`。两个旧式 `*_owned()` 入口及 `post()` / `record()` 的 `options.owner` 已直接移除。
 - 新增公开类型 `GFPlatformContractDescriptor`、`GFPlatformContractMethodDescriptor`、`GFPlatformActivationIntent`、`GFPlatformAdapterConformance`、`GFNetworkLobbyOperationRequest`、`GFNetworkLobbyOperationHandle`、`GFNetworkLobbyOperationResult`、`GFMultiplayerPeerNetworkBackend` 和 `GFNetworkTransportMetrics`，均标记为 `@since unreleased`。
 - `GFPlatformAdapter.configure()` 现在要求 `contract_ids` 与 `contract_descriptors` 一一对应，并新增 `activation_intent`、Contract Descriptor 查询和受保护发布入口；`GFPlatformRuntime` 新增 Activation Intent 接收、丢弃、按 Adapter 作用域消费、确认和容量配置 API。
 - `GFNetworkLobbyBackend` 移除旧的同步 accepted `Dictionary` 操作与请求完成信号，改为 `invoke_operation()` 和受保护 `_dispatch_operation()`；Network 扩展版本升至 `5.0.0`。`GFNetworkLobbyService` 的 create/query/join/leave/metadata 入口改为返回 `GFNetworkLobbyOperationHandle`，`set_backend()` 从 `void` 改为 `bool`，`lobby_created`、`lobbies_queried`、`lobby_joined`、`lobby_left` 的参数统一改为 `GFNetworkLobbyOperationResult`，并移除 `GFNetworkLobbyJoinResult`。
@@ -121,6 +127,7 @@
 
 ### 📘 升级指南 (Migration Guide)
 
+- 通过 `post_owned(owner, Callable(owner, method))`、`record_owned(owner, Callable(owner, method))`、`post/record(options.owner)` 或捕获 owner 的 lambda 延迟调用 owner 自身方法时，必须改用零参数 `post_method(owner, method_name)` / `record_method(owner, method_name)`。无 owner 的独立 Callable 继续使用 `post()` / `record()`。需要携带参数的自定义容器应保存 `GFWeakMethodInvocation`，只在实际执行点调用 `invoke(arguments)`；不要把 owner、Callable、Signal 或对象图重新塞进长期 options/metadata 绕过弱生命周期。
 - 旧 Lobby Backend 应把 create/query/join/leave/metadata 覆写合并到 `_dispatch_operation(request, handle)`，在 Provider callback 中调用 `_succeed_operation()` / `_fail_operation()`；项目调用方保存返回 Handle 并读取 `GFNetworkLobbyOperationResult`，不再等待无法按请求关联的旧完成信号。
 - 新 Platform Adapter 应为正式 Contract 提供 Descriptor 并运行 `GFPlatformAdapterConformance.inspect()`；启动、邀请和 Join 回调转换为稳定 ID 的 `GFPlatformActivationIntent`。SDK 已提供 `MultiplayerPeer` 时采用通用 Backend 并明确所有权，不要在 GF 内新增 Provider 命名 Manager。
 - 读取传输指标前先调用 `has_metric()`；缺少 RTT 等指标表示 Backend 不支持或当前未知，不能把 `get_metric()` 的默认零值解释为观测结果。长时间会话应设置有界采样容量。
@@ -148,6 +155,10 @@
 
 ### 📁 核心受影响文件 (Affected Files)
 
+- `addons/gf/kernel/core/gf_weak_method_invocation.gd`
+- `addons/gf/standard/common/gf_main_thread_dispatch_queue.gd`
+- `addons/gf/standard/common/gf_deferred_mutation_queue.gd`
+- `docs/zh/standard/utilities/runtime/time-signal-pool/async-primitives.md`
 - `addons/gf/standard/foundation/platform/`
 - `addons/gf/standard/platform/gf_platform_adapter.gd`
 - `addons/gf/standard/platform/gf_platform_runtime.gd`

--- a/docs/zh/reference/api/classes/GFDeferredMutationQueue.md
+++ b/docs/zh/reference/api/classes/GFDeferredMutationQueue.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`7.0.0`
 
-确定性延迟变更队列。 用于把运行时或工具流程中收集到的状态变更延迟到显式 playback 点执行。 队列只保存 Callable、排序信息和诊断 metadata，不解释调用方的实体、组件、 节点或资源语义。
+确定性延迟变更队列。 用于把运行时或工具流程中收集到的状态变更延迟到显式 playback 点执行。 record() 保存无 owner 的强 Callable；record_method() 通过弱 owner 和方法名 保存生命周期调用。队列不解释调用方的实体、组件、节点或资源语义。
 
 ## 成员概览
 
@@ -21,7 +21,7 @@
 | 方法 | [`init`](#member-gfdeferredmutationqueue-methods-init) | `func init() -> void:` |
 | 方法 | [`dispose`](#member-gfdeferredmutationqueue-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`record`](#member-gfdeferredmutationqueue-methods-record) | `func record(mutation: Callable, options: Dictionary = {}) -> int:` |
-| 方法 | [`record_owned`](#member-gfdeferredmutationqueue-methods-record_owned) | `func record_owned(owner: Object, mutation: Callable, options: Dictionary = {}) -> int:` |
+| 方法 | [`record_method`](#member-gfdeferredmutationqueue-methods-record_method) | `func record_method( owner: Object, method_name: StringName, options: Dictionary = {} ) -> int:` |
 | 方法 | [`playback`](#member-gfdeferredmutationqueue-methods-playback) | `func playback(options: Dictionary = {}) -> Dictionary:` |
 | 方法 | [`preview`](#member-gfdeferredmutationqueue-methods-preview) | `func preview(options: Dictionary = {}) -> Array[Dictionary]:` |
 | 方法 | [`cancel`](#member-gfdeferredmutationqueue-methods-cancel) | `func cancel(handle: int) -> bool:` |
@@ -113,47 +113,47 @@ func dispose() -> void:
 func record(mutation: Callable, options: Dictionary = {}) -> int:
 ```
 
-记录一条延迟变更。
+记录一条无 owner 的延迟变更。 该入口会强持有 mutation；需要绑定 owner 生命周期时使用 record_method()。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
 | `mutation` | playback() 时执行的回调。 |
-| `options` | 记录选项，支持 phase、sort_key、order、label、metadata 和 owner。 |
+| `options` | 记录选项，支持 phase、sort_key、order、label 和 metadata。 |
 
 返回：变更句柄；mutation 无效时返回 0。
 
 结构：
 
-- `options`: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary、owner: Object。
+- `options`: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary。
 
-<a id="member-gfdeferredmutationqueue-methods-record_owned"></a>
+<a id="member-gfdeferredmutationqueue-methods-record_method"></a>
 
-### `record_owned`
+### `record_method`
 
 - API：`public`
-- 首次版本：`7.0.0`
+- 首次版本：`unreleased`
 
 ```gdscript
-func record_owned(owner: Object, mutation: Callable, options: Dictionary = {}) -> int:
+func record_method( owner: Object, method_name: StringName, options: Dictionary = {} ) -> int:
 ```
 
-记录一条绑定 owner 的延迟变更。owner 释放后变更会在 playback() 时跳过。
+通过弱引用 owner 与方法名记录延迟变更。 队列不会保存 owner、Callable 或任意持久调用参数的强引用。为避免 metadata 间接保活 owner，安全入口只保存 phase、sort_key、order 和 label 选项。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
 | `owner` | 变更拥有者。 |
-| `mutation` | playback() 时执行的回调。 |
-| `options` | 记录选项，支持 phase、sort_key、order、label 和 metadata。 |
+| `method_name` | playback() 时调用的 owner 方法名。 |
+| `options` | 记录选项，支持 phase、sort_key、order 和 label。 |
 
 返回：变更句柄；参数无效时返回 0。
 
 结构：
 
-- `options`: Dictionary，可包含 phase: StringName、sort_key: int、order: int、label: String、metadata: Dictionary。
+- `options`: Dictionary，可包含 phase: StringName、sort_key: int、order: int 和 label: String；不会保存 metadata。
 
 <a id="member-gfdeferredmutationqueue-methods-playback"></a>
 
@@ -224,7 +224,7 @@ func cancel(handle: int) -> bool:
 
 | 名称 | 说明 |
 |---|---|
-| `handle` | record() 返回的变更句柄。 |
+| `handle` | record() 或 record_method() 返回的变更句柄。 |
 
 返回：找到并取消时返回 true。
 
@@ -239,7 +239,7 @@ func cancel(handle: int) -> bool:
 func cancel_owner(owner: Object) -> int:
 ```
 
-取消指定 owner 绑定的全部待应用变更。
+取消指定 owner 的全部待应用弱方法调用。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFMainThreadDispatchQueue.md
+++ b/docs/zh/reference/api/classes/GFMainThreadDispatchQueue.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`7.0.0`
 
-主线程回调派发队列。 用于让后台线程、资源加载回调或项目侧异步流程把最终应用逻辑排回主线程。 队列只保存和派发 Callable，不创建线程、不校验线程身份，也不解释调用方的业务语义。
+主线程回调派发队列。 用于让后台线程、资源加载回调或项目侧异步流程把最终应用逻辑排回主线程。 post() 保存无 owner 的强 Callable；post_method() 通过弱 owner 和方法名保存生命周期调用。 队列不创建线程、不校验线程身份，也不解释调用方的业务语义。
 
 ## 成员概览
 
@@ -21,7 +21,7 @@
 | 方法 | [`tick`](#member-gfmainthreaddispatchqueue-methods-tick) | `func tick(_delta: float = 0.0) -> void:` |
 | 方法 | [`dispose`](#member-gfmainthreaddispatchqueue-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`post`](#member-gfmainthreaddispatchqueue-methods-post) | `func post(callback: Callable, options: Dictionary = {}) -> int:` |
-| 方法 | [`post_owned`](#member-gfmainthreaddispatchqueue-methods-post_owned) | `func post_owned(owner: Object, callback: Callable, options: Dictionary = {}) -> int:` |
+| 方法 | [`post_method`](#member-gfmainthreaddispatchqueue-methods-post_method) | `func post_method(owner: Object, method_name: StringName, options: Dictionary = {}) -> int:` |
 | 方法 | [`dispatch`](#member-gfmainthreaddispatchqueue-methods-dispatch) | `func dispatch(max_count: int = 0, max_seconds: float = 0.0) -> Dictionary:` |
 | 方法 | [`cancel`](#member-gfmainthreaddispatchqueue-methods-cancel) | `func cancel(handle: int) -> bool:` |
 | 方法 | [`cancel_owner`](#member-gfmainthreaddispatchqueue-methods-cancel_owner) | `func cancel_owner(owner: Object) -> int:` |
@@ -118,47 +118,47 @@ func dispose() -> void:
 func post(callback: Callable, options: Dictionary = {}) -> int:
 ```
 
-把回调加入主线程派发队列。
+把无 owner 的回调加入主线程派发队列。 该入口会强持有 callback；需要绑定 owner 生命周期时使用 post_method()。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
 | `callback` | 需要在显式派发点执行的回调。 |
-| `options` | 队列选项，支持 owner、metadata、label 和 front。 |
+| `options` | 队列选项，支持 metadata、label 和 front。 |
 
 返回：派发句柄；callback 无效时返回 0。
 
 结构：
 
-- `options`: Dictionary，可包含 owner: Object、metadata: Dictionary、label: String、front: bool。
+- `options`: Dictionary，可包含 metadata: Dictionary、label: String、front: bool。
 
-<a id="member-gfmainthreaddispatchqueue-methods-post_owned"></a>
+<a id="member-gfmainthreaddispatchqueue-methods-post_method"></a>
 
-### `post_owned`
+### `post_method`
 
 - API：`public`
-- 首次版本：`7.0.0`
+- 首次版本：`unreleased`
 
 ```gdscript
-func post_owned(owner: Object, callback: Callable, options: Dictionary = {}) -> int:
+func post_method(owner: Object, method_name: StringName, options: Dictionary = {}) -> int:
 ```
 
-把 owner 绑定回调加入主线程派发队列。owner 释放后回调会被跳过。
+把弱 owner 方法调用加入主线程派发队列。 队列只保存 owner 的弱引用与方法名，不保存绑定 Callable、调用参数或 owner 强引用。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
-| `owner` | 回调拥有者。 |
-| `callback` | 需要在显式派发点执行的回调。 |
-| `options` | 队列选项，支持 metadata、label 和 front。 |
+| `owner` | 方法调用拥有者。 |
+| `method_name` | 派发时调用的方法名。 |
+| `options` | 队列选项，支持 label 和 front。 |
 
-返回：派发句柄；参数无效时返回 0。
+返回：派发句柄；owner 或 method_name 无效时返回 0。
 
 结构：
 
-- `options`: Dictionary，可包含 metadata: Dictionary、label: String、front: bool。
+- `options`: Dictionary，可包含 label: String、front: bool。
 
 <a id="member-gfmainthreaddispatchqueue-methods-dispatch"></a>
 
@@ -203,7 +203,7 @@ func cancel(handle: int) -> bool:
 
 | 名称 | 说明 |
 |---|---|
-| `handle` | post() 返回的派发句柄。 |
+| `handle` | post() 或 post_method() 返回的派发句柄。 |
 
 返回：找到并取消时返回 true。
 
@@ -218,7 +218,7 @@ func cancel(handle: int) -> bool:
 func cancel_owner(owner: Object) -> int:
 ```
 
-取消指定 owner 绑定的全部待派发回调。
+取消指定 owner 的全部待派发弱方法调用。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFWeakMethodInvocation.md
+++ b/docs/zh/reference/api/classes/GFWeakMethodInvocation.md
@@ -1,0 +1,125 @@
+# GFWeakMethodInvocation
+
+[API Reference](../index.md) / [Kernel](../kernel.md) / [类索引](index.md)
+
+- 路径：`addons/gf/kernel/core/gf_weak_method_invocation.gd`
+- 模块：`Kernel`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+不强持有目标对象的方法调用记录。 记录只保留目标的 WeakRef、创建时实例 ID 与方法名，并在调用时接收参数。 它不会保存 Callable，因此目标为 RefCounted 时不会被绑定回调意外延长生命周期。 `invoked` 只表示方法通过定义与参数数量预检且 Object.callv() 已返回；GDScript 无法捕获 callv 期间的类型错误或被调方法内部错误，因此这类错误不会转换为 `failed`。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_INVOKED`](#member-gfweakmethodinvocation-constants-status_invoked) | `const STATUS_INVOKED: StringName = &"invoked"` |
+| 常量 | [`STATUS_OWNER_RELEASED`](#member-gfweakmethodinvocation-constants-status_owner_released) | `const STATUS_OWNER_RELEASED: StringName = &"owner_released"` |
+| 常量 | [`STATUS_METHOD_MISSING`](#member-gfweakmethodinvocation-constants-status_method_missing) | `const STATUS_METHOD_MISSING: StringName = &"method_missing"` |
+| 常量 | [`STATUS_FAILED`](#member-gfweakmethodinvocation-constants-status_failed) | `const STATUS_FAILED: StringName = &"failed"` |
+| 方法 | [`_init`](#member-gfweakmethodinvocation-methods-_init) | `func _init(owner: Object = null, method_name: StringName = &"") -> void:` |
+| 方法 | [`invoke`](#member-gfweakmethodinvocation-methods-invoke) | `func invoke(arguments: Array = []) -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfweakmethodinvocation-constants-status_invoked"></a>
+
+### `STATUS_INVOKED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVOKED: StringName = &"invoked"
+```
+
+方法已被调用并返回。
+
+<a id="member-gfweakmethodinvocation-constants-status_owner_released"></a>
+
+### `STATUS_OWNER_RELEASED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_OWNER_RELEASED: StringName = &"owner_released"
+```
+
+目标对象已释放。
+
+<a id="member-gfweakmethodinvocation-constants-status_method_missing"></a>
+
+### `STATUS_METHOD_MISSING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_METHOD_MISSING: StringName = &"method_missing"
+```
+
+目标对象不再提供记录的方法。
+
+<a id="member-gfweakmethodinvocation-constants-status_failed"></a>
+
+### `STATUS_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_FAILED: StringName = &"failed"
+```
+
+调用记录或参数未通过显式预检。
+
+## 方法
+
+<a id="member-gfweakmethodinvocation-methods-_init"></a>
+
+### `_init`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func _init(owner: Object = null, method_name: StringName = &"") -> void:
+```
+
+创建弱方法调用记录。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner` | 调用目标；无效目标会构造一个始终返回 failed 的记录。 |
+| `method_name` | 调用时解析的方法名；空名称会构造一个始终返回 failed 的记录。 |
+
+<a id="member-gfweakmethodinvocation-methods-invoke"></a>
+
+### `invoke`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func invoke(arguments: Array = []) -> Dictionary:
+```
+
+调用仍存活目标上的记录方法。 参数只在本次调用期间使用，不会保存到调用记录。返回 `invoked` 只代表定义与参数 数量预检通过且 callv 已返回，不代表 callv 期间没有类型错误或被调方法内部错误。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `arguments` | 传给 Object.callv() 的调用时参数数组。 |
+
+返回：调用状态、返回值与稳定目标身份。
+
+结构：
+
+- `arguments`: Array of invocation-time arguments; values are never retained by this record.
+- `return`: Dictionary with status, invoked, value, error_code, initial_owner_instance_id, and method_name.

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -6,7 +6,7 @@
 
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
-| Kernel | 70 | 987 | [Kernel](#module-kernel) |
+| Kernel | 71 | 993 | [Kernel](#module-kernel) |
 | Standard | 434 | 6856 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
@@ -78,6 +78,7 @@
 | [`GFSignalSubscriptionToken`](GFSignalSubscriptionToken.md#gfsignalsubscriptiontoken) | 运行时句柄 (`runtime_handle`) | `GFSubscriptionToken` | 4 | `addons/gf/kernel/core/gf_signal_subscription_token.gd` |
 | [`GFSubscriptionToken`](GFSubscriptionToken.md#gfsubscriptiontoken) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 4 | `addons/gf/kernel/core/gf_subscription_token.gd` |
 | [`GFThumbnailRenderTask`](GFThumbnailRenderTask.md#gfthumbnailrendertask) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 23 | `addons/gf/kernel/editor/gf_thumbnail_render_task.gd` |
+| [`GFWeakMethodInvocation`](GFWeakMethodInvocation.md#gfweakmethodinvocation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 6 | `addons/gf/kernel/core/gf_weak_method_invocation.gd` |
 | [`GFBindingLifetimes`](GFBindingLifetimes.md#gfbindinglifetimes) | 值对象 (`value_object`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_binding_lifetimes.gd` |
 | [`GFEventListener`](GFEventListener.md#gfeventlistener) | 事件契约 (`event_contract`) | `RefCounted` | 10 | `addons/gf/kernel/core/gf_event_listener.gd` |
 | [`GFAccessGenerator`](GFAccessGenerator.md#gfaccessgenerator) | 编辑器 API (`editor_api`) | `RefCounted` | 13 | `addons/gf/kernel/editor/gf_access_generator.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,15 +5,15 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`778`
-- 公开成员：`11288`
-- 公开方法：`6981`
+- 公开类：`779`
+- 公开成员：`11294`
+- 公开方法：`6983`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
-| Kernel | 70 | 987 | 715 | [kernel.md](kernel.md) |
+| Kernel | 71 | 993 | 717 | [kernel.md](kernel.md) |
 | Standard | 434 | 6856 | 4353 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |

--- a/docs/zh/reference/api/kernel.md
+++ b/docs/zh/reference/api/kernel.md
@@ -9,7 +9,7 @@
 | [运行时服务](#category-runtime_service) | 14 | 285 | 219 |
 | [协议与扩展点](#category-protocol) | 19 | 195 | 170 |
 | [资源定义](#category-resource_definition) | 2 | 45 | 15 |
-| [运行时句柄](#category-runtime_handle) | 8 | 80 | 68 |
+| [运行时句柄](#category-runtime_handle) | 9 | 86 | 70 |
 | [值对象](#category-value_object) | 1 | 1 | 0 |
 | [事件契约](#category-event_contract) | 1 | 10 | 10 |
 | [编辑器 API](#category-editor_api) | 25 | 371 | 233 |
@@ -86,6 +86,7 @@
 | [`GFSignalSubscriptionToken`](classes/GFSignalSubscriptionToken.md#gfsignalsubscriptiontoken) | `GFSubscriptionToken` | `addons/gf/kernel/core/gf_signal_subscription_token.gd` |
 | [`GFSubscriptionToken`](classes/GFSubscriptionToken.md#gfsubscriptiontoken) | `RefCounted` | `addons/gf/kernel/core/gf_subscription_token.gd` |
 | [`GFThumbnailRenderTask`](classes/GFThumbnailRenderTask.md#gfthumbnailrendertask) | `RefCounted` | `addons/gf/kernel/editor/gf_thumbnail_render_task.gd` |
+| [`GFWeakMethodInvocation`](classes/GFWeakMethodInvocation.md#gfweakmethodinvocation) | `RefCounted` | `addons/gf/kernel/core/gf_weak_method_invocation.gd` |
 
 <a id="category-value_object"></a>
 

--- a/docs/zh/standard/utilities/runtime/time-signal-pool/async-primitives.md
+++ b/docs/zh/standard/utilities/runtime/time-signal-pool/async-primitives.md
@@ -170,14 +170,16 @@ var report := await GFAsyncWaitUtility.await_signal_payload(batch.settled)
 var dispatch_queue := GFMainThreadDispatchQueue.new()
 dispatch_queue.init()
 
-dispatch_queue.post_owned(self, func() -> void:
-	_apply_loaded_data()
-, { "label": "apply_loaded_data" })
+dispatch_queue.post_method(self, &"_apply_loaded_data", {
+	"label": "apply_loaded_data",
+})
 
 dispatch_queue.dispatch(8, 0.002)
 ```
 
-队列只保证回调在调用 `dispatch()` 的位置执行；它不会自动创建线程，也不会判断回调是否应该重试、回滚或显示 UI。跨线程传入的载荷建议保持为纯数据，节点和资源修改放在派发回调中完成。
+`post_method()` 只保存 owner 的弱引用、初始实例 ID、方法名、label 和 front 选项，不保存 Callable、调用参数或 metadata；owner 已释放时记录会进入 `skipped_owner_count`。`post()` 只接收无 owner 的强 Callable；`post_owned()` 与 `post(options.owner)` 已移除，传入旧 owner 选项会 fail closed。
+
+队列只保证回调在调用 `dispatch()` 的位置执行；它不会自动创建线程，也不会判断回调是否应该重试、回滚或显示 UI。跨线程传入的载荷建议保持为纯数据，节点和资源修改放在派发方法中完成。
 
 需要把一批状态变化延后到帧末、系统阶段末或编辑器 apply 阶段时，用 `GFDeferredMutationQueue` 收集变更，再在明确的 playback 点稳定执行：
 
@@ -200,7 +202,11 @@ var damage_report := mutations.playback({ "phase": &"damage" })
 var cleanup_report := mutations.playback({ "phase": &"cleanup" })
 ```
 
+owner 自身的无参变更应使用 `record_method(owner, method_name, options)`。该入口保留 phase、sort key、order 和 label，但不会保存 metadata；owner 释放时记录会安全跳过。`record()` 只接收无 owner 的强 Callable；`record_owned()` 与 `record(options.owner)` 已移除，旧 owner 选项会被拒绝。
+
 队列不理解变更对象是什么，也不替代 UndoRedo、事务或存档系统。它只解决“先收集、后应用、顺序可诊断”的运行时边界。
+
+自定义运行时容器需要同样的语义时，可以直接保存 `GFWeakMethodInvocation`，在执行点调用 `invoke(arguments)`，并处理 `invoked`、`owner_released`、`method_missing`、`failed`。原语不保存参数，也不会把业务返回的 `false` 或 `{ "ok": false }` 擅自解释为调用失败；`failed` 覆盖无效定义和参数数量预检，`invoked` 只表示预检通过且 `Object.callv()` 已返回。GDScript 无法捕获 callv 期间的类型错误或被调方法内部错误，消费者仍须按自己的结果契约处理。
 
 需要把同一对象短时间内连续到达的变化合并成一次处理时，使用静默窗口协调器。例如文件监听器可能连续报告同一资源的写入，设置面板可能在拖动滑杆时产生大量变化，网络适配器也可能希望按实体把短时间内的 patch 合成一批：
 

--- a/tests/gf_core/kernel/core/test_gf_weak_method_invocation.gd
+++ b/tests/gf_core/kernel/core/test_gf_weak_method_invocation.gd
@@ -1,0 +1,176 @@
+## 测试 GFWeakMethodInvocation 的弱所有权、调用状态与调用时参数预检。
+extends GutTest
+
+
+# --- 测试 ---
+
+func test_invoke_returns_method_value_and_stable_identity() -> void:
+	var target: InvocationTarget = InvocationTarget.new()
+	var target_id: int = target.get_instance_id()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"add_values")
+
+	var result: Dictionary = invocation.invoke([3, 4])
+
+	assert_eq(_get_report_status(result), GFWeakMethodInvocation.STATUS_INVOKED, "有效目标方法应报告 invoked。")
+	assert_true(_get_report_bool(result, "invoked"), "invoked 报告应设置调用标记。")
+	assert_eq(GFVariantData.get_option_int(result, "value"), 7, "调用结果应保留方法返回值。")
+	assert_eq(GFVariantData.get_option_int(result, "error_code"), OK, "成功调用应报告 OK。")
+	assert_eq(GFVariantData.get_option_int(result, "initial_owner_instance_id"), target_id, "报告应保留创建时目标实例 ID。")
+	assert_eq(GFVariantData.get_option_string_name(result, "method_name"), &"add_values", "报告应保留方法名。")
+	assert_eq(target.call_count, 1, "目标方法应只调用一次。")
+
+
+func test_false_business_result_is_still_invoked() -> void:
+	var target: InvocationTarget = InvocationTarget.new()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"return_false")
+
+	var result: Dictionary = invocation.invoke()
+
+	assert_eq(_get_report_status(result), GFWeakMethodInvocation.STATUS_INVOKED, "false 业务结果仍应报告 invoked。")
+	assert_false(_get_report_bool(result, "value", true), "调用结果应原样保留 false。")
+	assert_eq(target.call_count, 1, "原语不得把业务 false 当作预检失败。")
+
+
+func test_ref_counted_owner_can_release_without_callable_retention() -> void:
+	var target: InvocationTarget = InvocationTarget.new()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"add_values")
+	target = null
+
+	var result: Dictionary = invocation.invoke([1, 2])
+
+	assert_eq(
+		_get_report_status(result),
+		GFWeakMethodInvocation.STATUS_OWNER_RELEASED,
+		"调用记录不应阻止 RefCounted owner 释放。"
+	)
+	assert_false(_get_report_bool(result, "invoked", true), "已释放 owner 不应被调用。")
+
+
+func test_node_owner_release_is_reported_without_dereference() -> void:
+	var target: NodeInvocationTarget = NodeInvocationTarget.new()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"get_marker")
+	target.free()
+
+	var result: Dictionary = invocation.invoke()
+
+	assert_eq(
+		_get_report_status(result),
+		GFWeakMethodInvocation.STATUS_OWNER_RELEASED,
+		"已 free 的 Node owner 应报告 owner_released。"
+	)
+	assert_true(result.get("value") == null, "释放后调用不应产生返回值。")
+
+
+func test_missing_method_is_distinct_from_released_owner() -> void:
+	var target: InvocationTarget = InvocationTarget.new()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"missing_method")
+
+	var result: Dictionary = invocation.invoke()
+
+	assert_eq(
+		_get_report_status(result),
+		GFWeakMethodInvocation.STATUS_METHOD_MISSING,
+		"存活 owner 缺少方法时应报告 method_missing。"
+	)
+	assert_false(_get_report_bool(result, "invoked", true), "缺失方法不应被标记为已调用。")
+
+
+func test_invalid_construction_reports_failed() -> void:
+	var missing_owner: GFWeakMethodInvocation = GFWeakMethodInvocation.new(null, &"add_values")
+	var target: InvocationTarget = InvocationTarget.new()
+	var missing_method: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"")
+
+	var owner_result: Dictionary = missing_owner.invoke([1, 2])
+	var method_result: Dictionary = missing_method.invoke([1, 2])
+
+	assert_eq(_get_report_status(owner_result), GFWeakMethodInvocation.STATUS_FAILED, "空 owner 应在构造预检后报告 failed。")
+	assert_eq(_get_report_status(method_result), GFWeakMethodInvocation.STATUS_FAILED, "空方法名应在构造预检后报告 failed。")
+	assert_eq(GFVariantData.get_option_int(owner_result, "error_code"), ERR_INVALID_PARAMETER, "无效构造应报告参数错误。")
+	assert_eq(target.call_count, 0, "无效方法记录不得调用 owner。")
+
+
+func test_invalid_argument_count_reports_failed_without_calling_owner() -> void:
+	var target: InvocationTarget = InvocationTarget.new()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"add_values")
+
+	var too_few_result: Dictionary = invocation.invoke([1])
+	var too_many_result: Dictionary = invocation.invoke([1, 2, 3])
+
+	assert_eq(_get_report_status(too_few_result), GFWeakMethodInvocation.STATUS_FAILED, "缺少必需参数应报告 failed。")
+	assert_eq(_get_report_status(too_many_result), GFWeakMethodInvocation.STATUS_FAILED, "多余参数应报告 failed。")
+	assert_eq(GFVariantData.get_option_int(too_few_result, "error_code"), ERR_INVALID_PARAMETER, "参数数量预检失败应报告参数错误。")
+	assert_eq(target.call_count, 0, "参数预检失败不得调用 owner。")
+
+
+func test_argument_preflight_supports_defaults_and_native_varargs() -> void:
+	var target: InvocationTarget = InvocationTarget.new()
+	var default_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+		target,
+		&"add_with_default"
+	)
+	var native_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"call")
+
+	var default_result: Dictionary = default_invocation.invoke([5])
+	var native_result: Dictionary = native_invocation.invoke([&"return_false"])
+
+	assert_eq(_get_report_status(default_result), GFWeakMethodInvocation.STATUS_INVOKED, "默认参数应通过数量预检。")
+	assert_eq(GFVariantData.get_option_int(default_result, "value"), 7, "调用应使用目标方法的默认参数。")
+	assert_eq(_get_report_status(native_result), GFWeakMethodInvocation.STATUS_INVOKED, "原生可变参数方法应通过预检。")
+	assert_false(_get_report_bool(native_result, "value", true), "原生 call() 的业务返回值应原样保留。")
+	assert_eq(target.call_count, 2, "两个通过预检的方法应各执行一次。")
+
+
+func test_argument_preflight_accepts_script_override_with_wider_range() -> void:
+	var target: ExtendedNativeVirtualTarget = ExtendedNativeVirtualTarget.new()
+	var invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(target, &"_to_string")
+
+	var result: Dictionary = invocation.invoke(["!"])
+
+	assert_eq(_get_report_status(result), GFWeakMethodInvocation.STATUS_INVOKED, "脚本覆写扩展的可选参数应通过预检。")
+	assert_eq(GFVariantData.get_option_string(result, "value"), "target!", "调用应落到脚本覆写，而非同名原生签名。")
+	assert_eq(target.call_count, 1, "脚本覆写应只调用一次。")
+
+
+# --- 私有/辅助方法 ---
+
+func _get_report_bool(report: Dictionary, key: String, fallback: bool = false) -> bool:
+	return GFVariantData.get_option_bool(report, key, fallback)
+
+
+func _get_report_status(report: Dictionary) -> StringName:
+	return GFVariantData.get_option_string_name(
+		report,
+		"status",
+		GFWeakMethodInvocation.STATUS_FAILED
+	)
+
+
+# --- 内部类 ---
+
+class InvocationTarget extends RefCounted:
+	var call_count: int = 0
+
+	func add_values(left: int, right: int) -> int:
+		call_count += 1
+		return left + right
+
+	func return_false() -> bool:
+		call_count += 1
+		return false
+
+	func add_with_default(left: int, right: int = 2) -> int:
+		call_count += 1
+		return left + right
+
+
+class NodeInvocationTarget extends Node:
+	func get_marker() -> StringName:
+		return &"alive"
+
+
+class ExtendedNativeVirtualTarget extends RefCounted:
+	var call_count: int = 0
+
+	func _to_string(suffix: String = "") -> String:
+		call_count += 1
+		return "target%s" % suffix

--- a/tests/gf_core/kernel/core/test_gf_weak_method_invocation.gd.uid
+++ b/tests/gf_core/kernel/core/test_gf_weak_method_invocation.gd.uid
@@ -1,0 +1,1 @@
+uid://bsoe5eu4no8c1

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -73,6 +73,7 @@
     "gf.kernel": [
       "res://tests/gf_core/kernel/core/test_gf_report_value_codec.gd",
       "res://tests/gf_core/kernel/core/test_gf_singleton.gd",
+      "res://tests/gf_core/kernel/core/test_gf_weak_method_invocation.gd",
       "res://tests/gf_core/kernel/editor/test_gf_bake_dependency_report.gd",
       "res://tests/gf_core/kernel/editor/test_gf_editor_command_tools.gd",
       "res://tests/gf_core/kernel/editor/test_gf_editor_operation_plan.gd",

--- a/tests/gf_core/standard/common/test_gf_deferred_mutation_queue.gd
+++ b/tests/gf_core/standard/common/test_gf_deferred_mutation_queue.gd
@@ -38,7 +38,7 @@ func test_deferred_mutation_queue_plays_back_deterministic_phase_order() -> void
 	assert_true(queue.is_empty(), "全部 playback 后队列应为空。")
 
 
-func test_deferred_mutation_queue_cancels_and_skips_released_owner() -> void:
+func test_deferred_mutation_queue_cancels_pending_mutation() -> void:
 	var queue: GF_DEFERRED_MUTATION_QUEUE_SCRIPT = GF_DEFERRED_MUTATION_QUEUE_SCRIPT.new()
 	queue.init()
 	var events: Array[String] = []
@@ -48,17 +48,178 @@ func test_deferred_mutation_queue_cancels_and_skips_released_owner() -> void:
 	)
 	assert_true(queue.cancel(cancelled_handle), "未应用变更应可取消。")
 
-	var mutation_owner: RefCounted = RefCounted.new()
-	var owner_handle: int = queue.record_owned(mutation_owner, func() -> void:
-		events.append("owned")
-	)
-	assert_gt(owner_handle, 0, "owner 绑定变更应返回句柄。")
-	mutation_owner = null
-
 	var report: Dictionary = queue.playback()
 	var snapshot: Dictionary = queue.get_debug_snapshot()
 
-	assert_eq(events, [], "取消和 owner 释放的变更都不应执行。")
-	assert_eq(GFVariantData.get_option_int(report, "skipped_owner_count"), 1, "报告应统计 owner 跳过。")
+	assert_eq(events, [], "取消的变更不应执行。")
+	assert_eq(GFVariantData.get_option_int(report, "skipped_owner_count"), 0, "普通 Callable 不应具有 owner 生命周期。")
 	assert_eq(GFVariantData.get_option_int(snapshot, "cancelled_count"), 1, "快照应统计取消数量。")
-	assert_eq(GFVariantData.get_option_int(snapshot, "skipped_owner_count"), 1, "快照应统计 owner 跳过数量。")
+	assert_eq(GFVariantData.get_option_int(snapshot, "skipped_owner_count"), 0, "快照不应产生 owner 跳过统计。")
+
+
+func test_record_rejects_removed_owner_option() -> void:
+	var queue: GF_DEFERRED_MUTATION_QUEUE_SCRIPT = GF_DEFERRED_MUTATION_QUEUE_SCRIPT.new()
+	queue.init()
+	var legacy_owner: MutationTarget = MutationTarget.new()
+
+	var string_key_handle: int = queue.record(func() -> bool:
+		return legacy_owner.apply()
+	, { "owner": legacy_owner })
+
+	assert_push_error("[GFDeferredMutationQueue] record 失败：owner 选项已移除，请使用 record_method()。")
+	var string_name_key_handle: int = queue.record(func() -> bool:
+		return legacy_owner.apply()
+	, { &"owner": legacy_owner })
+	assert_push_error("[GFDeferredMutationQueue] record 失败：owner 选项已移除，请使用 record_method()。")
+
+	assert_eq(string_key_handle, 0, "String owner 选项必须 fail closed。")
+	assert_eq(string_name_key_handle, 0, "StringName owner 选项必须 fail closed。")
+	assert_true(queue.is_empty(), "被拒绝的旧式 owner 变更不得进入队列。")
+
+
+func test_record_method_invokes_live_owner_without_persisting_metadata() -> void:
+	var queue: GF_DEFERRED_MUTATION_QUEUE_SCRIPT = GF_DEFERRED_MUTATION_QUEUE_SCRIPT.new()
+	queue.init()
+	var mutation_target: MutationTarget = MutationTarget.new()
+
+	var handle: int = queue.record_method(mutation_target, &"apply", {
+		"phase": &"physics",
+		"sort_key": 4,
+		"label": "safe_method",
+		"metadata": {
+			"owner": mutation_target,
+		},
+	})
+	var preview_records: Array[Dictionary] = queue.preview({ "phase": &"physics" })
+	var report: Dictionary = queue.playback({ "phase": &"physics" })
+
+	assert_gt(handle, 0, "安全方法变更应返回句柄。")
+	assert_eq(preview_records.size(), 1, "安全方法变更应保留 phase 等排序选项。")
+	assert_eq(
+		GFVariantData.get_option_string(preview_records[0], "label"),
+		"safe_method",
+		"安全方法变更应保留诊断 label。"
+	)
+	assert_true(
+		GFVariantData.get_option_dictionary(preview_records[0], "metadata").is_empty(),
+		"安全方法变更不应持久化可能强引用 owner 的 metadata。"
+	)
+	assert_eq(mutation_target.invocation_count, 1, "存活 owner 的目标方法应执行一次。")
+	assert_eq(GFVariantData.get_option_int(report, "applied_count"), 1, "成功方法调用应计为 applied。")
+
+
+func test_record_method_does_not_retain_released_ref_counted_owner() -> void:
+	var queue: GF_DEFERRED_MUTATION_QUEUE_SCRIPT = GF_DEFERRED_MUTATION_QUEUE_SCRIPT.new()
+	queue.init()
+	var mutation_target: MutationTarget = MutationTarget.new()
+	var target_ref: WeakRef = weakref(mutation_target)
+	var options: Dictionary = {
+		"metadata": {
+			"owner": mutation_target,
+		},
+	}
+
+	var handle: int = queue.record_method(mutation_target, &"apply", options)
+	options.clear()
+	mutation_target = null
+
+	assert_gt(handle, 0, "RefCounted owner 的安全方法变更应入队。")
+	assert_true(target_ref.get_ref() == null, "队列和被忽略的 metadata 都不应强持有 RefCounted owner。")
+
+	var report: Dictionary = queue.playback()
+
+	assert_eq(
+		GFVariantData.get_option_int(report, "skipped_owner_count"),
+		1,
+		"释放的 RefCounted owner 应映射为 skipped owner。"
+	)
+	assert_eq(GFVariantData.get_option_int(report, "failed_count"), 0, "owner 释放不应计为调用失败。")
+
+
+func test_record_method_skips_freed_node_owner() -> void:
+	var queue: GF_DEFERRED_MUTATION_QUEUE_SCRIPT = GF_DEFERRED_MUTATION_QUEUE_SCRIPT.new()
+	queue.init()
+	var mutation_target: MutationNodeTarget = MutationNodeTarget.new()
+	var target_instance_id: int = mutation_target.get_instance_id()
+
+	var handle: int = queue.record_method(mutation_target, &"apply")
+	mutation_target.free()
+	mutation_target = null
+	var report: Dictionary = queue.playback()
+
+	assert_gt(handle, 0, "Node owner 的安全方法变更应入队。")
+	assert_false(is_instance_id_valid(target_instance_id), "测试 Node 应已同步释放。")
+	assert_eq(
+		GFVariantData.get_option_int(report, "skipped_owner_count"),
+		1,
+		"已 free 的 Node owner 应映射为 skipped owner。"
+	)
+	assert_eq(GFVariantData.get_option_int(report, "failed_count"), 0, "Node 释放不应计为调用失败。")
+
+
+func test_record_method_maps_missing_failed_and_business_false_to_failure() -> void:
+	var queue: GF_DEFERRED_MUTATION_QUEUE_SCRIPT = GF_DEFERRED_MUTATION_QUEUE_SCRIPT.new()
+	queue.init()
+	var mutation_target: MutationTarget = MutationTarget.new()
+
+	var missing_handle: int = queue.record_method(mutation_target, &"missing_method", {
+		"sort_key": 1,
+	})
+	var invalid_arguments_handle: int = queue.record_method(mutation_target, &"requires_value", {
+		"sort_key": 2,
+	})
+	var rejected_handle: int = queue.record_method(mutation_target, &"reject", {
+		"sort_key": 3,
+	})
+	var report: Dictionary = queue.playback()
+	var snapshot: Dictionary = queue.get_debug_snapshot()
+
+	assert_gt(missing_handle, 0, "缺失方法应在 playback 时按状态判定，记录阶段仍返回句柄。")
+	assert_gt(invalid_arguments_handle, 0, "参数数量不匹配应在 playback 时映射为 failed。")
+	assert_gt(rejected_handle, 0, "返回 false 的业务方法应正常入队。")
+	assert_eq(
+		mutation_target.invocation_count,
+		1,
+		"缺失方法和参数预检失败不得执行，业务拒绝方法应执行一次。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(report, "failed_count"),
+		3,
+		"method_missing、failed 预检与 invoked false 都应映射为 failed。"
+	)
+	assert_eq(GFVariantData.get_option_int(report, "applied_count"), 0, "失败记录不应计为 applied。")
+	assert_eq(
+		GFVariantData.get_option_int(snapshot, "failed_count"),
+		3,
+		"累计调试快照应保留安全方法调用失败数。"
+	)
+
+
+# --- 内部类 ---
+
+class MutationTarget extends RefCounted:
+	var invocation_count: int = 0
+
+
+	func apply() -> bool:
+		invocation_count += 1
+		return true
+
+
+	func reject() -> bool:
+		invocation_count += 1
+		return false
+
+
+	func requires_value(_value: int) -> bool:
+		invocation_count += 1
+		return true
+
+
+class MutationNodeTarget extends Node:
+	var invocation_count: int = 0
+
+
+	func apply() -> bool:
+		invocation_count += 1
+		return true

--- a/tests/gf_core/standard/common/test_gf_main_thread_dispatch_queue.gd
+++ b/tests/gf_core/standard/common/test_gf_main_thread_dispatch_queue.gd
@@ -28,7 +28,7 @@ func test_dispatch_queue_orders_front_and_tracks_counts() -> void:
 	assert_true(queue.has_dispatch_context(), "init 后队列应标记显式派发点。")
 
 
-func test_dispatch_queue_cancels_and_skips_released_owner() -> void:
+func test_dispatch_queue_cancels_pending_callback() -> void:
 	var queue: GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT = GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT.new()
 	queue.init()
 	var events: Array[String] = []
@@ -38,16 +38,148 @@ func test_dispatch_queue_cancels_and_skips_released_owner() -> void:
 	)
 	assert_true(queue.cancel(cancelled_handle), "未执行回调应可取消。")
 
-	var callback_owner: RefCounted = RefCounted.new()
-	var owner_handle: int = queue.post_owned(callback_owner, func() -> void:
-		events.append("owned")
+	var report: Dictionary = queue.dispatch()
+	var snapshot: Dictionary = queue.get_debug_snapshot()
+	assert_eq(events, [], "取消的回调不应执行。")
+	assert_eq(GFVariantData.get_option_int(report, "skipped_owner_count"), 0, "无 owner 回调不应产生 owner 跳过。")
+	assert_eq(GFVariantData.get_option_int(snapshot, "cancelled_count"), 1, "快照应统计取消数量。")
+
+
+func test_post_rejects_removed_owner_option() -> void:
+	var queue: GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT = GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT.new()
+	queue.init()
+	var legacy_owner: _MethodOwner = _MethodOwner.new()
+
+	var string_key_handle: int = queue.post(func() -> bool:
+		return legacy_owner.record_tail()
+	, { "owner": legacy_owner })
+
+	assert_push_error("[GFMainThreadDispatchQueue] post 失败：owner 选项已移除，请使用 post_method()。")
+	var string_name_key_handle: int = queue.post(func() -> bool:
+		return legacy_owner.record_tail()
+	, { &"owner": legacy_owner })
+	assert_push_error("[GFMainThreadDispatchQueue] post 失败：owner 选项已移除，请使用 post_method()。")
+
+	assert_eq(string_key_handle, 0, "String owner 选项必须 fail closed。")
+	assert_eq(string_name_key_handle, 0, "StringName owner 选项必须 fail closed。")
+	assert_true(queue.is_empty(), "被拒绝的旧式 owner 回调不得进入队列。")
+
+
+func test_post_method_preserves_order_and_owner_cancellation() -> void:
+	var queue: GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT = GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT.new()
+	queue.init()
+	var method_owner: _MethodOwner = _MethodOwner.new()
+	var cancelled_owner: _MethodOwner = _MethodOwner.new()
+
+	var tail_handle: int = queue.post_method(method_owner, &"record_tail")
+	var front_handle: int = queue.post_method(
+		method_owner,
+		&"record_front",
+		{ "front": true }
 	)
-	assert_gt(owner_handle, 0, "owner 回调应返回句柄。")
-	callback_owner = null
+	var cancelled_handle: int = queue.post_method(cancelled_owner, &"record_cancelled")
+
+	assert_gt(tail_handle, 0, "弱方法调用应返回句柄。")
+	assert_gt(front_handle, 0, "front 弱方法调用应返回句柄。")
+	assert_gt(cancelled_handle, 0, "可取消的弱方法调用应返回句柄。")
+	assert_eq(queue.cancel_owner(cancelled_owner), 1, "cancel_owner 应识别弱方法调用的初始 owner。")
 
 	var report: Dictionary = queue.dispatch()
 	var snapshot: Dictionary = queue.get_debug_snapshot()
-	assert_eq(events, [], "取消和 owner 释放的回调都不应执行。")
-	assert_eq(GFVariantData.get_option_int(report, "skipped_owner_count"), 1, "派发报告应统计 owner 跳过。")
-	assert_eq(GFVariantData.get_option_int(snapshot, "cancelled_count"), 1, "快照应统计取消数量。")
-	assert_eq(GFVariantData.get_option_int(snapshot, "skipped_owner_count"), 1, "快照应统计 owner 跳过数量。")
+	assert_eq(method_owner.events, ["front", "tail"], "弱方法调用应保留 front 顺序。")
+	assert_eq(GFVariantData.get_option_int(report, "dispatched_count"), 2, "成功的弱方法调用应计为 dispatched。")
+	assert_eq(GFVariantData.get_option_int(snapshot, "cancelled_count"), 1, "弱方法取消应进入既有统计。")
+
+
+func test_post_method_does_not_retain_ref_counted_owner() -> void:
+	var queue: GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT = GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT.new()
+	queue.init()
+	var method_owner: _MethodOwner = _MethodOwner.new()
+	var owner_ref: WeakRef = weakref(method_owner)
+	var options: Dictionary = { "metadata": { "owner": method_owner } }
+
+	var handle: int = queue.post_method(method_owner, &"record_tail", options)
+	assert_gt(handle, 0, "RefCounted owner 的弱方法调用应成功入队。")
+	options.clear()
+	method_owner = null
+
+	assert_true(owner_ref.get_ref() == null, "安全入口不得通过 Callable 或未声明 metadata 强持有 RefCounted owner。")
+	var report: Dictionary = queue.dispatch()
+	assert_eq(GFVariantData.get_option_int(report, "skipped_owner_count"), 1, "已释放 RefCounted owner 应计为 skipped。")
+	assert_eq(GFVariantData.get_option_int(report, "failed_count"), 0, "owner 释放不应计为调用失败。")
+
+
+func test_post_method_skips_freed_node_owner() -> void:
+	var queue: GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT = GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT.new()
+	queue.init()
+	var node_owner: Node = Node.new()
+	var owner_ref: WeakRef = weakref(node_owner)
+
+	var handle: int = queue.post_method(node_owner, &"get_name")
+	assert_gt(handle, 0, "Node owner 的弱方法调用应成功入队。")
+	node_owner.free()
+	node_owner = null
+
+	assert_true(owner_ref.get_ref() == null, "free 后 WeakRef 不应继续解析 Node。")
+	var report: Dictionary = queue.dispatch()
+	assert_eq(GFVariantData.get_option_int(report, "skipped_owner_count"), 1, "已 free 的 Node owner 应计为 skipped。")
+	assert_eq(GFVariantData.get_option_int(report, "failed_count"), 0, "Node owner 释放不应计为调用失败。")
+
+
+func test_post_method_maps_missing_and_failure_results_to_failed_count() -> void:
+	var queue: GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT = GF_MAIN_THREAD_DISPATCH_QUEUE_SCRIPT.new()
+	queue.init()
+	var method_owner: _MethodOwner = _MethodOwner.new()
+
+	var missing_handle: int = queue.post_method(method_owner, &"missing_method")
+	var argument_mismatch_handle: int = queue.post_method(method_owner, &"requires_argument")
+	var false_handle: int = queue.post_method(method_owner, &"return_false")
+	var report_handle: int = queue.post_method(method_owner, &"return_failed_report")
+	assert_gt(missing_handle, 0, "缺失方法应延迟到派发时判定。")
+	assert_gt(argument_mismatch_handle, 0, "参数数量不匹配应延迟到派发时判定。")
+	assert_gt(false_handle, 0, "返回 false 的方法应成功入队。")
+	assert_gt(report_handle, 0, "返回失败报告的方法应成功入队。")
+
+	var report: Dictionary = queue.dispatch()
+	assert_eq(GFVariantData.get_option_int(report, "failed_count"), 4, "method_missing、原语 failed、false 和 ok=false 都应进入既有失败统计。")
+	assert_eq(GFVariantData.get_option_int(report, "dispatched_count"), 0, "失败结果不应计为成功派发。")
+	assert_eq(method_owner.invoked_count, 2, "缺失方法不应调用 owner，两个显式失败方法应各调用一次。")
+
+
+# --- 内部类 ---
+
+class _MethodOwner:
+	extends RefCounted
+
+	var events: Array[String] = []
+	var invoked_count: int = 0
+
+
+	func record_front() -> bool:
+		events.append("front")
+		return true
+
+
+	func record_tail() -> bool:
+		events.append("tail")
+		return true
+
+
+	func record_cancelled() -> bool:
+		events.append("cancelled")
+		return true
+
+
+	func requires_argument(_value: String) -> bool:
+		invoked_count += 1
+		return true
+
+
+	func return_false() -> bool:
+		invoked_count += 1
+		return false
+
+
+	func return_failed_report() -> Dictionary:
+		invoked_count += 1
+		return { "ok": false }


### PR DESCRIPTION
## Summary
- add `GFWeakMethodInvocation` as the shared weak owner + method-name invocation record
- move main-thread dispatch and deferred mutation lifecycle entries to `post_method()` / `record_method()`
- remove unsafe `*_owned()` and `options.owner` paths; legacy dynamic owner keys now fail closed
- regenerate API/catalog/AI Developer references and document the migration

## Breaking changes
- removes `GFMainThreadDispatchQueue.post_owned()`
- removes `GFDeferredMutationQueue.record_owned()`
- removes `owner` from `post()` / `record()` options

No compatibility layer is retained: lifecycle-aware work must use the explicit method APIs.

## Validation
- framework-static: 17/17
- framework-lsp: 1200 scripts, 0 diagnostics
- framework-gut: 322 scripts, 4782 tests, 36632 assertions
- package-focused mapping: 52/52 packages, 190 focused tests
- API reference check: 779 classes, 11294 members
- AI Developer compact index check: 755 classes

This PR establishes the 1C framework primitive and migrates the two queue consumers. Timer, signal, reactive, event, and asynchronous consumers will move onto the same primitive in focused follow-up PRs.