### PR TITLE
test: enforce lifecycle-clean GUT hard gate

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,0 +1,4 @@
+{
+  "pre_run_script": "res://tests/gf_core/support/gf_gut_pre_run_hook.gd",
+  "post_run_script": "res://tests/gf_core/support/gf_gut_post_run_hook.gd"
+}

--- a/AI_MAINTENANCE.md
+++ b/AI_MAINTENANCE.md
@@ -254,7 +254,7 @@ python tools\gf_maintenance.py check --check gdscript_lsp_diagnostics --json
 python tools\gf_maintenance.py log-hygiene --dry-run --json
 ```
 
-该测试集包含静态维护检查，例如 API 注释同步和 GDScript 布局约束。`gdscript_warnings` 会用 headless editor 捕获普通 GUT 可能漏掉的 GDScript reload warning。`gdscript_lsp_diagnostics` 优先连接已有 Godot editor LSP，通过 `textDocument/publishDiagnostics` 读取编辑器诊断；CI 没有可连接的 LSP 时才由 `--connect-or-spawn` 启动临时进程。该检查补充日志中没有稳定输出、但 Godot 面板能显示的 GDScript warning，并作为 `full` 与 `release` 的硬门禁：error、warning、诊断超时、连接或传输失败都会阻止 CI / 发布。Godot 退出期 ObjectDB、resource still in use 与 RID allocation leak warning 先由维护工具结构化记录为 cleanup debt，不立即作为 CI 失败条件；清理完成并建立稳定零基线后，再改成 hard fail。能用机器稳定判断的维护规则，应优先补到测试或工具中，而不是只写在文字说明里。
+该测试集包含静态维护检查，例如 API 注释同步和 GDScript 布局约束。`gdscript_warnings` 会用 headless editor 捕获普通 GUT 可能漏掉的 GDScript reload warning。`gdscript_lsp_diagnostics` 优先连接已有 Godot editor LSP，通过 `textDocument/publishDiagnostics` 读取编辑器诊断；CI 没有可连接的 LSP 时才由 `--connect-or-spawn` 启动临时进程。该检查补充日志中没有稳定输出、但 Godot 面板能显示的 GDScript warning，并作为 `full` 与 `release` 的硬门禁：error、warning、诊断超时、连接或传输失败都会阻止 CI / 发布。GUT 通过 pre/post hook 建立进程级 orphan 基线，并把未由 GUT warning 断言消费的 `push_warning`、新增 orphan Node 与 ObjectDB/resource/RID 退出泄漏全部作为硬失败；维护工具要求 `GF_TEST_LIFECYCLE_GATE` 结构化证据存在且为零，同时复核 GUT Summary。其他 Godot 检查的退出泄漏仍会结构化记录为 cleanup debt，直到各自建立零基线。能用机器稳定判断的维护规则，应优先补到测试或工具中，而不是只写在文字说明里。
 
 排查退出期泄漏时，先用 `--verbose` 生成 stdout/stderr 日志，再运行 `python tools\gf_maintenance.py godot-exit-leak-report --log <stdout.log> --log <stderr.log> --json` 聚合 ObjectDB、RID、resource path prefix 和 leaked instance type。维护命令成功后会自动删除本次生成或改写的托管日志；需要在后续命令中读取日志时，给产生日志的命令添加 `--keep-logs`，也可临时设置 `GF_MAINTENANCE_KEEP_LOGS=1`。该报告命令默认只诊断不失败；只有准备把基线接入闸门时才显式使用 `--fail-on-leaks`。
 

--- a/AI_MAINTENANCE.md
+++ b/AI_MAINTENANCE.md
@@ -69,7 +69,7 @@ addons/gf/kernel <- addons/gf/standard <- addons/gf/extensions
 - 新增 `preload()`、`load()`、`ResourceLoader.load()`、`ResourceLoader.load_interactive()`、`ResourceLoader.load_threaded_request()` 或 `ResourceLoader.load_threaded_get()` 字面量时，先判断它是脚本依赖、编辑器工具、测试 fixture、迁移脚本，还是应收敛到 resolver/asset handle/content package 的运行时资源。不能收敛时，在代码或测试上下文中保留足够理由。
 - 使用 `GFAssetUtility` 加载可释放运行时资源时，应优先绑定 owner、group 或明确 cache/pin 策略；不要依赖 Godot 退出时的资源回收来证明生命周期正确。GF 只能追踪经过 GF 入口的引用，无法强制释放仍被节点、Resource、单例、脚本变量或第三方插件持有的对象。
 - 内容包、资源域或项目 profile 的目录和依赖规则只能作为项目侧或外部插件策略；GF 内核和标准库只沉淀稳定的 manifest、validator、resolver、diagnostics 和维护 gate，不硬编码单个游戏的包名、目录布局、热更流程或 CDN 规则。
-- `python tools\gf_maintenance.py resource-boundary --json` 用于统计直接资源加载字面量。默认 `issues` 只保留需要行动的资源加载问题；脚本依赖 preload/load 与编辑器 metadata 加载会进入 `observations` 汇总，并按 `source_kind` 区分 runtime、editor、tool、test 等来源，按 package manifest 归属汇总到 `source_package` / `target_package` 和 source-to-target package 矩阵，需要完整明细时显式传 `--include-observations --json`。维护检查套件使用 `--fail-on-issues`，让真实资源加载问题成为硬闸门，同时保留脚本依赖观测项。
+- `python tools\gf_maintenance.py resource-boundary --json` 用于统计直接资源加载字面量。默认 `issues` 只保留需要行动的资源加载问题；脚本依赖 preload/load、编辑器 metadata 加载，以及 `tests/gf_core/**` 内测试代码对同一测试树固定 fixture 的加载会进入 `observations` 汇总，并按 `source_kind` 区分 runtime、editor、tool、test 等来源，按 package manifest 归属汇总到 `source_package` / `target_package` 和 source-to-target package 矩阵，需要完整明细时显式传 `--include-observations --json`。测试 fixture 例外要求 source/target 都是无 `..` traversal 的规范化测试树路径，不得扩展到运行时代码或测试代码加载非测试资源。维护检查套件使用 `--fail-on-issues`，让真实资源加载问题成为硬闸门，同时保留脚本依赖观测项。
 - `python tools\gf_maintenance.py content-package-boundary --json` 是内容包 manifest 硬 gate；它扫描 tracked 和未忽略的 untracked `gf_content_package.json`，拒绝无效 JSON、非白名单字段、缺失或重复包 ID、缺失或循环依赖、资源路径越过包根，以及把下载地址、安装器、包管理策略写进 manifest 的做法。
 - `python tools\gf_maintenance.py asset-lifecycle-boundary --json` 当前是 report-only 生命周期基线检查；它扫描运行时代码中的 `acquire_handle()`、`load_handle_async()` 和 `request_entry_handle_async()`，报告同时缺少 owner 与 group 的句柄获取，因为这类资源只能依赖手动 release，容易形成长期 cache pin。
 - `python tools\gf_maintenance.py project-profile-boundary --json` 是可选项目结构 profile 检查；默认查找 `gf_project_profile.json`、`.gf/project_profile.json` 或 `project_profile.json`，没有 profile 时通过。Profile 只表达项目自有目录约定、zone、glob、扩展名、路径存在、命名、Feature 模块契约、生成物边界和大桶目录增长规则，不能反向变成 GF 对所有项目的固定目录要求。
@@ -254,7 +254,7 @@ python tools\gf_maintenance.py check --check gdscript_lsp_diagnostics --json
 python tools\gf_maintenance.py log-hygiene --dry-run --json
 ```
 
-该测试集包含静态维护检查，例如 API 注释同步和 GDScript 布局约束。`gdscript_warnings` 会用 headless editor 捕获普通 GUT 可能漏掉的 GDScript reload warning。`gdscript_lsp_diagnostics` 优先连接已有 Godot editor LSP，通过 `textDocument/publishDiagnostics` 读取编辑器诊断；CI 没有可连接的 LSP 时才由 `--connect-or-spawn` 启动临时进程。该检查补充日志中没有稳定输出、但 Godot 面板能显示的 GDScript warning，并作为 `full` 与 `release` 的硬门禁：error、warning、诊断超时、连接或传输失败都会阻止 CI / 发布。GUT 通过 pre/post hook 建立进程级 orphan 基线，并把未由 GUT warning 断言消费的 `push_warning`、新增 orphan Node 与 ObjectDB/resource/RID 退出泄漏全部作为硬失败；维护工具要求 `GF_TEST_LIFECYCLE_GATE` 结构化证据存在且为零，同时复核 GUT Summary。其他 Godot 检查的退出泄漏仍会结构化记录为 cleanup debt，直到各自建立零基线。能用机器稳定判断的维护规则，应优先补到测试或工具中，而不是只写在文字说明里。
+该测试集包含静态维护检查，例如 API 注释同步和 GDScript 布局约束。`gdscript_warnings` 会用 headless editor 捕获普通 GUT 可能漏掉的 GDScript reload warning。`gdscript_lsp_diagnostics` 优先连接已有 Godot editor LSP，通过 `textDocument/publishDiagnostics` 读取编辑器诊断；CI 没有可连接的 LSP 时才由 `--connect-or-spawn` 启动临时进程。该检查补充日志中没有稳定输出、但 Godot 面板能显示的 GDScript warning，并作为 `full` 与 `release` 的硬门禁：error、warning、诊断超时、连接或传输失败都会阻止 CI / 发布。GUT 通过 pre/post hook 建立进程级 orphan 基线，terminal capture 必须先于 tracker 最终快照切换，并把未由 GUT warning 断言消费的 `push_warning`、新增 orphan Node 与 ObjectDB/resource/RID 退出泄漏全部作为硬失败；失败 marker 必须同步产生非零进程退出码。维护工具要求 `GF_TEST_LIFECYCLE_GATE` closed-schema 证据存在且为零，只允许一份证据或 stdout/log 两份完全相同的镜像，同时复核 GUT Summary。生命周期 smoke 必须由统一 process-tree supervisor 执行 bootstrap、并发 cutover 和真实 orphan 故障注入，并在读取报告前确认完整后代树已退出。其他 Godot 检查的退出泄漏仍会结构化记录为 cleanup debt，直到各自建立零基线。能用机器稳定判断的维护规则，应优先补到测试或工具中，而不是只写在文字说明里。
 
 排查退出期泄漏时，先用 `--verbose` 生成 stdout/stderr 日志，再运行 `python tools\gf_maintenance.py godot-exit-leak-report --log <stdout.log> --log <stderr.log> --json` 聚合 ObjectDB、RID、resource path prefix 和 leaked instance type。维护命令成功后会自动删除本次生成或改写的托管日志；需要在后续命令中读取日志时，给产生日志的命令添加 `--keep-logs`，也可临时设置 `GF_MAINTENANCE_KEEP_LOGS=1`。该报告命令默认只诊断不失败；只有准备把基线接入闸门时才显式使用 `--fail-on-leaks`。
 
@@ -266,7 +266,7 @@ python tools\gf_maintenance.py log-hygiene --dry-run --json
 
 ```powershell
 godot --headless --path . --import
-godot --headless --path . -s res://addons/gut/gut_cmdln.gd -gtest=res://tests/gf_core/maintenance/test_layer_boundary_validation.gd -gexit
+godot --headless --path . -s res://tests/gf_core/support/gf_gut_cli.gd -gtest=res://tests/gf_core/maintenance/test_layer_boundary_validation.gd -gexit
 ```
 
 ## 文档维护标准

--- a/addons/gf/extensions/feedback/runtime/gf_haptic_utility.gd
+++ b/addons/gf/extensions/feedback/runtime/gf_haptic_utility.gd
@@ -217,6 +217,10 @@ func ready() -> void:
 ## @since 7.0.0
 func dispose() -> void:
 	clear()
+	input_device_utility = null
+	haptic_backend = null
+	output_handler = Callable()
+	stop_handler = Callable()
 
 
 ## 推进震动播放状态。

--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -444,6 +444,7 @@ func dispose() -> void:
 	last_initialization_error = ""
 	_reset_project_installers()
 	_refresh_tick_caches()
+	_parent_architecture = null
 	if was_initializing:
 		initialization_finished.emit()
 	_runtime.finish_dispose()
@@ -2623,6 +2624,12 @@ func _reset_project_installers() -> void:
 func _assign_parent_architecture(parent_architecture: GFArchitecture, context: String) -> void:
 	if parent_architecture == null:
 		_parent_architecture = null
+		return
+	if _runtime.is_disposing() or _runtime.is_disposed():
+		push_error(
+			"[GFArchitecture] %s 失败：架构正在 dispose 或已 dispose，不能设置父级架构。"
+			% context
+		)
 		return
 	if parent_architecture == self:
 		push_error("[GFArchitecture] %s 失败：父级架构不能是自身。" % context)

--- a/addons/gf/standard/common/gf_async_wait_support.gd
+++ b/addons/gf/standard/common/gf_async_wait_support.gd
@@ -381,7 +381,7 @@ static func _wait_signal_loop(
 	var tree: SceneTree = _get_scene_tree(options)
 	var process_in_physics: bool = GFVariantData.get_option_bool(options, "process_in_physics", false)
 	var should_continue: Callable = _get_callable(options, "should_continue")
-	var should_continue_was_provided: bool = options.has("should_continue")
+	var should_continue_is_configured: bool = not should_continue.is_null()
 	var should_pause_timeout: Callable = _get_callable(options, "should_pause_timeout")
 
 	while not GFVariantData.get_option_bool(completion_state, "completed"):
@@ -400,7 +400,7 @@ static func _wait_signal_loop(
 			completion_state["reason"] = &"guard_exited"
 			return STATUS_INVALID
 
-		if should_continue_was_provided:
+		if should_continue_is_configured:
 			if not should_continue.is_valid():
 				completion_state["reason"] = &"should_continue_invalid"
 				return STATUS_CANCELLED

--- a/addons/gf/standard/common/gf_async_wait_support.gd
+++ b/addons/gf/standard/common/gf_async_wait_support.gd
@@ -381,6 +381,7 @@ static func _wait_signal_loop(
 	var tree: SceneTree = _get_scene_tree(options)
 	var process_in_physics: bool = GFVariantData.get_option_bool(options, "process_in_physics", false)
 	var should_continue: Callable = _get_callable(options, "should_continue")
+	var should_continue_was_provided: bool = options.has("should_continue")
 	var should_pause_timeout: Callable = _get_callable(options, "should_pause_timeout")
 
 	while not GFVariantData.get_option_bool(completion_state, "completed"):
@@ -399,9 +400,13 @@ static func _wait_signal_loop(
 			completion_state["reason"] = &"guard_exited"
 			return STATUS_INVALID
 
-		if should_continue.is_valid() and not GFVariantData.to_bool(should_continue.call()):
-			completion_state["reason"] = &"should_continue_false"
-			return STATUS_CANCELLED
+		if should_continue_was_provided:
+			if not should_continue.is_valid():
+				completion_state["reason"] = &"should_continue_invalid"
+				return STATUS_CANCELLED
+			if not GFVariantData.to_bool(should_continue.call()):
+				completion_state["reason"] = &"should_continue_false"
+				return STATUS_CANCELLED
 
 		var current_timeout_msec: int = Time.get_ticks_msec()
 		if timeout_msec > 0.0:

--- a/addons/gf/standard/common/gf_async_wait_support.gd
+++ b/addons/gf/standard/common/gf_async_wait_support.gd
@@ -399,6 +399,10 @@ static func _wait_signal_loop(
 			completion_state["reason"] = &"guard_exited"
 			return STATUS_INVALID
 
+		if should_continue.is_valid() and not GFVariantData.to_bool(should_continue.call()):
+			completion_state["reason"] = &"should_continue_false"
+			return STATUS_CANCELLED
+
 		var current_timeout_msec: int = Time.get_ticks_msec()
 		if timeout_msec > 0.0:
 			var timeout_is_paused: bool = (
@@ -415,10 +419,6 @@ static func _wait_signal_loop(
 				if elapsed_timeout_msec >= timeout_msec:
 					return STATUS_TIMEOUT
 		last_timeout_msec = current_timeout_msec
-
-		if should_continue.is_valid() and not GFVariantData.to_bool(should_continue.call()):
-			completion_state["reason"] = &"should_continue_false"
-			return STATUS_CANCELLED
 
 		await _await_frame(tree, process_in_physics)
 

--- a/addons/gf/standard/foundation/tags/gf_tag_expression.gd
+++ b/addons/gf/standard/foundation/tags/gf_tag_expression.gd
@@ -47,12 +47,17 @@ const _MAX_RESTORE_DEPTH: int = 128
 ## @api public
 @export var query: GFTagQuery = null
 
-## 子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。
+## 子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。公开语义只接受
+## GFTagExpression 或 null；其他 Resource 会保留索引并按 null_expression 失败，
+## 不会被静默忽略。推荐通过 configure_all()、configure_any() 或 configure_none()
+## 写入强类型子表达式。
 ## [br]
 ## @api public
 ## [br]
-## @schema expressions: Array[GFTagExpression]，按数组顺序参与组合判断。
-@export var expressions: Array[GFTagExpression] = []
+## @since 3.18.0
+## [br]
+## @schema expressions: Array[GFTagExpression | null]，按数组顺序参与组合判断；底层使用 Array[Resource] 避免自引用 Resource 脚本被引擎永久保留。
+@export var expressions: Array[Resource] = []
 
 
 # --- 公共方法 ---
@@ -123,7 +128,7 @@ func configure_query(tag_query: GFTagQuery) -> GFTagExpression:
 func configure_all(child_expressions: Array[GFTagExpression]) -> GFTagExpression:
 	operator = Operator.ALL
 	query = null
-	expressions = child_expressions.duplicate()
+	_assign_expressions(child_expressions)
 	return self
 
 
@@ -139,7 +144,7 @@ func configure_all(child_expressions: Array[GFTagExpression]) -> GFTagExpression
 func configure_any(child_expressions: Array[GFTagExpression]) -> GFTagExpression:
 	operator = Operator.ANY
 	query = null
-	expressions = child_expressions.duplicate()
+	_assign_expressions(child_expressions)
 	return self
 
 
@@ -155,7 +160,7 @@ func configure_any(child_expressions: Array[GFTagExpression]) -> GFTagExpression
 func configure_none(child_expressions: Array[GFTagExpression]) -> GFTagExpression:
 	operator = Operator.NONE
 	query = null
-	expressions = child_expressions.duplicate()
+	_assign_expressions(child_expressions)
 	return self
 
 
@@ -271,7 +276,8 @@ func _duplicate_expression(visited: Dictionary) -> GFTagExpression:
 	visited[instance_id] = copy
 	copy.operator = operator
 	copy.query = query.duplicate_query() if query != null else null
-	for expression: GFTagExpression in expressions:
+	for expression_index: int in range(expressions.size()):
+		var expression: GFTagExpression = _get_expression_at(expression_index)
 		copy.expressions.append(expression._duplicate_expression(visited) if expression != null else null)
 	return copy
 
@@ -283,7 +289,8 @@ func _to_dictionary(visited: Dictionary) -> Dictionary:
 	visited[instance_id] = true
 
 	var child_dictionaries: Array[Dictionary] = []
-	for expression: GFTagExpression in expressions:
+	for expression_index: int in range(expressions.size()):
+		var expression: GFTagExpression = _get_expression_at(expression_index)
 		child_dictionaries.append(_make_null_dictionary() if expression == null else expression._to_dictionary(visited))
 	var _removed_visit: bool = visited.erase(instance_id)
 
@@ -356,7 +363,7 @@ func _get_children_match_report(
 	var matched_indices: Array[int] = []
 	var failed_indices: Array[int] = []
 	for index: int in range(expressions.size()):
-		var child: GFTagExpression = expressions[index]
+		var child: GFTagExpression = _get_expression_at(index)
 		var child_report: Dictionary = _get_null_child_report() if child == null else child._get_match_report(source, visited)
 		child_reports.append(child_report)
 		if GFVariantData.get_option_bool(child_report, "ok", false):
@@ -383,7 +390,7 @@ func _get_none_match_report(source: Variant, visited: Array[int]) -> Dictionary:
 	var matched_indices: Array[int] = []
 	var failed_indices: Array[int] = []
 	for index: int in range(expressions.size()):
-		var child: GFTagExpression = expressions[index]
+		var child: GFTagExpression = _get_expression_at(index)
 		var child_report: Dictionary = _get_null_child_report() if child == null else child._get_match_report(source, visited)
 		child_reports.append(child_report)
 		if GFVariantData.get_option_bool(child_report, "ok", false):
@@ -413,6 +420,22 @@ func _get_null_child_report() -> Dictionary:
 		"matched_indices": [],
 		"failed_indices": [],
 	}
+
+
+func _assign_expressions(child_expressions: Array[GFTagExpression]) -> void:
+	expressions.clear()
+	for child_expression: GFTagExpression in child_expressions:
+		expressions.append(child_expression)
+
+
+func _get_expression_at(index: int) -> GFTagExpression:
+	if index < 0 or index >= expressions.size():
+		return null
+	var value: Resource = expressions[index]
+	if value is GFTagExpression:
+		var expression: GFTagExpression = value
+		return expression
+	return null
 
 
 static func _make_null_dictionary() -> Dictionary:

--- a/addons/gf/standard/utilities/analytics/gf_analytics_utility.gd
+++ b/addons/gf/standard/utilities/analytics/gf_analytics_utility.gd
@@ -184,11 +184,14 @@ func init() -> void:
 	_is_initialized = true
 
 
-## 释放事件队列、HTTP 节点和关闭监听。
+## 释放事件队列、HTTP 节点、关闭监听和项目注入的回调。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 func dispose() -> void:
 	if not _is_initialized:
+		_release_injected_callbacks()
 		return
 	_shutdown_watcher_attach_serial += 1
 	_flush_generation += 1
@@ -216,6 +219,7 @@ func dispose() -> void:
 		_free_shutdown_watcher(_shutdown_watcher)
 	_shutdown_watcher = null
 	_is_initialized = false
+	_release_injected_callbacks()
 
 
 ## 推进运行时逻辑。
@@ -975,6 +979,12 @@ func _trim_queue_to_max_size() -> void:
 		trimmed = true
 	if trimmed:
 		_queue_generation += 1
+
+
+func _release_injected_callbacks() -> void:
+	payload_builder = Callable()
+	transport_callback = Callable()
+	response_parser = Callable()
 
 
 func _validation_has_budget_issue(report: GFValidationReport) -> bool:

--- a/addons/gf/standard/utilities/ui/gf_reactive_state_control_binder.gd
+++ b/addons/gf/standard/utilities/ui/gf_reactive_state_control_binder.gd
@@ -273,6 +273,10 @@ func _disconnect_binding(binding: Dictionary) -> void:
 	):
 		control.tree_exited.disconnect(tree_exited_callable)
 
+	# Binding callbacks capture this Dictionary, so releasing external connections alone
+	# does not break the self-reference cycle.
+	binding.clear()
+
 
 func _get_binding_store(binding: Dictionary) -> _GF_REACTIVE_STATE_STORE_SCRIPT:
 	var store_ref: WeakRef = _get_binding_weak_ref(binding, "store_ref")

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "a1b5758e4dcb654df9a361dfb6d3be50040dc2b7712fe45c95ac89a7f07b0c42",
+  "source_digest": "04110f0aa20b6a4379ad862db42ec564d2b904c1b14165d841d8e7e973304fd5",
   "class_count": 755,
   "package_count": 52,
   "packages": [
@@ -1857,7 +1857,7 @@
           "kind": "func",
           "name": "dispose",
           "signature": "func dispose() -> void",
-          "summary": "释放事件队列、HTTP 节点和关闭监听。",
+          "summary": "释放事件队列、HTTP 节点、关闭监听和项目注入的回调。",
           "visibility": "public"
         },
         {
@@ -79277,8 +79277,8 @@
         {
           "kind": "var",
           "name": "expressions",
-          "signature": "var expressions: Array[GFTagExpression] = []",
-          "summary": "子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。",
+          "signature": "var expressions: Array[Resource] = []",
+          "summary": "子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。公开语义只接受",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFAnalyticsUtility.xml
+++ b/docs/api_catalog/classes/GFAnalyticsUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFAnalyticsUtility" path="addons/gf/standard/utilities/analytics/gf_analytics_utility.gd" module="standard" extends="GFUtility" classDigest="9c87abf084c65baa50bdb2832c152eebb81e1b8233209149ebcffbc42bcf6052">
+<class name="GFAnalyticsUtility" path="addons/gf/standard/utilities/analytics/gf_analytics_utility.gd" module="standard" extends="GFUtility" classDigest="ffa764544ce188bd56f4b0c8840ce3f3141b5a038cc89806e1ff921070210aad">
 	<description>GFAnalyticsUtility: 通用事件分析与批量上报工具。
 负责事件排队、环境上下文采集、批量 flush 与失败重排。
 endpoint 为空时不会访问网络，可作为本地事件汇聚或测试通道使用。</description>
@@ -107,9 +107,10 @@ flush 按最终信封字节预算从最大前缀向下有界校验时可能多�
 		</member>
 		<member kind="method" name="dispose">
 			<signature>func dispose() -&gt; void:</signature>
-			<description>释放事件队列、HTTP 节点和关闭监听。</description>
+			<description>释放事件队列、HTTP 节点、关闭监听和项目注入的回调。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="tick">

--- a/docs/api_catalog/classes/GFTagExpression.xml
+++ b/docs/api_catalog/classes/GFTagExpression.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTagExpression" path="addons/gf/standard/foundation/tags/gf_tag_expression.gd" module="standard" extends="Resource" classDigest="1acdd8ee6d96230e1821eeb621c2e5f2fd476b54e4122406abb450c000b3ed1e">
+<class name="GFTagExpression" path="addons/gf/standard/foundation/tags/gf_tag_expression.gd" module="standard" extends="Resource" classDigest="169967d22195d203e0342a22579604aef2b6d7c245017caf4ce7922c032aac47">
 	<description>GFTagExpression: 可嵌套标签查询表达式资源。
 在 GFTagQuery 的 all/any/none 单层查询之上提供组合表达式，适合描述
 “任意一组条件成立”“全部子条件成立”或“没有子条件成立”等通用标签规则。
@@ -45,11 +45,15 @@
 			</tags>
 		</member>
 		<member kind="property" name="expressions" decorators="@export">
-			<signature>var expressions: Array[GFTagExpression] = []</signature>
-			<description>子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。</description>
+			<signature>var expressions: Array[Resource] = []</signature>
+			<description>子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。公开语义只接受
+GFTagExpression 或 null；其他 Resource 会保留索引并按 null_expression 失败，
+不会被静默忽略。推荐通过 configure_all()、configure_any() 或 configure_none()
+写入强类型子表达式。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="schema">expressions: Array[GFTagExpression]，按数组顺序参与组合判断。</tag>
+				<tag name="schema">expressions: Array[GFTagExpression | null]，按数组顺序参与组合判断；底层使用 Array[Resource] 避免自引用 Resource 脚本被引擎永久保留。</tag>
+				<tag name="since">3.18.0</tag>
 			</tags>
 		</member>
 	</properties>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="5119bbdcd17c5ab66ab5b25228c0cd2017d397ac27f912b11530ede6d56b6a6e" classCount="779" methodCount="6983">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="0ce647ff5745b666f61da42ba14dae420f92326511267b3d4b0217263d03a63a" classCount="779" methodCount="6983">
 	<module id="kernel" label="Kernel" classCount="71" methodCount="717">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -77,6 +77,7 @@
 - 模块根与 Adapter 根额外采用跨平台规范化校验，并以大小写无关方式拒绝 `res://addons/gf` 及 Windows 尾点、保留名称等别名，避免把 GF 源码误归属为项目模块；普通源码资源引用不受这项契约限制。
 - CI 与 Release 工作流统一采用 Node.js 24 世代的 `actions/checkout@v7`、`actions/setup-python@v7`、`actions/upload-artifact@v7` 和 `actions/download-artifact@v8`，维护自检会阻止旧主版本回退。
 - 验证链路将 Draft quick gate 与 Ready/main 完整门禁分离，`GF repository policy` 与 `GF merge gate` 共同作为 required checks，并把 framework 检查拆成 GUT、LSP 与静态检查并行分片；Ready/main 另由 `windows-latest` 聚焦任务验证原生 Job Object 清理并汇入 merge gate，非 `main` 手工运行不会生成同名 required context。本地 Full Suite 默认使用 3 个隔离 worker（可显式调整为 2–6 个），按批创建/执行/验收/清理工作区与私有用户目录，Windows 同时约束 clone、staging 和临时目录的投影路径预算并拒绝映射盘与 SUBST 别名，启动前由真实 Godot 验证平台用户目录边界，suite deadline 覆盖准备、源码分块捕获、制品扫描/哈希/复制、执行与复核全链路。每个 shard 由 POSIX process group 或 Windows Job Object 持有至完整后代树清空；单次 suite 的 package smoke 复用一份经源码指纹和哈希封存的构建产物，父进程精确核对 consumer 报告的 manifest 摘要与产物数量，并对报告和失败日志执行有界读取与完整目录链校验，同时保留严格 LSP 硬门禁与 `--jobs 1` 串行诊断退路。
+- GUT 新增生命周期感知的 pre/post run hook 与可复用 LIFO cleanup scope；完整测试入口要求稳定的 `GF_TEST_LIFECYCLE_GATE` JSON 证据，并对未处理 `push_warning`、新增 orphan Node、非零 GUT Warnings/Orphans 摘要及 Godot 退出泄漏执行 fail-closed 硬门禁。
 
 ### 🐛 Bug 修复 (Fixed)
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -77,10 +77,16 @@
 - 模块根与 Adapter 根额外采用跨平台规范化校验，并以大小写无关方式拒绝 `res://addons/gf` 及 Windows 尾点、保留名称等别名，避免把 GF 源码误归属为项目模块；普通源码资源引用不受这项契约限制。
 - CI 与 Release 工作流统一采用 Node.js 24 世代的 `actions/checkout@v7`、`actions/setup-python@v7`、`actions/upload-artifact@v7` 和 `actions/download-artifact@v8`，维护自检会阻止旧主版本回退。
 - 验证链路将 Draft quick gate 与 Ready/main 完整门禁分离，`GF repository policy` 与 `GF merge gate` 共同作为 required checks，并把 framework 检查拆成 GUT、LSP 与静态检查并行分片；Ready/main 另由 `windows-latest` 聚焦任务验证原生 Job Object 清理并汇入 merge gate，非 `main` 手工运行不会生成同名 required context。本地 Full Suite 默认使用 3 个隔离 worker（可显式调整为 2–6 个），按批创建/执行/验收/清理工作区与私有用户目录，Windows 同时约束 clone、staging 和临时目录的投影路径预算并拒绝映射盘与 SUBST 别名，启动前由真实 Godot 验证平台用户目录边界，suite deadline 覆盖准备、源码分块捕获、制品扫描/哈希/复制、执行与复核全链路。每个 shard 由 POSIX process group 或 Windows Job Object 持有至完整后代树清空；单次 suite 的 package smoke 复用一份经源码指纹和哈希封存的构建产物，父进程精确核对 consumer 报告的 manifest 摘要与产物数量，并对报告和失败日志执行有界读取与完整目录链校验，同时保留严格 LSP 硬门禁与 `--jobs 1` 串行诊断退路。
-- GUT 新增生命周期感知的 pre/post run hook 与可复用 LIFO cleanup scope；完整测试入口要求稳定的 `GF_TEST_LIFECYCLE_GATE` JSON 证据，并对未处理 `push_warning`、新增 orphan Node、非零 GUT Warnings/Orphans 摘要及 Godot 退出泄漏执行 fail-closed 硬门禁。
+- GUT 新增生命周期感知的 CLI wrapper、自定义 Runner、pre/post run hook、进程级 early/tracked/terminal warning 汇聚和可复用 LIFO cleanup scope；terminal capture 会在 tracker 快照前原子切换，完整测试入口只在 SceneTree 最终化阶段输出一份、至多由 stdout/log 镜像为两份的 `GF_TEST_LIFECYCLE_GATE` closed-schema JSON 证据，失败报告同步设置非零进程退出码。专用 smoke 通过统一进程树监督执行 bootstrap 静态 warning、线程切换 warning、真实 orphan、配置缺失和有界详情等故障注入，并对测试发现期与终态 `push_warning`、新增 orphan Node、GDScript reload warning、非零 GUT Warnings/Orphans 摘要及 Godot 退出泄漏执行 fail-closed 硬门禁。
+- `GFTagExpression.expressions` 改为导出 `Array[Resource]`，并在读取、复制、匹配和序列化边界严格收窄到 `GFTagExpression`；这规避 Godot 4.7 对自引用脚本类型数组形成的脚本资源引用环，同时继续把 null 或其他 Resource 按非法子表达式处理。
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复已销毁的 `GFArchitecture` 仍会保留父架构强引用的问题；`dispose()` 现在会在模块、工厂、服务和事件系统完成清理后断开 parent link，并拒绝 dispose 完成信号同步回调或后续调用重新注入 parent，即使内部状态被破坏为父链循环也不会让整组架构残留到进程退出。
+- 修复 `GFAsyncWaitSupport` 的 `should_continue` 回调宿主释放后，等待器会把失效 Callable 误当作未配置并继续存活到 timeout、进而在后续测试或场景中迟发 warning 的问题；只要调用方显式提交继续检查，进入等待前或等待期间失效都会立即以 `should_continue_invalid` 取消。
+- 修复 `GFTagExpression` 被加载或实例化后会在 Godot 退出时残留一个 `GDScript` 与一个 `GDScriptNativeClass` 的问题；Network 生成器和动态 Model 测试也统一拆除瞬态 GDScript 依赖图，不再把整张脚本资源图保留到测试进程退出。
+- 修复 `GFAnalyticsUtility.dispose()` 未释放项目注入的 payload builder、transport callback 和 response parser，以及 flush 终态通知同步回调可在 dispose 期间重新注入自引用回调的问题；最终通知结束后会再次清理注入引用。`GFReactiveStateControlBinder` 也不再在退订后由 binding callback 自引用保留整组状态与控件绑定。
+- 修复 `GFHapticUtility.dispose()` 只清空播放状态，却继续持有输入设备工具、震动后端、输出回调和停止回调的问题；这些项目注入依赖现在由工具生命周期统一释放，测试不再承担内部所有权清理。
 - 修复长期活动的 `GFRuntimeTask` 所持 `Node` requirement 已释放后，`GFRuntimeTaskScheduler` 的 owner 索引与诊断快照仍可能保留陈旧 ObjectID 的问题；活动任务和 live requirements 现在是唯一事实源，调度边界会先完整校验候选 owner map，再与活动集合一起提交，并在仲裁或释放回调期间拒绝会破坏已提交状态的重入写操作。
 - 修复 UI 路由启用资源存在性检查时，脚本或其他现有非场景资源可能被误判为健康 `PackedScene` 候选的问题；新增 `invalid_scene_type_paths`，将“资源存在但类型错误”与 `missing_scene_paths` 的“路径不存在”诊断明确分离。
 - 修复 Session Trace 在 `debug` 或 `support` 下注册的长期 context、通道 metadata 与 provider metadata，可能在随后收紧 profile 后继续保留对象实例 ID、节点名称或原始路径的问题；这些长期数据现在统一使用 `privacy` 安全下限。
@@ -122,6 +128,7 @@
 - 新增公开类型 `GFRuntimeAgentEnvironment`，以及 endpoint 注册/目录、session 签发/撤销、`invalidate_policy_context()`、版本化请求执行、安全审计和调试快照入口；均标记为 `@since unreleased`。该类型绑定创建线程，只保护不可信请求进入受信同步 handler 的协议边界，不是 OS sandbox。
 - 新增公开类型 `GFSaveProfile`、`GFSaveSectionProvider`、`GFSaveRecoveryPolicy`、`GFSaveProfileOperation`、`GFSaveProfileResult`、`GFSaveRollbackFailure` 和 `GFSaveProfileUtility`；Save 扩展安装器会自动注册 Profile Utility，既有 Save Graph 和 Slot API 不变。
 - 新增公开类型 `GFStorageAsyncOperation`、`GFStorageAsyncResult`，以及 `GFStorageUtility.save_data_request_async()`、`load_data_request_async()`、`canonicalize_data_file_name()`；`GFStorageReadResult` 新增只追加的 `FailureKind` 与 `failure_kind`。
+- `GFTagExpression.expressions` 的公开存储类型从 `Array[GFTagExpression]` 改为 `Array[Resource]`；元素语义仍严格限定为 `GFTagExpression` 或 null，方法参数和返回值不变。
 - `GFUIRoute.get_route_id()` 以及 Router 的注册、查询、打开信号和异步 pending 身份统一去除 route ID 首尾空白。
 - AI Developer 项目契约从 schema v1 升为 v2，项目快照从 schema v3 升为 v4，AI Developer Kit 工具协议同步升为 4.0.0；旧契约不保留双轨解析，旧 Snapshot 不进入迁移路径。
 - GF 开发身份从 `9.1.0-dev.0` 升为 `10.0.0-dev.0`，用于明确承载项目契约 v2、项目快照 v4 与相关破坏性工具协议变化；本条只切换开发线，不创建正式版本或发布标签。
@@ -147,6 +154,7 @@
 - 既有诊断命令、开发者控制台与 AI Developer 工具无需迁移，也不得直接当作 Runtime Agent 权限入口。只有明确需要运行时自动化时才安装 `gf.standard.agent_environment`，在禁用态注册最小 endpoint 与 closed Schema，由项目策略负责业务授权/批准，并由外层传输负责身份认证和凭据保护。
 - 既有 Save Graph、Slot 和直接 Storage 调用无需迁移。需要跨模块自动保存时，为每个稳定数据边界实现一个可回滚 `GFSaveSectionProvider`，注册 Profile 和完整迁移链；不要把缺失、损坏或未来版本统一重置为空存档。
 - 历史配置若有意使用带首尾空白的 route ID，需迁移为去除空白后的稳定 ID；规范化后重复的 ID 会指向同一注册身份，不应再依赖空白区分页面。
+- 直接读取 `GFTagExpression.expressions` 时，应把元素先用 `is GFTagExpression` 收窄再使用；项目若依赖变量的静态 `Array[GFTagExpression]` 类型，应改为通过 `configure_all()`、`configure_any()`、`configure_none()` 提交强类型输入，或显式构造经过校验的 `Array[Resource]`。
 - 严格 warning 项目必须接收 `push_route_async()` / `replace_route_async()` 的新返回值；需要结果时保存 `GFUIRouteOperation`，只需 fire-and-observe 全局信号时也应赋给带下划线的局部变量。打开前预加载必须显式选择策略，默认仍为 `PRELOAD_NONE`。
 - AI Developer 工具协议 3.x 的 schema v1 契约必须先运行 `contract-migration-plan`，审阅 `pending_review`、`owner: project` 默认值和完整候选，再由用户在交互终端用计划返回的 `plan_sha256` 执行 `contract-migrate` 并输入完整确认短语；随后确认 owner、Recipe 与验收条件并运行 `validate`。
 - Snapshot v4 是有意的破坏性生成协议升级：消费方应先升级到 AI Developer 工具协议 4.x，再重新生成快照；不要迁移 v3、复制字段或把观测结果反写为项目意图。独立 Kit ZIP 版本仍与 GF Framework 版本一致。
@@ -173,6 +181,9 @@
 - `addons/gf/standard/utilities/spatial_canvas/`
 - `packages/standard/gf.standard.spatial.canvas.json`
 - `docs/zh/standard/input-flow/spatial-canvas-2d.md`
+- `addons/gf/standard/foundation/tags/gf_tag_expression.gd`
+- `addons/gf/standard/common/gf_async_wait_support.gd`
+- `tests/gf_core/support/gf_gut_*.gd`
 - `addons/gf/standard/utilities/assets/gf_asset_collection.gd`
 - `addons/gf/standard/utilities/assets/gf_asset_catalog_runtime.gd`
 - `addons/gf/standard/utilities/assets/gf_asset_catalog_mount.gd`

--- a/docs/zh/reference/api/classes/GFAnalyticsUtility.md
+++ b/docs/zh/reference/api/classes/GFAnalyticsUtility.md
@@ -217,12 +217,13 @@ func init() -> void:
 ### `dispose`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func dispose() -> void:
 ```
 
-释放事件队列、HTTP 节点和关闭监听。
+释放事件队列、HTTP 节点、关闭监听和项目注入的回调。
 
 <a id="member-gfanalyticsutility-methods-tick"></a>
 

--- a/docs/zh/reference/api/classes/GFTagExpression.md
+++ b/docs/zh/reference/api/classes/GFTagExpression.md
@@ -18,7 +18,7 @@
 | 枚举 | [`Operator`](#member-gftagexpression-enums-operator) | `enum Operator` |
 | 属性 | [`operator`](#member-gftagexpression-properties-operator) | `var operator: Operator = Operator.QUERY` |
 | 属性 | [`query`](#member-gftagexpression-properties-query) | `var query: GFTagQuery = null` |
-| 属性 | [`expressions`](#member-gftagexpression-properties-expressions) | `var expressions: Array[GFTagExpression] = []` |
+| 属性 | [`expressions`](#member-gftagexpression-properties-expressions) | `var expressions: Array[Resource] = []` |
 | 方法 | [`is_empty`](#member-gftagexpression-methods-is_empty) | `func is_empty() -> bool:` |
 | 方法 | [`matches`](#member-gftagexpression-methods-matches) | `func matches(source: Variant) -> bool:` |
 | 方法 | [`get_match_report`](#member-gftagexpression-methods-get_match_report) | `func get_match_report(source: Variant) -> Dictionary:` |
@@ -85,16 +85,17 @@ var query: GFTagQuery = null
 ### `expressions`
 
 - API：`public`
+- 首次版本：`3.18.0`
 
 ```gdscript
-var expressions: Array[GFTagExpression] = []
+var expressions: Array[Resource] = []
 ```
 
-子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。
+子表达式列表。operator 为 ALL、ANY 或 NONE 时使用。公开语义只接受 GFTagExpression 或 null；其他 Resource 会保留索引并按 null_expression 失败， 不会被静默忽略。推荐通过 configure_all()、configure_any() 或 configure_none() 写入强类型子表达式。
 
 结构：
 
-- `expressions`: Array[GFTagExpression]，按数组顺序参与组合判断。
+- `expressions`: Array[GFTagExpression | null]，按数组顺序参与组合判断；底层使用 Array[Resource] 避免自引用 Resource 脚本被引擎永久保留。
 
 ## 方法
 

--- a/tests/gf_core/README.md
+++ b/tests/gf_core/README.md
@@ -7,6 +7,7 @@ GUT tests mirror the framework source layers:
 - `standard`: foundation, input, utilities, sequence, command, and state-machine tests.
 - `extensions`: tests for optional GF extensions, grouped by extension ID.
 - `fixtures`: shared scenes, installers, and small scripts used by multiple tests.
+- `support`: lifecycle scopes and GUT run hooks shared by the full suite.
 
 Run all tests with:
 
@@ -14,4 +15,11 @@ Run all tests with:
 python tools\gf_maintenance.py check --check gut --failed-only
 ```
 
-该入口会先导入干净项目，再运行 GUT，并校验 Godot 日志与整套测试通过摘要。
+该入口会先导入干净项目，再运行 GUT，并校验 Godot 日志、整套测试通过摘要与
+`GF_TEST_LIFECYCLE_GATE` 结构化结果。未由 GUT warning 断言消费的
+`push_warning`、新增 orphan Node 或 Godot 退出期泄漏都会让检查失败。
+
+需要管理多项延迟清理时，使用
+`res://tests/gf_core/support/gf_test_lifecycle_scope.gd` 注册 LIFO cleanup，并在
+`after_each()` 中 `await scope.assert_clean(self)`；不要通过清空 error tracker、
+隐藏 orphan 输出或保留强引用来绕过生命周期断言。

--- a/tests/gf_core/extensions/action_queue/test_gf_action_queue.gd
+++ b/tests/gf_core/extensions/action_queue/test_gf_action_queue.gd
@@ -641,6 +641,7 @@ func test_signal_timeout_allows_queue_to_continue() -> void:
 	assert_push_warning("[GFActionQueueSystem] 等待动作 Signal 超时，队列将继续执行后续动作。")
 	assert_eq(order, ["AFTER_TIMEOUT"], "Signal 超时后队列应继续执行后续动作。")
 	assert_false(_is_queue_processing(_system), "Signal 超时后队列不应继续卡在处理中。")
+	emitter.free()
 
 
 func test_signal_timeout_respects_time_utility_pause() -> void:
@@ -678,6 +679,7 @@ func test_signal_timeout_respects_time_utility_pause() -> void:
 	assert_eq(order, ["AFTER_TIMEOUT"], "恢复时间后，Signal 超时应继续推进并执行后续动作。")
 	assert_false(_is_queue_processing(queue), "恢复时间并超时后队列应排空。")
 
+	emitter.free()
 	arch.dispose()
 
 
@@ -708,6 +710,7 @@ func test_signal_timeout_is_frozen_while_current_action_is_paused() -> void:
 
 	assert_push_warning("[GFActionQueueSystem] 等待动作 Signal 超时，队列将继续执行后续动作。")
 	assert_eq(order, ["AFTER_TIMEOUT"], "恢复后 Signal timeout 应继续执行后续动作。")
+	emitter.free()
 
 
 func test_no_deadlock_on_freed_node() -> void:

--- a/tests/gf_core/extensions/action_queue/test_gf_action_queue.gd
+++ b/tests/gf_core/extensions/action_queue/test_gf_action_queue.gd
@@ -197,6 +197,7 @@ func after_each() -> void:
 	_dispose_queue(_system)
 	_system = null
 	_interceptor_fixtures = null
+	await get_tree().process_frame
 
 
 func _signal_from_result(result: Variant) -> Signal:

--- a/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
+++ b/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
@@ -2,7 +2,7 @@
 extends GutTest
 
 
-class TestAudioUtility:
+class AudioUtilityProbe:
 	extends GFAudioUtility
 
 	var played_paths: Array[String] = []
@@ -204,6 +204,7 @@ func test_move_tween_action_rejects_incompatible_target_value() -> void:
 
 	var action: GFVisualAction = GFMoveTweenAction.new(node, "bad_target", 0.0)
 	var result: Variant = action.execute()
+	assert_push_warning("[GFMoveTweenAction] 目标属性与目标值类型不兼容：position。")
 
 	assert_true(result == null, "类型不兼容的移动动作不应创建 Tween。")
 	assert_eq(node.position, Vector2.ZERO, "类型不兼容时不应写入目标属性。")
@@ -215,6 +216,7 @@ func test_move_tween_action_rejects_missing_property() -> void:
 
 	var action: GFVisualAction = GFMoveTweenAction.new(node, Vector2.ONE, 0.0, ^"missing_position")
 	var result: Variant = action.execute()
+	assert_push_warning("[GFMoveTweenAction] 目标属性不存在：missing_position。")
 
 	assert_true(result == null, "缺失属性不应创建移动 Tween。")
 
@@ -605,6 +607,9 @@ func test_action_race_can_keep_remaining_children_running() -> void:
 	assert_true(completed[0], "race 动作组应仍在首个子动作完成后结束。")
 	assert_false(slow.cancelled, "关闭取消策略时，race 不应替调用方取消剩余动作。")
 
+	slow.cancel()
+	await get_tree().process_frame
+
 
 func test_sequence_group_reexecute_cancels_previous_run_and_releases_waiter() -> void:
 	var first: ManualSignalAction = ManualSignalAction.new()
@@ -624,6 +629,9 @@ func test_sequence_group_reexecute_cancels_previous_run_and_releases_waiter() ->
 	assert_true(first.cancelled, "运行中重复 execute 应取消上一轮正在等待的子动作。")
 	assert_true(first_completed[0], "运行中重复 execute 应释放上一轮等待者。")
 	assert_true(second_result is Signal, "新一轮 execute 仍应返回可等待信号。")
+
+	group.cancel()
+	await get_tree().process_frame
 
 
 func test_repeat_action_creates_fresh_action_each_iteration() -> void:
@@ -661,6 +669,9 @@ func test_repeat_action_reexecute_cancels_previous_active_action() -> void:
 	assert_true(actions[0].cancelled, "运行中重复 execute 应取消上一轮当前动作。")
 	assert_true(first_completed[0], "运行中重复 execute 应释放上一轮等待者。")
 	assert_true(second_result is Signal, "第二轮 repeat 仍应返回完成信号。")
+
+	repeat.cancel()
+	await get_tree().process_frame
 
 
 func test_tween_action_step_apply_instant_relative_vector2() -> void:
@@ -817,6 +828,7 @@ func test_flash_action_rejects_non_color_property() -> void:
 
 	var action: GFVisualAction = GFFlashAction.new(item, Color.RED, 0.01, ^"visible")
 	var result: Variant = action.execute()
+	assert_push_warning("[GFFlashAction] 目标属性不是 Color：visible。")
 
 	assert_true(result == null, "非 Color 属性不应创建闪色 Tween。")
 	assert_true(item.visible, "非 Color 属性不应被闪色动作改写。")
@@ -828,6 +840,7 @@ func test_flash_action_rejects_missing_property() -> void:
 
 	var action: GFVisualAction = GFFlashAction.new(item, Color.RED, 0.01, ^"missing_color")
 	var result: Variant = action.execute()
+	assert_push_warning("[GFFlashAction] 目标属性不存在：missing_color。")
 
 	assert_true(result == null, "缺失属性不应创建闪色 Tween。")
 
@@ -1024,7 +1037,7 @@ func test_audio_action_is_fire_and_forget() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	Gf._architecture = arch
 
-	var audio: TestAudioUtility = TestAudioUtility.new()
+	var audio: AudioUtilityProbe = AudioUtilityProbe.new()
 	await Gf.register_utility(audio)
 	await Gf.set_architecture(arch)
 	await get_tree().process_frame
@@ -1041,7 +1054,7 @@ func test_audio_action_can_play_bank_clip() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	Gf._architecture = arch
 
-	var audio: TestAudioUtility = TestAudioUtility.new()
+	var audio: AudioUtilityProbe = AudioUtilityProbe.new()
 	await Gf.register_utility(audio)
 	await Gf.set_architecture(arch)
 	await get_tree().process_frame

--- a/tests/gf_core/extensions/capability/test_gf_capability_utility.gd
+++ b/tests/gf_core/extensions/capability/test_gf_capability_utility.gd
@@ -827,6 +827,7 @@ func test_add_scene_capability_frees_ignored_duplicate_instance() -> void:
 	var scene: PackedScene = _make_counting_capability_scene()
 
 	var result: Object = _utility.add_scene_capability(receiver, scene, CountingCapabilityNode)
+	assert_push_warning("[GFCapabilityUtility] add_scene_capability：目标对象已拥有该能力，已忽略新实例。")
 	var duplicate_node: CountingCapabilityNode = CountingCapabilityNode.created_nodes.back()
 
 	assert_eq(result, existing, "重复挂载场景能力时应返回已有实例。")

--- a/tests/gf_core/extensions/combat/test_gf_buff_recipe.gd
+++ b/tests/gf_core/extensions/combat/test_gf_buff_recipe.gd
@@ -61,6 +61,8 @@ func test_buff_check_blocks_combat_system_add_buff() -> void:
 	system.add_buff(entity, buff)
 
 	assert_false(system.has_buff(entity, &"blocked"), "检查失败的 Buff 不应进入 CombatSystem。")
+	system.dispose()
+	entity.free()
 
 
 func test_buff_state_snapshot_restores_generic_runtime_fields_and_effect_state() -> void:

--- a/tests/gf_core/extensions/combat/test_gf_combat_extension.gd
+++ b/tests/gf_core/extensions/combat/test_gf_combat_extension.gd
@@ -8,7 +8,7 @@ const _GF_SKILL_ACTIVATION_STEP_SCRIPT = preload("res://addons/gf/extensions/com
 
 # --- 辅助类 (模拟战斗实体) ---
 
-class MockEntity extends Object:
+class MockEntity extends RefCounted:
 	var tag_component: GFTagComponent = GFTagComponent.new()
 	var attributes: Dictionary = {}
 	var buffs: Array[GFBuff] = []
@@ -352,6 +352,7 @@ func test_skill_requires_tags_when_owner_has_no_tag_component() -> void:
 	skill.require_tags.append(&"Armed")
 
 	assert_false(skill.can_execute(), "存在必需标签但 owner 无标签组件时，技能不应允许施放。")
+	plain_owner.free()
 
 
 func test_skill_custom_can_execute_runs_without_tag_component() -> void:
@@ -360,6 +361,7 @@ func test_skill_custom_can_execute_runs_without_tag_component() -> void:
 	skill.owner = plain_owner
 
 	assert_false(skill.can_execute(), "owner 无标签组件且无必需标签时，仍应执行自定义施放检查。")
+	plain_owner.free()
 
 
 func test_skill_activation_report_uses_tag_query_and_callbacks() -> void:
@@ -429,6 +431,7 @@ func test_skill_commit_failure_blocks_activation_side_effects() -> void:
 	assert_eq(skill.cooldown_left, 0.0, "提交失败不应进入冷却。")
 	assert_eq(step.calls, [&"validate", &"apply"], "失败步骤不应被标记为已应用或进入回滚。")
 	assert_signal_emitted(skill, "activation_failed", "提交失败应发出激活失败信号。")
+	step.applied_context = null
 
 
 func test_skill_activation_context_commit_and_cooldown_flow() -> void:
@@ -462,6 +465,8 @@ func test_skill_activation_context_commit_and_cooldown_flow() -> void:
 	assert_true(GFVariantData.get_option_bool(context_metadata, "committed"), "提交回调 metadata 应合并到上下文。")
 	assert_eq(GFVariantData.get_option_string(context_metadata, "request"), "primary", "调用方 metadata 应保留。")
 	assert_signal_emitted(skill, "activation_committed", "执行成功应发出提交信号。")
+	step.applied_context = null
+	skill.activation_context = null
 
 
 func test_skill_rejects_freed_owner() -> void:
@@ -499,7 +504,7 @@ func test_buff_modifier_requires_explicit_attribute_id() -> void:
 
 
 func test_buff_ignores_freed_owner() -> void:
-	var entity: MockEntity = MockEntity.new()
+	var entity: Object = Object.new()
 	var buff: GFBuff = GFBuff.new()
 	buff.tags.append(&"Buffed")
 	buff.setup(&"Detached", 1.0, entity)
@@ -636,6 +641,7 @@ func test_skill_does_not_start_cooldown_when_execute_hook_fails() -> void:
 	assert_eq(step.calls, [&"validate", &"apply", &"rollback"], "执行失败应逆序回滚已应用步骤。")
 	assert_eq(resource_balance[0], 1, "执行失败不应留下已经扣除的资源。")
 	assert_eq(skill.cooldown_left, 0.0, "执行钩子失败时不应进入冷却。")
+	step.applied_context = null
 
 
 func test_add_skill_rebinds_existing_owner_to_registered_entity() -> void:
@@ -1051,7 +1057,7 @@ func test_update_active_status_cleans_orphaned_active_entry() -> void:
 
 func test_tick_cleans_freed_entities_from_internal_indices() -> void:
 	var system: GFCombatSystem = GFCombatSystem.new()
-	var entity: MockEntity = MockEntity.new()
+	var entity: Object = Object.new()
 
 	system._entities[entity.get_instance_id()] = {
 		"buffs": [],
@@ -1086,6 +1092,7 @@ func test_tick_skips_entity_removed_by_earlier_entity_callback() -> void:
 	system.tick(0.1)
 
 	assert_false(system._entities.has(entity_b.get_instance_id()), "tick 中被前一个实体注销的后续实体不应再被访问。")
+	system.dispose()
 
 
 func test_combat_event_dispatching() -> void:

--- a/tests/gf_core/extensions/combat/test_gf_combat_extension.gd
+++ b/tests/gf_core/extensions/combat/test_gf_combat_extension.gd
@@ -1240,6 +1240,7 @@ func test_hit_collision_shape_config_2d_generates_reusable_shapes() -> void:
 	hit_box.clear_generated_collision_shape()
 	assert_null(hit_box.get_generated_collision_shape(), "clear_generated_collision_shape 应移除框架管理的形状节点。")
 	instantiated.free()
+	await get_tree().process_frame
 
 
 func test_hit_collision_shape_config_3d_generates_reusable_shapes() -> void:
@@ -1306,6 +1307,7 @@ func test_hit_collision_shape_config_3d_generates_reusable_shapes() -> void:
 	hit_box.clear_generated_collision_shape()
 	assert_null(hit_box.get_generated_collision_shape(), "clear_generated_collision_shape 应移除框架管理的 3D 形状节点。")
 	instantiated.free()
+	await get_tree().process_frame
 
 
 func test_hit_box_2d_sends_generic_hit_context() -> void:

--- a/tests/gf_core/extensions/combat/test_gf_projectiles.gd
+++ b/tests/gf_core/extensions/combat/test_gf_projectiles.gd
@@ -490,6 +490,7 @@ func test_projectile_emitter_2d_uses_explicit_object_pool() -> void:
 	assert_eq(pool.get_active_count(scene), 1, "发射器应通过显式对象池获取节点。")
 
 	pool.dispose()
+	await get_tree().process_frame
 
 
 func test_projectile_emitter_2d_disables_pooled_auto_launch_before_add() -> void:
@@ -511,6 +512,7 @@ func test_projectile_emitter_2d_disables_pooled_auto_launch_before_add() -> void
 	assert_not_null(motion, "池化发射体应保持测试用 motion。")
 	if motion == null:
 		pool.dispose()
+		await get_tree().process_frame
 		return
 
 	assert_eq(motion.setup_count, 1, "对象池新建节点不应在 emitter 准备上下文前 auto launch。")
@@ -519,6 +521,7 @@ func test_projectile_emitter_2d_disables_pooled_auto_launch_before_add() -> void
 	assert_eq(GFVariantData.get_option_string(context, "skill_id"), "pool_test", "唯一 launch 应使用调用方上下文。")
 
 	pool.dispose()
+	await get_tree().process_frame
 
 
 func test_projectile_emitter_2d_uses_injected_architecture_pool() -> void:
@@ -541,6 +544,7 @@ func test_projectile_emitter_2d_uses_injected_architecture_pool() -> void:
 	assert_eq(pool.get_active_count(scene), 1, "发射器应通过注入架构查询对象池。")
 
 	architecture.dispose()
+	await get_tree().process_frame
 
 
 func test_projectile_line_spawn_pattern_2d_distributes_points() -> void:

--- a/tests/gf_core/extensions/dialogue/test_gf_dialogue_extension.gd
+++ b/tests/gf_core/extensions/dialogue/test_gf_dialogue_extension.gd
@@ -727,16 +727,20 @@ func test_dialogue_response_mutation_reentry_preserves_replacement_session() -> 
 		return true
 	var runner: GFDialogueRunner = GFDialogueRunner.new()
 	var replaced: Array[bool] = [false]
-	var _connected: Error = runner.mutation_requested.connect(
+	var mutation_requested_callback: Callable = (
 		func(_mutation_id: StringName, _payload: Variant, _line: GFDialogueLine) -> void:
 			if replaced[0]:
 				return
 			replaced[0] = true
 			var _replacement_line: GFDialogueLine = runner.start(replacement)
+	)
+	var _connected: Error = runner.mutation_requested.connect(
+		mutation_requested_callback
 	) as Error
 	var _original_line: GFDialogueLine = runner.start(original, &"", context)
 
 	var stale_result: GFDialogueLine = runner.choose_response(&"pick")
+	runner.mutation_requested.disconnect(mutation_requested_callback)
 
 	assert_null(stale_result, "旧响应调用链在会话被替换后必须返回 null。")
 	assert_true(runner.is_running(), "旧 mutation 调用链不得结束重入创建的新会话。")
@@ -759,15 +763,19 @@ func test_dialogue_line_mutation_reentry_cannot_end_replacement_session() -> voi
 	replacement.set_line(_make_text_line(&"replacement", "Replacement", &""))
 	var runner: GFDialogueRunner = GFDialogueRunner.new()
 	var replaced: Array[bool] = [false]
-	var _connected: Error = runner.mutation_requested.connect(
+	var mutation_requested_callback: Callable = (
 		func(_mutation_id: StringName, _payload: Variant, _line: GFDialogueLine) -> void:
 			if replaced[0]:
 				return
 			replaced[0] = true
 			var _replacement_line: GFDialogueLine = runner.start(replacement)
+	)
+	var _connected: Error = runner.mutation_requested.connect(
+		mutation_requested_callback
 	) as Error
 
 	var stale_result: GFDialogueLine = runner.start(original, &"", GFDialogueContext.new())
+	runner.mutation_requested.disconnect(mutation_requested_callback)
 
 	assert_null(stale_result, "旧 mutation 行推进在会话被替换后必须返回 null。")
 	assert_true(runner.is_running(), "旧 mutation 行失败路径不得停止替换会话。")

--- a/tests/gf_core/extensions/domain/test_gf_domain_extensions.gd
+++ b/tests/gf_core/extensions/domain/test_gf_domain_extensions.gd
@@ -792,6 +792,8 @@ func test_attribute_set_skips_entire_derived_cycle_without_partial_writes() -> v
 	attributes.derived_rules = [rule_a, rule_b]
 
 	attributes.recalculate_derived()
+	assert_push_warning("[GFAttributeSet] 检测到派生属性循环，已跳过：a")
+	assert_push_warning("[GFAttributeSet] 检测到派生属性循环，已跳过：b")
 
 	assert_eq(attributes.get_value(&"a"), 5.0, "派生规则成环时环内目标不应被部分写入。")
 	assert_eq(attributes.get_value(&"b"), 7.0, "派生规则成环时整组环内目标都应跳过。")

--- a/tests/gf_core/extensions/domain/test_gf_domain_extensions.gd
+++ b/tests/gf_core/extensions/domain/test_gf_domain_extensions.gd
@@ -519,14 +519,16 @@ func test_slot_inventory_rejects_reentrant_sort_during_change_signal() -> void:
 	var _add_item_to_slot_result_361: Variant = inventory.add_item_to_slot(0, &"HealthPotion", 1)
 	var sort_results: Array = []
 	var listener_snapshots: Array = []
-	var _connect_result_364: Variant = inventory.slot_state_changed.connect(func(_slot_index: int, _before_stack_data: Dictionary, _after_stack_data: Dictionary) -> void:
+	var sort_callback: Callable = func(_slot_index: int, _before_stack_data: Dictionary, _after_stack_data: Dictionary) -> void:
 		sort_results.append(inventory.sort_slots())
-	)
-	var _connect_result_367: Variant = inventory.slot_state_changed.connect(func(_slot_index: int, _before_stack_data: Dictionary, after_stack_data: Dictionary) -> void:
+	var snapshot_callback: Callable = func(_slot_index: int, _before_stack_data: Dictionary, after_stack_data: Dictionary) -> void:
 		listener_snapshots.append(after_stack_data.duplicate(true))
-	)
+	var _connect_result_364: Variant = inventory.slot_state_changed.connect(sort_callback)
+	var _connect_result_367: Variant = inventory.slot_state_changed.connect(snapshot_callback)
 
 	var _remove_item_from_slot_result_371: Variant = inventory.remove_item_from_slot(0, 1)
+	inventory.slot_state_changed.disconnect(sort_callback)
+	inventory.slot_state_changed.disconnect(snapshot_callback)
 
 	assert_push_error("[GFSlotInventoryModel] sort_slots 失败：库存变更通知派发中不允许同步修改库存。请使用 call_deferred() 或在当前通知结束后再修改。")
 	assert_eq(sort_results, [false], "通知派发中的同步排序应失败。")
@@ -542,12 +544,13 @@ func test_slot_inventory_deferred_sort_after_signal_is_safe() -> void:
 	inventory.set_slot_count(3)
 	var _add_item_to_slot_result_385: Variant = inventory.add_item_to_slot(0, &"z_item", 1)
 	var _add_item_to_slot_result_386: Variant = inventory.add_item_to_slot(1, &"a_item", 1)
-	var _connect_result_387: Variant = inventory.slot_emptied.connect(func(_slot_index: int, _previous_stack_data: Dictionary) -> void:
+	var emptied_callback: Callable = func(_slot_index: int, _previous_stack_data: Dictionary) -> void:
 		inventory.call_deferred("sort_slots")
-	)
+	var _connect_result_387: Variant = inventory.slot_emptied.connect(emptied_callback)
 
 	var _remove_item_from_slot_result_391: Variant = inventory.remove_item_from_slot(0, 1)
 	await get_tree().process_frame
+	inventory.slot_emptied.disconnect(emptied_callback)
 
 	assert_eq(GFVariantData.get_option_string(inventory.get_stack_data(0), "item_id"), "a_item", "延迟排序应在通知结束后把非空槽位前移。")
 	assert_true(inventory.is_slot_empty(1), "排序后原第二槽位应变为空。")
@@ -622,6 +625,7 @@ func test_slot_inventory_rejects_mutation_from_acceptance_checker() -> void:
 	assert_true(inventory.set_slot_definition(0, slot_definition))
 
 	var result: GFInventoryOperationResult = inventory.add_item_to_slot(0, &"item_a", 1)
+	slot_definition.acceptance_checker = Callable()
 
 	assert_true(result.ok, "只读接收回调仍应能返回接收结果。")
 	assert_true(attempted_clear[0], "测试回调应尝试一次嵌套 clear。")

--- a/tests/gf_core/extensions/domain/test_gf_level_utility.gd
+++ b/tests/gf_core/extensions/domain/test_gf_level_utility.gd
@@ -7,7 +7,7 @@ const GF_LEVEL_UTILITY = preload("res://addons/gf/extensions/domain/level/gf_lev
 
 # --- 辅助类型 ---
 
-class TestConfigProvider extends GFConfigProvider:
+class ConfigProviderStub extends GFConfigProvider:
 	var records: Dictionary = {}
 
 	func get_record(table_name: StringName, id: Variant) -> Variant:
@@ -15,7 +15,7 @@ class TestConfigProvider extends GFConfigProvider:
 		return GFVariantData.get_option_value(table_records, id)
 
 
-class TestCommand extends GFUndoableCommand:
+class UndoableCommandStub extends GFUndoableCommand:
 	func execute() -> Variant:
 		return null
 
@@ -39,7 +39,7 @@ class WaitingAction extends GFVisualAction:
 
 var _arch: GFArchitecture
 var _level: GFLevelUtility
-var _config: TestConfigProvider
+var _config: ConfigProviderStub
 var _history: GFCommandHistoryUtility
 var _actions: GFActionQueueSystem
 var _progress: GFLevelProgressModel
@@ -50,7 +50,7 @@ var _progress: GFLevelProgressModel
 func before_each() -> void:
 	_arch = GFArchitecture.new()
 	_level = GF_LEVEL_UTILITY.new()
-	_config = TestConfigProvider.new()
+	_config = ConfigProviderStub.new()
 	_history = GFCommandHistoryUtility.new()
 	_actions = GFActionQueueSystem.new()
 	_progress = GFLevelProgressModel.new()
@@ -155,7 +155,7 @@ func test_strict_start_level_rejects_missing_data() -> void:
 
 
 func test_restart_level_clears_runtime_and_emits_signal() -> void:
-	var command: TestCommand = TestCommand.new()
+	var command: UndoableCommandStub = UndoableCommandStub.new()
 	_history.record(command)
 	var _start_level_result_139: Variant = _level.start_level(1)
 	watch_signals(_level)

--- a/tests/gf_core/extensions/feedback/test_gf_feedback_extension.gd
+++ b/tests/gf_core/extensions/feedback/test_gf_feedback_extension.gd
@@ -823,6 +823,37 @@ func test_haptic_output_callback_cannot_reenter_state_mutation() -> void:
 	assert_push_error("[GFHapticUtility] clear 失败：输出后端或回调执行期间不允许同步修改震动状态。请在当前输出结束后再修改。")
 	assert_true(utility.is_haptic_active(haptic_id), "被拒绝的回调重入不得清除活跃状态。")
 	assert_eq(GFVariantData.get_option_int(report, "applied_count"), 1, "回调自身成功时本轮输出仍应按稳定快照完成。")
+	utility.dispose()
+	assert_false(utility.output_handler.is_valid(), "dispose 应由工具自身释放捕获工具的输出回调。")
+
+
+func test_haptic_dispose_releases_injected_dependencies_and_callbacks() -> void:
+	var utility: GFHapticUtility = GFHapticUtility.new()
+	utility.init()
+	utility.input_device_utility = GFInputDeviceUtility.new()
+	utility.haptic_backend = RefCounted.new()
+	utility.output_handler = func(
+		_target_type: int,
+		_target_id: int,
+		_weak_magnitude: float,
+		_strong_magnitude: float,
+		_duration_seconds: float,
+		_metadata: Dictionary
+	) -> bool:
+		return utility != null
+	utility.stop_handler = func(
+		_target_type: int,
+		_target_id: int,
+		_metadata: Dictionary
+	) -> bool:
+		return utility != null
+
+	utility.dispose()
+
+	assert_null(utility.input_device_utility, "dispose 应释放注入的输入设备工具。")
+	assert_null(utility.haptic_backend, "dispose 应释放注入的震动后端。")
+	assert_false(utility.output_handler.is_valid(), "dispose 应释放输出回调。")
+	assert_false(utility.stop_handler.is_valid(), "dispose 应释放停止回调。")
 
 
 func test_haptic_utility_clear_stops_and_clears_last_output_targets() -> void:

--- a/tests/gf_core/extensions/flow/test_gf_flow_graph.gd
+++ b/tests/gf_core/extensions/flow/test_gf_flow_graph.gd
@@ -621,6 +621,7 @@ func test_flow_runner_loop_guard_cancels_instead_of_completing() -> void:
 	watch_signals(runner)
 
 	var report: Dictionary = await runner.run(graph, GFFlowContext.new())
+	assert_push_warning("[GFFlowRunner] 达到最大节点执行数量，流程停止。")
 
 	assert_eq(order, ["start", "start"], "loop guard 应在达到上限后停止。")
 	assert_eq(GFVariantData.get_option_string(report, "outcome"), "aborted", "loop guard 应报告 aborted。")
@@ -971,6 +972,7 @@ func test_flow_graph_dock_rejects_non_project_resource_paths_and_clears_view() -
 	assert_eq(dock._graph_path, "", "非项目资源路径不得保留为 dock 的可加载路径。")
 	assert_eq(dock.get_last_view_model(), {}, "拒绝路径后不得保留旧 graph 的 view model。")
 	dock.free()
+	await get_tree().process_frame
 
 
 func test_flow_graph_dock_starts_with_compact_empty_state() -> void:
@@ -1016,6 +1018,7 @@ func test_flow_graph_dock_connection_request_updates_graph() -> void:
 
 	assert_true(graph.has_connection(&"start", &"", &"end", &""), "GraphEdit 连线请求应写入 FlowGraph。")
 	dock.free()
+	await get_tree().process_frame
 
 
 func test_flow_graph_dock_canvas_move_updates_node_position() -> void:
@@ -1032,6 +1035,7 @@ func test_flow_graph_dock_canvas_move_updates_node_position() -> void:
 
 	assert_eq(start.editor_position, Vector2(42.0, 64.0), "GraphEdit 节点移动应写回 editor_position。")
 	dock.free()
+	await get_tree().process_frame
 
 
 ## 验证流程上下文可注册通用条件查询处理器。

--- a/tests/gf_core/extensions/flow/test_gf_flow_graph.gd
+++ b/tests/gf_core/extensions/flow/test_gf_flow_graph.gd
@@ -420,12 +420,13 @@ func test_flow_runner_cancel_from_node_started_skips_execution() -> void:
 	graph.start_node_id = &"start"
 	graph.nodes = [RecordingFlowNode.new(&"start", order)]
 	var runner: GFFlowRunner = GFFlowRunner.new()
-	var _connected: Variant = runner.node_started.connect(func(_node_id: StringName, _node: GFFlowNode) -> void:
+	var node_started_callback: Callable = func(_node_id: StringName, _node: GFFlowNode) -> void:
 		runner.cancel()
-	)
+	var _connected: Variant = runner.node_started.connect(node_started_callback)
 	watch_signals(runner)
 
 	var report: Dictionary = await runner.run(graph, GFFlowContext.new())
+	runner.node_started.disconnect(node_started_callback)
 
 	assert_eq(order, [], "node_started 中取消后不应继续执行当前节点。")
 	assert_eq(GFVariantData.get_option_string(report, "outcome"), "cancelled", "node_started 中取消应报告 cancelled。")
@@ -1052,6 +1053,7 @@ func test_flow_context_queries_condition_handlers() -> void:
 	var result: Dictionary = context.query_condition(&"ready", "go")
 	var missing: Dictionary = context.query_condition(&"missing")
 	var result_metadata: Dictionary = GFVariantData.get_option_dictionary(result, "metadata")
+	context.unregister_condition_handler(&"ready")
 
 	assert_true(GFVariantData.get_option_bool(result, "ok"), "有效条件查询应成功。")
 	assert_true(GFVariantData.get_option_bool(result, "value"), "条件处理器应返回归一化 value。")

--- a/tests/gf_core/extensions/network/test_gf_network_extension.gd
+++ b/tests/gf_core/extensions/network/test_gf_network_extension.gd
@@ -1,6 +1,14 @@
 ## 测试 GF 网络抽象的消息编码、后端桥接与限流器。
 extends GutTest
 
+
+# --- 常量 ---
+
+const GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT = preload(
+	"res://tests/gf_core/support/gf_transient_gdscript_test_support.gd"
+)
+
+
 # --- 辅助类 ---
 
 class FakeBackend extends GFNetworkBackend:
@@ -1226,9 +1234,13 @@ func test_network_contract_generator_builds_typed_helpers() -> void:
 	assert_true(source.contains("static func send_player_ready(network: GFNetworkUtility, peer_id: int, slot: int, ready: bool = false, options: Dictionary = {}) -> Error:"), "应生成强类型发送函数。")
 	assert_true(source.contains("static func get_player_ready_slot(message: GFNetworkMessage, default_value: int = 0) -> int:"), "应生成字段读取函数。")
 
-	var runtime_script: GDScript = GDScript.new()
-	runtime_script.source_code = source.replace("class_name LobbyNetworkMessages\n", "")
-	assert_eq(runtime_script.reload(), OK, "生成源码去掉全局类注册行后应能被 GDScript 编译。")
+	var compile_report: Dictionary = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.compile_and_release(
+		source.replace("class_name LobbyNetworkMessages\n", "")
+	)
+	assert_true(
+		GFVariantData.get_option_bool(compile_report, "ok"),
+		"生成源码去掉全局类注册行后应能被 GDScript 编译：%s" % compile_report
+	)
 
 
 func test_network_contract_generator_omits_optional_null_fields() -> void:
@@ -1252,9 +1264,13 @@ func test_network_contract_generator_omits_optional_null_fields() -> void:
 	assert_true(source.contains("static func make_player_note(slot: int, note: Variant = null, options: Dictionary = {}) -> GFNetworkMessage:"), "无默认值的可选字段应保留 null 作为未提供语义。")
 	assert_true(source.contains("if note != null or GFVariantData.get_option_bool(options, \"include_null_optional_fields\"):"), "payload 构建应默认省略 null 可选字段。")
 
-	var runtime_script: GDScript = GDScript.new()
-	runtime_script.source_code = source.replace("class_name LobbyNetworkMessages\n", "")
-	assert_eq(runtime_script.reload(), OK, "可选 null 语义生成源码应能编译。")
+	var compile_report: Dictionary = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.compile_and_release(
+		source.replace("class_name LobbyNetworkMessages\n", "")
+	)
+	assert_true(
+		GFVariantData.get_option_bool(compile_report, "ok"),
+		"可选 null 语义生成源码应能编译：%s" % compile_report
+	)
 
 
 func test_network_contract_generator_reports_invalid_resources_with_standard_report() -> void:

--- a/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
@@ -172,6 +172,8 @@ func after_each() -> void:
 	if _utility != null:
 		_utility.dispose()
 	_utility = null
+	if _storage != null:
+		_storage.dispose()
 	_storage = null
 	_clock = null
 
@@ -586,6 +588,7 @@ func test_provider_reentrant_save_is_rejected_without_recursive_io() -> void:
 	assert_eq(nested_operations[0].get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
 	_storage.complete_save(OK)
 	assert_true(outer.get_result().is_successful())
+	provider.gather_callback = Callable()
 
 
 func test_completion_callback_dispose_leaves_disposed_as_final_state() -> void:
@@ -1136,6 +1139,7 @@ func test_real_storage_round_trip_completes_through_async_signals() -> void:
 	real_storage.wait_for_async_tasks()
 	var _delete_error: Error = real_storage.delete_file(profile.file_name)
 	real_utility.dispose()
+	real_storage.dispose()
 
 
 func test_extension_installer_ready_injects_storage_for_real_round_trip() -> void:

--- a/tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd
@@ -15,6 +15,7 @@ func after_each() -> void:
 	if _storage != null:
 		for file_name: String in _storage.list_files("", "", true):
 			var _delete_result: Error = _storage.delete_file(file_name)
+		_storage.dispose()
 		_storage = null
 
 

--- a/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
+++ b/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
@@ -335,6 +335,7 @@ func test_advance_phase_skips_null_phase_entries_safely() -> void:
 	var order: Array[String] = []
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
 	system.phases = [null, RecordingPhase.new(&"play", order)]
+	assert_push_warning("[GFTurnFlowSystem] set_phases 跳过空阶段。")
 
 	system.start()
 	await system.advance_phase()
@@ -669,7 +670,8 @@ func test_action_instance_is_one_shot_and_configuration_seals_on_enqueue() -> vo
 	assert_eq(_get_queued_actions(system_a).size(), 1, "同一 action 实例不得重复入队。")
 	assert_eq(_get_queued_actions(system_b).size(), 0, "同一 action 实例不得跨 flow 复用。")
 	assert_eq(action.priority, 3, "action 入队后配置必须冻结。")
-	assert_push_warning_count(2, "重复与跨 flow 入队都应被拒绝。")
+	for _index: int in range(2):
+		assert_push_warning("[GFTurnFlowSystem] enqueue_action 失败：action 实例只能入队一次。")
 	assert_push_error("[GFTurnAction] 行动已入队，不能修改配置：priority。")
 	system_a.stop(true)
 

--- a/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
+++ b/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
@@ -222,21 +222,29 @@ func test_turn_flow_start_and_stop_are_idempotent_under_signal_reentry() -> void
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
 	var started_count: Array[int] = [0]
 	var stopped_count: Array[int] = [0]
-	var _started_connection: Error = system.flow_started.connect(
+	var started_callback: Callable = (
 		func(_context: GFTurnContext) -> void:
 			started_count[0] += 1
 			system.start()
+	)
+	var _started_connection: Error = system.flow_started.connect(
+		started_callback
 	) as Error
-	var _stopped_connection: Error = system.flow_stopped.connect(
+	var stopped_callback: Callable = (
 		func(_context: GFTurnContext) -> void:
 			stopped_count[0] += 1
 			system.stop()
+	)
+	var _stopped_connection: Error = system.flow_stopped.connect(
+		stopped_callback
 	) as Error
 
 	system.start()
 	system.start(false)
 	system.stop()
 	system.stop(false)
+	system.flow_started.disconnect(started_callback)
+	system.flow_stopped.disconnect(stopped_callback)
 
 	assert_eq(started_count[0], 1, "start 及 flow_started 重入不得重复发出生命周期信号。")
 	assert_eq(stopped_count[0], 1, "stop 及 flow_stopped 重入不得重复发出生命周期信号。")
@@ -246,16 +254,20 @@ func test_turn_flow_start_and_stop_are_idempotent_under_signal_reentry() -> void
 func test_turn_flow_can_restart_from_completed_stop_notification() -> void:
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
 	var restarted: Array[bool] = [false]
-	var _stopped_connection: Error = system.flow_stopped.connect(
+	var stopped_callback: Callable = (
 		func(_context: GFTurnContext) -> void:
 			if restarted[0]:
 				return
 			restarted[0] = true
 			system.start(false)
+	)
+	var _stopped_connection: Error = system.flow_stopped.connect(
+		stopped_callback
 	) as Error
 
 	system.start()
 	system.stop()
+	system.flow_stopped.disconnect(stopped_callback)
 
 	assert_true(restarted[0], "flow_stopped 应观察到已完成的 stopped 状态并可启动新周期。")
 	assert_true(system.is_running, "旧 stop 调用链不得在通知返回后覆盖重入启动的新周期。")
@@ -303,12 +315,13 @@ func test_phase_changed_stop_prevents_phase_enter() -> void:
 	var phase: RecordingPhase = RecordingPhase.new(&"prepare", order)
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
 	system.set_phases([phase])
-	var _connect_result: Error = system.phase_changed.connect(func(_phase: GFTurnPhase, _index: int) -> void:
+	var phase_changed_callback: Callable = func(_phase: GFTurnPhase, _index: int) -> void:
 		system.stop()
-	) as Error
+	var _connect_result: Error = system.phase_changed.connect(phase_changed_callback) as Error
 
 	system.start()
 	await system.advance_phase()
+	system.phase_changed.disconnect(phase_changed_callback)
 
 	assert_eq(order, [], "phase_changed 中 stop 后不应继续调用新阶段 enter。")
 
@@ -325,6 +338,7 @@ func test_sync_phase_stop_prevents_auto_finish() -> void:
 
 	system.start()
 	await system.advance_phase()
+	phase.system = null
 
 	assert_eq(order, ["execute"], "同步 stop 后不应继续阶段完成流程。")
 	assert_eq(finished_count[0], 0, "同步 stop 后不应发出 finished。")

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_bootstrap_warning_fixture.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_bootstrap_warning_fixture.gd
@@ -1,0 +1,8 @@
+extends RefCounted
+
+
+const WARNING_CODE: String = "GF lifecycle bootstrap fixture warning"
+
+
+static func _static_init() -> void:
+	push_warning(WARNING_CODE)

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_bootstrap_warning_fixture.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_bootstrap_warning_fixture.gd.uid
@@ -1,0 +1,1 @@
+uid://b075qsjj233ov

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_clean_fixture.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_clean_fixture.gd
@@ -1,0 +1,5 @@
+extends GutTest
+
+
+func test_clean_lifecycle_fixture() -> void:
+	assert_true(true, "干净夹具应完成一次普通断言。")

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_clean_fixture.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_clean_fixture.gd.uid
@@ -1,0 +1,1 @@
+uid://dqqnak6ys2iwk

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_cutover_thread_warning_post_hook.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_cutover_thread_warning_post_hook.gd
@@ -1,0 +1,21 @@
+extends "res://tests/gf_core/support/gf_gut_post_run_hook.gd"
+
+
+const WARNING_CODE: String = "GF lifecycle cutover thread fixture warning"
+
+
+func _collect_unhandled_warnings(gut_main: GutMain) -> Dictionary:
+	var warning_thread: Thread = Thread.new()
+	var start_error: Error = warning_thread.start(_emit_warning)
+	if start_error != OK:
+		push_error(
+			"GF lifecycle cutover fixture could not start its warning thread: %s"
+			% error_string(start_error)
+		)
+	else:
+		var _thread_result: Variant = warning_thread.wait_to_finish()
+	return super._collect_unhandled_warnings(gut_main)
+
+
+func _emit_warning() -> void:
+	push_warning(WARNING_CODE)

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_cutover_thread_warning_post_hook.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_cutover_thread_warning_post_hook.gd.uid
@@ -1,0 +1,1 @@
+uid://cdvegqmqfgfe8

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_many_warnings_fixture.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_many_warnings_fixture.gd
@@ -1,0 +1,16 @@
+extends GutTest
+
+const WARNING_COUNT: int = 25
+
+
+static func _static_init() -> void:
+	var long_warning_suffix: String = "界".repeat(600)
+	for warning_index: int in range(WARNING_COUNT):
+		push_warning(
+			"GF lifecycle bounded warning %02d: %s"
+			% [warning_index, long_warning_suffix]
+		)
+
+
+func test_many_warnings_fixture_body_passes() -> void:
+	assert_true(true, "超量 warning 的测试体可以通过，但门禁证据必须失败并截断。")

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_many_warnings_fixture.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_many_warnings_fixture.gd.uid
@@ -1,0 +1,1 @@
+uid://hwx30co46mir

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_cleanup_post_hook.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_cleanup_post_hook.gd
@@ -1,0 +1,14 @@
+extends "res://tests/gf_core/support/gf_gut_post_run_hook.gd"
+
+
+const ORPHAN_META_KEY: StringName = &"gf_lifecycle_gate_orphan_fixture"
+
+
+func run() -> void:
+	var _snapshot_result: Variant = await super.run()
+	var orphan_value: Variant = Engine.get_meta(ORPHAN_META_KEY)
+	if orphan_value is Node:
+		var orphan: Node = orphan_value
+		if is_instance_valid(orphan):
+			orphan.free()
+	Engine.remove_meta(ORPHAN_META_KEY)

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_cleanup_post_hook.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_cleanup_post_hook.gd.uid
@@ -1,0 +1,1 @@
+uid://ccwpx1u0r28lo

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_fixture.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_fixture.gd
@@ -1,0 +1,13 @@
+extends GutTest
+
+
+const ORPHAN_META_KEY: StringName = &"gf_lifecycle_gate_orphan_fixture"
+const ORPHAN_NAME: StringName = &"GF lifecycle gate orphan fixture"
+
+
+func test_creates_a_real_orphan_node() -> void:
+	var orphan: Node = Node.new()
+	orphan.name = ORPHAN_NAME
+	Engine.set_meta(ORPHAN_META_KEY, orphan)
+
+	assert_true(orphan.is_inside_tree() == false, "故障注入节点必须是真实 orphan。")

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_fixture.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_orphan_fixture.gd.uid
@@ -1,0 +1,1 @@
+uid://bt2e40uo4n24n

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_static_warning_fixture.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_static_warning_fixture.gd
@@ -1,0 +1,11 @@
+extends GutTest
+
+const WARNING_CODE: String = "GF lifecycle static-init fixture warning"
+
+
+static func _static_init() -> void:
+	push_warning(WARNING_CODE)
+
+
+func test_static_warning_fixture_body_passes() -> void:
+	assert_true(true, "测试体通过时，static-init warning 仍必须由进程门禁拒绝。")

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_static_warning_fixture.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_static_warning_fixture.gd.uid
@@ -1,0 +1,1 @@
+uid://bq2adbq321sgo

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_terminal_warning_post_hook.gd
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_terminal_warning_post_hook.gd
@@ -1,0 +1,14 @@
+extends "res://tests/gf_core/support/gf_gut_post_run_hook.gd"
+
+const WARNING_CODE: String = "GF lifecycle terminal fixture warning"
+const DELAY_FRAME_COUNT: int = 4
+
+
+func run() -> void:
+	var _post_snapshot_result: Variant = await super.run()
+	if not gut is GutMain:
+		return
+	var gut_main: GutMain = gut
+	for _frame_index: int in range(DELAY_FRAME_COUNT):
+		await gut_main.get_tree().process_frame
+	push_warning(WARNING_CODE)

--- a/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_terminal_warning_post_hook.gd.uid
+++ b/tests/gf_core/fixtures/lifecycle_gate/lifecycle_gate_terminal_warning_post_hook.gd.uid
@@ -1,0 +1,1 @@
+uid://djh4ispbb6y56

--- a/tests/gf_core/kernel/base/test_gf_model_serialization.gd
+++ b/tests/gf_core/kernel/base/test_gf_model_serialization.gd
@@ -5,6 +5,9 @@ extends GutTest
 const SCORE_MODEL_FIXTURE_PATH: String = "res://tests/gf_core/fixtures/model_serialization/score_model_fixture.gd"
 const SETTINGS_MODEL_FIXTURE_PATH: String = "res://tests/gf_core/fixtures/model_serialization/settings_model_fixture.gd"
 const GF_VARIANT_ACCESS = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
+const GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT = preload(
+	"res://tests/gf_core/support/gf_transient_gdscript_test_support.gd"
+)
 
 
 # --- 测试：单 Model 序列化 ---
@@ -80,6 +83,12 @@ func to_dict() -> Dictionary:
 
 	assert_eq(state.size(), 0, "缺少稳定标识的运行时 Model 不应进入快照。")
 	assert_push_error("[GFArchitecture] 可序列化 Model 缺少稳定标识：请为脚本声明 class_name 或重写 get_save_key()。")
+
+	arch.dispose()
+	runtime_model = null
+	var cleanup_errors: Array[int] = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.release(runtime_script)
+	runtime_script = null
+	assert_eq(cleanup_errors, [], "动态 Model 脚本依赖图应在实例和架构释放后完整拆除。")
 
 
 func test_architecture_prefers_model_save_key_for_serialization() -> void:

--- a/tests/gf_core/kernel/core/test_gf_bindable_property.gd
+++ b/tests/gf_core/kernel/core/test_gf_bindable_property.gd
@@ -227,6 +227,8 @@ func test_subscribe_collection_payloads_are_isolated_between_listeners() -> void
 	)
 
 	prop.set_value({ "hp": 20 })
+	var _unsubscribe_first_result: Variant = _unsubscribe_first.call()
+	var _unsubscribe_second_result: Variant = _unsubscribe_second.call()
 
 	assert_eq(second_listener_values.size(), 1, "第二个监听者应收到一次变化。")
 	if second_listener_values.size() == 1:
@@ -568,6 +570,7 @@ func test_computed_property_updates_from_sources() -> void:
 	first.value = 4
 
 	assert_eq(_value_int(computed), 12, "来源属性变化后 computed 属性应刷新。")
+	computed.dispose()
 
 
 func test_computed_property_dispose_stops_auto_refresh() -> void:
@@ -593,6 +596,7 @@ func test_computed_property_rejects_external_set() -> void:
 
 	assert_eq(_value_int(computed), 2, "外部写入 computed 属性不应改变派生值。")
 	assert_push_error("[GFComputedProperty] 当前属性由 compute 回调派生，请修改来源属性。")
+	computed.dispose()
 
 
 func test_computed_property_rejects_in_place_mutation_helpers() -> void:
@@ -621,6 +625,8 @@ func test_computed_property_rejects_in_place_mutation_helpers() -> void:
 	assert_signal_not_emitted(computed_array, "value_changed", "拒绝原地修改时不应发出数组变化信号。")
 	assert_signal_not_emitted(computed_dict, "value_changed", "拒绝原地修改时不应发出字典变化信号。")
 	assert_push_error_count(7, "每次外部原地修改尝试都应报告只读错误。")
+	computed_array.dispose()
+	computed_dict.dispose()
 
 
 func test_computed_property_get_value_returns_collection_copy() -> void:
@@ -639,6 +645,8 @@ func test_computed_property_get_value_returns_collection_copy() -> void:
 
 	assert_eq(_value_array(computed_array), ["base"], "computed get_value() 返回的数组副本不应影响内部值。")
 	assert_eq(_value_dictionary(computed_dict), { "hp": 1 }, "computed get_value() 返回的字典副本不应影响内部值。")
+	computed_array.dispose()
+	computed_dict.dispose()
 
 
 func test_read_only_bindable_property_rejects_in_place_mutation_helpers() -> void:

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -2498,7 +2498,8 @@ func test_architecture_dispose_rejects_parent_reinjection_from_completion_signal
 	await get_tree().process_frame
 	var reinject_parent: Callable = func() -> void:
 		child_arch.set_parent_architecture(parent_arch)
-	child_arch.initialization_finished.connect(reinject_parent)
+	var connect_error: Error = child_arch.initialization_finished.connect(reinject_parent) as Error
+	assert_eq(connect_error, OK, "dispose 回归测试必须成功连接完成信号。")
 
 	child_arch.dispose()
 	child_arch.initialization_finished.disconnect(reinject_parent)

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -587,6 +587,7 @@ class ReadyLookupReplacementUtility extends GFUtility:
 
 	func dispose() -> void:
 		disposed = true
+		ready_lookup = null
 
 
 class ReadyFailingReplacementUtility extends GFUtility:
@@ -764,7 +765,7 @@ func after_each() -> void:
 	if Gf.has_architecture():
 		var arch: GFArchitecture = Gf.get_architecture()
 		arch.dispose()
-		await Gf.set_architecture(GFArchitecture.new())
+		Gf._architecture = null
 	_clear_test_project_settings()
 
 # --- 测试用例 ---
@@ -2470,6 +2471,48 @@ func test_parent_architecture_rejects_self_and_cycles() -> void:
 	assert_push_error("[GFArchitecture] set_parent_architecture 失败：父级架构不能是自身。")
 	assert_push_error("[GFArchitecture] set_parent_architecture 失败：父级架构会形成循环引用。")
 	child_arch.dispose()
+	parent_arch.dispose()
+
+
+func test_architecture_dispose_releases_parent_reference() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+
+	child_arch.dispose()
+
+	assert_null(
+		child_arch.get_parent_architecture(),
+		"dispose 后架构不得继续持有父架构强引用。"
+	)
+	parent_arch.dispose()
+
+
+func test_architecture_dispose_rejects_parent_reinjection_from_completion_signal() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	var child_arch: GFArchitecture = GFArchitecture.new()
+	var slow_utility: SlowInitUtility = SlowInitUtility.new()
+	await child_arch.register_utility_instance(slow_utility)
+	var init_state: Dictionary = { "done": false }
+	@warning_ignore("missing_await")
+	_await_arch_init(child_arch, init_state)
+	await get_tree().process_frame
+	var reinject_parent: Callable = func() -> void:
+		child_arch.set_parent_architecture(parent_arch)
+	child_arch.initialization_finished.connect(reinject_parent)
+
+	child_arch.dispose()
+	child_arch.initialization_finished.disconnect(reinject_parent)
+	await get_tree().process_frame
+
+	assert_null(
+		child_arch.get_parent_architecture(),
+		"dispose 完成信号的同步回调不得重新注入父架构强引用。"
+	)
+	assert_push_error(
+		"[GFArchitecture] set_parent_architecture 失败：架构正在 dispose 或已 dispose，不能设置父级架构。"
+	)
+	slow_utility.async_continue.emit()
+	await get_tree().process_frame
 	parent_arch.dispose()
 
 

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -1121,6 +1121,7 @@ func test_assignable_lookup_cache_invalidates_when_registry_changes() -> void:
 
 	await arch.register_utility_instance(alternate)
 	assert_null(arch.get_utility(UtilityBase), "新增第二个实现后，旧的基类查询缓存不应继续返回旧实例。")
+	assert_push_warning("[GFArchitecture] get_utility() 匹配到多个本地实例，本次查询不会回退父架构；请使用显式 alias 注册以消除歧义。")
 
 	arch.unregister_utility(AlternateConcreteUtility)
 	assert_eq(arch.get_utility(UtilityBase), concrete, "移除歧义实现后，基类查询应重新解析唯一实现。")

--- a/tests/gf_core/kernel/core/test_gf_type_event_system.gd
+++ b/tests/gf_core/kernel/core/test_gf_type_event_system.gd
@@ -18,6 +18,7 @@ func before_each() -> void:
 
 
 func after_each() -> void:
+	_system.clear()
 	_system = null
 
 
@@ -29,6 +30,13 @@ func _type_listener(callback: Callable, debug_label: String = "type_event") -> G
 
 func _simple_listener(callback: Callable, debug_label: String = "simple_event") -> GFEventListener:
 	return GFEventListener.from_callable(callback, 1, debug_label)
+
+
+func _clear_state_callbacks(state: EventTestState) -> void:
+	state.cb_a = Callable()
+	state.cb_b = Callable()
+	state.late_cb = Callable()
+	state.replacement = Callable()
 
 
 # --- 辅助类型 ---
@@ -590,6 +598,7 @@ func test_unregister_during_traversal() -> void:
 
 	assert_eq(state.order.size(), 1, "回调 B 被注销后不应在本次 send 中执行。")
 	assert_eq(state.order[0], "A", "只有回调 A 应被执行。")
+	_clear_state_callbacks(state)
 
 
 ## 验证在回调内注销自身时，不会崩溃且逻辑正确。
@@ -606,6 +615,7 @@ func test_unregister_self_during_traversal() -> void:
 	_system.send(SampleEventA.new())
 
 	assert_eq(state.count, 1, "回调应该只执行一次，并在本次调用后注销自身。")
+	_clear_state_callbacks(state)
 
 
 ## 验证多个监听器都能收到事件。
@@ -718,6 +728,7 @@ func test_send_simple_unregister_during_traversal() -> void:
 
 	assert_eq(state.order.size(), 1, "简单事件：回调 B 被注销后不应在本次 send 中执行。")
 	assert_eq(state.order[0], "A", "只有回调 A 应被执行。")
+	_clear_state_callbacks(state)
 
 
 ## 验证简单事件回调注销自身时，不会崩溃且逻辑正确。
@@ -734,6 +745,7 @@ func test_send_simple_unregister_self_during_traversal() -> void:
 	_system.send_simple(event_id)
 
 	assert_eq(state.count, 1, "回调应该只执行一次，并在本次调用后注销自身。")
+	_clear_state_callbacks(state)
 
 
 ## 验证注销简单事件后不再触发。
@@ -801,6 +813,7 @@ func test_send_simple_register_during_nested_dispatch_waits_for_outermost_flush(
 
 	_system.send_simple(event_id)
 	assert_eq(state.order.slice(4), ["outer", "existing", "late"], "下一次简单事件派发应包含之前新增的回调。")
+	_clear_state_callbacks(state)
 
 
 ## 验证同一轮简单事件中先注册再注销的回调不会在 flush 后残留。
@@ -821,6 +834,7 @@ func test_send_simple_register_then_unregister_during_dispatch_does_not_leave_li
 	_system.send_simple(event_id)
 
 	assert_eq(state.count, 2, "同一轮派发中先注册再注销的简单事件回调不应残留到下一次派发。")
+	_clear_state_callbacks(state)
 
 
 ## 验证派发中跨简单事件 ID 先注册再注销的回调不会在 flush 后残留。
@@ -842,6 +856,7 @@ func test_send_simple_register_then_unregister_different_id_during_dispatch_does
 	_system.send_simple(inner_id)
 
 	assert_eq(state.count, 1, "跨简单事件 ID pending add 被注销后不应在下一次派发中触发。")
+	_clear_state_callbacks(state)
 
 
 # --- 测试：拥有者绑定 ---
@@ -977,6 +992,7 @@ func test_unregister_owner_then_register_same_owner_during_dispatch_keeps_new_li
 	_system.send(SampleEventA.new())
 
 	assert_eq(state.order, ["old", "replacement"], "同一 owner 重新注册的新监听应在下一轮派发生效。")
+	_clear_state_callbacks(state)
 
 
 # --- 测试：优先级排序 ---
@@ -1162,6 +1178,7 @@ func test_register_during_nested_dispatch_waits_for_outermost_flush() -> void:
 
 	_system.send(SampleEventA.new())
 	assert_eq(state.order.slice(4), ["outer", "existing", "late"], "下一次派发应包含之前新增的回调。")
+	_clear_state_callbacks(state)
 
 
 ## 验证同一轮类型事件中先注册再注销的回调不会在 flush 后残留。
@@ -1182,6 +1199,7 @@ func test_register_then_unregister_during_dispatch_does_not_leave_listener() -> 
 	_system.send(SampleEventA.new())
 
 	assert_eq(state.count, 2, "同一轮派发中先注册再注销的类型事件回调不应残留到下一次派发。")
+	_clear_state_callbacks(state)
 
 
 ## 验证派发中跨事件类型先注册再注销的回调不会在 flush 后残留。
@@ -1201,6 +1219,7 @@ func test_register_then_unregister_different_type_during_dispatch_does_not_leave
 	_system.send(SampleEventB.new())
 
 	assert_eq(state.count, 1, "跨事件类型 pending add 被注销后不应在下一次派发中触发。")
+	_clear_state_callbacks(state)
 
 
 ## 验证派发中跨可赋值类型先注册再注销的回调不会在 flush 后残留。
@@ -1220,6 +1239,7 @@ func test_register_then_unregister_different_assignable_type_during_dispatch_doe
 	_system.send(SampleEventB.new())
 
 	assert_eq(state.count, 1, "跨可赋值类型 pending add 被注销后不应在下一次派发中触发。")
+	_clear_state_callbacks(state)
 
 
 func _sum_listener_counts(value: Variant) -> int:

--- a/tests/gf_core/kernel/editor/test_gf_editor_command_tools.gd
+++ b/tests/gf_core/kernel/editor/test_gf_editor_command_tools.gd
@@ -470,7 +470,7 @@ class NonExecutableCommand extends GFEditorCommand:
 		return false
 
 
-class FakeUndoManager extends Object:
+class FakeUndoManager extends RefCounted:
 	var do_target: Object
 	var do_method: String = ""
 	var undo_target: Object

--- a/tests/gf_core/kernel/editor/test_gf_plugin_helpers.gd
+++ b/tests/gf_core/kernel/editor/test_gf_plugin_helpers.gd
@@ -207,6 +207,7 @@ func test_plugin_actions_use_dependency_provider_for_generation_and_extension_pa
 	_call_void(actions, &"handle_menu_id", [GF_PLUGIN_ACTIONS.MENU_GENERATE_ACCESSORS])
 	_call_void(actions, &"handle_menu_id", [GF_PLUGIN_ACTIONS.MENU_GENERATE_PROJECT_ACCESSORS])
 	_call_void(actions, &"cleanup")
+	await get_tree().process_frame
 
 	assert_eq(fake_dependencies.editor_action_path_call_count, 1, "扩展编辑器动作路径应由依赖 provider 提供。")
 	assert_eq(fake_dependencies.generated_access_path, fake_dependencies.access_output_path, "强类型访问器生成应通过依赖 provider 执行。")
@@ -1419,6 +1420,7 @@ func test_extension_manager_dock_writes_setup_policy_to_project_settings() -> vo
 	_restore_project_setting(GF_EXTENSION_SETTINGS_BASE.EXPORT_EXCLUDE_DISABLED_SETTING, export_exclude_restore)
 	_restore_project_setting(GF_EXTENSION_SETTINGS_BASE.AUTO_INSTALL_ENABLED_INSTALLERS_SETTING, auto_install_restore)
 	_restore_project_setting(GF_EXTENSION_SETTINGS_BASE.ENABLED_EXTENSIONS_SETTING, enabled_restore)
+	await get_tree().process_frame
 
 	assert_eq(stored_enabled_ids, [], "扩展 setup 面板应把当前勾选状态写入启用扩展设置。")
 	assert_eq(stored_selection_mode, GF_EXTENSION_SETTINGS_BASE.SELECTION_MODE_EXPLICIT, "手动勾选保存应进入显式扩展选择模式。")
@@ -1446,6 +1448,7 @@ func test_extension_manager_dock_restore_default_writes_default_selection_mode()
 	dock.free()
 	_restore_project_setting(GF_EXTENSION_SETTINGS_BASE.EXTENSION_SELECTION_MODE_SETTING, mode_restore)
 	_restore_project_setting(GF_EXTENSION_SETTINGS_BASE.ENABLED_EXTENSIONS_SETTING, enabled_restore)
+	await get_tree().process_frame
 
 	assert_eq(stored_selection_mode, GF_EXTENSION_SETTINGS_BASE.SELECTION_MODE_DEFAULT, "恢复默认保存时应保留 default 模式，而不是固化当前默认列表。")
 
@@ -1470,6 +1473,7 @@ func test_extension_manager_dock_exposes_extension_presets() -> void:
 	assert_true(selected_ids.is_empty(), "全部关闭 preset 应清空当前扩展选择。")
 
 	dock.free()
+	await get_tree().process_frame
 
 
 func test_extension_manager_dock_manages_project_preset_file_paths() -> void:

--- a/tests/gf_core/kernel/editor/test_gf_thumbnail_renderer.gd
+++ b/tests/gf_core/kernel/editor/test_gf_thumbnail_renderer.gd
@@ -27,11 +27,12 @@ func test_free_render_instance_removes_temporary_child() -> void:
 func test_thumbnail_render_task_cancels_pending_task_through_kernel_token() -> void:
 	var task: GFThumbnailRenderTask = GFThumbnailRenderTask.new(GFThumbnailRenderRequest.new(), 7)
 	var completed_tasks: Array[GFThumbnailRenderTask] = []
-	var _connected_completed: Error = task.completed.connect(func(completed_task: GFThumbnailRenderTask) -> void:
+	var completed_callback: Callable = func(completed_task: GFThumbnailRenderTask) -> void:
 		completed_tasks.append(completed_task)
-	) as Error
+	var _connected_completed: Error = task.completed.connect(completed_callback) as Error
 
 	assert_true(task.cancel(&"test_cancel"), "pending 任务应能立即取消。")
+	task.completed.disconnect(completed_callback)
 
 	var completion: GFAsyncCompletion = task.get_completion()
 	assert_true(task.is_cancelled(), "任务应进入取消终态。")

--- a/tests/gf_core/standard/common/test_gf_quiet_window_coalescer.gd
+++ b/tests/gf_core/standard/common/test_gf_quiet_window_coalescer.gd
@@ -144,14 +144,14 @@ func test_pending_limit_reserves_target_before_reentrant_same_key_submit() -> vo
 	coalescer.auto_flush = false
 	coalescer.max_pending_batches = 2
 	var callback_state: Dictionary = { "reentered": false }
-	var connect_error: Error = coalescer.batch_closed.connect(func(report: Dictionary) -> void:
+	var on_batch_closed: Callable = func(report: Dictionary) -> void:
 		if (
 			GFVariantData.get_option_string(report, "reason") == "pending_limit"
 			and not GFVariantData.get_option_bool(callback_state, "reentered")
 		):
 			callback_state["reentered"] = true
 			var _reentrant_batch_id: int = coalescer.submit_at(&"target", "callback", 1002)
-	) as Error
+	var connect_error: Error = coalescer.batch_closed.connect(on_batch_closed) as Error
 	assert_eq(connect_error, OK, "测试应能监听同 key 重入提交。")
 
 	var _first_batch_id: int = coalescer.submit_at(&"first", 1, 1000)
@@ -166,6 +166,7 @@ func test_pending_limit_reserves_target_before_reentrant_same_key_submit() -> vo
 		["outer", "callback"],
 		"容量回调提交到目标 key 时不得覆盖或丢失任一消息。"
 	)
+	coalescer.batch_closed.disconnect(on_batch_closed)
 
 
 func test_pending_limit_defers_reentrant_capacity_notifications() -> void:
@@ -303,11 +304,11 @@ func test_cancel_clear_and_flush_all_are_bounded_against_late_or_reentrant_timer
 	var coalescer: GF_QUIET_WINDOW_COALESCER_SCRIPT = GF_QUIET_WINDOW_COALESCER_SCRIPT.new()
 	coalescer.quiet_window_msec = 10
 	var emitted: Array[Dictionary] = []
-	var connect_error: Error = coalescer.batch_closed.connect(func(report: Dictionary) -> void:
+	var on_batch_closed: Callable = func(report: Dictionary) -> void:
 		emitted.append(report)
 		if GFVariantData.get_option_string(report, "key") == "first":
 			var _reentrant_batch_id: int = coalescer.submit(&"reentrant", 3)
-	) as Error
+	var connect_error: Error = coalescer.batch_closed.connect(on_batch_closed) as Error
 	assert_eq(connect_error, OK, "测试应能监听清理与重入边界。")
 
 	var _cancelled_batch_id: int = coalescer.submit(&"cancelled", 0)
@@ -327,6 +328,7 @@ func test_cancel_clear_and_flush_all_are_bounded_against_late_or_reentrant_timer
 	assert_eq(coalescer.get_pending_batch_count(), 1, "关闭回调重入提交的新批次应留给下一轮处理。")
 	var reentrant_report: Dictionary = coalescer.flush(&"reentrant")
 	assert_eq(GFVariantData.get_option_string(reentrant_report, "key"), "reentrant", "显式 flush 应关闭重入批次。")
+	coalescer.batch_closed.disconnect(on_batch_closed)
 
 
 func _wait_until_batch_count(

--- a/tests/gf_core/standard/foundation/schema/test_gf_dictionary_schema.gd
+++ b/tests/gf_core/standard/foundation/schema/test_gf_dictionary_schema.gd
@@ -217,6 +217,7 @@ func test_dictionary_schema_definition_detects_circular_schema() -> void:
 
 	assert_false(report.is_ok(), "循环 schema 定义应被报告而不是无限递归。")
 	assert_eq(_find_issue_kind(report, "circular_schema"), "circular_schema", "循环 schema 应有稳定 issue kind。")
+	child_field.dictionary_schema = null
 
 
 func test_dictionary_schema_required_default_still_requires_source_value() -> void:
@@ -246,6 +247,8 @@ func test_dictionary_schema_duplicate_preserves_circular_schema_references() -> 
 
 	assert_not_null(copied_child, "循环 schema 副本应保留字段。")
 	assert_same(copied_child.dictionary_schema, copied_schema, "循环 schema 副本应指向副本自身。")
+	child_field.dictionary_schema = null
+	copied_child.dictionary_schema = null
 
 
 func test_schema_field_duplicate_preserves_self_referential_array_item() -> void:
@@ -255,6 +258,8 @@ func test_schema_field_duplicate_preserves_self_referential_array_item() -> void
 	var copied_field: GFSchemaField = field.duplicate_field()
 
 	assert_same(copied_field.array_item_schema, copied_field, "字段自引用副本应指向字段副本自身。")
+	field.array_item_schema = null
+	copied_field.array_item_schema = null
 
 
 func test_dictionary_schema_configure_applies_options_without_fields() -> void:
@@ -390,6 +395,7 @@ func test_dictionary_schema_validate_dictionary_short_circuits_recursive_schema(
 
 	assert_false(report.is_ok(), "循环 schema 数据校验应返回报告而不是递归挂起。")
 	assert_eq(_find_issue_kind(report, "circular_schema"), "circular_schema", "循环 schema 应由定义自检稳定报告。")
+	child_field.dictionary_schema = null
 
 
 func test_schema_field_validation_rules_inherit_field_context() -> void:

--- a/tests/gf_core/standard/foundation/tags/test_gf_tag_expression.gd
+++ b/tests/gf_core/standard/foundation/tags/test_gf_tag_expression.gd
@@ -59,6 +59,31 @@ func test_expression_dictionary_roundtrip_preserves_nested_logic() -> void:
 	assert_false(restored.matches([&"team.neutral"]), "字典往返后未满足条件仍应失败。")
 
 
+func test_expression_resource_roundtrip_preserves_typed_children() -> void:
+	var child: GFTagExpression = GFTagExpression.from_query(_make_query([&"team.enemy"]))
+	var children: Array[GFTagExpression] = [child]
+	var expression: GFTagExpression = GFTagExpression.new().configure_all(children)
+	var resource_path: String = "user://gf_tag_expression_roundtrip.tres"
+	var absolute_path: String = ProjectSettings.globalize_path(resource_path)
+	var _previous_file_removed: Error = DirAccess.remove_absolute(absolute_path)
+
+	var save_error: Error = ResourceSaver.save(expression, resource_path)
+	var loaded_resource: Resource = ResourceLoader.load(
+		resource_path,
+		"",
+		ResourceLoader.CACHE_MODE_IGNORE
+	)
+
+	assert_eq(save_error, OK, "标签表达式应能保存为 Resource。")
+	assert_true(loaded_resource is GFTagExpression, "资源往返后应恢复 GFTagExpression 类型。")
+	if loaded_resource is GFTagExpression:
+		var restored: GFTagExpression = loaded_resource
+		assert_eq(restored.expressions.size(), 1, "资源往返后应保留子表达式。")
+		assert_true(restored.expressions[0] is GFTagExpression, "资源往返后子项应保持表达式类型。")
+		assert_true(restored.matches([&"team.enemy"]), "资源往返后应保留嵌套匹配语义。")
+	var _resource_file_removed: Error = DirAccess.remove_absolute(absolute_path)
+
+
 func test_expression_dictionary_roundtrip_preserves_null_children() -> void:
 	var enemy: GFTagExpression = GFTagExpression.from_query(_make_query([&"team.enemy"]))
 	var children: Array[GFTagExpression] = [enemy, null]
@@ -70,6 +95,17 @@ func test_expression_dictionary_roundtrip_preserves_null_children() -> void:
 	assert_false(GFVariantData.get_option_bool(report, "ok"), "null 子表达式往返后仍应按失败处理。")
 	assert_eq(GFVariantData.get_option_array(report, "matched_indices"), [0], "非空子表达式应保留原索引。")
 	assert_eq(GFVariantData.get_option_array(report, "failed_indices"), [1], "null 子表达式不应在序列化时被静默丢弃。")
+
+
+func test_expression_treats_non_expression_resources_as_invalid_children() -> void:
+	var expression: GFTagExpression = GFTagExpression.new()
+	expression.operator = GFTagExpression.Operator.ALL
+	expression.expressions.append(Resource.new())
+
+	var report: Dictionary = expression.get_match_report([&"team.enemy"])
+
+	assert_false(GFVariantData.get_option_bool(report, "ok"), "非 GFTagExpression 资源不得被解释为有效子表达式。")
+	assert_eq(GFVariantData.get_option_array(report, "failed_indices"), [0], "非法资源应保留原索引并按失败处理。")
 
 
 func test_expression_dictionary_serialization_marks_cycles() -> void:

--- a/tests/gf_core/standard/foundation/test_gf_budget_ledger.gd
+++ b/tests/gf_core/standard/foundation/test_gf_budget_ledger.gd
@@ -99,18 +99,20 @@ func test_budget_consumed_reentrancy_never_emits_stale_budget_changed_state() ->
 	var ledger: GFBudgetLedgerBase = GFBudgetLedgerBase.new()
 	ledger.set_capacity(&"energy", 10.0)
 	var observed_available: Array[float] = []
-	var _consumed_connected: Error = ledger.budget_consumed.connect(func(budget_id: StringName, _amount: float) -> void:
+	var on_budget_consumed: Callable = func(budget_id: StringName, _amount: float) -> void:
 		ledger.release(budget_id, 1.0)
-	) as Error
-	var _changed_connected: Error = ledger.budget_changed.connect(func(_budget_id: StringName, available: float, _capacity: float) -> void:
+	var on_budget_changed: Callable = func(_budget_id: StringName, available: float, _capacity: float) -> void:
 		observed_available.append(available)
-	) as Error
+	var _consumed_connected: Error = ledger.budget_consumed.connect(on_budget_consumed) as Error
+	var _changed_connected: Error = ledger.budget_changed.connect(on_budget_changed) as Error
 
 	var result: Dictionary = ledger.consume(&"energy", 3.0)
 
 	assert_true(GFVariantData.get_option_bool(result, "ok"), "测试消费应成功。")
 	assert_eq(ledger.get_available(&"energy"), 8.0, "重入 release 后账本真值应为 8。")
 	assert_eq(observed_available, [8.0, 8.0], "consume 的后续变化信号只能描述发射时的当前状态。")
+	ledger.budget_consumed.disconnect(on_budget_consumed)
+	ledger.budget_changed.disconnect(on_budget_changed)
 
 
 # --- 内部类 ---

--- a/tests/gf_core/standard/foundation/test_gf_observable_resources.gd
+++ b/tests/gf_core/standard/foundation/test_gf_observable_resources.gd
@@ -35,19 +35,21 @@ func test_observable_array_batches_changes_until_end_batch() -> void:
 func test_observable_array_linearizes_reentrant_change_signals() -> void:
 	var resource: GFObservableArrayResource = GFObservableArrayResource.new()
 	var signal_order: Array[String] = []
-	var _item_connected: Error = resource.item_changed.connect(func(_operation: StringName, index: int, _old_value: Variant, _new_value: Variant, _metadata: Dictionary) -> void:
+	var on_item_changed: Callable = func(_operation: StringName, index: int, _old_value: Variant, _new_value: Variant, _metadata: Dictionary) -> void:
 		signal_order.append("item_%d" % index)
 		if index == 0:
 			var _nested_change: Dictionary = resource.append_item("nested")
-	) as Error
-	var _items_connected: Error = resource.items_changed.connect(func(changes: Array[Dictionary], _metadata: Dictionary) -> void:
+	var on_items_changed: Callable = func(changes: Array[Dictionary], _metadata: Dictionary) -> void:
 		signal_order.append("items_%d" % GFVariantData.get_option_int(changes[0], "index", -1))
-	) as Error
+	var _item_connected: Error = resource.item_changed.connect(on_item_changed) as Error
+	var _items_connected: Error = resource.items_changed.connect(on_items_changed) as Error
 
 	var _outer_change: Dictionary = resource.append_item("outer")
 
 	assert_eq(resource.get_items(), ["outer", "nested"], "重入 mutation 仍应立即更新集合。")
 	assert_eq(signal_order, ["item_0", "items_0", "item_1", "items_1"], "每条 mutation 的单项和汇总信号应连续、可重放。")
+	resource.item_changed.disconnect(on_item_changed)
+	resource.items_changed.disconnect(on_items_changed)
 
 
 func test_observable_dictionary_reports_set_and_erase() -> void:

--- a/tests/gf_core/standard/sequence/test_gf_runtime_task_scheduler.gd
+++ b/tests/gf_core/standard/sequence/test_gf_runtime_task_scheduler.gd
@@ -209,6 +209,10 @@ func test_scheduled_task_rejects_requirement_mutation() -> void:
 	assert_false(task.remove_requirement(requirement_a), "已调度任务不应允许移除 requirement。")
 	task.clear_requirements()
 	var _set_result: GFRuntimeTask = task.set_requirements([requirement_b])
+	for _index: int in range(4):
+		assert_push_warning(
+			"[GFRuntimeTask] 调度仲裁中或已调度的任务不能修改 requirements；请取消并重新配置。"
+		)
 
 	assert_true(task.has_requirement(requirement_a), "已调度任务应保留原 requirement。")
 	assert_false(task.has_requirement(requirement_b), "已调度任务不应接受新增 requirement。")
@@ -223,6 +227,7 @@ func test_register_default_task_rejects_scheduled_task_missing_requirement() -> 
 
 	assert_true(scheduler.schedule(task), "任务应能先进入调度器。")
 	assert_false(scheduler.register_default_task(default_requirement, task), "已调度且不能新增 requirement 的任务不应注册为默认任务。")
+	assert_push_warning("[GFRuntimeTask] 调度仲裁中或已调度的任务不能修改 requirements；请取消并重新配置。")
 
 	assert_false(task.has_requirement(default_requirement), "失败注册不应修改已调度任务 requirement。")
 	assert_null(scheduler.get_default_task(default_requirement), "失败注册不应留下默认任务记录。")
@@ -329,6 +334,8 @@ func test_scheduled_task_group_rejects_child_mutation() -> void:
 	var _add_result: GFRuntimeTaskGroup = group.add_task(second)
 	assert_false(group.remove_task(first), "已调度任务组不应允许移除子任务。")
 	group.rebuild_requirements()
+	for _index: int in range(3):
+		assert_push_warning("[GFRuntimeTaskGroup] 调度仲裁中或已调度的任务组不能修改配置。")
 
 	assert_eq(group.get_tasks(), [first], "已调度任务组不应接受子任务集合变更。")
 
@@ -384,6 +391,7 @@ func test_parallel_task_group_rejects_duplicate_child_requirements() -> void:
 	var group: GFRuntimeTaskGroup = GFRuntimeTaskGroup.new([first], GFRuntimeTaskGroup.Mode.PARALLEL_ALL)
 
 	var _add_result: GFRuntimeTaskGroup = group.add_task(second)
+	assert_push_warning("[GFRuntimeTaskGroup] 并行任务组不能包含占用相同 requirement 的子任务。")
 
 	assert_eq(group.get_tasks(), [first], "并行任务组不应接受共享 requirement 的第二个子任务。")
 
@@ -504,6 +512,7 @@ func test_schedule_commits_requirement_ownership_before_interrupt_callbacks() ->
 	assert_true(scheduler.schedule(protected_owner), "受保护 requirement 应先被不可中断任务占用。")
 	assert_true(scheduler.schedule(replacement_owner), "可中断 owner 应进入调度器。")
 	assert_true(scheduler.schedule(challenger), "challenger 应原子替换可中断 owner。")
+	assert_push_warning("[GFRuntimeTask] 调度仲裁中或已调度的任务不能修改 requirements；请取消并重新配置。")
 
 	assert_same(replacement_owner.observed_owner, challenger, "中断回调应观察到已经提交的新 owner。")
 	assert_false(challenger.has_requirement(protected_requirement), "中断回调不能修改已提交任务的 requirements。")
@@ -693,6 +702,7 @@ func test_task_group_configuration_is_controlled_and_transactional() -> void:
 	assert_eq(group.get_tasks(), [first], "失败的批量配置不应产生部分更新。")
 	assert_true(group.set_mode(GFRuntimeTaskGroup.Mode.PARALLEL_ALL), "无内部冲突的单任务组应允许切换到并行模式。")
 	var _add_conflicting_task_result: GFRuntimeTaskGroup = group.add_task(second)
+	assert_push_warning("[GFRuntimeTaskGroup] 并行任务组不能包含占用相同 requirement 的子任务。")
 	assert_eq(group.get_mode(), GFRuntimeTaskGroup.Mode.PARALLEL_ALL, "无内部冲突的单任务组应允许切换到并行模式。")
 	assert_eq(group.get_tasks(), [first], "冲突子任务不应被加入并行任务组。")
 

--- a/tests/gf_core/standard/sequence/test_gf_runtime_task_scheduler.gd
+++ b/tests/gf_core/standard/sequence/test_gf_runtime_task_scheduler.gd
@@ -687,6 +687,7 @@ func test_task_group_stops_initialization_when_child_cancels_parent() -> void:
 	assert_eq(cancelling_child.end_count, 1, "父组取消应只结束当前子任务一次。")
 	assert_false(cancelling_child.has_initialized(), "已被父组结束的子任务不应在 initialize 返回后重新标记 initialized。")
 	assert_true(sibling_order.is_empty(), "父组取消后不应继续初始化后续并行子任务。")
+	cancelling_child.parent_group = null
 
 
 func test_task_group_configuration_is_controlled_and_transactional() -> void:

--- a/tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd
+++ b/tests/gf_core/standard/utilities/agent/test_gf_runtime_agent_environment.gd
@@ -102,6 +102,7 @@ func test_registration_requires_closed_json_only_schema_and_rejects_duplicates()
 	assert_true(GFVariantData.get_option_bool(first, "ok"), "严格 schema 应可注册。")
 	assert_false(GFVariantData.get_option_bool(duplicate_result, "ok"), "重复 endpoint 不得隐式替换 handler。")
 	assert_eq(GFVariantData.get_option_string(duplicate_result, "reason"), "endpoint_already_registered")
+	recursive_field.dictionary_schema = null
 
 
 func test_catalog_exposes_only_structural_schema_without_handler_metadata_or_defaults() -> void:

--- a/tests/gf_core/standard/utilities/analytics/test_gf_analytics_utility.gd
+++ b/tests/gf_core/standard/utilities/analytics/test_gf_analytics_utility.gd
@@ -50,6 +50,54 @@ func test_dispose_defers_shutdown_watcher_detach_during_autoload_tree_exit() -> 
 	await get_tree().process_frame
 	assert_false(is_instance_valid(watcher), "退出阶段登记 queue_free 后关闭监听仍应完成释放。")
 
+
+func test_dispose_releases_project_owned_callbacks() -> void:
+	_analytics.payload_builder = func(_batch: Array) -> Dictionary:
+		return {}
+	_analytics.transport_callback = func(_payload: Dictionary) -> Dictionary:
+		return {}
+	_analytics.response_parser = func(
+		_response_code: int,
+		_body: PackedByteArray,
+		_fallback_accepted: int
+	) -> Dictionary:
+		return {}
+
+	_analytics.dispose()
+
+	assert_false(_analytics.payload_builder.is_valid(), "dispose 应释放项目注入的 payload builder。")
+	assert_false(_analytics.transport_callback.is_valid(), "dispose 应释放项目注入的 transport callback。")
+	assert_false(_analytics.response_parser.is_valid(), "dispose 应释放项目注入的 response parser。")
+
+
+func test_dispose_releases_callbacks_reinjected_by_flush_notifications() -> void:
+	var analytics: PendingAnalyticsUtility = PendingAnalyticsUtility.new()
+	analytics.init()
+	analytics.config.auto_capture_context = false
+	analytics.config.flush_interval_seconds = 0.0
+	analytics.track(&"pending")
+	analytics.flush()
+	var reinject_callbacks: Callable = func(_result: Dictionary) -> void:
+		analytics.payload_builder = func(_batch: Array) -> Dictionary:
+			return {}
+		analytics.transport_callback = func(_payload: Dictionary) -> Dictionary:
+			return {}
+		analytics.response_parser = func(
+			_response_code: int,
+			_body: PackedByteArray,
+			_fallback_accepted: int
+		) -> Dictionary:
+			return {}
+	analytics.flush_completed.connect(reinject_callbacks)
+
+	analytics.dispose()
+	analytics.flush_completed.disconnect(reinject_callbacks)
+
+	assert_false(analytics.payload_builder.is_valid(), "dispose 终态应释放通知回调重新注入的 payload builder。")
+	assert_false(analytics.transport_callback.is_valid(), "dispose 终态应释放通知回调重新注入的 transport callback。")
+	assert_false(analytics.response_parser.is_valid(), "dispose 终态应释放通知回调重新注入的 response parser。")
+
+
 ## 验证事件记录会进入队列并带上基础标识。
 func test_track_adds_event_to_queue() -> void:
 	_analytics.identify("client-a")
@@ -570,10 +618,9 @@ func test_flush_started_dispose_prevents_transport_after_notification() -> void:
 		captured.call_count += 1
 		return { "success": true, "accepted": 1 }
 	var analytics_ref: GFAnalyticsUtility = _analytics
-	var _started_connected: Error = _analytics.flush_started.connect(
-		func(_batch: Array) -> void:
-			analytics_ref.dispose()
-	) as Error
+	var on_flush_started: Callable = func(_batch: Array) -> void:
+		analytics_ref.dispose()
+	var _started_connected: Error = _analytics.flush_started.connect(on_flush_started) as Error
 	watch_signals(_analytics)
 	_analytics.track(&"dispose_on_start")
 
@@ -582,6 +629,7 @@ func test_flush_started_dispose_prevents_transport_after_notification() -> void:
 	assert_eq(captured.call_count, 0, "flush_started 中 dispose 后不得继续调用 transport。")
 	assert_signal_emitted(_analytics, "flush_failed", "被 dispose 中断的批次应明确失败。")
 	assert_signal_emitted(_analytics, "flush_completed", "中断批次仍应完成一次生命周期。")
+	_analytics.flush_started.disconnect(on_flush_started)
 
 
 func test_transport_dispose_does_not_double_finish_flush() -> void:
@@ -608,17 +656,17 @@ func test_transport_dispose_does_not_double_finish_flush() -> void:
 	assert_eq(captured.call_count, 1, "transport 应只调用一次。")
 	assert_eq(signal_counts[0], 1, "transport 中 dispose 应只完成一次失败。")
 	assert_eq(signal_counts[1], 1, "transport 中 dispose 应只完成一次 completion。")
+	assert_false(_analytics.transport_callback.is_valid(), "transport 中 dispose 应释放 transport callback。")
 
 
 func test_flush_failed_dispose_is_non_recursive_and_completes_once() -> void:
 	_analytics.config.batch_size = 10
 	var signal_counts: Array[int] = [0, 0]
 	var analytics_ref: GFAnalyticsUtility = _analytics
-	var _failure_connected: Error = _analytics.flush_failed.connect(
-		func(_result: Dictionary) -> void:
-			signal_counts[0] += 1
-			analytics_ref.dispose()
-	) as Error
+	var on_flush_failed: Callable = func(_result: Dictionary) -> void:
+		signal_counts[0] += 1
+		analytics_ref.dispose()
+	var _failure_connected: Error = _analytics.flush_failed.connect(on_flush_failed) as Error
 	var _completion_connected: Error = _analytics.flush_completed.connect(
 		func(_result: Dictionary) -> void:
 			signal_counts[1] += 1
@@ -631,6 +679,7 @@ func test_flush_failed_dispose_is_non_recursive_and_completes_once() -> void:
 
 	assert_eq(signal_counts[0], 1, "flush_failed 监听器 dispose 不得递归再次发出失败。")
 	assert_eq(signal_counts[1], 1, "失败批次应只发出一次 completion。")
+	_analytics.flush_failed.disconnect(on_flush_failed)
 
 
 func test_flush_completed_shutdown_drains_remaining_batches_without_looping() -> void:
@@ -643,14 +692,13 @@ func test_flush_completed_shutdown_drains_remaining_batches_without_looping() ->
 		return {
 			"success": true,
 			"accepted": GFVariantData.get_option_array(payload, "events").size(),
-		}
+	}
 	var analytics_ref: GFAnalyticsUtility = _analytics
-	var _completed_connected: Error = _analytics.flush_completed.connect(
-		func(_result: Dictionary) -> void:
-			completed_calls[0] += 1
-			if completed_calls[0] == 1:
-				analytics_ref.shutdown(true)
-	) as Error
+	var on_flush_completed: Callable = func(_result: Dictionary) -> void:
+		completed_calls[0] += 1
+		if completed_calls[0] == 1:
+			analytics_ref.shutdown(true)
+	var _completed_connected: Error = _analytics.flush_completed.connect(on_flush_completed) as Error
 	_analytics.track(&"first")
 	_analytics.track(&"second")
 	_analytics.config.batch_size = 1
@@ -660,6 +708,7 @@ func test_flush_completed_shutdown_drains_remaining_batches_without_looping() ->
 	assert_eq(transport_calls[0], 2, "通知中的 shutdown 应在通知结束后继续排空剩余批次。")
 	assert_eq(completed_calls[0], 2, "每个排空批次都应完成一次。")
 	assert_eq(_analytics.get_queue_size(), 0, "shutdown drain 应清空剩余同步批次。")
+	_analytics.flush_completed.disconnect(on_flush_completed)
 
 
 func test_partial_accepted_flush_requeues_unaccepted_events() -> void:
@@ -938,16 +987,16 @@ func test_oversized_drop_notifications_do_not_reenter_flush() -> void:
 		return { "padding": "p".repeat(900) }
 	var started_count: Array[int] = [0]
 	var analytics_ref: GFAnalyticsUtility = _analytics
-	var _started_connected: Error = _analytics.flush_started.connect(
-		func(_batch: Array) -> void:
-			started_count[0] += 1
-			if started_count[0] == 1:
-				analytics_ref.track(&"replacement", { "value": "v".repeat(180) })
-	) as Error
+	var on_flush_started: Callable = func(_batch: Array) -> void:
+		started_count[0] += 1
+		if started_count[0] == 1:
+			analytics_ref.track(&"replacement", { "value": "v".repeat(180) })
+	var _started_connected: Error = _analytics.flush_started.connect(on_flush_started) as Error
 	_analytics.track(&"oversized", { "value": "v".repeat(180) })
 
 	assert_eq(started_count[0], 1, "drop 通知中的自动 flush 必须被通知 guard 阻止。")
 	assert_eq(_analytics.get_queue_size(), 1, "通知中新入队事件应留给后续显式 flush。")
+	_analytics.flush_started.disconnect(on_flush_started)
 
 
 func test_drop_notification_shutdown_drains_remaining_events() -> void:
@@ -958,12 +1007,11 @@ func test_drop_notification_shutdown_drains_remaining_events() -> void:
 		return { "padding": "p".repeat(900) }
 	var completion_count: Array[int] = [0]
 	var analytics_ref: GFAnalyticsUtility = _analytics
-	var _completed_connected: Error = _analytics.flush_completed.connect(
-		func(_result: Dictionary) -> void:
-			completion_count[0] += 1
-			if completion_count[0] == 1:
-				analytics_ref.shutdown(true)
-	) as Error
+	var on_flush_completed: Callable = func(_result: Dictionary) -> void:
+		completion_count[0] += 1
+		if completion_count[0] == 1:
+			analytics_ref.shutdown(true)
+	var _completed_connected: Error = _analytics.flush_completed.connect(on_flush_completed) as Error
 	_analytics.track(&"first_oversized", { "value": "v".repeat(180) })
 	_analytics.track(&"second_oversized", { "value": "v".repeat(180) })
 
@@ -971,6 +1019,7 @@ func test_drop_notification_shutdown_drains_remaining_events() -> void:
 
 	assert_eq(completion_count[0], 2, "drop 通知中的 shutdown 应在通知结束后继续 drain。")
 	assert_eq(_analytics.get_queue_size(), 0, "shutdown drain 应处理全部不可发送事件并终止。")
+	_analytics.flush_completed.disconnect(on_flush_completed)
 
 
 func test_response_parser_non_dictionary_fails_closed_and_requeues_batch() -> void:
@@ -1025,6 +1074,7 @@ func test_response_parser_state_change_cannot_finish_a_new_generation() -> void:
 
 	assert_eq(parser_calls[0], 1, "response_parser 应调用一次。")
 	assert_eq(analytics.get_queue_size(), 1, "旧 HTTP callback 不得完成 parser 中创建的新 generation。")
+	assert_false(analytics.response_parser.is_valid(), "parser 中 dispose 应释放旧 generation 的 parser。")
 	analytics.dispose()
 
 

--- a/tests/gf_core/standard/utilities/analytics/test_gf_analytics_utility.gd
+++ b/tests/gf_core/standard/utilities/analytics/test_gf_analytics_utility.gd
@@ -88,7 +88,8 @@ func test_dispose_releases_callbacks_reinjected_by_flush_notifications() -> void
 			_fallback_accepted: int
 		) -> Dictionary:
 			return {}
-	analytics.flush_completed.connect(reinject_callbacks)
+	var connect_error: Error = analytics.flush_completed.connect(reinject_callbacks) as Error
+	assert_eq(connect_error, OK, "dispose 回归测试必须成功连接 flush 完成信号。")
 
 	analytics.dispose()
 	analytics.flush_completed.disconnect(reinject_callbacks)

--- a/tests/gf_core/standard/utilities/assets/test_gf_resource_variant_graph_artifact.gd
+++ b/tests/gf_core/standard/utilities/assets/test_gf_resource_variant_graph_artifact.gd
@@ -60,6 +60,10 @@ func test_resource_graph_scanner_reports_paths_and_cycles_without_editor_ui() ->
 	assert_true(paths.has("child"), "路径列表应包含资源属性路径。")
 	assert_true(paths.has("items"), "路径列表应包含数组属性路径。")
 	assert_true(paths.has("map"), "路径列表应包含字典属性路径。")
+	child.child = null
+	root.child = null
+	root.items.clear()
+	root.map.clear()
 
 
 func test_raw_resource_artifact_materializes_to_user_path_explicitly() -> void:

--- a/tests/gf_core/standard/utilities/audio/test_gf_audio_beat_clock.gd
+++ b/tests/gf_core/standard/utilities/audio/test_gf_audio_beat_clock.gd
@@ -42,18 +42,19 @@ func test_audio_beat_clock_boundary_callback_can_reset_state() -> void:
 	var clock: GFAudioBeatClock = GFAudioBeatClock.new()
 	clock.configure(120.0, 4, 0.0)
 	var reset_done: Array[bool] = [false]
-	var _beat_connected: Error = clock.beat_reached.connect(func(_beat_index: int, _beat_in_measure: int, _position_seconds: float) -> void:
+	var on_beat_reached: Callable = func(_beat_index: int, _beat_in_measure: int, _position_seconds: float) -> void:
 		if reset_done[0]:
 			return
 		reset_done[0] = true
 		var _reset_snapshot: Dictionary = clock.reset(0.0)
-	) as Error
+	var _beat_connected: Error = clock.beat_reached.connect(on_beat_reached) as Error
 
 	var _initial_snapshot: Dictionary = clock.update(0.0)
 	var _later_snapshot: Dictionary = clock.update(2.1)
 
 	assert_true(reset_done[0], "推进时应触发至少一个 beat 回调。")
 	assert_almost_eq(clock.get_last_position_seconds(), 0.0, 0.001, "回调中的 reset 不应被 update 末尾覆盖。")
+	clock.beat_reached.disconnect(on_beat_reached)
 
 
 ## 验证同一次 update 内的边界位置使用采样时的节拍参数。
@@ -61,11 +62,11 @@ func test_audio_beat_clock_boundary_positions_use_sampled_timing() -> void:
 	var clock: GFAudioBeatClock = GFAudioBeatClock.new()
 	clock.configure(120.0, 4, 0.0)
 	var positions: Array[float] = []
-	var _beat_connected: Error = clock.beat_reached.connect(func(beat_index: int, _beat_in_measure: int, position_seconds: float) -> void:
+	var on_beat_reached: Callable = func(beat_index: int, _beat_in_measure: int, position_seconds: float) -> void:
 		positions.append(position_seconds)
 		if beat_index == 1:
 			clock.configure(60.0, 4, 1.0, false)
-	) as Error
+	var _beat_connected: Error = clock.beat_reached.connect(on_beat_reached) as Error
 
 	var _initial_snapshot: Dictionary = clock.update(0.0)
 	var _later_snapshot: Dictionary = clock.update(2.1)
@@ -75,6 +76,7 @@ func test_audio_beat_clock_boundary_positions_use_sampled_timing() -> void:
 	assert_almost_eq(positions[1], 1.0, 0.001, "后续边界不应被回调中修改 BPM 影响。")
 	assert_almost_eq(positions[2], 1.5, 0.001, "后续边界不应被回调中修改 offset 影响。")
 	assert_almost_eq(positions[3], 2.0, 0.001, "同一 update 内的边界时间应一致。")
+	clock.beat_reached.disconnect(on_beat_reached)
 
 
 ## 验证 reset 会建立当前位置但不发出历史边界。

--- a/tests/gf_core/standard/utilities/audio/test_gf_audio_utility.gd
+++ b/tests/gf_core/standard/utilities/audio/test_gf_audio_utility.gd
@@ -768,6 +768,7 @@ func test_audio_catalog_provider_ignores_unknown_catalog_ids() -> void:
 	var catalog: GFAudioCatalogProvider = GFAudioCatalogProvider.new()
 
 	catalog.set_entry(&"parameter", &"intensity", { "min": 0.0 })
+	assert_push_warning("[GFAudioCatalogProvider] 未知音频目录：parameter。")
 
 	assert_eq(catalog.get_ids(&"events"), PackedStringArray(), "未知目录 ID 不应默认写入 events。")
 	assert_eq(catalog.get_ids(&"parameter"), PackedStringArray(), "未知目录 ID 查询应返回空列表。")

--- a/tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd
@@ -40,7 +40,9 @@ func test_register_command() -> void:
 
 func test_register_command_rejects_empty_name_and_invalid_callback() -> void:
 	_register_command("", Callable(), "空指令。")
+	assert_push_warning("[GFConsoleUtility] 注册命令失败：命令名为空。")
 	_register_command("broken", Callable(), "无效回调。")
+	assert_push_warning("[GFConsoleUtility] 注册命令失败：callback 无效：broken。")
 
 	assert_false(_console.has_command(""), "空命令名不应进入命令表。")
 	assert_false(_console.has_command("broken"), "无效 callback 不应进入命令表。")

--- a/tests/gf_core/standard/utilities/debug/test_gf_diagnostics_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_diagnostics_utility.gd
@@ -405,7 +405,9 @@ func test_diagnostics_rejects_external_contributions_for_reserved_snapshot_keys(
 	diagnostics.init()
 
 	var section_registered: bool = diagnostics.publish_snapshot_section(self, &"build", { "fake": true })
+	assert_push_warning("[GFDiagnosticsUtility] 快照分区使用了保留字段，已拒绝：build。")
 	var tool_registered: bool = diagnostics.publish_tool_snapshot(self, &"timer", { "fake": true })
+	assert_push_warning("[GFDiagnosticsUtility] 工具快照使用了内置字段，已拒绝：timer。")
 	var snapshot: Dictionary = diagnostics.collect_snapshot({
 		"include_recent_logs": false,
 	})

--- a/tests/gf_core/standard/utilities/debug/test_gf_support_report_workflow.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_support_report_workflow.gd
@@ -208,13 +208,17 @@ func test_workflow_queue_listener_observes_count_and_dispose_keeps_it_reset() ->
 		outbox
 	)
 	var observed_queued_count: Array[int] = [-1]
+	var on_workflow_report_queued: Callable = func(
+		_report: Dictionary,
+		_envelope: GFRequestEnvelope
+	) -> void:
+		observed_queued_count[0] = GFVariantData.get_option_int(
+			workflow.get_debug_snapshot(),
+			"reports_queued_count"
+		)
+		workflow.dispose()
 	var _queued_connected: Error = workflow.workflow_report_queued.connect(
-		func(_report: Dictionary, _envelope: GFRequestEnvelope) -> void:
-			observed_queued_count[0] = GFVariantData.get_option_int(
-				workflow.get_debug_snapshot(),
-				"reports_queued_count"
-			)
-			workflow.dispose()
+		on_workflow_report_queued
 	) as Error
 
 	var result: Dictionary = workflow.queue_report({
@@ -230,6 +234,7 @@ func test_workflow_queue_listener_observes_count_and_dispose_keeps_it_reset() ->
 		"监听器 dispose 后不得由通知尾部重新写回旧计数。"
 	)
 	assert_eq(outbox.get_queue_size(), 1, "工作流 dispose 不得撤销外部 Outbox 的耐久所有权。")
+	workflow.workflow_report_queued.disconnect(on_workflow_report_queued)
 	outbox.dispose()
 
 

--- a/tests/gf_core/standard/utilities/logging/test_gf_log_utility.gd
+++ b/tests/gf_core/standard/utilities/logging/test_gf_log_utility.gd
@@ -502,6 +502,10 @@ func test_json_line_log_sink_can_fail_when_custom_file_exists() -> void:
 
 	_log_util.add_sink(sink)
 	var snapshot: Dictionary = sink.get_debug_snapshot()
+	assert_push_warning(
+		"[GFJsonLineLogSink] JSONL 日志文件已存在：%s，错误码：%d"
+		% [jsonl_path, ERR_ALREADY_EXISTS]
+	)
 
 	assert_false(GFVariantData.get_option_bool(snapshot, "is_open", true), "FAIL_IF_EXISTS 应拒绝打开已有 JSONL 文件。")
 	assert_eq(GFVariantData.get_option_int(snapshot, "last_error"), ERR_ALREADY_EXISTS, "FAIL_IF_EXISTS 应报告 ERR_ALREADY_EXISTS。")
@@ -550,9 +554,14 @@ func test_json_line_log_sink_reports_parent_directory_errors() -> void:
 
 	_log_util.add_sink(sink)
 	var snapshot: Dictionary = sink.get_debug_snapshot()
+	var last_error: int = GFVariantData.get_option_int(snapshot, "last_error")
+	assert_push_warning(
+		"[GFJsonLineLogSink] 无法创建日志文件：%s，错误码：%d"
+		% [sink.file_path, last_error]
+	)
 
 	assert_false(GFVariantData.get_option_bool(snapshot, "is_open", true), "目录创建失败时 JSONL 文件不应保持打开。")
-	assert_ne(GFVariantData.get_option_int(snapshot, "last_error"), OK, "目录创建失败应记录错误码。")
+	assert_ne(last_error, OK, "目录创建失败应记录错误码。")
 	assert_true(
 		GFVariantData.get_option_string(snapshot, "last_error_message").contains(blocker_path),
 		"调试快照应保留失败路径。"

--- a/tests/gf_core/standard/utilities/scene/test_gf_scene_utility.gd
+++ b/tests/gf_core/standard/utilities/scene/test_gf_scene_utility.gd
@@ -312,6 +312,7 @@ func test_scene_transition_config_can_drive_scene_load() -> void:
 	config.cache_loaded_scene = false
 	config.params = { "spawn": "door_a" }
 	config.minimum_duration_seconds = 0.25
+	_scene_util.put_preloaded_scene(config.target_scene_path, _make_empty_scene())
 
 	var error: Error = _scene_util.load_scene_with_transition(config)
 

--- a/tests/gf_core/standard/utilities/signals/test_gf_async_primitives.gd
+++ b/tests/gf_core/standard/utilities/signals/test_gf_async_primitives.gd
@@ -10,11 +10,12 @@ const GF_ASYNC_PROGRESS_AGGREGATOR_SCRIPT = preload("res://addons/gf/standard/co
 
 func test_cancel_source_cancels_token_once_with_metadata() -> void:
 	var source: GFCancellationSource = GFCancellationSource.new()
+	var token: GFCancellationToken = source.get_token()
 	var signal_state: Dictionary = {}
-	var connect_error: Error = source.get_token().cancel_requested.connect(func(reason: StringName) -> void:
+	var on_cancel_requested: Callable = func(reason: StringName) -> void:
 		signal_state["reason"] = reason
-		signal_state["metadata"] = source.get_token().get_cancel_metadata()
-	) as Error
+		signal_state["metadata"] = token.get_cancel_metadata()
+	var connect_error: Error = token.cancel_requested.connect(on_cancel_requested) as Error
 	assert_eq(connect_error, OK, "测试应能监听 token 取消信号。")
 
 	assert_true(source.cancel(&"user_cancelled", { "scope": "menu" }), "首次取消应成功。")
@@ -27,6 +28,7 @@ func test_cancel_source_cancels_token_once_with_metadata() -> void:
 	assert_eq(GFVariantData.get_option_string(metadata, "scope"), "menu", "token 应保留取消元数据。")
 	assert_eq(GFVariantData.get_option_string_name(signal_state, "reason"), &"user_cancelled", "取消信号应发出原因。")
 	assert_eq(GFVariantData.get_option_string(emitted_metadata, "scope"), "menu", "取消信号应复制元数据。")
+	token.cancel_requested.disconnect(on_cancel_requested)
 
 
 func test_cancel_source_links_upstream_and_timeout() -> void:

--- a/tests/gf_core/standard/utilities/signals/test_gf_async_wait_support.gd
+++ b/tests/gf_core/standard/utilities/signals/test_gf_async_wait_support.gd
@@ -55,14 +55,56 @@ func test_await_signal_state_prioritizes_cancellation_over_due_timeout() -> void
 		"respect_time_scale": false,
 		"timeout_warning": "[GFAsyncWaitSupportTest] cancellation must win over timeout.",
 		"should_continue": func() -> bool:
-			continue_state["check_count"] = int(continue_state["check_count"]) + 1
-			return int(continue_state["check_count"]) < 2,
+			continue_state["check_count"] = (
+				GFVariantData.get_option_int(continue_state, "check_count") + 1
+			)
+			return GFVariantData.get_option_int(continue_state, "check_count") < 2,
 	})
 
 	assert_eq(GFVariantData.get_option_string_name(result, "status"), GF_ASYNC_WAIT_SUPPORT.STATUS_CANCELLED, "同一帧同时满足取消与超时时必须优先返回 cancelled。")
 	assert_eq(GFVariantData.get_option_string_name(result, "reason"), &"should_continue_false", "取消结果应保留 should_continue 终止原因。")
-	assert_eq(int(continue_state["check_count"]), 2, "测试必须跨帧进入取消与 timeout 同时成立的仲裁点。")
+	assert_eq(GFVariantData.get_option_int(continue_state, "check_count"), 2, "测试必须跨帧进入取消与 timeout 同时成立的仲裁点。")
 	assert_push_warning_count(0, "取消优先时不得迟发 timeout warning。")
+
+
+func test_await_signal_state_cancels_when_continue_owner_is_released() -> void:
+	var emitter: WideSignalEmitter = WideSignalEmitter.new()
+	var continue_owner: ContinueOwner = ContinueOwner.new()
+	add_child_autofree(emitter)
+	continue_owner.call_deferred(&"free")
+
+	var result: Dictionary = await GF_ASYNC_WAIT_SUPPORT.await_signal_state(emitter.payload_ready, {
+		"tree": get_tree(),
+		"timeout_seconds": 0.001,
+		"respect_time_scale": false,
+		"timeout_warning": "[GFAsyncWaitSupportTest] invalid continuation must cancel.",
+		"should_continue": Callable(continue_owner, &"should_continue"),
+	})
+
+	assert_eq(GFVariantData.get_option_string_name(result, "status"), GF_ASYNC_WAIT_SUPPORT.STATUS_CANCELLED, "继续检查宿主释放后应取消等待。")
+	assert_eq(GFVariantData.get_option_string_name(result, "reason"), &"should_continue_invalid", "取消结果应区分失效回调与主动返回 false。")
+	assert_push_warning_count(0, "失效继续检查必须先于 timeout 结束等待，不得迟发 warning。")
+
+
+func test_await_signal_state_rejects_continue_owner_released_before_wait() -> void:
+	var emitter: WideSignalEmitter = WideSignalEmitter.new()
+	var continue_owner: ContinueOwner = ContinueOwner.new()
+	add_child_autofree(emitter)
+	var stale_continue: Callable = Callable(continue_owner, &"should_continue")
+	continue_owner.free()
+
+	var result: Dictionary = await GF_ASYNC_WAIT_SUPPORT.await_signal_state(
+		emitter.payload_ready,
+		{
+			"tree": get_tree(),
+			"timeout_seconds": 0.1,
+			"respect_time_scale": false,
+			"should_continue": stale_continue,
+		}
+	)
+
+	assert_eq(GFVariantData.get_option_string_name(result, "status"), GF_ASYNC_WAIT_SUPPORT.STATUS_CANCELLED, "等待开始前已经失效的继续检查必须立即取消。")
+	assert_eq(GFVariantData.get_option_string_name(result, "reason"), &"should_continue_invalid", "预先失效的继续检查必须保留稳定原因。")
 
 
 func test_await_signal_safely_source_checks_connect_results() -> void:
@@ -92,6 +134,13 @@ class WideSignalEmitter:
 
 	func emit_payload_ready() -> void:
 		payload_ready.emit(1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+
+class ContinueOwner:
+	extends Object
+
+	func should_continue() -> bool:
+		return true
 
 
 # --- 私有/辅助方法 ---

--- a/tests/gf_core/standard/utilities/signals/test_gf_async_wait_support.gd
+++ b/tests/gf_core/standard/utilities/signals/test_gf_async_wait_support.gd
@@ -44,6 +44,27 @@ func test_await_signal_state_reports_cancelled_token() -> void:
 	assert_eq(GFVariantData.get_option_string(metadata, "scope"), "test", "等待状态应保留取消元数据。")
 
 
+func test_await_signal_state_prioritizes_cancellation_over_due_timeout() -> void:
+	var emitter: WideSignalEmitter = WideSignalEmitter.new()
+	var continue_state: Dictionary = { "check_count": 0 }
+	add_child_autofree(emitter)
+
+	var result: Dictionary = await GF_ASYNC_WAIT_SUPPORT.await_signal_state(emitter.payload_ready, {
+		"tree": get_tree(),
+		"timeout_seconds": 0.001,
+		"respect_time_scale": false,
+		"timeout_warning": "[GFAsyncWaitSupportTest] cancellation must win over timeout.",
+		"should_continue": func() -> bool:
+			continue_state["check_count"] = int(continue_state["check_count"]) + 1
+			return int(continue_state["check_count"]) < 2,
+	})
+
+	assert_eq(GFVariantData.get_option_string_name(result, "status"), GF_ASYNC_WAIT_SUPPORT.STATUS_CANCELLED, "同一帧同时满足取消与超时时必须优先返回 cancelled。")
+	assert_eq(GFVariantData.get_option_string_name(result, "reason"), &"should_continue_false", "取消结果应保留 should_continue 终止原因。")
+	assert_eq(int(continue_state["check_count"]), 2, "测试必须跨帧进入取消与 timeout 同时成立的仲裁点。")
+	assert_push_warning_count(0, "取消优先时不得迟发 timeout warning。")
+
+
 func test_await_signal_safely_source_checks_connect_results() -> void:
 	var source: String = _read_text_file("res://addons/gf/standard/common/gf_async_wait_support.gd")
 

--- a/tests/gf_core/standard/utilities/spatial/test_gf_spatial_query_index.gd
+++ b/tests/gf_core/standard/utilities/spatial/test_gf_spatial_query_index.gd
@@ -87,7 +87,7 @@ func test_spatial_query_identity_is_shared_by_2d_and_3d_indexes() -> void:
 	var index_3d: GF_SPATIAL_QUERY_INDEX_3D_SCRIPT = GF_SPATIAL_QUERY_INDEX_3D_SCRIPT.new()
 	var _configured_3d: GF_SPATIAL_QUERY_INDEX_3D_SCRIPT = index_3d.configure(GF_SPATIAL_QUERY_INDEX_3D_SCRIPT.STRATEGY_LINEAR)
 	var node: Node = Node.new()
-	add_child(node)
+	add_child_autofree(node)
 
 	var _inserted_2d_name: bool = index_2d.upsert(&"unit", Rect2(Vector2.ZERO, Vector2(10.0, 10.0)))
 	var _inserted_3d_name: bool = index_3d.upsert(&"unit", AABB(Vector3.ZERO, Vector3.ONE))

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -47,6 +47,11 @@ func before_each() -> void:
 	_storage.init()
 
 
+func _replace_storage(storage: GFStorageUtility) -> void:
+	_storage.dispose()
+	_storage = storage
+
+
 func after_each() -> void:
 	if _storage != null:
 		for file_name: String in [
@@ -100,6 +105,7 @@ func after_each() -> void:
 		_remove_directory_if_exists("_invalid_storage_directory")
 		_remove_directory_if_exists("nested")
 
+		_storage.dispose()
 		_storage = null
 
 
@@ -538,7 +544,7 @@ func test_transaction_marker_cannot_expand_recovery_beyond_requested_files() -> 
 
 func test_save_data_group_removes_orphaned_files_when_member_write_fails() -> void:
 	var faulty_storage: FaultyStorageUtility = FaultyStorageUtility.new()
-	_storage = faulty_storage
+	_replace_storage(faulty_storage)
 	_storage.save_dir_name = "test_saves"
 	_storage.init()
 	var data_file_name: String = "group/data.json"
@@ -566,7 +572,7 @@ func test_save_data_group_preserves_existing_files_when_member_write_fails() -> 
 	}), OK, "预置旧事务数据应成功。")
 
 	var faulty_storage: FaultyStorageUtility = FaultyStorageUtility.new()
-	_storage = faulty_storage
+	_replace_storage(faulty_storage)
 	_storage.save_dir_name = "test_saves"
 	_storage.encrypt_key = 0
 	_storage.init()
@@ -891,7 +897,7 @@ func test_load_data_preserves_migrate_data_override_extension_point() -> void:
 	var override_storage: MigrationOverrideStorageUtility = MigrationOverrideStorageUtility.new()
 	override_storage.save_dir_name = "test_saves"
 	override_storage.init()
-	_storage = override_storage
+	_replace_storage(override_storage)
 	_storage.encrypt_key = 0
 	_storage.save_version = 2
 	_storage.default_values_for_new_keys = {"framework_default": true}
@@ -953,7 +959,7 @@ func test_registered_migration_wrong_return_type_fails_without_advancing_version
 	var inherited_storage: InheritedMigrationStorageUtility = InheritedMigrationStorageUtility.new()
 	inherited_storage.save_dir_name = "test_saves"
 	inherited_storage.init()
-	_storage = inherited_storage
+	_replace_storage(inherited_storage)
 	_storage.encrypt_key = 0
 	_storage.save_version = 2
 	assert_true(_storage.register_migration(1, 2, func(

--- a/tests/gf_core/standard/utilities/ui/test_gf_form_binder.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_form_binder.gd
@@ -5,11 +5,15 @@ extends GutTest
 # --- 私有变量 ---
 
 var _controls: Array[Control] = []
+var _binders: Array[GFFormBinder] = []
 
 
 # --- Godot 生命周期方法 ---
 
 func after_each() -> void:
+	for binder: GFFormBinder in _binders:
+		binder.clear()
+	_binders.clear()
 	for control: Control in _controls:
 		if is_instance_valid(control):
 			control.free()
@@ -29,7 +33,7 @@ func test_option_button_uses_selected_index_not_button_pressed() -> void:
 
 
 func test_form_binder_reads_and_writes_common_controls() -> void:
-	var binder: GFFormBinder = GFFormBinder.new()
+	var binder: GFFormBinder = _make_binder()
 	var name_edit: LineEdit = LineEdit.new()
 	var enabled_check: CheckBox = CheckBox.new()
 	_track_control(name_edit)
@@ -49,7 +53,7 @@ func test_form_binder_reads_and_writes_common_controls() -> void:
 
 
 func test_form_binder_emits_field_changed_from_control_signal() -> void:
-	var binder: GFFormBinder = GFFormBinder.new()
+	var binder: GFFormBinder = _make_binder()
 	var name_edit: LineEdit = LineEdit.new()
 	_track_control(name_edit)
 	binder.bind_field(&"name", name_edit)
@@ -62,7 +66,7 @@ func test_form_binder_emits_field_changed_from_control_signal() -> void:
 
 
 func test_form_binder_rebind_disconnects_previous_signal_handlers() -> void:
-	var binder: GFFormBinder = GFFormBinder.new()
+	var binder: GFFormBinder = _make_binder()
 	var name_edit: LineEdit = LineEdit.new()
 	_track_control(name_edit)
 	binder.bind_field(&"name", name_edit)
@@ -76,7 +80,7 @@ func test_form_binder_rebind_disconnects_previous_signal_handlers() -> void:
 
 
 func test_form_binder_unbind_disconnects_signal_handlers() -> void:
-	var binder: GFFormBinder = GFFormBinder.new()
+	var binder: GFFormBinder = _make_binder()
 	var name_edit: LineEdit = LineEdit.new()
 	_track_control(name_edit)
 	binder.bind_field(&"name", name_edit)
@@ -93,3 +97,9 @@ func test_form_binder_unbind_disconnects_signal_handlers() -> void:
 
 func _track_control(control: Control) -> void:
 	_controls.append(control)
+
+
+func _make_binder() -> GFFormBinder:
+	var binder: GFFormBinder = GFFormBinder.new()
+	_binders.append(binder)
+	return binder

--- a/tests/gf_core/standard/utilities/ui/test_gf_reactive_state_control_binder.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_reactive_state_control_binder.gd
@@ -11,11 +11,15 @@ const GFReactiveStateStoreBase = preload("res://addons/gf/standard/utilities/sta
 # --- 私有变量 ---
 
 var _controls: Array[Control] = []
+var _binders: Array[GFReactiveStateControlBinderBase] = []
 
 
 # --- Godot 生命周期方法 ---
 
 func after_each() -> void:
+	for binder: GFReactiveStateControlBinderBase in _binders:
+		binder.dispose()
+	_binders.clear()
 	for control: Control in _controls:
 		if is_instance_valid(control):
 			control.free()
@@ -30,7 +34,7 @@ func test_bind_control_syncs_store_value_to_control() -> void:
 			"name": "Ada",
 		},
 	})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	_track_control(line_edit)
 
@@ -42,7 +46,7 @@ func test_bind_control_syncs_store_value_to_control() -> void:
 func test_bind_control_rejects_invalid_store_and_control() -> void:
 	var store: GFReactiveStateStoreBase = GFReactiveStateStoreBase.new({})
 	var invalid_store: RefCounted = RefCounted.new()
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	var null_control: Control = null
 	_track_control(line_edit)
@@ -60,7 +64,7 @@ func test_control_signal_updates_store_path() -> void:
 			"name": "Ada",
 		},
 	})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	_track_control(line_edit)
 	var _bind_result: Variant = binder.bind_control(store, "profile.name", line_edit)
@@ -78,7 +82,7 @@ func test_rebinding_same_control_replaces_previous_path_subscription() -> void:
 			"last": "Lovelace",
 		},
 	})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	_track_control(line_edit)
 
@@ -99,7 +103,7 @@ func test_control_signal_prunes_binding_when_store_is_released() -> void:
 			"name": "Ada",
 		},
 	})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	_track_control(line_edit)
 	var _bind_result: Variant = binder.bind_control(store, "profile.name", line_edit)
@@ -119,7 +123,7 @@ func test_store_path_change_updates_control_without_duplicate_loop() -> void:
 	var store: GFReactiveStateStoreBase = GFReactiveStateStoreBase.new({
 		"enabled": false,
 	})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var checkbox: CheckBox = CheckBox.new()
 	_track_control(checkbox)
 	var _bind_result: Variant = binder.bind_control(store, "enabled", checkbox)
@@ -133,7 +137,7 @@ func test_store_path_change_updates_control_without_duplicate_loop() -> void:
 
 func test_write_initial_to_store_uses_control_value() -> void:
 	var store: GFReactiveStateStoreBase = GFReactiveStateStoreBase.new({})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	line_edit.text = "Initial"
 	_track_control(line_edit)
@@ -149,7 +153,7 @@ func test_control_tree_exit_clears_binding_and_store_subscription() -> void:
 	var store: GFReactiveStateStoreBase = GFReactiveStateStoreBase.new({
 		"name": "Ada",
 	})
-	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	var binder: GFReactiveStateControlBinderBase = _make_binder()
 	var line_edit: LineEdit = LineEdit.new()
 	add_child(line_edit)
 	_controls.append(line_edit)
@@ -166,6 +170,12 @@ func test_control_tree_exit_clears_binding_and_store_subscription() -> void:
 
 func _track_control(control: Control) -> void:
 	_controls.append(control)
+
+
+func _make_binder() -> GFReactiveStateControlBinderBase:
+	var binder: GFReactiveStateControlBinderBase = GFReactiveStateControlBinderBase.new()
+	_binders.append(binder)
+	return binder
 
 
 func _get_signal_connection_count(control: Object, signal_name: StringName) -> int:

--- a/tests/gf_core/standard/utilities/ui/test_gf_repeater_binder.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_repeater_binder.gd
@@ -20,6 +20,7 @@ func after_each() -> void:
 		if is_instance_valid(node):
 			node.free()
 	_nodes.clear()
+	await get_tree().process_frame
 
 
 # --- 测试方法 ---

--- a/tests/gf_core/standard/utilities/ui/test_gf_ui_router_utility.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_ui_router_utility.gd
@@ -255,6 +255,7 @@ func test_async_route_sync_fallback_reaches_terminal_state() -> void:
 	assert_true(_router.register_route(route), "有效路由应可注册。")
 
 	var operation: GFUIRouteOperation = _router.push_route_async(&"inventory")
+	assert_push_warning("[GFUIUtility] GFAssetUtility 未注册，回退为同步加载。")
 	await get_tree().process_frame
 
 	var snapshot: Dictionary = _router.get_debug_snapshot()
@@ -338,6 +339,7 @@ func test_async_replace_failure_preserves_existing_route_history() -> void:
 	asset_util.resolve("res://tests/missing_async_replace_panel.tscn", null)
 	await get_tree().process_frame
 	await get_tree().process_frame
+	assert_push_warning("[GFUIRouterUtility] 路由打开失败：second (panel_async_failed)")
 
 	assert_eq(_router.get_current_route_id(), &"first", "异步 replace 失败后应保留旧路由历史。")
 	assert_true(_ui_utility.is_panel_open(first_panel, GFUIUtility.Layer.POPUP), "异步 replace 失败后旧面板应仍在 UI 栈中。")

--- a/tests/gf_core/support/gf_gut_cli.gd
+++ b/tests/gf_core/support/gf_gut_cli.gd
@@ -1,0 +1,160 @@
+# Lifecycle-aware SceneTree wrapper for command-line GUT runs.
+extends SceneTree
+
+
+# --- 常量 ---
+
+const GF_GUT_LIFECYCLE_LOGGER_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_gut_lifecycle_logger.gd"
+)
+const GF_GUT_LIFECYCLE_STATE_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_gut_lifecycle_state.gd"
+)
+const GF_GUT_RUNNER_SCENE_PATH: String = "res://tests/gf_core/support/gf_gut_runner.tscn"
+const GUT_VERSION_CONVERSION_SCRIPT_PATH: String = "res://addons/gut/version_conversion.gd"
+const BOOTSTRAP_FIXTURE_ENVIRONMENT: String = "GF_GUT_LIFECYCLE_BOOTSTRAP_FIXTURE"
+const BOOTSTRAP_WARNING_FIXTURE_PATH: String = (
+	"res://tests/gf_core/fixtures/lifecycle_gate/"
+	+ "lifecycle_gate_bootstrap_warning_fixture.gd"
+)
+const SENTINEL_PREFIX: String = "GF_TEST_LIFECYCLE_GATE="
+const EXIT_FAILURE: int = 1
+const MAIN_LOOP_WAIT_LIMIT: int = 20
+
+
+# --- 私有变量 ---
+
+var _raw_logger: Logger
+var _cli: Node
+
+
+# --- Godot 生命周期方法 ---
+
+func _init() -> void:
+	GF_GUT_LIFECYCLE_STATE_SCRIPT.begin_run()
+	var raw_logger_value: Variant = GF_GUT_LIFECYCLE_LOGGER_SCRIPT.new()
+	if not raw_logger_value is Logger:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"raw_logger_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+
+	_raw_logger = raw_logger_value
+	OS.add_logger(_raw_logger)
+
+	if not _load_requested_bootstrap_fixture():
+		quit(EXIT_FAILURE)
+		return
+
+	var version_conversion_resource: Resource = load(
+		GUT_VERSION_CONVERSION_SCRIPT_PATH
+	)
+	if not version_conversion_resource is GDScript:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_version_conversion_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+	var version_conversion_script: GDScript = version_conversion_resource
+	var conversion_error_value: Variant = version_conversion_script.call(
+		&"error_if_not_all_classes_imported"
+	)
+	if not conversion_error_value is bool:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_version_conversion_invalid"
+		)
+		quit(EXIT_FAILURE)
+		return
+	var conversion_has_error: bool = conversion_error_value
+	if conversion_has_error:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_classes_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+
+	var gut_loader_resource: Resource = load("res://addons/gut/gut_loader.gd")
+	if gut_loader_resource == null:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_loader_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+
+	var iteration: int = 0
+	while Engine.get_main_loop() == null and iteration < MAIN_LOOP_WAIT_LIMIT:
+		await create_timer(0.01).timeout
+		iteration += 1
+	if Engine.get_main_loop() == null:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"main_loop_start_timeout"
+		)
+		quit(EXIT_FAILURE)
+		return
+
+	var runner_scene_resource: Resource = load(GF_GUT_RUNNER_SCENE_PATH)
+	if not runner_scene_resource is PackedScene:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_runner_scene_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+	var runner_scene: PackedScene = runner_scene_resource
+
+	var cli_resource: Resource = load("res://addons/gut/cli/gut_cli.gd")
+	if not cli_resource is GDScript:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_cli_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+
+	var cli_script: GDScript = cli_resource
+	var cli_value: Variant = cli_script.new()
+	if not cli_value is Node:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_cli_instance_unavailable"
+		)
+		quit(EXIT_FAILURE)
+		return
+
+	_cli = cli_value
+	_cli.set(&"GutRunner", runner_scene)
+	get_root().add_child(_cli)
+	var _main_result: Variant = _cli.call(&"main")
+
+
+func _finalize() -> void:
+	var report: Dictionary = GF_GUT_LIFECYCLE_STATE_SCRIPT.finalize_report()
+	var report_ok_value: Variant = report.get("ok")
+	if not report_ok_value is bool or not report_ok_value:
+		quit(EXIT_FAILURE)
+	if _raw_logger != null:
+		OS.remove_logger(_raw_logger)
+	print(SENTINEL_PREFIX + JSON.stringify(report))
+	_cli = null
+	_raw_logger = null
+
+
+# --- 私有/辅助方法 ---
+
+func _load_requested_bootstrap_fixture() -> bool:
+	var fixture_path: String = OS.get_environment(
+		BOOTSTRAP_FIXTURE_ENVIRONMENT
+	)
+	if fixture_path.is_empty():
+		return true
+	if fixture_path != BOOTSTRAP_WARNING_FIXTURE_PATH:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"bootstrap_fixture_not_allowed"
+		)
+		return false
+
+	var fixture_resource: Resource = load(fixture_path)
+	if not fixture_resource is GDScript:
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"bootstrap_fixture_unavailable"
+		)
+		return false
+	return true

--- a/tests/gf_core/support/gf_gut_cli.gd.uid
+++ b/tests/gf_core/support/gf_gut_cli.gd.uid
@@ -1,0 +1,1 @@
+uid://ctdfqkifofx1t

--- a/tests/gf_core/support/gf_gut_lifecycle_logger.gd
+++ b/tests/gf_core/support/gf_gut_lifecycle_logger.gd
@@ -1,0 +1,26 @@
+# Captures push_warning calls outside GUT's tracked-test phase.
+extends Logger
+
+
+# --- 常量 ---
+
+const GF_GUT_LIFECYCLE_STATE_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_gut_lifecycle_state.gd"
+)
+
+
+# --- Godot 回调方法 ---
+
+func _log_error(
+	source_function: String,
+	file: String,
+	line: int,
+	code: String,
+	_rationale: String,
+	_editor_notify: bool,
+	_error_type: int,
+	_script_backtraces: Array[ScriptBacktrace]
+) -> void:
+	if source_function != "push_warning":
+		return
+	GF_GUT_LIFECYCLE_STATE_SCRIPT.record_raw_warning(code, file, line)

--- a/tests/gf_core/support/gf_gut_lifecycle_logger.gd.uid
+++ b/tests/gf_core/support/gf_gut_lifecycle_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://d2h3etp6qwy60

--- a/tests/gf_core/support/gf_gut_lifecycle_state.gd
+++ b/tests/gf_core/support/gf_gut_lifecycle_state.gd
@@ -1,0 +1,278 @@
+# Process-wide lifecycle evidence shared by the GF GUT CLI wrapper and hooks.
+extends RefCounted
+
+
+# --- 枚举 ---
+
+enum CapturePhase {
+	IDLE,
+	EARLY,
+	TRACKED,
+	TERMINAL,
+	FINALIZED,
+}
+
+
+# --- 常量 ---
+
+const REPORT_SCHEMA_VERSION: int = 1
+const MAX_DETAIL_COUNT: int = 20
+const MAX_TEXT_UTF8_BYTES: int = 512
+
+
+# --- 私有变量 ---
+
+static var _mutex: Mutex = Mutex.new()
+static var _capture_phase: int = CapturePhase.IDLE
+static var _baseline_available: bool = false
+static var _warning_tracking_available: bool = false
+static var _post_hook_completed: bool = false
+static var _orphan_baseline: Dictionary = {}
+static var _warning_count: int = 0
+static var _warning_details: Array[Dictionary] = []
+static var _orphans_by_id: Dictionary = {}
+static var _configuration_error: String = ""
+
+
+# --- 框架内部方法 ---
+
+static func begin_run() -> void:
+	_mutex.lock()
+	_capture_phase = CapturePhase.EARLY
+	_baseline_available = false
+	_warning_tracking_available = false
+	_post_hook_completed = false
+	_orphan_baseline = {}
+	_warning_count = 0
+	_warning_details = []
+	_orphans_by_id = {}
+	_configuration_error = ""
+	_mutex.unlock()
+
+
+static func record_configuration_error(error_code: String) -> void:
+	_mutex.lock()
+	_set_configuration_error_locked(error_code)
+	_mutex.unlock()
+
+
+static func enter_tracking_phase(tracker_registered: bool) -> void:
+	_mutex.lock()
+	if tracker_registered:
+		_capture_phase = CapturePhase.TRACKED
+	else:
+		_set_configuration_error_locked("warning_tracker_registration_failed")
+	_mutex.unlock()
+
+
+static func begin_terminal_capture() -> void:
+	_mutex.lock()
+	if _capture_phase == CapturePhase.EARLY or _capture_phase == CapturePhase.TRACKED:
+		_capture_phase = CapturePhase.TERMINAL
+	elif _capture_phase != CapturePhase.TERMINAL:
+		_set_configuration_error_locked("terminal_capture_out_of_order")
+	_mutex.unlock()
+
+
+static func record_raw_warning(code: String, file: String, line: int) -> void:
+	_mutex.lock()
+	var test_id: String = ""
+	if _capture_phase == CapturePhase.EARLY:
+		test_id = "early"
+	elif _capture_phase == CapturePhase.TERMINAL:
+		test_id = "terminal"
+	if not test_id.is_empty():
+		_append_warning_locked(test_id, code, file, line)
+	_mutex.unlock()
+
+
+static func commit_orphan_baseline(orphan_ids: Dictionary) -> void:
+	_mutex.lock()
+	_orphan_baseline = orphan_ids.duplicate()
+	_baseline_available = true
+	_mutex.unlock()
+
+
+static func snapshot_new_orphans() -> Dictionary:
+	_mutex.lock()
+	var baseline_available: bool = _baseline_available
+	var orphan_baseline: Dictionary = _orphan_baseline.duplicate()
+	_mutex.unlock()
+
+	var orphan_details: Array[Dictionary] = []
+	if baseline_available:
+		for orphan_id: int in Node.get_orphan_node_ids():
+			if not orphan_baseline.has(orphan_id):
+				orphan_details.append(_orphan_detail(orphan_id))
+	return {
+		"ok": baseline_available,
+		"orphans": orphan_details,
+	}
+
+
+static func commit_post_snapshot(
+	tracked_warnings: Array[Dictionary],
+	tracker_available: bool,
+	orphan_snapshot: Dictionary
+) -> bool:
+	_mutex.lock()
+	_post_hook_completed = true
+	_warning_tracking_available = tracker_available
+	for warning_detail: Dictionary in tracked_warnings:
+		_append_warning_locked(
+			_dictionary_string(warning_detail, "test_id"),
+			_dictionary_string(warning_detail, "code"),
+			_dictionary_string(warning_detail, "file"),
+			_dictionary_int(warning_detail, "line")
+		)
+	_merge_orphan_snapshot_locked(orphan_snapshot)
+	if not _baseline_available:
+		_set_configuration_error_locked("orphan_baseline_unavailable")
+	if not tracker_available:
+		_set_configuration_error_locked("warning_tracker_unavailable")
+	var snapshot_clean: bool = _snapshot_is_clean_locked()
+	_mutex.unlock()
+	return snapshot_clean
+
+
+static func finalize_report() -> Dictionary:
+	var final_orphan_snapshot: Dictionary = snapshot_new_orphans()
+
+	_mutex.lock()
+	_merge_orphan_snapshot_locked(final_orphan_snapshot)
+	if not _post_hook_completed:
+		_set_configuration_error_locked("post_hook_unavailable")
+	if not _baseline_available:
+		_set_configuration_error_locked("orphan_baseline_unavailable")
+	if not _warning_tracking_available:
+		_set_configuration_error_locked("warning_tracker_unavailable")
+	_capture_phase = CapturePhase.FINALIZED
+
+	var orphan_ids: Array = _orphans_by_id.keys()
+	orphan_ids.sort()
+	var orphan_details: Array[Dictionary] = []
+	for orphan_id_value: Variant in orphan_ids.slice(0, MAX_DETAIL_COUNT):
+		var raw_detail: Variant = _orphans_by_id.get(orphan_id_value)
+		if raw_detail is Dictionary:
+			var orphan_detail: Dictionary = raw_detail
+			orphan_details.append(orphan_detail.duplicate())
+
+	var orphan_count: int = _orphans_by_id.size()
+	var report: Dictionary = {
+		"schema_version": REPORT_SCHEMA_VERSION,
+		"ok": _snapshot_is_clean_locked(),
+		"baseline_available": _baseline_available,
+		"warning_tracking_available": _warning_tracking_available,
+		"unhandled_warning_count": _warning_count,
+		"orphan_count": orphan_count,
+		"warnings": _warning_details.duplicate(true),
+		"orphans": orphan_details,
+		"details_truncated": (
+			_warning_count > MAX_DETAIL_COUNT
+			or orphan_count > MAX_DETAIL_COUNT
+		),
+		"configuration_error": _bounded_text(_configuration_error),
+	}
+	_mutex.unlock()
+	return report
+
+
+# --- 私有/辅助方法 ---
+
+static func _append_warning_locked(
+	test_id: String,
+	code: String,
+	file: String,
+	line: int
+) -> void:
+	_warning_count += 1
+	if _warning_details.size() >= MAX_DETAIL_COUNT:
+		return
+	_warning_details.append({
+		"test_id": _bounded_text(test_id),
+		"code": _bounded_text(code),
+		"file": _bounded_text(file),
+		"line": maxi(line, 0),
+	})
+
+
+static func _merge_orphan_snapshot_locked(orphan_snapshot: Dictionary) -> void:
+	var raw_orphans: Variant = orphan_snapshot.get("orphans")
+	if not raw_orphans is Array:
+		return
+	var orphan_values: Array = raw_orphans
+	for raw_orphan: Variant in orphan_values:
+		if not raw_orphan is Dictionary:
+			continue
+		var orphan_detail: Dictionary = raw_orphan
+		var instance_id: int = _dictionary_int(orphan_detail, "instance_id")
+		if instance_id <= 0 or _orphans_by_id.has(instance_id):
+			continue
+		_orphans_by_id[instance_id] = {
+			"instance_id": instance_id,
+			"class": _bounded_text(_dictionary_string(orphan_detail, "class")),
+			"name": _bounded_text(_dictionary_string(orphan_detail, "name")),
+		}
+
+
+static func _snapshot_is_clean_locked() -> bool:
+	return (
+		_baseline_available
+		and _warning_tracking_available
+		and _post_hook_completed
+		and _warning_count == 0
+		and _orphans_by_id.is_empty()
+		and _configuration_error.is_empty()
+	)
+
+
+static func _set_configuration_error_locked(error_code: String) -> void:
+	if _configuration_error.is_empty() and not error_code.is_empty():
+		_configuration_error = _bounded_text(error_code)
+
+
+static func _orphan_detail(orphan_id: int) -> Dictionary:
+	var detail: Dictionary = {
+		"instance_id": orphan_id,
+		"class": "<released>",
+		"name": "",
+	}
+	if not is_instance_id_valid(orphan_id):
+		return detail
+
+	var orphan_object: Object = instance_from_id(orphan_id)
+	if not orphan_object is Node:
+		return detail
+
+	var orphan_node: Node = orphan_object
+	detail["class"] = _bounded_text(orphan_node.get_class())
+	detail["name"] = _bounded_text(String(orphan_node.name))
+	return detail
+
+
+static func _bounded_text(value: String) -> String:
+	var result: String = ""
+	var byte_count: int = 0
+	for character_index: int in range(value.length()):
+		var character: String = String.chr(value.unicode_at(character_index))
+		var character_bytes: int = character.to_utf8_buffer().size()
+		if byte_count + character_bytes > MAX_TEXT_UTF8_BYTES:
+			break
+		result += character
+		byte_count += character_bytes
+	return result
+
+
+static func _dictionary_int(source: Dictionary, key: String) -> int:
+	var raw_value: Variant = source.get(key, 0)
+	return raw_value if raw_value is int else 0
+
+
+static func _dictionary_string(source: Dictionary, key: String) -> String:
+	var raw_value: Variant = source.get(key, "")
+	if raw_value is String:
+		return raw_value
+	if raw_value is StringName:
+		var string_name_value: StringName = raw_value
+		return String(string_name_value)
+	return str(raw_value)

--- a/tests/gf_core/support/gf_gut_lifecycle_state.gd.uid
+++ b/tests/gf_core/support/gf_gut_lifecycle_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dbje2fx3o5axe

--- a/tests/gf_core/support/gf_gut_post_run_hook.gd
+++ b/tests/gf_core/support/gf_gut_post_run_hook.gd
@@ -1,25 +1,23 @@
-# Enforces process-wide test lifecycle invariants after GUT has settled queued frees.
+# Commits the tracked-test terminal snapshot to the process lifecycle state.
 extends GutHookScript
 
 
 # --- 常量 ---
 
-const ORPHAN_BASELINE_META_KEY: StringName = &"_gf_test_orphan_baseline"
-const SENTINEL_PREFIX: String = "GF_TEST_LIFECYCLE_GATE="
-const REPORT_SCHEMA_VERSION: int = 1
+const GF_GUT_LIFECYCLE_STATE_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_gut_lifecycle_state.gd"
+)
 const EXIT_FAILURE: int = 1
-const MAX_DETAIL_COUNT: int = 20
 const SETTLE_FRAME_COUNT: int = 3
 
 
 # --- 可重写钩子 / 虚方法 ---
 
 func run() -> void:
-	var report: Dictionary = _make_empty_report()
 	if not gut is GutMain:
-		report["ok"] = false
-		report["configuration_error"] = "gut_instance_unavailable"
-		_emit_report(report)
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.record_configuration_error(
+			"gut_instance_unavailable"
+		)
 		set_exit_code(EXIT_FAILURE)
 		return
 
@@ -27,96 +25,29 @@ func run() -> void:
 	for _frame_index: int in range(SETTLE_FRAME_COUNT):
 		await gut_main.get_tree().process_frame
 
-	var baseline_result: Dictionary = _read_orphan_baseline(gut_main)
-	var baseline_available: bool = _dictionary_bool(baseline_result, "ok")
-	report["baseline_available"] = baseline_available
-	if not baseline_available:
-		report["configuration_error"] = "orphan_baseline_unavailable"
-
-	var warning_result: Dictionary = _collect_unhandled_warnings(gut_main)
-	var warning_tracking_available: bool = _dictionary_bool(warning_result, "ok")
-	report["warning_tracking_available"] = warning_tracking_available
-	if not warning_tracking_available:
-		report["configuration_error"] = "warning_tracker_unavailable"
-
-	var unhandled_warnings: Array[Dictionary] = []
-	var raw_warnings: Variant = warning_result.get("warnings")
-	if raw_warnings is Array:
-		var warning_values: Array = raw_warnings
-		for raw_warning: Variant in warning_values:
-			if raw_warning is Dictionary:
-				var warning_detail: Dictionary = raw_warning
-				unhandled_warnings.append(warning_detail)
-
-	var new_orphans: Array[Dictionary] = []
-	if baseline_available:
-		var raw_baseline_ids: Variant = baseline_result.get("orphan_ids")
-		if raw_baseline_ids is Dictionary:
-			var baseline_ids: Dictionary = raw_baseline_ids
-			new_orphans = _collect_new_orphans(baseline_ids)
-		else:
-			baseline_available = false
-			report["baseline_available"] = false
-			report["configuration_error"] = "orphan_baseline_invalid"
-
-	report["unhandled_warning_count"] = unhandled_warnings.size()
-	report["orphan_count"] = new_orphans.size()
-	report["warnings"] = unhandled_warnings.slice(0, MAX_DETAIL_COUNT)
-	report["orphans"] = new_orphans.slice(0, MAX_DETAIL_COUNT)
-	report["details_truncated"] = (
-		unhandled_warnings.size() > MAX_DETAIL_COUNT
-		or new_orphans.size() > MAX_DETAIL_COUNT
+	# Switch the raw logger first so warnings racing the tracker snapshot fail closed.
+	GF_GUT_LIFECYCLE_STATE_SCRIPT.begin_terminal_capture()
+	var warning_snapshot: Dictionary = _collect_unhandled_warnings(gut_main)
+	var tracked_warnings: Array[Dictionary] = _dictionary_array(
+		warning_snapshot,
+		"warnings"
 	)
-	report["ok"] = (
-		baseline_available
-		and warning_tracking_available
-		and unhandled_warnings.is_empty()
-		and new_orphans.is_empty()
+	var tracker_available: bool = _dictionary_bool(warning_snapshot, "ok")
+	var orphan_snapshot: Dictionary = (
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.snapshot_new_orphans()
 	)
-
-	_emit_report(report)
-	if not _dictionary_bool(report, "ok"):
+	var snapshot_clean: bool = (
+		GF_GUT_LIFECYCLE_STATE_SCRIPT.commit_post_snapshot(
+			tracked_warnings,
+			tracker_available,
+			orphan_snapshot
+		)
+	)
+	if not snapshot_clean:
 		set_exit_code(EXIT_FAILURE)
 
 
 # --- 私有/辅助方法 ---
-
-func _make_empty_report() -> Dictionary:
-	return {
-		"schema_version": REPORT_SCHEMA_VERSION,
-		"ok": true,
-		"baseline_available": false,
-		"warning_tracking_available": false,
-		"unhandled_warning_count": 0,
-		"orphan_count": 0,
-		"warnings": [],
-		"orphans": [],
-		"details_truncated": false,
-		"configuration_error": "",
-	}
-
-
-func _read_orphan_baseline(gut_main: GutMain) -> Dictionary:
-	if not gut_main.has_meta(ORPHAN_BASELINE_META_KEY):
-		return {
-			"ok": false,
-			"orphan_ids": {},
-		}
-
-	var raw_baseline: Variant = gut_main.get_meta(ORPHAN_BASELINE_META_KEY)
-	gut_main.remove_meta(ORPHAN_BASELINE_META_KEY)
-	if not raw_baseline is Dictionary:
-		return {
-			"ok": false,
-			"orphan_ids": {},
-		}
-
-	var baseline_ids: Dictionary = raw_baseline
-	return {
-		"ok": true,
-		"orphan_ids": baseline_ids,
-	}
-
 
 func _collect_unhandled_warnings(gut_main: GutMain) -> Dictionary:
 	var warning_details: Array[Dictionary] = []
@@ -146,56 +77,66 @@ func _collect_unhandled_warnings(gut_main: GutMain) -> Dictionary:
 			"warnings": warning_details,
 		}
 
-	var raw_error_groups: Variant = error_tracker.get("errors")
-	if not raw_error_groups is Object:
+	var raw_mutex: Variant = error_tracker.get("_mutex")
+	if not raw_mutex is Mutex:
 		return {
 			"ok": false,
 			"warnings": warning_details,
 		}
 
+	var tracker_mutex: Mutex = raw_mutex
+	tracker_mutex.lock()
+	var snapshot_valid: bool = _copy_warning_snapshot_locked(
+		error_tracker,
+		warning_details
+	)
+	tracker_mutex.unlock()
+	return {
+		"ok": snapshot_valid,
+		"warnings": warning_details,
+	}
+
+
+func _copy_warning_snapshot_locked(
+	error_tracker: GutErrorTracker,
+	warning_details: Array[Dictionary]
+) -> bool:
+	var raw_error_groups: Variant = error_tracker.get("errors")
+	if not raw_error_groups is Object:
+		return false
+
 	var error_groups: Object = raw_error_groups
 	var raw_items: Variant = error_groups.get("items")
 	if not raw_items is Dictionary:
-		return {
-			"ok": false,
-			"warnings": warning_details,
-		}
+		return false
 
 	var grouped_errors: Dictionary = raw_items
 	for test_id_value: Variant in grouped_errors:
 		var raw_errors: Variant = grouped_errors.get(test_id_value)
 		if not raw_errors is Array:
-			return {
-				"ok": false,
-				"warnings": warning_details,
-			}
+			return false
 
 		var tracked_errors: Array = raw_errors
 		for raw_error: Variant in tracked_errors:
 			if not raw_error is GutTrackedError:
-				return {
-					"ok": false,
-					"warnings": warning_details,
-				}
+				return false
 
 			var tracked_error: GutTrackedError = raw_error
 			var handled_value: Variant = tracked_error.get("handled")
 			if not handled_value is bool:
-				return {
-					"ok": false,
-					"warnings": warning_details,
-				}
+				return false
 			var handled: bool = handled_value
 			if tracked_error.is_push_warning() and not handled:
-				warning_details.append(_warning_detail(test_id_value, tracked_error))
-
-	return {
-		"ok": true,
-		"warnings": warning_details,
-	}
+				warning_details.append(
+					_warning_detail(test_id_value, tracked_error)
+				)
+	return true
 
 
-func _warning_detail(test_id_value: Variant, tracked_error: GutTrackedError) -> Dictionary:
+func _warning_detail(
+	test_id_value: Variant,
+	tracked_error: GutTrackedError
+) -> Dictionary:
 	return {
 		"test_id": _variant_to_text(test_id_value),
 		"code": _variant_to_text(tracked_error.get("code")),
@@ -204,36 +145,17 @@ func _warning_detail(test_id_value: Variant, tracked_error: GutTrackedError) -> 
 	}
 
 
-func _collect_new_orphans(baseline_ids: Dictionary) -> Array[Dictionary]:
-	var orphan_details: Array[Dictionary] = []
-	for orphan_id: int in Node.get_orphan_node_ids():
-		if baseline_ids.has(orphan_id):
-			continue
-		orphan_details.append(_orphan_detail(orphan_id))
-	return orphan_details
-
-
-func _orphan_detail(orphan_id: int) -> Dictionary:
-	var detail: Dictionary = {
-		"instance_id": orphan_id,
-		"class": "<released>",
-		"name": "",
-	}
-	if not is_instance_id_valid(orphan_id):
-		return detail
-
-	var orphan_object: Object = instance_from_id(orphan_id)
-	if not orphan_object is Node:
-		return detail
-
-	var orphan_node: Node = orphan_object
-	detail["class"] = orphan_node.get_class()
-	detail["name"] = String(orphan_node.name)
-	return detail
-
-
-func _emit_report(report: Dictionary) -> void:
-	print(SENTINEL_PREFIX + JSON.stringify(report))
+func _dictionary_array(source: Dictionary, key: String) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var raw_value: Variant = source.get(key)
+	if not raw_value is Array:
+		return result
+	var values: Array = raw_value
+	for raw_entry: Variant in values:
+		if raw_entry is Dictionary:
+			var entry: Dictionary = raw_entry
+			result.append(entry)
+	return result
 
 
 func _dictionary_bool(source: Dictionary, key: String) -> bool:

--- a/tests/gf_core/support/gf_gut_post_run_hook.gd
+++ b/tests/gf_core/support/gf_gut_post_run_hook.gd
@@ -1,0 +1,254 @@
+# Enforces process-wide test lifecycle invariants after GUT has settled queued frees.
+extends GutHookScript
+
+
+# --- 常量 ---
+
+const ORPHAN_BASELINE_META_KEY: StringName = &"_gf_test_orphan_baseline"
+const SENTINEL_PREFIX: String = "GF_TEST_LIFECYCLE_GATE="
+const REPORT_SCHEMA_VERSION: int = 1
+const EXIT_FAILURE: int = 1
+const MAX_DETAIL_COUNT: int = 20
+const SETTLE_FRAME_COUNT: int = 3
+
+
+# --- 可重写钩子 / 虚方法 ---
+
+func run() -> void:
+	var report: Dictionary = _make_empty_report()
+	if not gut is GutMain:
+		report["ok"] = false
+		report["configuration_error"] = "gut_instance_unavailable"
+		_emit_report(report)
+		set_exit_code(EXIT_FAILURE)
+		return
+
+	var gut_main: GutMain = gut
+	for _frame_index: int in range(SETTLE_FRAME_COUNT):
+		await gut_main.get_tree().process_frame
+
+	var baseline_result: Dictionary = _read_orphan_baseline(gut_main)
+	var baseline_available: bool = _dictionary_bool(baseline_result, "ok")
+	report["baseline_available"] = baseline_available
+	if not baseline_available:
+		report["configuration_error"] = "orphan_baseline_unavailable"
+
+	var warning_result: Dictionary = _collect_unhandled_warnings(gut_main)
+	var warning_tracking_available: bool = _dictionary_bool(warning_result, "ok")
+	report["warning_tracking_available"] = warning_tracking_available
+	if not warning_tracking_available:
+		report["configuration_error"] = "warning_tracker_unavailable"
+
+	var unhandled_warnings: Array[Dictionary] = []
+	var raw_warnings: Variant = warning_result.get("warnings")
+	if raw_warnings is Array:
+		var warning_values: Array = raw_warnings
+		for raw_warning: Variant in warning_values:
+			if raw_warning is Dictionary:
+				var warning_detail: Dictionary = raw_warning
+				unhandled_warnings.append(warning_detail)
+
+	var new_orphans: Array[Dictionary] = []
+	if baseline_available:
+		var raw_baseline_ids: Variant = baseline_result.get("orphan_ids")
+		if raw_baseline_ids is Dictionary:
+			var baseline_ids: Dictionary = raw_baseline_ids
+			new_orphans = _collect_new_orphans(baseline_ids)
+		else:
+			baseline_available = false
+			report["baseline_available"] = false
+			report["configuration_error"] = "orphan_baseline_invalid"
+
+	report["unhandled_warning_count"] = unhandled_warnings.size()
+	report["orphan_count"] = new_orphans.size()
+	report["warnings"] = unhandled_warnings.slice(0, MAX_DETAIL_COUNT)
+	report["orphans"] = new_orphans.slice(0, MAX_DETAIL_COUNT)
+	report["details_truncated"] = (
+		unhandled_warnings.size() > MAX_DETAIL_COUNT
+		or new_orphans.size() > MAX_DETAIL_COUNT
+	)
+	report["ok"] = (
+		baseline_available
+		and warning_tracking_available
+		and unhandled_warnings.is_empty()
+		and new_orphans.is_empty()
+	)
+
+	_emit_report(report)
+	if not _dictionary_bool(report, "ok"):
+		set_exit_code(EXIT_FAILURE)
+
+
+# --- 私有/辅助方法 ---
+
+func _make_empty_report() -> Dictionary:
+	return {
+		"schema_version": REPORT_SCHEMA_VERSION,
+		"ok": true,
+		"baseline_available": false,
+		"warning_tracking_available": false,
+		"unhandled_warning_count": 0,
+		"orphan_count": 0,
+		"warnings": [],
+		"orphans": [],
+		"details_truncated": false,
+		"configuration_error": "",
+	}
+
+
+func _read_orphan_baseline(gut_main: GutMain) -> Dictionary:
+	if not gut_main.has_meta(ORPHAN_BASELINE_META_KEY):
+		return {
+			"ok": false,
+			"orphan_ids": {},
+		}
+
+	var raw_baseline: Variant = gut_main.get_meta(ORPHAN_BASELINE_META_KEY)
+	gut_main.remove_meta(ORPHAN_BASELINE_META_KEY)
+	if not raw_baseline is Dictionary:
+		return {
+			"ok": false,
+			"orphan_ids": {},
+		}
+
+	var baseline_ids: Dictionary = raw_baseline
+	return {
+		"ok": true,
+		"orphan_ids": baseline_ids,
+	}
+
+
+func _collect_unhandled_warnings(gut_main: GutMain) -> Dictionary:
+	var warning_details: Array[Dictionary] = []
+	var raw_tracker: Variant = gut_main.get("error_tracker")
+	if not raw_tracker is GutErrorTracker:
+		return {
+			"ok": false,
+			"warnings": warning_details,
+		}
+
+	var error_tracker: GutErrorTracker = raw_tracker
+	var tracker_disabled_value: Variant = error_tracker.get("disabled")
+	if not tracker_disabled_value is bool:
+		return {
+			"ok": false,
+			"warnings": warning_details,
+		}
+	var tracker_disabled: bool = tracker_disabled_value
+	if tracker_disabled or not GutErrorTracker.register_loggers:
+		return {
+			"ok": false,
+			"warnings": warning_details,
+		}
+	if not GutErrorTracker.registered_loggers.has(error_tracker):
+		return {
+			"ok": false,
+			"warnings": warning_details,
+		}
+
+	var raw_error_groups: Variant = error_tracker.get("errors")
+	if not raw_error_groups is Object:
+		return {
+			"ok": false,
+			"warnings": warning_details,
+		}
+
+	var error_groups: Object = raw_error_groups
+	var raw_items: Variant = error_groups.get("items")
+	if not raw_items is Dictionary:
+		return {
+			"ok": false,
+			"warnings": warning_details,
+		}
+
+	var grouped_errors: Dictionary = raw_items
+	for test_id_value: Variant in grouped_errors:
+		var raw_errors: Variant = grouped_errors.get(test_id_value)
+		if not raw_errors is Array:
+			return {
+				"ok": false,
+				"warnings": warning_details,
+			}
+
+		var tracked_errors: Array = raw_errors
+		for raw_error: Variant in tracked_errors:
+			if not raw_error is GutTrackedError:
+				return {
+					"ok": false,
+					"warnings": warning_details,
+				}
+
+			var tracked_error: GutTrackedError = raw_error
+			var handled_value: Variant = tracked_error.get("handled")
+			if not handled_value is bool:
+				return {
+					"ok": false,
+					"warnings": warning_details,
+				}
+			var handled: bool = handled_value
+			if tracked_error.is_push_warning() and not handled:
+				warning_details.append(_warning_detail(test_id_value, tracked_error))
+
+	return {
+		"ok": true,
+		"warnings": warning_details,
+	}
+
+
+func _warning_detail(test_id_value: Variant, tracked_error: GutTrackedError) -> Dictionary:
+	return {
+		"test_id": _variant_to_text(test_id_value),
+		"code": _variant_to_text(tracked_error.get("code")),
+		"file": _variant_to_text(tracked_error.get("file")),
+		"line": _variant_to_int(tracked_error.get("line")),
+	}
+
+
+func _collect_new_orphans(baseline_ids: Dictionary) -> Array[Dictionary]:
+	var orphan_details: Array[Dictionary] = []
+	for orphan_id: int in Node.get_orphan_node_ids():
+		if baseline_ids.has(orphan_id):
+			continue
+		orphan_details.append(_orphan_detail(orphan_id))
+	return orphan_details
+
+
+func _orphan_detail(orphan_id: int) -> Dictionary:
+	var detail: Dictionary = {
+		"instance_id": orphan_id,
+		"class": "<released>",
+		"name": "",
+	}
+	if not is_instance_id_valid(orphan_id):
+		return detail
+
+	var orphan_object: Object = instance_from_id(orphan_id)
+	if not orphan_object is Node:
+		return detail
+
+	var orphan_node: Node = orphan_object
+	detail["class"] = orphan_node.get_class()
+	detail["name"] = String(orphan_node.name)
+	return detail
+
+
+func _emit_report(report: Dictionary) -> void:
+	print(SENTINEL_PREFIX + JSON.stringify(report))
+
+
+func _dictionary_bool(source: Dictionary, key: String) -> bool:
+	var raw_value: Variant = source.get(key, false)
+	return raw_value if raw_value is bool else false
+
+
+func _variant_to_int(value: Variant) -> int:
+	return value if value is int else 0
+
+
+func _variant_to_text(value: Variant) -> String:
+	if value is String:
+		return value
+	if value is StringName:
+		var string_name_value: StringName = value
+		return String(string_name_value)
+	return str(value)

--- a/tests/gf_core/support/gf_gut_post_run_hook.gd.uid
+++ b/tests/gf_core/support/gf_gut_post_run_hook.gd.uid
@@ -1,0 +1,1 @@
+uid://c7l1f3p05thk1

--- a/tests/gf_core/support/gf_gut_pre_run_hook.gd
+++ b/tests/gf_core/support/gf_gut_pre_run_hook.gd
@@ -1,0 +1,26 @@
+# Captures the process-local orphan baseline used by the GF post-run gate.
+extends GutHookScript
+
+
+# --- 常量 ---
+
+const ORPHAN_BASELINE_META_KEY: StringName = &"_gf_test_orphan_baseline"
+
+
+# --- 可重写钩子 / 虚方法 ---
+
+func run() -> void:
+	if not gut is GutMain:
+		return
+
+	var gut_main: GutMain = gut
+	gut_main.set_meta(ORPHAN_BASELINE_META_KEY, _capture_orphan_ids())
+
+
+# --- 私有/辅助方法 ---
+
+func _capture_orphan_ids() -> Dictionary:
+	var orphan_ids: Dictionary = {}
+	for orphan_id: int in Node.get_orphan_node_ids():
+		orphan_ids[orphan_id] = true
+	return orphan_ids

--- a/tests/gf_core/support/gf_gut_pre_run_hook.gd
+++ b/tests/gf_core/support/gf_gut_pre_run_hook.gd
@@ -1,20 +1,20 @@
-# Captures the process-local orphan baseline used by the GF post-run gate.
+# Captures the process-local orphan baseline used by the GF lifecycle gate.
 extends GutHookScript
 
 
 # --- 常量 ---
 
-const ORPHAN_BASELINE_META_KEY: StringName = &"_gf_test_orphan_baseline"
+const GF_GUT_LIFECYCLE_STATE_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_gut_lifecycle_state.gd"
+)
 
 
 # --- 可重写钩子 / 虚方法 ---
 
 func run() -> void:
-	if not gut is GutMain:
-		return
-
-	var gut_main: GutMain = gut
-	gut_main.set_meta(ORPHAN_BASELINE_META_KEY, _capture_orphan_ids())
+	GF_GUT_LIFECYCLE_STATE_SCRIPT.commit_orphan_baseline(
+		_capture_orphan_ids()
+	)
 
 
 # --- 私有/辅助方法 ---

--- a/tests/gf_core/support/gf_gut_pre_run_hook.gd.uid
+++ b/tests/gf_core/support/gf_gut_pre_run_hook.gd.uid
@@ -1,0 +1,1 @@
+uid://c7l1f3pr3h0k1

--- a/tests/gf_core/support/gf_gut_runner.gd
+++ b/tests/gf_core/support/gf_gut_runner.gd
@@ -1,0 +1,22 @@
+# Registers GUT error tracking before test discovery loads any test script.
+extends "res://addons/gut/gui/GutRunner.gd"
+
+
+# --- 常量 ---
+
+const GF_GUT_LIFECYCLE_STATE_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_gut_lifecycle_state.gd"
+)
+
+
+# --- 公共方法 ---
+
+func run_tests(show_gui: bool = true) -> void:
+	var raw_tracker: Variant = error_tracker
+	var tracker_registered: bool = false
+	if raw_tracker is GutErrorTracker:
+		var tracker: GutErrorTracker = raw_tracker
+		GutErrorTracker.register_logger(tracker)
+		tracker_registered = GutErrorTracker.registered_loggers.has(tracker)
+	GF_GUT_LIFECYCLE_STATE_SCRIPT.enter_tracking_phase(tracker_registered)
+	var _run_result: Variant = super.run_tests(show_gui)

--- a/tests/gf_core/support/gf_gut_runner.gd.uid
+++ b/tests/gf_core/support/gf_gut_runner.gd.uid
@@ -1,0 +1,1 @@
+uid://c2qbftaj3ale6

--- a/tests/gf_core/support/gf_gut_runner.tscn
+++ b/tests/gf_core/support/gf_gut_runner.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://tests/gf_core/support/gf_gut_runner.gd" id="1_gf"]
+[ext_resource type="PackedScene" uid="uid://m28heqtswbuq" path="res://addons/gut/GutScene.tscn" id="2_gut"]
+
+[node name="GutRunner" type="Node2D"]
+script = ExtResource("1_gf")
+
+[node name="GutLayer" type="CanvasLayer" parent="."]
+layer = 128
+
+[node name="GutScene" parent="GutLayer" instance=ExtResource("2_gut")]

--- a/tests/gf_core/support/gf_test_lifecycle_scope.gd
+++ b/tests/gf_core/support/gf_test_lifecycle_scope.gd
@@ -1,0 +1,227 @@
+# One-shot test cleanup scope with LIFO callbacks and lifecycle leak diagnostics.
+extends RefCounted
+
+
+# --- 常量 ---
+
+const DEFAULT_SETTLE_FRAME_COUNT: int = 3
+
+
+# --- 私有变量 ---
+
+var _scene_tree: SceneTree
+var _cleanup_callbacks: Array[Callable] = []
+var _release_expectations: Array[Dictionary] = []
+var _orphan_baseline: Dictionary = {}
+var _cleanup_started: bool = false
+var _cleanup_report: Dictionary = {}
+
+
+# --- Godot 生命周期方法 ---
+
+func _init(scene_tree: SceneTree) -> void:
+	_scene_tree = scene_tree
+	_orphan_baseline = _capture_orphan_ids()
+
+
+# --- 框架内部方法 ---
+
+func defer_cleanup(cleanup_callback: Callable) -> bool:
+	if _cleanup_started or not cleanup_callback.is_valid():
+		return false
+	_cleanup_callbacks.append(cleanup_callback)
+	return true
+
+
+func expect_released(target: Object, label: String = "") -> int:
+	if _cleanup_started or target == null:
+		return 0
+
+	var instance_id: int = target.get_instance_id()
+	_release_expectations.append({
+		"instance_id": instance_id,
+		"label": label,
+		"weak_ref": weakref(target),
+	})
+	return instance_id
+
+
+func defer_queue_free(target: Node, label: String = "") -> int:
+	if _cleanup_started or target == null:
+		return 0
+
+	var target_ref: WeakRef = weakref(target)
+	var instance_id: int = expect_released(target, label)
+	var registered: bool = defer_cleanup(func() -> void:
+		var raw_target: Variant = target_ref.get_ref()
+		if raw_target is Node:
+			var live_target: Node = raw_target
+			live_target.queue_free()
+	)
+	return instance_id if registered else 0
+
+
+func defer_free(target: Object, label: String = "") -> int:
+	if _cleanup_started or target == null or target is RefCounted:
+		return 0
+
+	var target_ref: WeakRef = weakref(target)
+	var instance_id: int = expect_released(target, label)
+	var registered: bool = defer_cleanup(func() -> void:
+		var raw_target: Variant = target_ref.get_ref()
+		if raw_target is Object:
+			var live_target: Object = raw_target
+			live_target.free()
+	)
+	return instance_id if registered else 0
+
+
+func cleanup(settle_frame_count: int = DEFAULT_SETTLE_FRAME_COUNT) -> Dictionary:
+	if _cleanup_started:
+		return _cleanup_report.duplicate(true)
+
+	_cleanup_started = true
+	var cleanup_failures: Array[String] = []
+	var cleanup_count: int = 0
+	while not _cleanup_callbacks.is_empty():
+		var cleanup_callback: Callable = _cleanup_callbacks.pop_back()
+		if not cleanup_callback.is_valid():
+			cleanup_failures.append("cleanup callback was released before teardown")
+			continue
+		var _cleanup_result: Variant = await cleanup_callback.call()
+		cleanup_count += 1
+
+	var frames_waited: int = await _settle_releases(settle_frame_count)
+	var unreleased: Array[Dictionary] = _collect_unreleased()
+	var new_orphans: Array[Dictionary] = _collect_new_orphans()
+	_release_expectations.clear()
+
+	_cleanup_report = {
+		"ok": cleanup_failures.is_empty() and unreleased.is_empty() and new_orphans.is_empty(),
+		"cleanup_count": cleanup_count,
+		"frames_waited": frames_waited,
+		"cleanup_failures": cleanup_failures,
+		"unreleased": unreleased,
+		"new_orphans": new_orphans,
+	}
+	return _cleanup_report.duplicate(true)
+
+
+func assert_clean(test_case: GutTest, settle_frame_count: int = DEFAULT_SETTLE_FRAME_COUNT) -> Dictionary:
+	var report: Dictionary = await cleanup(settle_frame_count)
+	var cleanup_failures: Array[String] = _dictionary_string_array(report, "cleanup_failures")
+	var unreleased: Array[Dictionary] = _dictionary_array(report, "unreleased")
+	var new_orphans: Array[Dictionary] = _dictionary_array(report, "new_orphans")
+
+	test_case.assert_eq(cleanup_failures, [], "生命周期清理回调必须全部可执行。")
+	test_case.assert_eq(unreleased, [], "生命周期 scope 登记的对象必须完成释放。")
+	test_case.assert_eq(new_orphans, [], "生命周期 scope 内不得新增孤儿节点。")
+	test_case.assert_no_new_orphans("生命周期 scope 清理后仍存在 GUT 记录的孤儿节点。")
+	return report
+
+
+# --- 私有/辅助方法 ---
+
+func _settle_releases(settle_frame_count: int) -> int:
+	if not is_instance_valid(_scene_tree):
+		return 0
+
+	var wait_limit: int = maxi(settle_frame_count, 1)
+	for frame_index: int in range(wait_limit):
+		await _scene_tree.process_frame
+		if _collect_unreleased().is_empty():
+			return frame_index + 1
+	return wait_limit
+
+
+func _collect_unreleased() -> Array[Dictionary]:
+	var unreleased: Array[Dictionary] = []
+	for expectation: Dictionary in _release_expectations:
+		var raw_weak_ref: Variant = expectation.get("weak_ref")
+		if not raw_weak_ref is WeakRef:
+			unreleased.append(_release_detail(expectation))
+			continue
+
+		var target_ref: WeakRef = raw_weak_ref
+		if target_ref.get_ref() != null:
+			unreleased.append(_release_detail(expectation))
+	return unreleased
+
+
+func _release_detail(expectation: Dictionary) -> Dictionary:
+	return {
+		"instance_id": _dictionary_int(expectation, "instance_id"),
+		"label": _dictionary_string(expectation, "label"),
+	}
+
+
+func _capture_orphan_ids() -> Dictionary:
+	var orphan_ids: Dictionary = {}
+	for orphan_id: int in Node.get_orphan_node_ids():
+		orphan_ids[orphan_id] = true
+	return orphan_ids
+
+
+func _collect_new_orphans() -> Array[Dictionary]:
+	var new_orphans: Array[Dictionary] = []
+	for orphan_id: int in Node.get_orphan_node_ids():
+		if _orphan_baseline.has(orphan_id):
+			continue
+		new_orphans.append(_orphan_detail(orphan_id))
+	return new_orphans
+
+
+func _orphan_detail(orphan_id: int) -> Dictionary:
+	var detail: Dictionary = {
+		"instance_id": orphan_id,
+		"class": "<released>",
+		"name": "",
+	}
+	if not is_instance_id_valid(orphan_id):
+		return detail
+
+	var orphan_object: Object = instance_from_id(orphan_id)
+	if not orphan_object is Node:
+		return detail
+
+	var orphan_node: Node = orphan_object
+	detail["class"] = orphan_node.get_class()
+	detail["name"] = String(orphan_node.name)
+	return detail
+
+
+func _dictionary_array(source: Dictionary, key: String) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var raw_value: Variant = source.get(key)
+	if not raw_value is Array:
+		return result
+
+	var values: Array = raw_value
+	for raw_entry: Variant in values:
+		if raw_entry is Dictionary:
+			var entry: Dictionary = raw_entry
+			result.append(entry)
+	return result
+
+
+func _dictionary_string_array(source: Dictionary, key: String) -> Array[String]:
+	var result: Array[String] = []
+	var raw_value: Variant = source.get(key)
+	if not raw_value is Array:
+		return result
+
+	var values: Array = raw_value
+	for raw_entry: Variant in values:
+		if raw_entry is String:
+			result.append(raw_entry)
+	return result
+
+
+func _dictionary_int(source: Dictionary, key: String) -> int:
+	var raw_value: Variant = source.get(key, 0)
+	return raw_value if raw_value is int else 0
+
+
+func _dictionary_string(source: Dictionary, key: String) -> String:
+	var raw_value: Variant = source.get(key, "")
+	return raw_value if raw_value is String else ""

--- a/tests/gf_core/support/gf_test_lifecycle_scope.gd.uid
+++ b/tests/gf_core/support/gf_test_lifecycle_scope.gd.uid
@@ -1,0 +1,1 @@
+uid://c7l1f3sc0p3a1

--- a/tests/gf_core/support/gf_transient_gdscript_test_support.gd
+++ b/tests/gf_core/support/gf_transient_gdscript_test_support.gd
@@ -25,12 +25,7 @@ static func compile_and_release(source: String) -> Dictionary:
 		if runtime_script.get_global_name().is_empty()
 		else "transient_script_root_declares_global_name"
 	)
-	_release_script_graph(
-		runtime_script,
-		runtime_script.resource_path,
-		{},
-		cleanup_errors
-	)
+	cleanup_errors = release(runtime_script)
 	return {
 		"ok": (
 			compile_error == OK
@@ -41,6 +36,20 @@ static func compile_and_release(source: String) -> Dictionary:
 		"cleanup_errors": cleanup_errors,
 		"configuration_error": configuration_error,
 	}
+
+
+static func release(runtime_script: GDScript) -> Array[int]:
+	var cleanup_errors: Array[int] = []
+	if runtime_script == null:
+		cleanup_errors.append(ERR_INVALID_PARAMETER)
+		return cleanup_errors
+	_release_script_graph(
+		runtime_script,
+		runtime_script.resource_path,
+		{},
+		cleanup_errors
+	)
+	return cleanup_errors
 
 
 # --- 私有/辅助方法 ---

--- a/tests/gf_core/support/gf_transient_gdscript_test_support.gd
+++ b/tests/gf_core/support/gf_transient_gdscript_test_support.gd
@@ -1,0 +1,74 @@
+# Compiles transient GDScript source and dismantles inner-script reference cycles afterwards.
+extends RefCounted
+
+
+# --- 框架内部方法 ---
+
+static func compile_and_release(source: String) -> Dictionary:
+	var runtime_script: GDScript = GDScript.new()
+	if (
+		not runtime_script.resource_path.is_empty()
+		or not runtime_script.is_built_in()
+		or not runtime_script.get_global_name().is_empty()
+	):
+		return {
+			"ok": false,
+			"compile_error": ERR_INVALID_DATA,
+			"cleanup_errors": [],
+			"configuration_error": "transient_script_root_is_not_anonymous",
+		}
+	runtime_script.source_code = source
+	var compile_error: Error = runtime_script.reload(false)
+	var cleanup_errors: Array[int] = []
+	var configuration_error: String = (
+		""
+		if runtime_script.get_global_name().is_empty()
+		else "transient_script_root_declares_global_name"
+	)
+	_release_script_graph(
+		runtime_script,
+		runtime_script.resource_path,
+		{},
+		cleanup_errors
+	)
+	return {
+		"ok": (
+			compile_error == OK
+			and cleanup_errors.is_empty()
+			and configuration_error.is_empty()
+		),
+		"compile_error": compile_error,
+		"cleanup_errors": cleanup_errors,
+		"configuration_error": configuration_error,
+	}
+
+
+# --- 私有/辅助方法 ---
+
+static func _release_script_graph(
+	runtime_script: GDScript,
+	root_resource_path: String,
+	visited: Dictionary,
+	cleanup_errors: Array[int]
+) -> void:
+	var instance_id: int = runtime_script.get_instance_id()
+	if visited.has(instance_id):
+		return
+	visited[instance_id] = true
+
+	for constant_value: Variant in runtime_script.get_script_constant_map().values():
+		if not constant_value is GDScript:
+			continue
+		var inner_script: GDScript = constant_value
+		if (
+			inner_script.resource_path != root_resource_path
+			or not inner_script.is_built_in()
+			or not inner_script.get_global_name().is_empty()
+		):
+			continue
+		_release_script_graph(inner_script, root_resource_path, visited, cleanup_errors)
+
+	runtime_script.source_code = "extends RefCounted\n"
+	var cleanup_error: Error = runtime_script.reload(false)
+	if cleanup_error != OK:
+		cleanup_errors.append(cleanup_error)

--- a/tests/gf_core/support/gf_transient_gdscript_test_support.gd.uid
+++ b/tests/gf_core/support/gf_transient_gdscript_test_support.gd.uid
@@ -1,0 +1,1 @@
+uid://d3u7t8n5r0p4a

--- a/tests/gf_core/support/test_gf_test_lifecycle_scope.gd
+++ b/tests/gf_core/support/test_gf_test_lifecycle_scope.gd
@@ -1,0 +1,95 @@
+extends GutTest
+
+const GF_TEST_LIFECYCLE_SCOPE_SCRIPT = preload(
+	"res://tests/gf_core/support/gf_test_lifecycle_scope.gd"
+)
+
+
+func test_cleanup_runs_callbacks_in_lifo_order() -> void:
+	var lifecycle_scope: GF_TEST_LIFECYCLE_SCOPE_SCRIPT = GF_TEST_LIFECYCLE_SCOPE_SCRIPT.new(
+		get_tree()
+	)
+	var events: Array[String] = []
+	var first_registered: bool = lifecycle_scope.defer_cleanup(func() -> void:
+		events.append("first")
+	)
+	var second_registered: bool = lifecycle_scope.defer_cleanup(func() -> void:
+		events.append("second")
+	)
+
+	var report: Dictionary = await lifecycle_scope.cleanup(1)
+
+	assert_true(first_registered, "第一个清理回调应成功登记。")
+	assert_true(second_registered, "第二个清理回调应成功登记。")
+	assert_eq(events, ["second", "first"], "清理回调必须按 LIFO 顺序执行。")
+	assert_eq(_report_int(report, "cleanup_count"), 2, "报告应记录已执行的清理回调数。")
+	assert_true(_report_bool(report, "ok"), "无泄漏的清理应成功。")
+
+
+func test_cleanup_waits_for_queue_free_and_verifies_weak_release() -> void:
+	var lifecycle_scope: GF_TEST_LIFECYCLE_SCOPE_SCRIPT = GF_TEST_LIFECYCLE_SCOPE_SCRIPT.new(
+		get_tree()
+	)
+	var owned_node: Node = Node.new()
+	add_child(owned_node)
+	var owned_node_ref: WeakRef = weakref(owned_node)
+	var owned_node_id: int = lifecycle_scope.defer_queue_free(owned_node, "owned_node")
+
+	var ref_target: RefCounted = RefCounted.new()
+	var ref_target_ref: WeakRef = weakref(ref_target)
+	var ref_target_id: int = lifecycle_scope.expect_released(ref_target, "ref_target")
+	owned_node = null
+	ref_target = null
+
+	var report: Dictionary = await lifecycle_scope.cleanup()
+
+	assert_ne(owned_node_id, 0, "queue_free 目标应登记实例 ID。")
+	assert_ne(ref_target_id, 0, "弱释放目标应登记实例 ID。")
+	assert_true(owned_node_ref.get_ref() == null, "cleanup 返回前 queue_free 目标必须完成释放。")
+	assert_true(ref_target_ref.get_ref() == null, "cleanup 返回前 RefCounted 目标必须完成释放。")
+	assert_eq(_report_array(report, "unreleased"), [], "报告不应包含未释放对象。")
+	assert_eq(_report_array(report, "new_orphans"), [], "清理不应留下新增孤儿节点。")
+	assert_true(_report_bool(report, "ok"), "完成释放的生命周期清理应成功。")
+
+
+func test_cleanup_is_one_shot_and_rejects_invalid_callbacks() -> void:
+	var lifecycle_scope: GF_TEST_LIFECYCLE_SCOPE_SCRIPT = GF_TEST_LIFECYCLE_SCOPE_SCRIPT.new(
+		get_tree()
+	)
+	var events: Array[String] = []
+	var invalid_registered: bool = lifecycle_scope.defer_cleanup(Callable())
+	var valid_registered: bool = lifecycle_scope.defer_cleanup(func() -> void:
+		events.append("cleanup")
+	)
+
+	var first_report: Dictionary = await lifecycle_scope.cleanup(1)
+	var late_registered: bool = lifecycle_scope.defer_cleanup(func() -> void:
+		events.append("late")
+	)
+	var second_report: Dictionary = await lifecycle_scope.cleanup(1)
+
+	assert_false(invalid_registered, "无效 Callable 不得进入清理栈。")
+	assert_true(valid_registered, "有效 Callable 应进入清理栈。")
+	assert_false(late_registered, "cleanup 开始后不得再登记回调。")
+	assert_eq(events, ["cleanup"], "重复 cleanup 不得再次执行回调。")
+	assert_eq(second_report, first_report, "重复 cleanup 应返回同一份终态报告。")
+
+
+# --- 私有/辅助方法 ---
+
+func _report_array(report: Dictionary, key: String) -> Array:
+	var raw_value: Variant = report.get(key)
+	if raw_value is Array:
+		var values: Array = raw_value
+		return values
+	return []
+
+
+func _report_bool(report: Dictionary, key: String) -> bool:
+	var raw_value: Variant = report.get(key, false)
+	return raw_value if raw_value is bool else false
+
+
+func _report_int(report: Dictionary, key: String) -> int:
+	var raw_value: Variant = report.get(key, -1)
+	return raw_value if raw_value is int else -1

--- a/tests/gf_core/support/test_gf_test_lifecycle_scope.gd.uid
+++ b/tests/gf_core/support/test_gf_test_lifecycle_scope.gd.uid
@@ -1,0 +1,1 @@
+uid://c7l1f3sc0p3t1

--- a/tests/gf_core/tools/config_pipeline/test_gf_config_access_generator.gd
+++ b/tests/gf_core/tools/config_pipeline/test_gf_config_access_generator.gd
@@ -235,9 +235,9 @@ func _assert_generated_source_compiles(source: String, access_class_name: String
 	var report: Dictionary = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.compile_and_release(
 		source.replace("class_name %s\n" % access_class_name, "")
 	)
-	assert_eq(report.get("compile_error"), OK, message)
-	assert_eq(report.get("cleanup_errors"), [], "动态编译测试必须释放生成脚本的内部类图。")
-	assert_eq(report.get("configuration_error"), "", "动态编译测试必须使用匿名内建 GDScript 根。")
+	assert_eq(GFVariantData.get_option_int(report, "compile_error"), OK, message)
+	assert_eq(GFVariantData.get_option_array(report, "cleanup_errors"), [], "动态编译测试必须释放生成脚本的内部类图。")
+	assert_eq(GFVariantData.get_option_string(report, "configuration_error"), "", "动态编译测试必须使用匿名内建 GDScript 根。")
 
 
 # --- 内部类 ---

--- a/tests/gf_core/tools/config_pipeline/test_gf_config_access_generator.gd
+++ b/tests/gf_core/tools/config_pipeline/test_gf_config_access_generator.gd
@@ -1,6 +1,13 @@
 extends GutTest
 
 
+# --- 常量 ---
+
+const GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT = preload(
+	"res://tests/gf_core/support/gf_transient_gdscript_test_support.gd"
+)
+
+
 # --- 测试用例 ---
 
 func test_build_source_generates_config_accessors() -> void:
@@ -225,9 +232,12 @@ func test_build_source_deduplicates_dirty_generated_identifiers() -> void:
 # --- 私有/辅助方法 ---
 
 func _assert_generated_source_compiles(source: String, access_class_name: String, message: String) -> void:
-	var runtime_script: GDScript = GDScript.new()
-	runtime_script.source_code = source.replace("class_name %s\n" % access_class_name, "")
-	assert_eq(runtime_script.reload(), OK, message)
+	var report: Dictionary = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.compile_and_release(
+		source.replace("class_name %s\n" % access_class_name, "")
+	)
+	assert_eq(report.get("compile_error"), OK, message)
+	assert_eq(report.get("cleanup_errors"), [], "动态编译测试必须释放生成脚本的内部类图。")
+	assert_eq(report.get("configuration_error"), "", "动态编译测试必须使用匿名内建 GDScript 根。")
 
 
 # --- 内部类 ---

--- a/tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd
+++ b/tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd
@@ -544,9 +544,9 @@ func test_pipeline_profile_exports_access_script() -> void:
 	var compile_report: Dictionary = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.compile_and_release(
 		access_source.replace("class_name ItemsConfigAccess\n", "")
 	)
-	assert_eq(compile_report.get("compile_error"), OK, "Profile 生成的访问器源码应能编译。")
-	assert_eq(compile_report.get("cleanup_errors"), [], "Profile 动态编译测试必须释放生成脚本的内部类图。")
-	assert_eq(compile_report.get("configuration_error"), "", "Profile 动态编译测试必须使用匿名内建 GDScript 根。")
+	assert_eq(GFVariantData.get_option_int(compile_report, "compile_error"), OK, "Profile 生成的访问器源码应能编译。")
+	assert_eq(GFVariantData.get_option_array(compile_report, "cleanup_errors"), [], "Profile 动态编译测试必须释放生成脚本的内部类图。")
+	assert_eq(GFVariantData.get_option_string(compile_report, "configuration_error"), "", "Profile 动态编译测试必须使用匿名内建 GDScript 根。")
 
 
 func test_pipeline_profile_and_source_duplicate_as_independent_resources() -> void:

--- a/tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd
+++ b/tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd
@@ -4,6 +4,11 @@ extends GutTest
 
 # --- 常量 ---
 
+const GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT = preload(
+	"res://tests/gf_core/support/gf_transient_gdscript_test_support.gd"
+)
+
+
 const GF_CONFIG_PIPELINE_COMMAND_SCRIPT = preload("res://addons/gf/tools/config_pipeline/gf_config_pipeline_command.gd")
 
 
@@ -536,9 +541,12 @@ func test_pipeline_profile_exports_access_script() -> void:
 	assert_true(access_source.contains("static func get_items_typed_record(id: Variant, provider: Variant = null) -> ItemsRecord:"), "访问器源码应包含 typed record 方法。")
 	assert_true(access_source.contains("func get_power() -> float:"), "访问器源码应根据 schema 字段生成 typed getter。")
 
-	var runtime_script: GDScript = GDScript.new()
-	runtime_script.source_code = access_source.replace("class_name ItemsConfigAccess\n", "")
-	assert_eq(runtime_script.reload(), OK, "Profile 生成的访问器源码应能编译。")
+	var compile_report: Dictionary = GF_TRANSIENT_GDSCRIPT_TEST_SUPPORT.compile_and_release(
+		access_source.replace("class_name ItemsConfigAccess\n", "")
+	)
+	assert_eq(compile_report.get("compile_error"), OK, "Profile 生成的访问器源码应能编译。")
+	assert_eq(compile_report.get("cleanup_errors"), [], "Profile 动态编译测试必须释放生成脚本的内部类图。")
+	assert_eq(compile_report.get("configuration_error"), "", "Profile 动态编译测试必须使用匿名内建 GDScript 根。")
 
 
 func test_pipeline_profile_and_source_duplicate_as_independent_resources() -> void:

--- a/tools/gf_gut_lifecycle_smoke.py
+++ b/tools/gf_gut_lifecycle_smoke.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Exercise the GF GUT lifecycle gate against process-level failure fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from gf_godot_process import resolve_godot_executable
+from gf_maintenance import (
+	GUT_LIFECYCLE_CLI_RESOURCE_PATH,
+	GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT,
+	GUT_LIFECYCLE_GATE_MAX_JSON_BYTES,
+	GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH,
+	GUT_LIFECYCLE_GATE_PREFIX,
+	GUT_POST_RUN_HOOK_RESOURCE_PATH,
+	GUT_PRE_RUN_HOOK_RESOURCE_PATH,
+	godot_exit_leak_report_from_output,
+	gut_report_all_tests_passed,
+	has_gdscript_reload_warning,
+	has_godot_script_error,
+	parse_gut_lifecycle_gate_output,
+)
+from gf_process_supervisor import run_supervised_process
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOG_ROOT = ROOT / "ai_analysis" / "godot_logs"
+FIXTURE_ROOT = "res://tests/gf_core/fixtures/lifecycle_gate"
+TERMINAL_WARNING_CODE = "GF lifecycle terminal fixture warning"
+BOOTSTRAP_WARNING_CODE = "GF lifecycle bootstrap fixture warning"
+CUTOVER_WARNING_CODE = "GF lifecycle cutover thread fixture warning"
+SCENARIO_TIMEOUT_SECONDS = 45
+BOOTSTRAP_FIXTURE_ENVIRONMENT = "GF_GUT_LIFECYCLE_BOOTSTRAP_FIXTURE"
+
+
+@dataclass(frozen=True)
+class Scenario:
+	name: str
+	fixture: str
+	expect_ok: bool
+	extra_arguments: tuple[str, ...] = ()
+	pre_run_argument: str = f"-gpre_run_script={GUT_PRE_RUN_HOOK_RESOURCE_PATH}"
+	post_run_argument: str = f"-gpost_run_script={GUT_POST_RUN_HOOK_RESOURCE_PATH}"
+	expected_configuration_error: str = ""
+	expected_warning_count: int | None = None
+	expected_orphan_count: int | None = None
+	expected_warning_code: str = ""
+	bootstrap_fixture: str = ""
+	require_terminal_order: bool = False
+	require_bounded_details: bool = False
+
+
+SCENARIOS: tuple[Scenario, ...] = (
+	Scenario(
+		name="clean",
+		fixture="lifecycle_gate_clean_fixture.gd",
+		expect_ok=True,
+	),
+	Scenario(
+		name="static_init_warning",
+		fixture="lifecycle_gate_static_warning_fixture.gd",
+		expect_ok=False,
+		expected_warning_count=1,
+	),
+	Scenario(
+		name="bootstrap_static_init_warning",
+		fixture="lifecycle_gate_clean_fixture.gd",
+		expect_ok=False,
+		expected_warning_count=1,
+		expected_warning_code=BOOTSTRAP_WARNING_CODE,
+		bootstrap_fixture=(
+			f"{FIXTURE_ROOT}/lifecycle_gate_bootstrap_warning_fixture.gd"
+		),
+	),
+	Scenario(
+		name="terminal_cutover_thread_warning",
+		fixture="lifecycle_gate_clean_fixture.gd",
+		expect_ok=False,
+		post_run_argument=(
+			"-gpost_run_script="
+			f"{FIXTURE_ROOT}/lifecycle_gate_cutover_thread_warning_post_hook.gd"
+		),
+		expected_warning_code=CUTOVER_WARNING_CODE,
+	),
+	Scenario(
+		name="terminal_warning",
+		fixture="lifecycle_gate_clean_fixture.gd",
+		expect_ok=False,
+		post_run_argument=(
+			"-gpost_run_script="
+			f"{FIXTURE_ROOT}/lifecycle_gate_terminal_warning_post_hook.gd"
+		),
+		expected_warning_count=1,
+		require_terminal_order=True,
+	),
+	Scenario(
+		name="no_error_tracking",
+		fixture="lifecycle_gate_clean_fixture.gd",
+		expect_ok=False,
+		extra_arguments=("-gno_error_tracking",),
+		expected_configuration_error="warning_tracker_unavailable",
+	),
+	Scenario(
+		name="missing_baseline",
+		fixture="lifecycle_gate_clean_fixture.gd",
+		expect_ok=False,
+		pre_run_argument="-gpre_run_script=",
+		expected_configuration_error="orphan_baseline_unavailable",
+	),
+	Scenario(
+		name="bounded_warning_details",
+		fixture="lifecycle_gate_many_warnings_fixture.gd",
+		expect_ok=False,
+		expected_warning_count=25,
+		require_bounded_details=True,
+	),
+	Scenario(
+		name="real_orphan",
+		fixture="lifecycle_gate_orphan_fixture.gd",
+		expect_ok=False,
+		post_run_argument=(
+			"-gpost_run_script="
+			f"{FIXTURE_ROOT}/lifecycle_gate_orphan_cleanup_post_hook.gd"
+		),
+		expected_orphan_count=1,
+	),
+)
+
+
+@dataclass
+class ScenarioResult:
+	name: str
+	ok: bool
+	issues: list[str] = field(default_factory=list)
+	process_exit_code: int | None = None
+	lifecycle_report: dict[str, Any] | None = None
+	log_path: str = ""
+	duration_seconds: float = 0.0
+	process_notes: list[str] = field(default_factory=list)
+
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			"name": self.name,
+			"ok": self.ok,
+			"issues": self.issues,
+			"process_exit_code": self.process_exit_code,
+			"lifecycle_report": self.lifecycle_report,
+			"log_path": self.log_path,
+			"duration_seconds": self.duration_seconds,
+			"process_notes": self.process_notes,
+		}
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(
+		description="Run process-level GF GUT lifecycle gate fixtures.",
+	)
+	parser.add_argument("--json", action="store_true", help="Print JSON output.")
+	args = parser.parse_args()
+
+	LOG_ROOT.mkdir(parents=True, exist_ok=True)
+	godot = resolve_godot_executable()
+	results = [run_scenario(godot, scenario) for scenario in SCENARIOS]
+	payload = {
+		"ok": all(result.ok for result in results),
+		"scenario_count": len(results),
+		"failure_count": sum(not result.ok for result in results),
+		"scenarios": [result.to_dict() for result in results],
+	}
+	if args.json:
+		print(json.dumps(payload, ensure_ascii=False, indent=2))
+	else:
+		for result in results:
+			status = "PASS" if result.ok else "FAIL"
+			print(f"[{status}] {result.name}")
+			for issue in result.issues:
+				print(f"  - {issue}")
+	return 0 if payload["ok"] else 1
+
+
+def run_scenario(godot: str, scenario: Scenario) -> ScenarioResult:
+	run_token = f"{os.getpid()}_{secrets.token_hex(4)}"
+	log_path = LOG_ROOT / f"gut_lifecycle_smoke_{scenario.name}_{run_token}.log"
+	log_path.unlink(missing_ok=True)
+	command = [
+		godot,
+		"--headless",
+		"--log-file",
+		str(log_path),
+		"--path",
+		str(ROOT),
+		"-s",
+		GUT_LIFECYCLE_CLI_RESOURCE_PATH,
+		f"-gtest={FIXTURE_ROOT}/{scenario.fixture}",
+		scenario.pre_run_argument,
+		scenario.post_run_argument,
+		"-gexit",
+		"-gdisable_colors",
+		*scenario.extra_arguments,
+	]
+	environment = os.environ.copy()
+	environment.pop(BOOTSTRAP_FIXTURE_ENVIRONMENT, None)
+	if scenario.bootstrap_fixture:
+		environment[BOOTSTRAP_FIXTURE_ENVIRONMENT] = scenario.bootstrap_fixture
+	try:
+		process_result = run_supervised_process(
+			command,
+			cwd=ROOT,
+			environment=environment,
+			timeout_seconds=SCENARIO_TIMEOUT_SECONDS,
+		)
+	except (OSError, RuntimeError) as error:
+		return ScenarioResult(
+			name=scenario.name,
+			ok=False,
+			issues=[f"supervised scenario failed: {type(error).__name__}: {error}"],
+			log_path=log_path.as_posix(),
+		)
+
+	log_text = read_log(log_path)
+	lifecycle_report = parse_gut_lifecycle_gate_output(
+		process_result.stdout,
+		f"{process_result.stderr}\n{log_text}",
+	)
+	issues = validate_scenario(
+		scenario,
+		process_result.return_code,
+		process_result.stdout,
+		process_result.stderr,
+		log_text,
+		lifecycle_report,
+	)
+	if process_result.timed_out:
+		issues.append(
+			f"scenario exceeded {SCENARIO_TIMEOUT_SECONDS}s or process-tree cleanup failed"
+		)
+	if process_result.cancelled:
+		issues.append("scenario was cancelled")
+	return ScenarioResult(
+		name=scenario.name,
+		ok=not issues,
+		issues=issues,
+		process_exit_code=process_result.return_code,
+		lifecycle_report=lifecycle_report,
+		log_path=log_path.as_posix(),
+		duration_seconds=process_result.duration_seconds,
+		process_notes=list(process_result.notes),
+	)
+
+
+def read_log(log_path: Path) -> str:
+	try:
+		return log_path.read_text(encoding="utf-8")
+	except (OSError, UnicodeError):
+		return ""
+
+
+def validate_scenario(
+	scenario: Scenario,
+	process_exit_code: int,
+	stdout: str,
+	stderr: str,
+	log_text: str,
+	lifecycle_report: dict[str, Any],
+) -> list[str]:
+	issues: list[str] = []
+	combined_output = f"{stdout}\n{stderr}\n{log_text}"
+	if has_godot_script_error(combined_output, ""):
+		issues.append("fixture run reported a Godot script loading or parse error")
+	if has_gdscript_reload_warning(combined_output, ""):
+		issues.append("fixture run reported a GDScript reload warning")
+	exit_leak_report = godot_exit_leak_report_from_output(
+		scenario.name,
+		stdout,
+		f"{stderr}\n{log_text}",
+	)
+	if exit_leak_report["has_leaks"]:
+		issues.append("fixture run reported a Godot exit leak")
+	if not gut_report_all_tests_passed(combined_output):
+		issues.append("fixture run did not report a non-empty all-tests-passed summary")
+	marker_errors = lifecycle_report.get("marker_errors")
+	if not isinstance(marker_errors, list) or marker_errors:
+		issues.append(f"lifecycle marker parser rejected evidence: {marker_errors!r}")
+	marker_count = lifecycle_report.get("marker_count")
+	if marker_count not in (1, 2):
+		issues.append(f"lifecycle marker count must be one or two, received {marker_count!r}")
+	source_marker_count = combined_output.count(GUT_LIFECYCLE_GATE_PREFIX)
+	if source_marker_count not in (1, 2):
+		issues.append(
+			"raw lifecycle evidence must occur once or in one stdout/log mirror pair, "
+			f"received {source_marker_count}"
+		)
+	marker = lifecycle_report.get("marker")
+	if not isinstance(marker, dict):
+		return ["lifecycle marker is missing or invalid"]
+
+	report_ok = bool(lifecycle_report.get("ok", False))
+	if report_ok != scenario.expect_ok:
+		issues.append(
+			f"expected lifecycle ok={scenario.expect_ok}, received {report_ok}"
+		)
+	if scenario.expect_ok and process_exit_code != 0:
+		issues.append(f"clean scenario exited with {process_exit_code}")
+	if not scenario.expect_ok and process_exit_code == 0:
+		issues.append("lifecycle failure scenario exited successfully")
+
+	configuration_error = marker.get("configuration_error")
+	if configuration_error != scenario.expected_configuration_error:
+		issues.append(
+			"expected configuration_error="
+			f"{scenario.expected_configuration_error!r}, received {configuration_error!r}"
+		)
+	if scenario.expected_warning_count is not None:
+		warning_count = marker.get("unhandled_warning_count")
+		if warning_count != scenario.expected_warning_count:
+			issues.append(
+				f"expected {scenario.expected_warning_count} warnings, received {warning_count!r}"
+			)
+	if scenario.expected_orphan_count is not None:
+		orphan_count = marker.get("orphan_count")
+		if orphan_count != scenario.expected_orphan_count:
+			issues.append(
+				f"expected {scenario.expected_orphan_count} orphans, received {orphan_count!r}"
+			)
+	if scenario.expected_warning_code:
+		warnings = marker.get("warnings")
+		matching_warning_count = 0
+		if isinstance(warnings, list):
+			matching_warning_count = sum(
+				isinstance(warning, dict)
+				and warning.get("code") == scenario.expected_warning_code
+				for warning in warnings
+			)
+		if matching_warning_count < 1:
+			issues.append(
+				f"expected warning code {scenario.expected_warning_code!r} was not captured"
+			)
+		if scenario.name == "terminal_cutover_thread_warning" and matching_warning_count > 2:
+			issues.append("terminal cutover warning was captured more than twice")
+	if scenario.require_terminal_order:
+		warning_index = log_text.find(f"WARNING: {TERMINAL_WARNING_CODE}")
+		marker_index = log_text.rfind(GUT_LIFECYCLE_GATE_PREFIX)
+		if warning_index < 0:
+			issues.append("terminal warning was not emitted")
+		elif marker_index <= warning_index:
+			issues.append("lifecycle marker was emitted before the terminal warning")
+
+	if scenario.require_bounded_details:
+		warnings = marker.get("warnings")
+		if not isinstance(warnings, list) or len(warnings) != GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT:
+			issues.append("warning details did not use the exact bounded detail count")
+		if marker.get("details_truncated") is not True:
+			issues.append("bounded warning details did not declare truncation")
+		if isinstance(warnings, list):
+			for warning in warnings:
+				if not isinstance(warning, dict):
+					issues.append("bounded warning detail is not an object")
+					continue
+				for key in ("test_id", "code", "file"):
+					value = warning.get(key)
+					if not isinstance(value, str):
+						issues.append(f"warning detail {key} is not text")
+					elif len(value) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH:
+						issues.append(f"warning detail {key} exceeds the character bound")
+					elif len(value.encode("utf-8")) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH:
+						issues.append(f"warning detail {key} exceeds the UTF-8 byte bound")
+		marker_line = next(
+			(
+				line
+				for line in log_text.splitlines()
+				if line.startswith(GUT_LIFECYCLE_GATE_PREFIX)
+			),
+			"",
+		)
+		marker_bytes = marker_line.removeprefix(GUT_LIFECYCLE_GATE_PREFIX).encode("utf-8")
+		if len(marker_bytes) > GUT_LIFECYCLE_GATE_MAX_JSON_BYTES:
+			issues.append("lifecycle marker JSON exceeds the byte bound")
+	return issues
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -169,6 +169,7 @@ GUT_LIFECYCLE_GATE_SCHEMA_VERSION = 1
 GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT = 20
 GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH = 512
 GUT_LIFECYCLE_GATE_MAX_JSON_BYTES = 65536
+GUT_LIFECYCLE_GATE_MAX_MIRRORED_MARKERS = 2
 GUT_LIFECYCLE_GATE_REQUIRED_KEYS = frozenset({
 	"schema_version",
 	"ok",
@@ -183,6 +184,7 @@ GUT_LIFECYCLE_GATE_REQUIRED_KEYS = frozenset({
 })
 GUT_LIFECYCLE_WARNING_DETAIL_KEYS = frozenset({"test_id", "code", "file", "line"})
 GUT_LIFECYCLE_ORPHAN_DETAIL_KEYS = frozenset({"instance_id", "class", "name"})
+GUT_LIFECYCLE_CLI_RESOURCE_PATH = "res://tests/gf_core/support/gf_gut_cli.gd"
 GUT_PRE_RUN_HOOK_RESOURCE_PATH = "res://tests/gf_core/support/gf_gut_pre_run_hook.gd"
 GUT_POST_RUN_HOOK_RESOURCE_PATH = "res://tests/gf_core/support/gf_gut_post_run_hook.gd"
 GUT_LIFECYCLE_HOOK_ARGUMENTS = (
@@ -377,6 +379,7 @@ RESOURCE_BOUNDARY_EDITOR_METADATA_TARGETS = {
 RESOURCE_BOUNDARY_OBSERVATION_KINDS = {
 	"direct_editor_metadata_load",
 	"direct_script_dependency_load",
+	"direct_test_fixture_resource_load",
 }
 RESOURCE_BOUNDARY_OBSERVATION_SAMPLE_LIMIT = 12
 CONTENT_PACKAGE_MANIFEST_FILE = "gf_content_package.json"
@@ -848,6 +851,11 @@ CHECK_DEFINITIONS: dict[str, list[str]] = {
 		".",
 		"--import",
 	],
+	"gut_lifecycle_smoke": [
+		sys.executable,
+		"tools/gf_gut_lifecycle_smoke.py",
+		"--json",
+	],
 	"gut": [
 		"godot",
 		"--headless",
@@ -856,7 +864,7 @@ CHECK_DEFINITIONS: dict[str, list[str]] = {
 		"--path",
 		".",
 		"-s",
-		"res://addons/gut/gut_cmdln.gd",
+		GUT_LIFECYCLE_CLI_RESOURCE_PATH,
 		"-gdir=res://tests/gf_core",
 		"-ginclude_subdirs",
 		*GUT_LIFECYCLE_HOOK_ARGUMENTS,
@@ -1033,6 +1041,7 @@ CHECK_DEFINITIONS: dict[str, list[str]] = {
 }
 
 CHECK_DEPENDENCIES: dict[str, list[str]] = {
+	"gut_lifecycle_smoke": ["godot_import"],
 	"gut": ["godot_import"],
 	"gdscript_warnings": ["godot_import"],
 	"gdscript_lsp_diagnostics": ["godot_import"],
@@ -1127,6 +1136,7 @@ QUICK_CHECKS: list[str] = [
 	*LIGHT_BOUNDARY_CHECKS,
 ]
 FULL_CHECKS: list[str] = [
+	"gut_lifecycle_smoke",
 	"gut",
 	"api",
 	"ai_api",
@@ -1151,6 +1161,7 @@ FULL_CHECKS: list[str] = [
 	"diff",
 ]
 RELEASE_CHECKS: list[str] = [
+	"gut_lifecycle_smoke",
 	"gut",
 	"api",
 	"ai_api",
@@ -1176,6 +1187,7 @@ RELEASE_CHECKS: list[str] = [
 	"release_metadata",
 ]
 FRAMEWORK_GUT_CHECKS: list[str] = [
+	"gut_lifecycle_smoke",
 	"gut",
 	"gdscript_warnings",
 ]
@@ -1200,6 +1212,7 @@ FRAMEWORK_STATIC_CHECKS: list[str] = [
 	"diff",
 ]
 FRAMEWORK_CHECKS: list[str] = [
+	"gut_lifecycle_smoke",
 	"gut",
 	"api",
 	"ai_api",
@@ -1465,6 +1478,8 @@ def check_command(
 
 DEFAULT_CHECK_TIMEOUT_SECONDS: int = 600
 CHECK_TIMEOUT_SECONDS: dict[str, int] = {
+	# Runs six focused process-level lifecycle scenarios after a shared import.
+	"gut_lifecycle_smoke": 360,
 	# The editor wizard smoke launches and tears down isolated editor projects;
 	# a clean Windows run is routinely longer than the generic ten-minute budget.
 	"package_editor_wizard_smoke": 1200,
@@ -5450,7 +5465,7 @@ def package_editor_wizard_smoke(
 		"--path",
 		".",
 		"-s",
-		"res://addons/gut/gut_cmdln.gd",
+		GUT_LIFECYCLE_CLI_RESOURCE_PATH,
 		f"-gtest={test_path}",
 		*GUT_LIFECYCLE_HOOK_ARGUMENTS,
 		"-gexit",
@@ -12999,14 +13014,19 @@ def maintenance_self_test() -> dict[str, Any]:
 			**clean_lifecycle_payload,
 			"configuration_error": "x" * (GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH + 1),
 		}
+		oversized_multibyte_text_payload = {
+			**clean_lifecycle_payload,
+			"configuration_error": "界" * GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH,
+		}
 		record_result(
 			"gut_lifecycle_marker_schema_is_closed_and_bounded",
 			validate_gut_lifecycle_gate_payload(clean_lifecycle_payload) == ""
 			and validate_gut_lifecycle_gate_payload(extra_field_payload) != ""
 			and validate_gut_lifecycle_gate_payload(invalid_truncation_payload) != ""
 			and validate_gut_lifecycle_gate_payload(invalid_warning_detail_payload) != ""
-			and validate_gut_lifecycle_gate_payload(oversized_text_payload) != "",
-			"Lifecycle marker v1 must reject extra fields, inconsistent truncation, malformed details, and oversized text.",
+			and validate_gut_lifecycle_gate_payload(oversized_text_payload) != ""
+			and validate_gut_lifecycle_gate_payload(oversized_multibyte_text_payload) != "",
+			"Lifecycle marker v1 must reject extra fields, inconsistent truncation, malformed details, and character/UTF-8 oversized text.",
 		)
 		clean_lifecycle_marker = (
 			GUT_LIFECYCLE_GATE_PREFIX
@@ -13026,6 +13046,10 @@ def maintenance_self_test() -> dict[str, Any]:
 			f"{clean_lifecycle_marker}\n{clean_lifecycle_marker}\n",
 			"",
 		)
+		excessive_identical_marker_report = parse_gut_lifecycle_gate_output(
+			"\n".join([clean_lifecycle_marker] * 3),
+			"",
+		)
 		conflicting_marker_report = parse_gut_lifecycle_gate_output(
 			f"{clean_lifecycle_marker}\n{invalid_lifecycle_marker}\n",
 			"",
@@ -13043,6 +13067,11 @@ def maintenance_self_test() -> dict[str, Any]:
 			identical_marker_report["ok"]
 			and identical_marker_report["marker_count"] == 2
 			and not identical_marker_report["marker_errors"]
+			and not excessive_identical_marker_report["ok"]
+			and (
+				"lifecycle marker exceeds the mirrored copy limit"
+				in excessive_identical_marker_report["marker_errors"]
+			)
 			and not conflicting_marker_report["ok"]
 			and "conflicting lifecycle markers" in conflicting_marker_report["marker_errors"]
 			and not malformed_marker_report["ok"]
@@ -13052,7 +13081,7 @@ def maintenance_self_test() -> dict[str, Any]:
 			)
 			and not oversized_marker_report["ok"]
 			and "lifecycle marker exceeds the byte limit" in oversized_marker_report["marker_errors"],
-			"Identical duplicate lifecycle evidence may be mirrored into logs; conflicts or malformed copies must fail.",
+			"Exactly one mirrored lifecycle copy is allowed; excessive, conflicting, or malformed copies must fail.",
 		)
 		run_summary_orphan_text = gut_success_summary.replace(
 			"---- All tests passed! ----\n",
@@ -15112,11 +15141,23 @@ def maintenance_self_test() -> dict[str, Any]:
 		and CHECK_DEPENDENCIES.get("gut") == ["godot_import"]
 		and expand_check_dependencies(["gut"]) == ["godot_import", "gut"]
 		and expand_check_dependencies(["godot_import", "gut"]) == ["godot_import", "gut"]
+		and GUT_LIFECYCLE_CLI_RESOURCE_PATH in CHECK_DEFINITIONS["gut"]
 		and all(argument in CHECK_DEFINITIONS["gut"] for argument in GUT_LIFECYCLE_HOOK_ARGUMENTS),
 		(
 			"GUT validation must import a clean Godot project exactly once before loading "
-			"class_name scripts and must install both lifecycle hooks."
+			"class_name scripts and must use the lifecycle-aware CLI with both hooks."
 		),
+	)
+	record_result(
+		"gut_lifecycle_smoke_is_a_framework_gate",
+		CHECK_DEPENDENCIES.get("gut_lifecycle_smoke") == ["godot_import"]
+		and expand_check_dependencies(["gut_lifecycle_smoke"])
+		== ["godot_import", "gut_lifecycle_smoke"]
+		and "gut_lifecycle_smoke" in CHECK_SUITES["framework-gut"]
+		and "gut_lifecycle_smoke" in CHECK_SUITES["framework"]
+		and "gut_lifecycle_smoke" in CHECK_SUITES["full"]
+		and "gut_lifecycle_smoke" in CHECK_SUITES["release"],
+		"Process-level lifecycle failure fixtures must remain a framework and release gate.",
 	)
 	gut_config_payload = read_json_object(ROOT / ".gutconfig.json")
 	record_result(
@@ -15125,8 +15166,12 @@ def maintenance_self_test() -> dict[str, Any]:
 			"pre_run_script": GUT_PRE_RUN_HOOK_RESOURCE_PATH,
 			"post_run_script": GUT_POST_RUN_HOOK_RESOURCE_PATH,
 		}
+		and GUT_LIFECYCLE_CLI_RESOURCE_PATH in CHECK_DEFINITIONS["gut"]
 		and all(argument in CHECK_DEFINITIONS["gut"] for argument in GUT_LIFECYCLE_HOOK_ARGUMENTS),
-		"Repository GUT defaults and the maintenance command must install the same lifecycle hooks.",
+		(
+			"Repository GUT defaults and the lifecycle-aware maintenance command must "
+			"install the same hooks."
+		),
 	)
 	record_result(
 		"gdscript_lsp_check_declares_clean_import_dependency",
@@ -16584,6 +16629,70 @@ def maintenance_self_test() -> dict[str, Any]:
 		"resource_boundary_ignores_load_calls_inside_plain_string_content",
 		not issue_exists(resource_boundary_issues, "direct_script_dependency_load", target="res://addons/gf/extensions/save_extra/example.gd"),
 		f"load calls embedded inside generated source strings should not be reported: {resource_boundary_issues}",
+	)
+	test_fixture_resource_issues = audit_resource_boundary_text(
+		'const RunnerScene = preload("res://tests/gf_core/support/runner.tscn")',
+		"tests/gf_core/support/fixture.gd",
+	)
+	record_result(
+		"resource_boundary_reports_test_owned_fixture_load_as_info",
+		issue_exists(
+			test_fixture_resource_issues,
+			"direct_test_fixture_resource_load",
+			target="res://tests/gf_core/support/runner.tscn",
+			severity="info",
+		),
+		f"test-owned fixture resources should remain observational: {test_fixture_resource_issues}",
+	)
+	runtime_test_fixture_issues = audit_resource_boundary_text(
+		'const RunnerScene = preload("res://tests/gf_core/support/runner.tscn")',
+		"addons/gf/kernel/fixture.gd",
+	)
+	record_result(
+		"resource_boundary_keeps_runtime_load_of_test_fixture_actionable",
+		issue_exists(
+			runtime_test_fixture_issues,
+			"direct_resource_path_load",
+			target="res://tests/gf_core/support/runner.tscn",
+			severity="warning",
+		),
+		f"runtime code must not inherit the test-fixture observation rule: {runtime_test_fixture_issues}",
+	)
+	traversal_fixture_resource_issues = audit_resource_boundary_text(
+		'const RuntimeScene = preload("res://tests/gf_core/../../addons/gf/runtime.tscn")',
+		"tests/gf_core/support/fixture.gd",
+	)
+	record_result(
+		"resource_boundary_rejects_test_fixture_path_traversal",
+		issue_exists(
+			traversal_fixture_resource_issues,
+			"direct_resource_path_load",
+			target="res://tests/gf_core/../../addons/gf/runtime.tscn",
+			severity="warning",
+		)
+		and not issue_exists(
+			traversal_fixture_resource_issues,
+			"direct_test_fixture_resource_load",
+		),
+		f"path traversal must not inherit the test-fixture observation rule: {traversal_fixture_resource_issues}",
+	)
+	traversal_source_resource_issues = audit_resource_boundary_text(
+		'const RunnerScene = preload("res://tests/gf_core/support/runner.tscn")',
+		"tests/gf_core/../runtime/fixture.gd",
+	)
+	record_result(
+		"resource_boundary_rejects_test_source_path_traversal",
+		issue_exists(
+			traversal_source_resource_issues,
+			"direct_resource_path_load",
+			target="res://tests/gf_core/support/runner.tscn",
+			severity="warning",
+		)
+		and not issue_exists(
+			traversal_source_resource_issues,
+			"direct_test_fixture_resource_load",
+		),
+		f"source traversal must not inherit the test-fixture observation rule: {traversal_source_resource_issues}",
 	)
 	record_result(
 		"resource_boundary_source_kind_classifies_common_roots",
@@ -22720,6 +22829,22 @@ def make_resource_boundary_issue(path: str, line_number: int, callee: str, targe
 			target_extension=extension,
 			source_kind=source_kind,
 		)
+	if (
+		source_kind == "test"
+		and is_normalized_test_owned_path(path)
+		and is_normalized_test_fixture_resource_path(target)
+	):
+		return make_boundary_issue(
+			"direct_test_fixture_resource_load",
+			path,
+			"Test-owned fixture resource loads remain visible without imposing runtime resource-domain policy.",
+			line=line_number,
+			severity="info",
+			callee=callee,
+			target=target,
+			target_extension=extension,
+			source_kind=source_kind,
+		)
 	if target.startswith("user://"):
 		return make_boundary_issue(
 			"direct_user_resource_load",
@@ -22755,6 +22880,24 @@ def make_resource_boundary_issue(path: str, line_number: int, callee: str, targe
 		target_extension=extension,
 		source_kind=source_kind,
 	)
+
+
+def is_normalized_test_owned_path(path: str) -> bool:
+	normalized_path = path.replace("\\", "/")
+	parts = normalized_path.split("/")
+	if ".." in parts:
+		return False
+	return posixpath.normpath(normalized_path).startswith("tests/gf_core/")
+
+
+def is_normalized_test_fixture_resource_path(target: str) -> bool:
+	if not target.startswith("res://"):
+		return False
+	resource_path = target[len("res://"):]
+	parts = resource_path.split("/")
+	if ".." in parts:
+		return False
+	return posixpath.normpath(resource_path).startswith("tests/gf_core/")
 
 
 def resource_boundary_source_kind(path: str) -> str:
@@ -26590,6 +26733,12 @@ def parse_gut_lifecycle_gate_output(stdout: str, stderr: str) -> dict[str, Any]:
 		json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 		for payload in marker_payloads
 	}
+	if len(marker_payloads) > GUT_LIFECYCLE_GATE_MAX_MIRRORED_MARKERS:
+		append_limited(
+			marker_errors,
+			"lifecycle marker exceeds the mirrored copy limit",
+			10,
+		)
 	if len(distinct_payloads) > 1:
 		append_limited(marker_errors, "conflicting lifecycle markers", 10)
 	marker = marker_payloads[-1] if marker_payloads else None
@@ -26665,7 +26814,11 @@ def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
 			return f"lifecycle marker {key} entries must be objects"
 	if not isinstance(payload.get("configuration_error"), str):
 		return "lifecycle marker configuration_error must be a string"
-	if len(payload["configuration_error"]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH:
+	if (
+		len(payload["configuration_error"]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
+		or len(payload["configuration_error"].encode("utf-8"))
+		> GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
+	):
 		return "lifecycle marker configuration_error exceeds the text limit"
 
 	warning_count = int(payload["unhandled_warning_count"])
@@ -26680,6 +26833,8 @@ def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
 			return "lifecycle marker warning detail text fields must be strings"
 		if any(
 			len(warning_detail[key]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
+			or len(warning_detail[key].encode("utf-8"))
+			> GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
 			for key in ("test_id", "code", "file")
 		):
 			return "lifecycle marker warning detail text exceeds the text limit"
@@ -26696,6 +26851,8 @@ def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
 			return "lifecycle marker orphan detail text fields must be strings"
 		if any(
 			len(orphan_detail[key]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
+			or len(orphan_detail[key].encode("utf-8"))
+			> GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
 			for key in ("class", "name")
 		):
 			return "lifecycle marker orphan detail text exceeds the text limit"

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -167,6 +167,8 @@ GODOT_EXIT_LEAK_PATTERNS = (
 GUT_LIFECYCLE_GATE_PREFIX = "GF_TEST_LIFECYCLE_GATE="
 GUT_LIFECYCLE_GATE_SCHEMA_VERSION = 1
 GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT = 20
+GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH = 512
+GUT_LIFECYCLE_GATE_MAX_JSON_BYTES = 65536
 GUT_LIFECYCLE_GATE_REQUIRED_KEYS = frozenset({
 	"schema_version",
 	"ok",
@@ -12993,13 +12995,64 @@ def maintenance_self_test() -> dict[str, Any]:
 			"unhandled_warning_count": 1,
 			"warnings": [{"test_id": "fixture", "code": "warning", "file": "fixture.gd"}],
 		}
+		oversized_text_payload = {
+			**clean_lifecycle_payload,
+			"configuration_error": "x" * (GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH + 1),
+		}
 		record_result(
 			"gut_lifecycle_marker_schema_is_closed_and_bounded",
 			validate_gut_lifecycle_gate_payload(clean_lifecycle_payload) == ""
 			and validate_gut_lifecycle_gate_payload(extra_field_payload) != ""
 			and validate_gut_lifecycle_gate_payload(invalid_truncation_payload) != ""
-			and validate_gut_lifecycle_gate_payload(invalid_warning_detail_payload) != "",
-			"Lifecycle marker v1 must reject extra fields, inconsistent truncation, and malformed details.",
+			and validate_gut_lifecycle_gate_payload(invalid_warning_detail_payload) != ""
+			and validate_gut_lifecycle_gate_payload(oversized_text_payload) != "",
+			"Lifecycle marker v1 must reject extra fields, inconsistent truncation, malformed details, and oversized text.",
+		)
+		clean_lifecycle_marker = (
+			GUT_LIFECYCLE_GATE_PREFIX
+			+ json.dumps(clean_lifecycle_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+		)
+		invalid_lifecycle_payload = {
+			**clean_lifecycle_payload,
+			"ok": False,
+			"baseline_available": False,
+			"configuration_error": "fixture_baseline_unavailable",
+		}
+		invalid_lifecycle_marker = (
+			GUT_LIFECYCLE_GATE_PREFIX
+			+ json.dumps(invalid_lifecycle_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+		)
+		identical_marker_report = parse_gut_lifecycle_gate_output(
+			f"{clean_lifecycle_marker}\n{clean_lifecycle_marker}\n",
+			"",
+		)
+		conflicting_marker_report = parse_gut_lifecycle_gate_output(
+			f"{clean_lifecycle_marker}\n{invalid_lifecycle_marker}\n",
+			"",
+		)
+		malformed_marker_report = parse_gut_lifecycle_gate_output(
+			f"{clean_lifecycle_marker}\n{GUT_LIFECYCLE_GATE_PREFIX}{{\n",
+			"",
+		)
+		oversized_marker_report = parse_gut_lifecycle_gate_output(
+			GUT_LIFECYCLE_GATE_PREFIX + ("x" * (GUT_LIFECYCLE_GATE_MAX_JSON_BYTES + 1)),
+			"",
+		)
+		record_result(
+			"gut_lifecycle_marker_duplicates_are_fail_closed",
+			identical_marker_report["ok"]
+			and identical_marker_report["marker_count"] == 2
+			and not identical_marker_report["marker_errors"]
+			and not conflicting_marker_report["ok"]
+			and "conflicting lifecycle markers" in conflicting_marker_report["marker_errors"]
+			and not malformed_marker_report["ok"]
+			and any(
+				error.startswith("invalid JSON:")
+				for error in malformed_marker_report["marker_errors"]
+			)
+			and not oversized_marker_report["ok"]
+			and "lifecycle marker exceeds the byte limit" in oversized_marker_report["marker_errors"],
+			"Identical duplicate lifecycle evidence may be mirrored into logs; conflicts or malformed copies must fail.",
 		)
 		run_summary_orphan_text = gut_success_summary.replace(
 			"---- All tests passed! ----\n",
@@ -15839,6 +15892,19 @@ def maintenance_self_test() -> dict[str, Any]:
 		and godot_47_summary_report["resource_summary_count"] == 1
 		and godot_47_summary_report["resource_summary_total"] == 113,
 		f"Godot 4.7 summary lines must be structured hard-gate evidence: {godot_47_summary_report}",
+	)
+	future_leak_report = godot_exit_leak_report_from_output(
+		"future_leak_fixture",
+		"WARNING: 3 objects were leaked at exit.",
+		"",
+	)
+	record_result(
+		"godot_exit_leak_report_fails_closed_on_unclassified_leak_evidence",
+		future_leak_report["has_leaks"]
+		and future_leak_report["warning_lines"] == [
+			"WARNING: 3 objects were leaked at exit."
+		],
+		f"Raw leak evidence must remain a hard gate when Godot changes its summary format: {future_leak_report}",
 	)
 	command_payload = CommandResult(
 		"fixture",
@@ -26299,7 +26365,8 @@ def godot_exit_leak_report_from_output(name: str, stdout: str, stderr: str) -> d
 
 def finalize_godot_exit_leak_report(report: dict[str, Any]) -> dict[str, Any]:
 	report["has_leaks"] = (
-		report["objectdb_warning_count"] > 0
+		bool(report["warning_lines"])
+		or report["objectdb_warning_count"] > 0
 		or report["resource_summary_count"] > 0
 		or report["resource_still_in_use_count"] > 0
 		or report["rid_allocation_total"] > 0
@@ -26505,6 +26572,9 @@ def parse_gut_lifecycle_gate_output(stdout: str, stderr: str) -> dict[str, Any]:
 		if not line.startswith(GUT_LIFECYCLE_GATE_PREFIX):
 			continue
 		payload_text = line[len(GUT_LIFECYCLE_GATE_PREFIX):]
+		if len(payload_text.encode("utf-8")) > GUT_LIFECYCLE_GATE_MAX_JSON_BYTES:
+			append_limited(marker_errors, "lifecycle marker exceeds the byte limit", 10)
+			continue
 		try:
 			payload = json.loads(payload_text)
 		except json.JSONDecodeError as exc:
@@ -26595,6 +26665,8 @@ def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
 			return f"lifecycle marker {key} entries must be objects"
 	if not isinstance(payload.get("configuration_error"), str):
 		return "lifecycle marker configuration_error must be a string"
+	if len(payload["configuration_error"]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH:
+		return "lifecycle marker configuration_error exceeds the text limit"
 
 	warning_count = int(payload["unhandled_warning_count"])
 	orphan_count = int(payload["orphan_count"])
@@ -26606,6 +26678,11 @@ def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
 			return "lifecycle marker warning detail fields do not match the closed schema"
 		if not all(isinstance(warning_detail[key], str) for key in ("test_id", "code", "file")):
 			return "lifecycle marker warning detail text fields must be strings"
+		if any(
+			len(warning_detail[key]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
+			for key in ("test_id", "code", "file")
+		):
+			return "lifecycle marker warning detail text exceeds the text limit"
 		line = warning_detail["line"]
 		if isinstance(line, bool) or not isinstance(line, int) or line < 0:
 			return "lifecycle marker warning detail line must be a non-negative integer"
@@ -26617,6 +26694,11 @@ def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
 			return "lifecycle marker orphan detail instance_id must be a positive integer"
 		if not all(isinstance(orphan_detail[key], str) for key in ("class", "name")):
 			return "lifecycle marker orphan detail text fields must be strings"
+		if any(
+			len(orphan_detail[key]) > GUT_LIFECYCLE_GATE_MAX_TEXT_LENGTH
+			for key in ("class", "name")
+		):
+			return "lifecycle marker orphan detail text exceeds the text limit"
 	expected_truncated = (
 		warning_count > GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT
 		or orphan_count > GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -164,6 +164,31 @@ GODOT_EXIT_LEAK_PATTERNS = (
 	"rid allocations",
 	"were leaked at exit",
 )
+GUT_LIFECYCLE_GATE_PREFIX = "GF_TEST_LIFECYCLE_GATE="
+GUT_LIFECYCLE_GATE_SCHEMA_VERSION = 1
+GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT = 20
+GUT_LIFECYCLE_GATE_REQUIRED_KEYS = frozenset({
+	"schema_version",
+	"ok",
+	"baseline_available",
+	"warning_tracking_available",
+	"unhandled_warning_count",
+	"orphan_count",
+	"warnings",
+	"orphans",
+	"details_truncated",
+	"configuration_error",
+})
+GUT_LIFECYCLE_WARNING_DETAIL_KEYS = frozenset({"test_id", "code", "file", "line"})
+GUT_LIFECYCLE_ORPHAN_DETAIL_KEYS = frozenset({"instance_id", "class", "name"})
+GUT_PRE_RUN_HOOK_RESOURCE_PATH = "res://tests/gf_core/support/gf_gut_pre_run_hook.gd"
+GUT_POST_RUN_HOOK_RESOURCE_PATH = "res://tests/gf_core/support/gf_gut_post_run_hook.gd"
+GUT_LIFECYCLE_HOOK_ARGUMENTS = (
+	f"-gpre_run_script={GUT_PRE_RUN_HOOK_RESOURCE_PATH}",
+	f"-gpost_run_script={GUT_POST_RUN_HOOK_RESOURCE_PATH}",
+)
+GUT_TEST_ORPHAN_RE = re.compile(r"^\s*(?P<count>[1-9]\d*)\s+[Oo]rphans?\s*$")
+GUT_RUN_SUMMARY_ORPHAN_RE = re.compile(r"^\s*Orphans\s+(?P<count>[1-9]\d*)\s*$")
 PACKAGE_GODOT_SMOKE_DEFAULT_ALL_PACKAGE_JOBS = 4
 PACKAGE_GODOT_SMOKE_INSTALL_TIMEOUT_SECONDS = 240
 PACKAGE_EDITOR_WIZARD_SMOKE_TRANSACTION_TIMEOUT_SECONDS = 240
@@ -177,7 +202,14 @@ GODOT_LEAKED_INSTANCE_RE = re.compile(
 GODOT_RESOURCE_STILL_IN_USE_RE = re.compile(
 	r"^Resource still in use: (?P<path>.+?) \((?P<type>[^)]+)\)"
 )
-GODOT_RESOURCE_SUMMARY_RE = re.compile(r"^(?:ERROR:\s*)?(?P<count>\d+) resources? still in use at exit\.")
+GODOT_OBJECTDB_SUMMARY_RE = re.compile(
+	r"^(?:WARNING:\s*)?(?:(?P<count>\d+)\s+)?ObjectDB instances (?:were )?leaked at exit"
+	r"(?: \(run with [^)]+\))?\.$"
+)
+GODOT_RESOURCE_SUMMARY_RE = re.compile(
+	r"^(?:ERROR:\s*)?(?P<count>\d+) resources? still in use at exit"
+	r"(?: \(run with [^)]+\))?\.$"
+)
 REFERENCE_PROJECT_ENV_VAR = "GF_REFERENCE_PROJECT_PATH"
 DEFAULT_REFERENCE_PROJECT = os.environ.get(REFERENCE_PROJECT_ENV_VAR, "../gf-reference-project")
 REFERENCE_BOOT_SCENE_ENV_VAR = "GF_REFERENCE_BOOT_SCENE"
@@ -825,6 +857,7 @@ CHECK_DEFINITIONS: dict[str, list[str]] = {
 		"res://addons/gut/gut_cmdln.gd",
 		"-gdir=res://tests/gf_core",
 		"-ginclude_subdirs",
+		*GUT_LIFECYCLE_HOOK_ARGUMENTS,
 		"-gexit",
 	],
 	"api": [sys.executable, "tools/generate_api_reference.py", "--check"],
@@ -1463,6 +1496,7 @@ class CommandResult:
 	notes: list[str] | None = None
 	godot_exit_leak_warnings: list[str] | None = None
 	godot_exit_leak_report: dict[str, Any] | None = None
+	gut_lifecycle_report: dict[str, Any] | None = None
 	cwd: str = str(ROOT)
 	duration_seconds: float = 0.0
 	timeout_seconds: float | None = None
@@ -1499,6 +1533,8 @@ class CommandResult:
 			payload["godot_exit_leak_warnings"] = self.godot_exit_leak_warnings[:20]
 		if self.godot_exit_leak_report:
 			payload["godot_exit_leak_report"] = self.godot_exit_leak_report
+		if self.gut_lifecycle_report:
+			payload["gut_lifecycle_report"] = self.gut_lifecycle_report
 		return payload
 
 
@@ -5414,6 +5450,7 @@ def package_editor_wizard_smoke(
 		"-s",
 		"res://addons/gut/gut_cmdln.gd",
 		f"-gtest={test_path}",
+		*GUT_LIFECYCLE_HOOK_ARGUMENTS,
 		"-gexit",
 		"-gdisable_colors",
 	]
@@ -5431,6 +5468,23 @@ def package_editor_wizard_smoke(
 		"--import",
 	]
 	try:
+		import_log_paths = prepare_command_log_paths(import_command)
+	except OSError as error:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_import_log_invalid",
+			test_path,
+			"Editor package wizard import preflight log path is unsafe or cannot be prepared.",
+			row_key=scenario,
+			error=trim_text(str(error), 600),
+		))
+		record_package_editor_wizard_smoke_scenario(
+			scenarios,
+			scenario,
+			False,
+			{"test_path": test_path, "log_path": import_log_path.as_posix()},
+		)
+		return make_package_editor_wizard_smoke_payload(command, scenarios, issues, test_path, log_path)
+	try:
 		import_completed = run_maintenance_subprocess(import_command, timeout_seconds=180)
 	except subprocess.TimeoutExpired as error:
 		issues.append(make_package_issue(
@@ -5444,19 +5498,44 @@ def package_editor_wizard_smoke(
 			scenarios,
 			scenario,
 			False,
-			{"test_path": test_path, "log_path": log_path.as_posix()},
+			{"test_path": test_path, "log_path": import_log_path.as_posix()},
 		)
 		return make_package_editor_wizard_smoke_payload(command, scenarios, issues, test_path, log_path)
-	import_log_text = read_text_file_if_exists(import_log_path)
+	import_log_text, import_log_errors = read_command_log_outputs(import_log_paths)
 	import_output = f"{import_completed.stdout}\n{import_completed.stderr}\n{import_log_text}"
-	if import_completed.returncode != 0 or has_godot_script_error(import_output, "") or has_gdscript_reload_warning(import_output, ""):
+	if (
+		import_completed.returncode != 0
+		or bool(import_log_errors)
+		or has_godot_script_error(import_output, "")
+		or has_gdscript_reload_warning(import_output, "")
+	):
 		issues.append(make_package_issue(
 			"package_editor_wizard_smoke_import_failed",
 			test_path,
 			"Editor package wizard focused GUT import preflight failed.",
 			row_key=scenario,
 			actual_value=str(import_completed.returncode),
-			error=trim_text(import_output.strip(), 1200),
+			error=trim_text(
+				"\n".join([*import_log_errors, import_output.strip()]).strip(),
+				1200,
+			),
+		))
+		record_package_editor_wizard_smoke_scenario(
+			scenarios,
+			scenario,
+			False,
+			{"test_path": test_path, "log_path": import_log_path.as_posix()},
+		)
+		return make_package_editor_wizard_smoke_payload(command, scenarios, issues, test_path, log_path)
+	try:
+		log_paths = prepare_command_log_paths(command)
+	except OSError as error:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_log_invalid",
+			test_path,
+			"Editor package wizard focused GUT log path is unsafe or cannot be prepared.",
+			row_key=scenario,
+			error=trim_text(str(error), 600),
 		))
 		record_package_editor_wizard_smoke_scenario(
 			scenarios,
@@ -5483,8 +5562,16 @@ def package_editor_wizard_smoke(
 		)
 		return make_package_editor_wizard_smoke_payload(command, scenarios, issues, test_path, log_path)
 
-	log_text = read_text_file_if_exists(log_path)
+	log_text, log_errors = read_command_log_outputs(log_paths)
 	combined_output = f"{completed.stdout}\n{completed.stderr}\n{log_text}"
+	if log_errors:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_log_missing",
+			test_path,
+			"Editor package wizard focused GUT did not produce a fresh readable managed log.",
+			row_key=scenario,
+			error=trim_text("\n".join(log_errors), 1200),
+		))
 	if completed.returncode != 0:
 		issues.append(make_package_issue(
 			"package_editor_wizard_smoke_command_failed",
@@ -5518,6 +5605,30 @@ def package_editor_wizard_smoke(
 			row_key=scenario,
 			error=trim_text(combined_output.strip(), 1200),
 		))
+	lifecycle_report = parse_gut_lifecycle_gate_output(combined_output, "")
+	if not lifecycle_report["ok"]:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_lifecycle_gate_failed",
+			test_path,
+			"Editor package wizard focused GUT did not produce a clean lifecycle report.",
+			row_key=scenario,
+			actual_value=json.dumps(lifecycle_report, ensure_ascii=False, sort_keys=True),
+			error=trim_text(combined_output.strip(), 1200),
+		))
+	exit_leak_report = godot_exit_leak_report_from_output(
+		"package_editor_wizard_smoke",
+		combined_output,
+		"",
+	)
+	if exit_leak_report["has_leaks"]:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_exit_leak",
+			test_path,
+			"Editor package wizard focused GUT reported a Godot exit leak.",
+			row_key=scenario,
+			actual_value=json.dumps(exit_leak_report, ensure_ascii=False, sort_keys=True),
+			error=trim_text(combined_output.strip(), 1200),
+		))
 
 	record_package_editor_wizard_smoke_scenario(
 		scenarios,
@@ -5527,6 +5638,8 @@ def package_editor_wizard_smoke(
 			"test_path": test_path,
 			"exit_code": completed.returncode,
 			"log_path": log_path.as_posix(),
+			"lifecycle_report": lifecycle_report,
+			"godot_exit_leak_report": exit_leak_report,
 		},
 	)
 	with strict_managed_temporary_directory(prefix="gf-package-editor-wizard-smoke-") as temp_dir:
@@ -6864,6 +6977,17 @@ def run_package_editor_wizard_smoke_script(
 		script_resource_path,
 	]
 	try:
+		log_paths = prepare_command_log_paths(command)
+	except OSError as error:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_minimal_log_invalid",
+			script_path.as_posix(),
+			"Minimal kernel editor wizard smoke log path is unsafe or cannot be prepared.",
+			row_key=scenario,
+			error=trim_text(str(error), 600),
+		))
+		return {}
+	try:
 		completed = run_maintenance_subprocess(
 			command,
 			timeout_seconds=PACKAGE_EDITOR_WIZARD_SMOKE_TRANSACTION_TIMEOUT_SECONDS,
@@ -6877,8 +7001,16 @@ def run_package_editor_wizard_smoke_script(
 			error=trim_text(str(error), 300),
 		))
 		return {}
-	log_text = read_text_file_if_exists(log_path)
+	log_text, log_errors = read_command_log_outputs(log_paths)
 	combined_output = f"{completed.stdout}\n{completed.stderr}\n{log_text}"
+	if log_errors:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_minimal_log_missing",
+			script_path.as_posix(),
+			"Minimal kernel editor wizard smoke did not produce a fresh readable managed log.",
+			row_key=scenario,
+			error=trim_text("\n".join(log_errors), 1200),
+		))
 	if completed.returncode != 0:
 		issues.append(make_package_issue(
 			"package_editor_wizard_smoke_minimal_script_failed",
@@ -6902,6 +7034,20 @@ def run_package_editor_wizard_smoke_script(
 			script_path.as_posix(),
 			"Minimal kernel editor wizard smoke script reported a GDScript reload warning.",
 			row_key=scenario,
+			error=trim_text(combined_output.strip(), 1200),
+		))
+	exit_leak_report = godot_exit_leak_report_from_output(
+		f"package_editor_wizard_smoke_{scenario}",
+		combined_output,
+		"",
+	)
+	if exit_leak_report["has_leaks"]:
+		issues.append(make_package_issue(
+			"package_editor_wizard_smoke_minimal_exit_leak",
+			script_path.as_posix(),
+			"Minimal kernel editor wizard smoke reported a Godot exit leak.",
+			row_key=scenario,
+			actual_value=json.dumps(exit_leak_report, ensure_ascii=False, sort_keys=True),
 			error=trim_text(combined_output.strip(), 1200),
 		))
 	data = parse_package_godot_cli_json(completed.stdout)
@@ -12639,6 +12785,12 @@ def maintenance_self_test() -> dict[str, Any]:
 			"Passing Tests 1",
 			"Asserts 1",
 			"---- All tests passed! ----",
+			(
+				f'{GUT_LIFECYCLE_GATE_PREFIX}'
+				'{"schema_version":1,"ok":true,"unhandled_warning_count":0,"orphan_count":0,'
+				'"baseline_available":true,"warning_tracking_available":true,'
+				'"warnings":[],"orphans":[],"details_truncated":false,"configuration_error":""}'
+			),
 			"",
 		])
 		passing_code = (
@@ -12654,9 +12806,16 @@ def maintenance_self_test() -> dict[str, Any]:
 			"run_command_reads_configured_log_for_gut_summary",
 			passing_result.exit_code == 0
 			and "---- All tests passed! ----" in passing_result.stdout
+			and passing_result.gut_lifecycle_report is not None
+			and passing_result.gut_lifecycle_report["ok"]
+			and passing_result.to_dict().get("gut_lifecycle_report", {}).get("schema_version")
+			== GUT_LIFECYCLE_GATE_SCHEMA_VERSION
 			and passing_result.duration_seconds > 0.0
 			and passing_result.timeout_seconds == 10,
-			f"configured GUT log must be part of command evaluation: {passing_result.to_dict()}",
+			(
+				"configured GUT log and lifecycle evidence must be part of command evaluation: "
+				f"{passing_result.to_dict()}"
+			),
 		)
 		per_script_code = (
 			"from pathlib import Path; "
@@ -12731,6 +12890,176 @@ def maintenance_self_test() -> dict[str, Any]:
 			"run_command_rejects_reload_warning_from_configured_log",
 			warning_result.exit_code != 0,
 			"GDScript reload warnings in --log-file output must fail the command.",
+		)
+		missing_lifecycle_marker_summary = gut_success_summary.replace(
+			next(
+				line
+				for line in gut_success_summary.splitlines()
+				if line.startswith(GUT_LIFECYCLE_GATE_PREFIX)
+			) + "\n",
+			"",
+		)
+		missing_lifecycle_marker_code = (
+			"from pathlib import Path; "
+			f"Path({str(log_path)!r}).write_text({missing_lifecycle_marker_summary!r}, encoding='utf-8')"
+		)
+		missing_lifecycle_marker_result = run_command(
+			"gut",
+			[sys.executable, "-c", missing_lifecycle_marker_code, "--log-file", str(log_path)],
+			10,
+		)
+		record_result(
+			"run_command_requires_gut_lifecycle_marker",
+			missing_lifecycle_marker_result.exit_code != 0
+			and missing_lifecycle_marker_result.gut_lifecycle_report is not None
+			and not missing_lifecycle_marker_result.gut_lifecycle_report["ok"],
+			"GUT success must be rejected when the lifecycle post-run hook did not report.",
+		)
+		warning_lifecycle_summary = gut_success_summary.replace(
+			'"ok":true,"unhandled_warning_count":0',
+			'"ok":false,"unhandled_warning_count":1',
+		).replace(
+			'"warnings":[]',
+			'"warnings":[{"test_id":"fixture","code":"warning","file":"fixture.gd","line":1}]',
+		).replace(
+			"Asserts 1\n",
+			"Asserts 1\nWarnings 1\n",
+		)
+		warning_lifecycle_code = (
+			"from pathlib import Path; "
+			f"Path({str(log_path)!r}).write_text({warning_lifecycle_summary!r}, encoding='utf-8')"
+		)
+		warning_lifecycle_result = run_command(
+			"gut",
+			[sys.executable, "-c", warning_lifecycle_code, "--log-file", str(log_path)],
+			10,
+		)
+		record_result(
+			"run_command_rejects_unhandled_gut_warnings",
+			warning_lifecycle_result.exit_code != 0
+			and warning_lifecycle_result.gut_lifecycle_report is not None
+			and warning_lifecycle_result.gut_lifecycle_report["unhandled_warning_count"] == 1
+			and warning_lifecycle_result.gut_lifecycle_report["summary_warning_count"] == 1,
+			"Unhandled push_warning records and non-zero GUT summary warnings must hard-fail.",
+		)
+		orphan_lifecycle_summary = gut_success_summary.replace(
+			'"ok":true,"unhandled_warning_count":0,"orphan_count":0',
+			'"ok":false,"unhandled_warning_count":0,"orphan_count":2',
+		).replace(
+			'"orphans":[]',
+			'"orphans":[{"instance_id":1,"class":"Node","name":"first"},'
+			'{"instance_id":2,"class":"Node","name":"second"}]',
+		).replace(
+			"---- All tests passed! ----\n",
+			"    2 Orphans\n---- All tests passed! ----\n",
+		)
+		orphan_lifecycle_code = (
+			"from pathlib import Path; "
+			f"Path({str(log_path)!r}).write_text({orphan_lifecycle_summary!r}, encoding='utf-8')"
+		)
+		orphan_lifecycle_result = run_command(
+			"gut",
+			[sys.executable, "-c", orphan_lifecycle_code, "--log-file", str(log_path)],
+			10,
+		)
+		record_result(
+			"run_command_rejects_gut_orphans",
+			orphan_lifecycle_result.exit_code != 0
+			and orphan_lifecycle_result.gut_lifecycle_report is not None
+			and orphan_lifecycle_result.gut_lifecycle_report["orphan_count"] == 2
+			and orphan_lifecycle_result.gut_lifecycle_report["reported_orphan_count"] == 2,
+			"GUT orphan reports must hard-fail even when every assertion passed.",
+		)
+		clean_lifecycle_payload = {
+			"schema_version": GUT_LIFECYCLE_GATE_SCHEMA_VERSION,
+			"ok": True,
+			"baseline_available": True,
+			"warning_tracking_available": True,
+			"unhandled_warning_count": 0,
+			"orphan_count": 0,
+			"warnings": [],
+			"orphans": [],
+			"details_truncated": False,
+			"configuration_error": "",
+		}
+		extra_field_payload = {**clean_lifecycle_payload, "unexpected": True}
+		invalid_truncation_payload = {
+			**clean_lifecycle_payload,
+			"details_truncated": True,
+		}
+		invalid_warning_detail_payload = {
+			**clean_lifecycle_payload,
+			"ok": False,
+			"unhandled_warning_count": 1,
+			"warnings": [{"test_id": "fixture", "code": "warning", "file": "fixture.gd"}],
+		}
+		record_result(
+			"gut_lifecycle_marker_schema_is_closed_and_bounded",
+			validate_gut_lifecycle_gate_payload(clean_lifecycle_payload) == ""
+			and validate_gut_lifecycle_gate_payload(extra_field_payload) != ""
+			and validate_gut_lifecycle_gate_payload(invalid_truncation_payload) != ""
+			and validate_gut_lifecycle_gate_payload(invalid_warning_detail_payload) != "",
+			"Lifecycle marker v1 must reject extra fields, inconsistent truncation, and malformed details.",
+		)
+		run_summary_orphan_text = gut_success_summary.replace(
+			"---- All tests passed! ----\n",
+			"Orphans              1\n---- All tests passed! ----\n",
+		)
+		run_summary_orphan_code = (
+			"from pathlib import Path; "
+			f"Path({str(log_path)!r}).write_text({run_summary_orphan_text!r}, encoding='utf-8')"
+		)
+		run_summary_orphan_result = run_command(
+			"gut",
+			[sys.executable, "-c", run_summary_orphan_code, "--log-file", str(log_path)],
+			10,
+		)
+		record_result(
+			"run_command_rejects_gut_run_summary_orphans_with_clean_hook_marker",
+			run_summary_orphan_result.exit_code != 0
+			and run_summary_orphan_result.gut_lifecycle_report is not None
+			and run_summary_orphan_result.gut_lifecycle_report["orphan_count"] == 0
+			and run_summary_orphan_result.gut_lifecycle_report["reported_orphan_count"] == 1,
+			"The label-first GUT Run Summary orphan count must independently hard-fail.",
+		)
+		exit_leak_summary = (
+			"WARNING: ObjectDB instances leaked at exit (run with --verbose for details).\n"
+			+ gut_success_summary
+		)
+		exit_leak_code = (
+			"from pathlib import Path; "
+			f"Path({str(log_path)!r}).write_text({exit_leak_summary!r}, encoding='utf-8')"
+		)
+		exit_leak_result = run_command(
+			"gut",
+			[sys.executable, "-c", exit_leak_code, "--log-file", str(log_path)],
+			10,
+		)
+		record_result(
+			"run_command_rejects_gut_exit_leaks",
+			exit_leak_result.exit_code != 0
+			and exit_leak_result.godot_exit_leak_report is not None
+			and exit_leak_result.godot_exit_leak_report["has_leaks"],
+			"Godot exit leak diagnostics from GUT must be a hard failure.",
+		)
+		lone_leaked_instance_summary = "Leaked instance: Node:123456\n" + gut_success_summary
+		lone_leaked_instance_code = (
+			"from pathlib import Path; "
+			f"Path({str(log_path)!r}).write_text({lone_leaked_instance_summary!r}, encoding='utf-8')"
+		)
+		lone_leaked_instance_result = run_command(
+			"gut",
+			[sys.executable, "-c", lone_leaked_instance_code, "--log-file", str(log_path)],
+			10,
+		)
+		record_result(
+			"run_command_rejects_structured_gut_exit_leak_without_summary_header",
+			lone_leaked_instance_result.exit_code != 0
+			and not lone_leaked_instance_result.godot_exit_leak_warnings
+			and lone_leaked_instance_result.godot_exit_leak_report is not None
+			and lone_leaked_instance_result.godot_exit_leak_report["has_leaks"]
+			and lone_leaked_instance_result.godot_exit_leak_report["leaked_instance_total"] == 1,
+			"Structured leaked-instance evidence must fail GUT even without an ObjectDB summary line.",
 		)
 		log_target_directory = Path(temp_dir) / "user-owned-logs"
 		log_target_directory.mkdir()
@@ -14729,8 +15058,22 @@ def maintenance_self_test() -> dict[str, Any]:
 		"godot_import" in CHECK_DEFINITIONS
 		and CHECK_DEPENDENCIES.get("gut") == ["godot_import"]
 		and expand_check_dependencies(["gut"]) == ["godot_import", "gut"]
-		and expand_check_dependencies(["godot_import", "gut"]) == ["godot_import", "gut"],
-		"GUT validation must import a clean Godot project exactly once before loading class_name scripts.",
+		and expand_check_dependencies(["godot_import", "gut"]) == ["godot_import", "gut"]
+		and all(argument in CHECK_DEFINITIONS["gut"] for argument in GUT_LIFECYCLE_HOOK_ARGUMENTS),
+		(
+			"GUT validation must import a clean Godot project exactly once before loading "
+			"class_name scripts and must install both lifecycle hooks."
+		),
+	)
+	gut_config_payload = read_json_object(ROOT / ".gutconfig.json")
+	record_result(
+		"gut_lifecycle_hook_configuration_is_canonical",
+		gut_config_payload == {
+			"pre_run_script": GUT_PRE_RUN_HOOK_RESOURCE_PATH,
+			"post_run_script": GUT_POST_RUN_HOOK_RESOURCE_PATH,
+		}
+		and all(argument in CHECK_DEFINITIONS["gut"] for argument in GUT_LIFECYCLE_HOOK_ARGUMENTS),
+		"Repository GUT defaults and the maintenance command must install the same lifecycle hooks.",
 	)
 	record_result(
 		"gdscript_lsp_check_declares_clean_import_dependency",
@@ -15479,6 +15822,23 @@ def maintenance_self_test() -> dict[str, Any]:
 			and output_leak_report["leaked_instance_types"][0]["key"] == "Object"
 		),
 		f"unexpected output leak report: {output_leak_report}",
+	)
+	godot_47_summary_report = godot_exit_leak_report_from_output(
+		"godot_47_fixture",
+		"",
+		"\n".join([
+			"WARNING: 235 ObjectDB instances were leaked at exit (run with `--verbose` for details).",
+			"ERROR: 113 resources still in use at exit (run with --verbose for details).",
+		]),
+	)
+	record_result(
+		"godot_exit_leak_report_accepts_current_summary_format",
+		godot_47_summary_report["has_leaks"]
+		and godot_47_summary_report["objectdb_warning_count"] == 1
+		and godot_47_summary_report["objectdb_instance_total"] == 235
+		and godot_47_summary_report["resource_summary_count"] == 1
+		and godot_47_summary_report["resource_summary_total"] == 113,
+		f"Godot 4.7 summary lines must be structured hard-gate evidence: {godot_47_summary_report}",
 	)
 	command_payload = CommandResult(
 		"fixture",
@@ -25223,22 +25583,44 @@ def completed_command_result(
 	has_reload_warning = has_gdscript_reload_warning(stdout, stderr)
 	exit_leak_warnings = collect_godot_exit_leak_warnings(stdout, stderr)
 	exit_leak_report: dict[str, Any] | None = None
+	gut_lifecycle_report: dict[str, Any] | None = None
 	godot_checked_names = {"godot_import", "gut", "gdscript_warnings", "examples_scan", "examples_boot", "examples_smoke"}
 	if name in godot_checked_names:
 		exit_leak_report = godot_exit_leak_report_from_output(name, stdout, stderr)
+	if name == "gut":
+		gut_lifecycle_report = parse_gut_lifecycle_gate_output(stdout, stderr)
 	if name in godot_checked_names and has_script_error:
 		exit_code = 1
 		notes = append_note(notes, "Godot reported script loading or parse errors in output.")
 	if name in {"godot_import", "gut", "gdscript_warnings"} and has_reload_warning:
 		exit_code = 1
 		notes = append_note(notes, "Godot reported GDScript reload warnings in output.")
-	if exit_leak_warnings:
+	has_exit_leaks = (
+		bool(exit_leak_warnings)
+		or (
+			exit_leak_report is not None
+			and bool(exit_leak_report["has_leaks"])
+		)
+	)
+	if has_exit_leaks and name == "gut":
+		exit_code = 1
+		notes = append_note(
+			notes,
+			"Godot reported exit leak warnings during GUT; the lifecycle gate requires a zero-leak run.",
+		)
+	elif has_exit_leaks:
 		notes = append_note(
 			notes,
 			(
 				"Godot reported exit leak warnings. Current policy records these as cleanup debt "
 				"but does not fail the check until the baseline is cleaned."
 			),
+		)
+	if name == "gut" and gut_lifecycle_report is not None and not gut_lifecycle_report["ok"]:
+		exit_code = 1
+		notes = append_note(
+			notes,
+			"GUT lifecycle gate rejected unhandled warnings, orphans, or missing/invalid hook evidence.",
 		)
 	if name == "gut" and exit_code == 0 and not gut_report_all_tests_passed(stdout):
 		exit_code = 1
@@ -25257,6 +25639,7 @@ def completed_command_result(
 			if exit_leak_report is not None and exit_leak_report["has_leaks"]
 			else None
 		),
+		gut_lifecycle_report=gut_lifecycle_report,
 		duration_seconds=duration_seconds,
 		timeout_seconds=timeout_seconds,
 		pid=pid,
@@ -25939,6 +26322,7 @@ def make_empty_godot_exit_leak_report() -> dict[str, Any]:
 		"line_count": 0,
 		"warning_lines": [],
 		"objectdb_warning_count": 0,
+		"objectdb_instance_total": 0,
 		"resource_summary_count": 0,
 		"resource_summary_total": 0,
 		"resource_still_in_use_count": 0,
@@ -25997,8 +26381,12 @@ def parse_godot_exit_leak_line(raw_line: str, payload: dict[str, Any]) -> None:
 	if any(pattern in normalized_line for pattern in GODOT_EXIT_LEAK_PATTERNS):
 		append_limited(payload["warning_lines"], trim_text(line, 240), 40)
 
-	if "objectdb instances leaked at exit" in normalized_line:
+	objectdb_match = GODOT_OBJECTDB_SUMMARY_RE.match(line)
+	if objectdb_match != None:
 		payload["objectdb_warning_count"] += 1
+		count_text = objectdb_match.group("count")
+		if count_text is not None:
+			payload["objectdb_instance_total"] += int(count_text)
 		return
 
 	rid_match = GODOT_RID_LEAK_RE.match(line)
@@ -26034,6 +26422,7 @@ def parse_godot_exit_leak_line(raw_line: str, payload: dict[str, Any]) -> None:
 def merge_godot_exit_leak_payload(report: dict[str, Any], payload: dict[str, Any]) -> None:
 	report["line_count"] += payload["line_count"]
 	report["objectdb_warning_count"] += payload["objectdb_warning_count"]
+	report["objectdb_instance_total"] += payload["objectdb_instance_total"]
 	report["resource_summary_count"] += payload["resource_summary_count"]
 	report["resource_summary_total"] += payload["resource_summary_total"]
 	report["resource_still_in_use_count"] += payload["resource_still_in_use_count"]
@@ -26105,6 +26494,150 @@ def append_note(notes: list[str] | None, note: str) -> list[str]:
 		return [note]
 	notes.append(note)
 	return notes
+
+
+def parse_gut_lifecycle_gate_output(stdout: str, stderr: str) -> dict[str, Any]:
+	output = strip_ansi_codes(f"{stdout}\n{stderr}")
+	marker_payloads: list[dict[str, Any]] = []
+	marker_errors: list[str] = []
+	for raw_line in output.splitlines():
+		line = raw_line.strip()
+		if not line.startswith(GUT_LIFECYCLE_GATE_PREFIX):
+			continue
+		payload_text = line[len(GUT_LIFECYCLE_GATE_PREFIX):]
+		try:
+			payload = json.loads(payload_text)
+		except json.JSONDecodeError as exc:
+			append_limited(marker_errors, f"invalid JSON: {exc.msg}", 10)
+			continue
+		payload_error = validate_gut_lifecycle_gate_payload(payload)
+		if payload_error:
+			append_limited(marker_errors, payload_error, 10)
+			continue
+		marker_payloads.append(payload)
+
+	distinct_payloads = {
+		json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+		for payload in marker_payloads
+	}
+	if len(distinct_payloads) > 1:
+		append_limited(marker_errors, "conflicting lifecycle markers", 10)
+	marker = marker_payloads[-1] if marker_payloads else None
+
+	summary_warning_count = 0
+	run_summary_index = output.rfind("= Run Summary")
+	if run_summary_index >= 0:
+		summary_tail = output[run_summary_index:]
+		summary_warning_match = re.search(r"(?m)^\s*Warnings\s+(\d+)\s*$", summary_tail)
+		if summary_warning_match is not None:
+			summary_warning_count = int(summary_warning_match.group(1))
+
+	reported_orphan_count = 0
+	orphan_lines: list[str] = []
+	for raw_line in output.splitlines():
+		line = strip_ansi_codes(raw_line).strip()
+		orphan_match = GUT_TEST_ORPHAN_RE.match(line)
+		if orphan_match is None:
+			orphan_match = GUT_RUN_SUMMARY_ORPHAN_RE.match(line)
+		if orphan_match is None:
+			continue
+		reported_orphan_count = max(reported_orphan_count, int(orphan_match.group("count")))
+		append_limited(orphan_lines, trim_text(line, 160), 20)
+
+	unhandled_warning_count = int(marker["unhandled_warning_count"]) if marker is not None else 0
+	orphan_count = int(marker["orphan_count"]) if marker is not None else 0
+	ok = (
+		marker is not None
+		and not marker_errors
+		and bool(marker["ok"])
+		and unhandled_warning_count == 0
+		and orphan_count == 0
+		and summary_warning_count == 0
+		and reported_orphan_count == 0
+	)
+	return {
+		"schema_version": GUT_LIFECYCLE_GATE_SCHEMA_VERSION,
+		"ok": ok,
+		"marker_count": len(marker_payloads),
+		"marker_errors": marker_errors,
+		"unhandled_warning_count": unhandled_warning_count,
+		"orphan_count": orphan_count,
+		"summary_warning_count": summary_warning_count,
+		"reported_orphan_count": reported_orphan_count,
+		"orphan_lines": orphan_lines,
+		"marker": marker,
+	}
+
+
+def validate_gut_lifecycle_gate_payload(payload: Any) -> str:
+	if not isinstance(payload, dict):
+		return "lifecycle marker root must be an object"
+	if set(payload) != GUT_LIFECYCLE_GATE_REQUIRED_KEYS:
+		return "lifecycle marker fields do not match the closed schema"
+	if payload.get("schema_version") != GUT_LIFECYCLE_GATE_SCHEMA_VERSION:
+		return "lifecycle marker schema_version is unsupported"
+	if not isinstance(payload.get("ok"), bool):
+		return "lifecycle marker ok must be a boolean"
+	for key in ("baseline_available", "warning_tracking_available", "details_truncated"):
+		if not isinstance(payload.get(key), bool):
+			return f"lifecycle marker {key} must be a boolean"
+	for key in ("unhandled_warning_count", "orphan_count"):
+		value = payload.get(key)
+		if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+			return f"lifecycle marker {key} must be a non-negative integer"
+	for key in ("warnings", "orphans"):
+		value = payload.get(key)
+		if not isinstance(value, list):
+			return f"lifecycle marker {key} must be an array"
+		if len(value) > GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT:
+			return f"lifecycle marker {key} exceeds the detail limit"
+		if not all(isinstance(item, dict) for item in value):
+			return f"lifecycle marker {key} entries must be objects"
+	if not isinstance(payload.get("configuration_error"), str):
+		return "lifecycle marker configuration_error must be a string"
+
+	warning_count = int(payload["unhandled_warning_count"])
+	orphan_count = int(payload["orphan_count"])
+	warning_details = payload["warnings"]
+	orphan_details = payload["orphans"]
+	details_truncated = bool(payload["details_truncated"])
+	for warning_detail in warning_details:
+		if set(warning_detail) != GUT_LIFECYCLE_WARNING_DETAIL_KEYS:
+			return "lifecycle marker warning detail fields do not match the closed schema"
+		if not all(isinstance(warning_detail[key], str) for key in ("test_id", "code", "file")):
+			return "lifecycle marker warning detail text fields must be strings"
+		line = warning_detail["line"]
+		if isinstance(line, bool) or not isinstance(line, int) or line < 0:
+			return "lifecycle marker warning detail line must be a non-negative integer"
+	for orphan_detail in orphan_details:
+		if set(orphan_detail) != GUT_LIFECYCLE_ORPHAN_DETAIL_KEYS:
+			return "lifecycle marker orphan detail fields do not match the closed schema"
+		instance_id = orphan_detail["instance_id"]
+		if isinstance(instance_id, bool) or not isinstance(instance_id, int) or instance_id <= 0:
+			return "lifecycle marker orphan detail instance_id must be a positive integer"
+		if not all(isinstance(orphan_detail[key], str) for key in ("class", "name")):
+			return "lifecycle marker orphan detail text fields must be strings"
+	expected_truncated = (
+		warning_count > GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT
+		or orphan_count > GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT
+	)
+	if details_truncated != expected_truncated:
+		return "lifecycle marker details_truncated is inconsistent with totals"
+	if (
+		len(warning_details) != min(warning_count, GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT)
+		or len(orphan_details) != min(orphan_count, GUT_LIFECYCLE_GATE_MAX_DETAIL_COUNT)
+	):
+		return "lifecycle marker detail arrays must exactly cover the bounded totals"
+	expected_ok = (
+		bool(payload["baseline_available"])
+		and bool(payload["warning_tracking_available"])
+		and warning_count == 0
+		and orphan_count == 0
+		and payload["configuration_error"] == ""
+	)
+	if bool(payload["ok"]) != expected_ok:
+		return "lifecycle marker ok is inconsistent with lifecycle evidence"
+	return ""
 
 
 def gut_report_all_tests_passed(stdout: str) -> bool:


### PR DESCRIPTION
## Summary

- add a lifecycle-aware GUT SceneTree wrapper with early and terminal warning capture, fail-closed marker validation, orphan baselines, and supervised smoke scenarios
- make framework GUT checks reject unhandled warnings plus ObjectDB, Resource, RID, and leaked-instance exit evidence
- harden affected runtime disposal paths and transient GDScript test cleanup, with focused lifecycle regressions
- document the lifecycle-clean test contract and keep generated API/AI indexes current

## Validation

Executed from a fresh detached worktree with isolated `APPDATA`, `LOCALAPPDATA`, `TEMP`, `HOME`, and explicit Godot executable:

- `python tools/gf_maintenance.py check --suite framework-gut --json --failed-only`
  - 323 scripts, 4795 tests, 36721 asserts; zero lifecycle warnings, orphans, and exit leaks
- `python tools/gf_maintenance.py check --suite framework-lsp --json --failed-only`
  - 1217 files, zero diagnostics and timeouts
- `python tools/gf_maintenance.py check --suite framework-static --json --failed-only`
  - all 17 checks passed

`addons/gut/**` is unchanged.