### PR TITLE
fix: preserve command history on failed transitions

### DIFF
--- a/addons/gf/standard/command/gf_undoable_command.gd
+++ b/addons/gf/standard/command/gf_undoable_command.gd
@@ -71,6 +71,40 @@ func should_record(_execute_result: Variant) -> bool:
 	return true
 
 
+## 判断一次 undo() 的终态结果是否成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## 该 hook 运行在非重入历史操作内，不得执行、记录、清空、调整容量或恢复历史。
+## [br]
+## @param _undo_result: 同步返回值，或异步完成 Signal 的规范化 payload；异步最多捕获 16 个参数。
+## [br]
+## @return 返回 false 时，GFCommandHistoryUtility 会保留原撤销栈位置并报告失败。
+## [br]
+## @schema _undo_result: Direct undo() result, null for a no-argument completion Signal, one emitted value, or an Array containing the first 2 to 16 emitted values.
+func is_undo_successful(_undo_result: Variant) -> bool:
+	return true
+
+
+## 判断一次重做 execute() 的终态结果是否成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## 该 hook 运行在非重入历史操作内，不得执行、记录、清空、调整容量或恢复历史。
+## [br]
+## @param _execute_result: 同步返回值，或异步完成 Signal 的规范化 payload；异步最多捕获 16 个参数。
+## [br]
+## @return 返回 false 时，GFCommandHistoryUtility 会保留原重做栈位置并报告失败。
+## [br]
+## @schema _execute_result: Direct execute() result, null for a no-argument completion Signal, one emitted value, or an Array containing the first 2 to 16 emitted values.
+func is_redo_successful(_execute_result: Variant) -> bool:
+	return true
+
+
 ## 保存执行前的状态快照。应在 execute() 内部、修改数据之前调用。
 ## [br]
 ## @api public

--- a/addons/gf/standard/utilities/history/gf_command_history_utility.gd
+++ b/addons/gf/standard/utilities/history/gf_command_history_utility.gd
@@ -28,6 +28,9 @@ var max_history_size: int:
 	get:
 		return _max_history_size
 	set(value):
+		if _is_processing_history_operation:
+			push_warning("[GFCommandHistoryUtility] 当前正在处理历史操作，忽略容量修改请求。")
+			return
 		_max_history_size = maxi(value, 0)
 		_trim_history_stacks()
 
@@ -55,9 +58,11 @@ var async_stall_warning_seconds: float = 30.0:
 		if is_finite(value):
 			async_stall_warning_seconds = maxf(value, 0.0)
 
-## 当前是否正在等待一条异步命令完成。
+## 当前是否正在处理一条异步命令的等待、终态判断或历史栈提交。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 var is_processing_async: bool:
 	get:
 		return _is_processing_async
@@ -74,8 +79,14 @@ var _redo_stack: Array[GFUndoableCommand] = []
 # 当前是否正在等待一条异步命令完成。
 var _is_processing_async: bool = false
 
+var _is_processing_history_operation: bool = false
 var _max_history_size: int = 1024
 var _lifecycle_serial: int = 0
+var _operation_serial: int = 0
+var _active_operation_serial: int = 0
+var _stall_warning_operation_serial: int = 0
+var _stall_warning_tree: SceneTree = null
+var _stall_warning_callback: Callable = Callable()
 
 
 # --- GF 生命周期方法 ---
@@ -84,20 +95,26 @@ var _lifecycle_serial: int = 0
 ## [br]
 ## @api public
 func init() -> void:
+	_disconnect_stall_warning_observer()
 	_lifecycle_serial += 1
 	_undo_stack = []
 	_redo_stack = []
 	_is_processing_async = false
+	_is_processing_history_operation = false
+	_active_operation_serial = 0
 
 
 ## 释放命令历史并取消等待中的异步历史操作。
 ## [br]
 ## @api public
 func dispose() -> void:
+	_disconnect_stall_warning_observer()
 	_lifecycle_serial += 1
 	_undo_stack.clear()
 	_redo_stack.clear()
 	_is_processing_async = false
+	_is_processing_history_operation = false
+	_active_operation_serial = 0
 
 
 # --- 公共方法 ---
@@ -124,8 +141,11 @@ func inject_dependencies(architecture: GFArchitecture) -> void:
 func record(cmd: GFUndoableCommand) -> void:
 	if not is_instance_valid(cmd):
 		return
-	if _is_processing_async:
-		push_warning("[GFCommandHistoryUtility] 当前正在处理异步命令，忽略新的历史记录。")
+	if _is_processing_history_operation:
+		_push_history_operation_rejection(
+			"[GFCommandHistoryUtility] 当前正在处理异步命令，忽略新的历史记录。",
+			"[GFCommandHistoryUtility] 当前正在处理历史操作，忽略新的历史记录。"
+		)
 		return
 
 	_inject_command_dependencies(cmd)
@@ -144,136 +164,208 @@ func record(cmd: GFUndoableCommand) -> void:
 func execute_command(cmd: GFUndoableCommand) -> Variant:
 	if not is_instance_valid(cmd):
 		return null
-	if _is_processing_async:
-		push_warning("[GFCommandHistoryUtility] 当前正在处理异步命令，忽略新的执行请求。")
+	if _is_processing_history_operation:
+		_push_history_operation_rejection(
+			"[GFCommandHistoryUtility] 当前正在处理异步命令，忽略新的执行请求。",
+			"[GFCommandHistoryUtility] 当前正在处理历史操作，忽略新的执行请求。"
+		)
 		return null
 
+	var lifecycle_serial: int = _lifecycle_serial
+	var operation_serial: int = _begin_history_operation()
 	_inject_command_dependencies(cmd)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return null
+
 	var result: Variant = cmd.execute()
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return result
 	if result is Signal:
 		_is_processing_async = true
-		var current_serial: int = _lifecycle_serial
 		var result_signal: Signal = result
-		var completed: bool = await _await_command_signal(result_signal, current_serial)
-		if current_serial != _lifecycle_serial:
+		var wait_state: Dictionary = await _await_command_signal(
+			result_signal,
+			operation_serial,
+			lifecycle_serial
+		)
+		if not _is_history_operation_current(operation_serial, lifecycle_serial):
+			_finish_history_operation(operation_serial)
 			return result
-		_is_processing_async = false
-		if not completed:
+		if not GFVariantData.get_option_bool(wait_state, "completed"):
+			_finish_history_operation(operation_serial)
 			return result
 	if not cmd.should_record(result):
+		_finish_history_operation(operation_serial)
+		return result
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
 		return result
 	_record_internal(cmd)
+	_finish_history_operation(operation_serial)
 	return result
 
 
-## 撤销最后一条命令。
+## 撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。
+## `is_undo_successful()` 返回 `false` 时，命令保留在撤销栈原位置，重做栈不变。
 ## [br]
 ## @api public
 ## [br]
-## @return 成功撤销时返回 `true`。
+## @since 3.17.0
+## [br]
+## @return 成功提交撤销历史时返回 `true`，否则返回 `false`。
 func undo_last() -> bool:
-	if _is_processing_async or _undo_stack.is_empty():
+	if _is_processing_history_operation or _undo_stack.is_empty():
 		return false
 
-	var cmd: GFUndoableCommand = _undo_stack.pop_back()
+	var lifecycle_serial: int = _lifecycle_serial
+	var operation_serial: int = _begin_history_operation()
+	var cmd: GFUndoableCommand = _undo_stack.back()
 	_inject_command_dependencies(cmd)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
+
 	var result: Variant = cmd.undo()
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
 	if result is Signal:
 		push_warning("[GFCommandHistoryUtility] undo_last() 不支持异步命令，请使用 await undo_last_async()。")
-		_undo_stack.push_back(cmd)
+		_finish_history_operation(operation_serial)
 		return false
-
-	_redo_stack.push_back(cmd)
-	_trim_redo_stack()
-	return true
+	return _complete_undo_operation(cmd, result, operation_serial, lifecycle_serial)
 
 
-## 异步撤销最后一条命令。
+## 异步撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。
+## Signal 完成参数会规范化后传入 `is_undo_successful()`：无参数为 null，一个参数为该值，
+## 两个至 16 个参数为保持发射顺序的 Array；超过 16 个时告警并只保留前 16 个。
+## 结果 hook 返回 `false` 时，命令保留在撤销栈原位置，重做栈不变。
 ## [br]
 ## @api public
 ## [br]
-## @return 成功撤销时返回 `true`。
+## @since 3.17.0
+## [br]
+## @return 成功提交撤销历史时返回 `true`，否则返回 `false`。
 func undo_last_async() -> bool:
-	if _is_processing_async or _undo_stack.is_empty():
+	if _is_processing_history_operation or _undo_stack.is_empty():
 		return false
 
-	var cmd: GFUndoableCommand = _undo_stack.pop_back()
+	var lifecycle_serial: int = _lifecycle_serial
+	var operation_serial: int = _begin_history_operation()
+	var cmd: GFUndoableCommand = _undo_stack.back()
 	_inject_command_dependencies(cmd)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
+
 	var result: Variant = cmd.undo()
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
 	if result is Signal:
 		_is_processing_async = true
-		var current_serial: int = _lifecycle_serial
 		var result_signal: Signal = result
-		var completed: bool = await _await_command_signal(result_signal, current_serial)
-		if current_serial != _lifecycle_serial:
+		var wait_state: Dictionary = await _await_command_signal(
+			result_signal,
+			operation_serial,
+			lifecycle_serial
+		)
+		if not _is_history_operation_current(operation_serial, lifecycle_serial):
+			_finish_history_operation(operation_serial)
 			return false
-		_is_processing_async = false
-		if not completed:
-			_undo_stack.push_back(cmd)
+		if not GFVariantData.get_option_bool(wait_state, "completed"):
+			_finish_history_operation(operation_serial)
 			return false
-
-	_redo_stack.push_back(cmd)
-	_trim_redo_stack()
-	return true
+		result = _normalize_signal_payload(GFVariantData.get_option_array(wait_state, "args"))
+	return _complete_undo_operation(cmd, result, operation_serial, lifecycle_serial)
 
 
-## 重做最近被撤销的命令。
+## 重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。
+## `is_redo_successful()` 返回 `false` 时，命令保留在重做栈原位置，撤销栈不变。
 ## [br]
 ## @api public
 ## [br]
-## @return 成功重做时返回 `true`。
+## @since 3.17.0
+## [br]
+## @return 成功提交重做历史时返回 `true`，否则返回 `false`。
 func redo() -> bool:
-	if _is_processing_async or _redo_stack.is_empty():
+	if _is_processing_history_operation or _redo_stack.is_empty():
 		return false
 
-	var cmd: GFUndoableCommand = _redo_stack.pop_back()
+	var lifecycle_serial: int = _lifecycle_serial
+	var operation_serial: int = _begin_history_operation()
+	var cmd: GFUndoableCommand = _redo_stack.back()
 	_inject_command_dependencies(cmd)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
+
 	var result: Variant = cmd.execute()
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
 	if result is Signal:
 		push_warning("[GFCommandHistoryUtility] redo() 不支持异步命令，请使用 await redo_async()。")
-		_redo_stack.push_back(cmd)
+		_finish_history_operation(operation_serial)
 		return false
-
-	_undo_stack.push_back(cmd)
-	_trim_undo_stack()
-	return true
+	return _complete_redo_operation(cmd, result, operation_serial, lifecycle_serial)
 
 
-## 异步重做最近被撤销的命令。
+## 异步重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。
+## Signal 完成参数会规范化后传入 `is_redo_successful()`：无参数为 null，一个参数为该值，
+## 两个至 16 个参数为保持发射顺序的 Array；超过 16 个时告警并只保留前 16 个。
+## 结果 hook 返回 `false` 时，命令保留在重做栈原位置，撤销栈不变。
 ## [br]
 ## @api public
 ## [br]
-## @return 成功重做时返回 `true`。
+## @since 3.17.0
+## [br]
+## @return 成功提交重做历史时返回 `true`，否则返回 `false`。
 func redo_async() -> bool:
-	if _is_processing_async or _redo_stack.is_empty():
+	if _is_processing_history_operation or _redo_stack.is_empty():
 		return false
 
-	var cmd: GFUndoableCommand = _redo_stack.pop_back()
+	var lifecycle_serial: int = _lifecycle_serial
+	var operation_serial: int = _begin_history_operation()
+	var cmd: GFUndoableCommand = _redo_stack.back()
 	_inject_command_dependencies(cmd)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
+
 	var result: Variant = cmd.execute()
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
 	if result is Signal:
 		_is_processing_async = true
-		var current_serial: int = _lifecycle_serial
 		var result_signal: Signal = result
-		var completed: bool = await _await_command_signal(result_signal, current_serial)
-		if current_serial != _lifecycle_serial:
+		var wait_state: Dictionary = await _await_command_signal(
+			result_signal,
+			operation_serial,
+			lifecycle_serial
+		)
+		if not _is_history_operation_current(operation_serial, lifecycle_serial):
+			_finish_history_operation(operation_serial)
 			return false
-		_is_processing_async = false
-		if not completed:
-			_redo_stack.push_back(cmd)
+		if not GFVariantData.get_option_bool(wait_state, "completed"):
+			_finish_history_operation(operation_serial)
 			return false
-
-	_undo_stack.push_back(cmd)
-	_trim_undo_stack()
-	return true
+		result = _normalize_signal_payload(GFVariantData.get_option_array(wait_state, "args"))
+	return _complete_redo_operation(cmd, result, operation_serial, lifecycle_serial)
 
 
 ## 清空所有历史记录。
 ## [br]
 ## @api public
 func clear() -> void:
-	if _is_processing_async:
-		push_warning("[GFCommandHistoryUtility] 当前正在处理异步命令，忽略清空请求。")
+	if _is_processing_history_operation:
+		_push_history_operation_rejection(
+			"[GFCommandHistoryUtility] 当前正在处理异步命令，忽略清空请求。",
+			"[GFCommandHistoryUtility] 当前正在处理历史操作，忽略清空请求。"
+		)
 		return
 
 	_undo_stack.clear()
@@ -286,7 +378,7 @@ func clear() -> void:
 ## [br]
 ## @return 有可撤销命令时返回 `true`。
 func can_undo() -> bool:
-	return not _is_processing_async and not _undo_stack.is_empty()
+	return not _is_processing_history_operation and not _undo_stack.is_empty()
 
 
 ## 检查当前是否允许重做。
@@ -295,7 +387,7 @@ func can_undo() -> bool:
 ## [br]
 ## @return 有可重做命令时返回 `true`。
 func can_redo() -> bool:
-	return not _is_processing_async and not _redo_stack.is_empty()
+	return not _is_processing_history_operation and not _redo_stack.is_empty()
 
 
 ## 获取撤销栈副本。
@@ -352,8 +444,11 @@ func serialize_full_history() -> Dictionary:
 ## [br]
 ## @param command_builder: 负责反序列化命令实例的构造器。
 func deserialize_history(data_array: Array, command_builder: Callable) -> void:
-	if _is_processing_async:
-		push_warning("[GFCommandHistoryUtility] 当前正在处理异步命令，忽略历史恢复请求。")
+	if _is_processing_history_operation:
+		_push_history_operation_rejection(
+			"[GFCommandHistoryUtility] 当前正在处理异步命令，忽略历史恢复请求。",
+			"[GFCommandHistoryUtility] 当前正在处理历史操作，忽略历史恢复请求。"
+		)
 		return
 
 	_undo_stack.clear()
@@ -383,8 +478,11 @@ func deserialize_history(data_array: Array, command_builder: Callable) -> void:
 ## [br]
 ## @param command_builder: 负责反序列化命令实例的构造器。
 func deserialize_full_history(data: Dictionary, command_builder: Callable) -> void:
-	if _is_processing_async:
-		push_warning("[GFCommandHistoryUtility] 当前正在处理异步命令，忽略完整历史恢复请求。")
+	if _is_processing_history_operation:
+		_push_history_operation_rejection(
+			"[GFCommandHistoryUtility] 当前正在处理异步命令，忽略完整历史恢复请求。",
+			"[GFCommandHistoryUtility] 当前正在处理历史操作，忽略完整历史恢复请求。"
+		)
 		return
 
 	_undo_stack.clear()
@@ -466,56 +564,165 @@ func _inject_command_dependencies(cmd: GFUndoableCommand) -> void:
 		cmd.call("inject", architecture)
 
 
-func _await_command_signal(result_signal: Signal, lifecycle_serial: int) -> bool:
-	if result_signal.is_null():
-		return true
+func _begin_history_operation() -> int:
+	_operation_serial += 1
+	_active_operation_serial = _operation_serial
+	_is_processing_history_operation = true
+	return _active_operation_serial
 
-	var target_obj: Object = result_signal.get_object()
-	if not is_instance_valid(target_obj):
+
+func _push_history_operation_rejection(async_message: String, sync_message: String) -> void:
+	push_warning(async_message if _is_processing_async else sync_message)
+
+
+func _is_history_operation_current(operation_serial: int, lifecycle_serial: int) -> bool:
+	return (
+		_is_processing_history_operation
+		and _active_operation_serial == operation_serial
+		and _lifecycle_serial == lifecycle_serial
+	)
+
+
+func _finish_history_operation(operation_serial: int) -> void:
+	if _active_operation_serial != operation_serial:
+		return
+	_disconnect_stall_warning_observer(operation_serial)
+	_active_operation_serial = 0
+	_is_processing_history_operation = false
+	_is_processing_async = false
+
+
+func _complete_undo_operation(
+	cmd: GFUndoableCommand,
+	result: Variant,
+	operation_serial: int,
+	lifecycle_serial: int
+) -> bool:
+	var successful: bool = cmd.is_undo_successful(result)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
 		return false
+	if not successful:
+		_finish_history_operation(operation_serial)
+		return false
+	var committed_cmd: GFUndoableCommand = _pop_expected_history_top(_undo_stack, cmd, "撤销")
+	if committed_cmd == null:
+		_finish_history_operation(operation_serial)
+		return false
+	_redo_stack.push_back(committed_cmd)
+	_trim_redo_stack()
+	_finish_history_operation(operation_serial)
+	return true
 
-	var completed: Array[bool] = [false]
-	var on_resume: Callable = func(
-		_arg1: Variant = null,
-		_arg2: Variant = null,
-		_arg3: Variant = null,
-		_arg4: Variant = null
-	) -> void:
-		completed[0] = true
 
-	var _connect_result_446: Variant = result_signal.connect(
-		on_resume,
-		CONNECT_ONE_SHOT as Object.ConnectFlags
-	)
+func _complete_redo_operation(
+	cmd: GFUndoableCommand,
+	result: Variant,
+	operation_serial: int,
+	lifecycle_serial: int
+) -> bool:
+	var successful: bool = cmd.is_redo_successful(result)
+	if not _is_history_operation_current(operation_serial, lifecycle_serial):
+		_finish_history_operation(operation_serial)
+		return false
+	if not successful:
+		_finish_history_operation(operation_serial)
+		return false
+	var committed_cmd: GFUndoableCommand = _pop_expected_history_top(_redo_stack, cmd, "重做")
+	if committed_cmd == null:
+		_finish_history_operation(operation_serial)
+		return false
+	_undo_stack.push_back(committed_cmd)
+	_trim_undo_stack()
+	_finish_history_operation(operation_serial)
+	return true
 
-	var warning_msec: int = (
-		maxi(ceili(async_stall_warning_seconds * 1000.0), 1)
-		if async_stall_warning_seconds > 0.0
-		else 0
-	)
+
+func _pop_expected_history_top(
+	source_stack: Array[GFUndoableCommand],
+	expected_cmd: GFUndoableCommand,
+	operation_name: String
+) -> GFUndoableCommand:
+	if source_stack.is_empty() or not is_same(source_stack.back(), expected_cmd):
+		push_error(
+			"[GFCommandHistoryUtility] %s提交失败：来源栈顶身份已变化。" % operation_name
+		)
+		return null
+	return source_stack.pop_back()
+
+
+func _await_command_signal(
+	result_signal: Signal,
+	operation_serial: int,
+	lifecycle_serial: int
+) -> Dictionary:
+	if result_signal.is_null():
+		return {
+			"completed": true,
+			"args": [],
+		}
+
+	_start_async_stall_warning_observer(operation_serial, lifecycle_serial)
+	var should_continue: Callable = func() -> bool:
+		return _is_history_operation_current(operation_serial, lifecycle_serial)
+	return await _GF_ASYNC_WAIT_SUPPORT.await_signal_state(result_signal, {
+		"capture_payload": true,
+		"should_continue": should_continue,
+		"timeout_seconds": 0.0,
+	})
+
+
+func _start_async_stall_warning_observer(operation_serial: int, lifecycle_serial: int) -> void:
+	_disconnect_stall_warning_observer()
+	var warning_seconds: float = async_stall_warning_seconds
+	if warning_seconds <= 0.0:
+		return
+	var main_loop: MainLoop = Engine.get_main_loop()
+	if not (main_loop is SceneTree):
+		return
+	var scene_tree: SceneTree = main_loop
+	var warning_msec: int = maxi(ceili(warning_seconds * 1000.0), 1)
 	var start_msec: int = Time.get_ticks_msec()
-	var stall_warning_emitted: bool = false
+	var on_process_frame: Callable = func() -> void:
+		if not _is_history_operation_current(operation_serial, lifecycle_serial):
+			_disconnect_stall_warning_observer(operation_serial)
+			return
+		if Time.get_ticks_msec() - start_msec < warning_msec:
+			return
+		push_warning("[GFCommandHistoryUtility] 异步命令尚未完成；历史锁将保持到真实终态。")
+		_disconnect_stall_warning_observer(operation_serial)
+	_stall_warning_operation_serial = operation_serial
+	_stall_warning_tree = scene_tree
+	_stall_warning_callback = on_process_frame
+	var connect_result: Error = scene_tree.process_frame.connect(on_process_frame) as Error
+	if connect_result != OK:
+		_stall_warning_operation_serial = 0
+		_stall_warning_tree = null
+		_stall_warning_callback = Callable()
 
-	while not completed[0]:
-		if lifecycle_serial != _lifecycle_serial:
-			break
-		if not is_instance_valid(target_obj):
-			break
-		if (
-			warning_msec > 0
-			and not stall_warning_emitted
-			and Time.get_ticks_msec() - start_msec >= warning_msec
-		):
-			stall_warning_emitted = true
-			push_warning("[GFCommandHistoryUtility] 异步命令尚未完成；历史锁将保持到真实终态。")
-		var main_loop: MainLoop = Engine.get_main_loop()
-		if not (main_loop is SceneTree):
-			break
-		var scene_tree: SceneTree = main_loop
-		await scene_tree.process_frame
 
-	_GF_ASYNC_WAIT_SUPPORT.disconnect_signal_if_connected(result_signal, on_resume)
-	return completed[0] and lifecycle_serial == _lifecycle_serial
+func _disconnect_stall_warning_observer(operation_serial: int = 0) -> void:
+	if operation_serial > 0 and _stall_warning_operation_serial != operation_serial:
+		return
+	if (
+		_stall_warning_tree != null
+		and _stall_warning_callback.is_valid()
+		and _stall_warning_tree.process_frame.is_connected(_stall_warning_callback)
+	):
+		_stall_warning_tree.process_frame.disconnect(_stall_warning_callback)
+	_stall_warning_operation_serial = 0
+	_stall_warning_tree = null
+	_stall_warning_callback = Callable()
+
+
+func _normalize_signal_payload(args: Array) -> Variant:
+	match args.size():
+		0:
+			return null
+		1:
+			return args[0]
+		_:
+			return args.duplicate(true)
 
 
 func _build_command(command_builder: Callable, command_data: Dictionary) -> GFUndoableCommand:

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "e5df39d918f5576ffcf94f502a1b7c33a97d4b296bd910ba4f7ff6ff1cf3233d",
+  "source_digest": "1fb53ddb3599ee632af501562e0789f8d06af57361f7c5df546847e6514025bb",
   "class_count": 755,
   "package_count": 52,
   "packages": [
@@ -15366,7 +15366,7 @@
           "kind": "var",
           "name": "is_processing_async",
           "signature": "var is_processing_async: bool",
-          "summary": "当前是否正在等待一条异步命令完成。",
+          "summary": "当前是否正在处理一条异步命令的等待、终态判断或历史栈提交。",
           "visibility": "public"
         },
         {
@@ -15401,28 +15401,28 @@
           "kind": "func",
           "name": "undo_last",
           "signature": "func undo_last() -> bool",
-          "summary": "撤销最后一条命令。",
+          "summary": "撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "undo_last_async",
           "signature": "func undo_last_async() -> bool",
-          "summary": "异步撤销最后一条命令。",
+          "summary": "异步撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "redo",
           "signature": "func redo() -> bool",
-          "summary": "重做最近被撤销的命令。",
+          "summary": "重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "redo_async",
           "signature": "func redo_async() -> bool",
-          "summary": "异步重做最近被撤销的命令。",
+          "summary": "异步重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。",
           "visibility": "public"
         },
         {
@@ -84465,6 +84465,20 @@
           "name": "should_record",
           "signature": "func should_record(_execute_result: Variant) -> bool",
           "summary": "判断 execute() 返回后是否应该写入命令历史。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_undo_successful",
+          "signature": "func is_undo_successful(_undo_result: Variant) -> bool",
+          "summary": "判断一次 undo() 的终态结果是否成功。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_redo_successful",
+          "signature": "func is_redo_successful(_execute_result: Variant) -> bool",
+          "summary": "判断一次重做 execute() 的终态结果是否成功。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFCommandHistoryUtility.xml
+++ b/docs/api_catalog/classes/GFCommandHistoryUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFCommandHistoryUtility" path="addons/gf/standard/utilities/history/gf_command_history_utility.gd" module="standard" extends="GFUtility" classDigest="1c3760648441f785923cda5fef895615c5709f59fc5bcfe5d4c7555c9e8a479f">
+<class name="GFCommandHistoryUtility" path="addons/gf/standard/utilities/history/gf_command_history_utility.gd" module="standard" extends="GFUtility" classDigest="1ca87ce78d3f61ad62657b32967a57469655c0d617fec9d43a77b0bb9c734de1">
 	<description>GFCommandHistoryUtility: 可撤销命令历史管理器。
 负责维护 `GFUndoableCommand` 的撤销栈与重做栈，
 并提供同步/异步重放与历史序列化能力。</description>
@@ -44,9 +44,10 @@
 		</member>
 		<member kind="property" name="is_processing_async">
 			<signature>var is_processing_async: bool:</signature>
-			<description>当前是否正在等待一条异步命令完成。</description>
+			<description>当前是否正在处理一条异步命令的等待、终态判断或历史栈提交。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</properties>
@@ -85,34 +86,46 @@
 		</member>
 		<member kind="method" name="undo_last">
 			<signature>func undo_last() -&gt; bool:</signature>
-			<description>撤销最后一条命令。</description>
+			<description>撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。
+`is_undo_successful()` 返回 `false` 时，命令保留在撤销栈原位置，重做栈不变。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">成功撤销时返回 `true`。</tag>
+				<tag name="return">成功提交撤销历史时返回 `true`，否则返回 `false`。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="undo_last_async">
 			<signature>func undo_last_async() -&gt; bool:</signature>
-			<description>异步撤销最后一条命令。</description>
+			<description>异步撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。
+Signal 完成参数会规范化后传入 `is_undo_successful()`：无参数为 null，一个参数为该值，
+两个至 16 个参数为保持发射顺序的 Array；超过 16 个时告警并只保留前 16 个。
+结果 hook 返回 `false` 时，命令保留在撤销栈原位置，重做栈不变。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">成功撤销时返回 `true`。</tag>
+				<tag name="return">成功提交撤销历史时返回 `true`，否则返回 `false`。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="redo">
 			<signature>func redo() -&gt; bool:</signature>
-			<description>重做最近被撤销的命令。</description>
+			<description>重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。
+`is_redo_successful()` 返回 `false` 时，命令保留在重做栈原位置，撤销栈不变。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">成功重做时返回 `true`。</tag>
+				<tag name="return">成功提交重做历史时返回 `true`，否则返回 `false`。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="redo_async">
 			<signature>func redo_async() -&gt; bool:</signature>
-			<description>异步重做最近被撤销的命令。</description>
+			<description>异步重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。
+Signal 完成参数会规范化后传入 `is_redo_successful()`：无参数为 null，一个参数为该值，
+两个至 16 个参数为保持发射顺序的 Array；超过 16 个时告警并只保留前 16 个。
+结果 hook 返回 `false` 时，命令保留在重做栈原位置，撤销栈不变。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">成功重做时返回 `true`。</tag>
+				<tag name="return">成功提交重做历史时返回 `true`，否则返回 `false`。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="clear">

--- a/docs/api_catalog/classes/GFUndoableCommand.xml
+++ b/docs/api_catalog/classes/GFUndoableCommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFUndoableCommand" path="addons/gf/standard/command/gf_undoable_command.gd" module="standard" extends="GFCommand" classDigest="79ed46c8bb37ec2fef09a5f180e02ca0ffd8eb62fba01c69936771c7d4f7d534">
+<class name="GFUndoableCommand" path="addons/gf/standard/command/gf_undoable_command.gd" module="standard" extends="GFCommand" classDigest="a8a83466481118205e83762b6badcd88511fdacd1ff80c33ee8082deae088816">
 	<description>GFUndoableCommand: 可撤销命令的抽象基类。
 继承自 GFCommand，在标准命令的基础上新增撤销能力。
 子类须在 execute() 执行前通过 set_snapshot() 保存当前状态快照，
@@ -49,6 +49,30 @@
 				<tag name="param">_execute_result: execute() 的最终返回值。</tag>
 				<tag name="return">返回 false 时，GFCommandHistoryUtility 不会记录该命令。</tag>
 				<tag name="schema">_execute_result: Variant returned by execute().</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_undo_successful">
+			<signature>func is_undo_successful(_undo_result: Variant) -&gt; bool:</signature>
+			<description>判断一次 undo() 的终态结果是否成功。
+该 hook 运行在非重入历史操作内，不得执行、记录、清空、调整容量或恢复历史。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_undo_result: 同步返回值，或异步完成 Signal 的规范化 payload；异步最多捕获 16 个参数。</tag>
+				<tag name="return">返回 false 时，GFCommandHistoryUtility 会保留原撤销栈位置并报告失败。</tag>
+				<tag name="schema">_undo_result: Direct undo() result, null for a no-argument completion Signal, one emitted value, or an Array containing the first 2 to 16 emitted values.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_redo_successful">
+			<signature>func is_redo_successful(_execute_result: Variant) -&gt; bool:</signature>
+			<description>判断一次重做 execute() 的终态结果是否成功。
+该 hook 运行在非重入历史操作内，不得执行、记录、清空、调整容量或恢复历史。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_execute_result: 同步返回值，或异步完成 Signal 的规范化 payload；异步最多捕获 16 个参数。</tag>
+				<tag name="return">返回 false 时，GFCommandHistoryUtility 会保留原重做栈位置并报告失败。</tag>
+				<tag name="schema">_execute_result: Direct execute() result, null for a no-argument completion Signal, one emitted value, or an Array containing the first 2 to 16 emitted values.</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="set_snapshot">

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="cef24d400933c4417cdadb4af5d4e986cb73f5e73033fb18eddf39c5bfe3698a" classCount="779" methodCount="6989">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="6c607d1065ccb57dbc1536778f9865fa9d93e52b75b42720539a933831438bb2" classCount="779" methodCount="6991">
 	<module id="kernel" label="Kernel" classCount="71" methodCount="720">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -73,7 +73,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="434" methodCount="4356">
+	<module id="standard" label="Standard" classCount="434" methodCount="4358">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -92,6 +92,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFCommandHistoryUtility` 在命令已进入终态但业务撤销/重做失败时仍推进历史游标的问题；`GFUndoableCommand` 新增默认成功的 `is_undo_successful()` / `is_redo_successful()` hook，同步与异步入口只在 hook 成功后复核来源栈顶身份并原子移动栈。异步 Signal 的零、单、二至 16 参数终态分别规范化为 `null`、单值和 `Array`，处理锁贯穿命令回调、等待、hook 与提交；等待和 hook 内的只读查询仍观察最近一次完整提交，失败不触碰任一栈的身份、顺序或容量，生命周期切代后的旧 continuation 也不会回填新历史。
 - 修复 Interaction Sensor 对类型化 Receiver 派发时绕过项目 `receive_interaction()` 覆写，以及自定义 sender 的 2D/3D 碰撞广播在规范化报告前发出公开信号的问题；公开覆写继续参与派发，返回值和信号报告统一保持 JSON-safe。
 - 修复 Audio backend 接管 `Master`、`BGM` 等本地同名总线时，duck、生命周期恢复和 mix snapshot 的逐总线 fallback 仍会静默写入 `AudioServer` 的问题；总线所有权和 backend identity 现在贯穿捕获、应用与恢复，只有 backend 明确拒绝的字段才进入本地回退。
 - 修复 Architecture 快照 capture/restore 在最终完整批次后仍多等待一帧，以及 Node State Machine 按 group/字段重复重置 `max_total_bytes` 的问题；异步批处理只在仍有后续工作时让帧，状态机与单组快照都对完整 raw 结构执行一次统一编码预算。
@@ -133,6 +134,7 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
+- `GFUndoableCommand` 新增 `is_undo_successful(_undo_result)` 与 `is_redo_successful(_execute_result)`，均标记为 `@since unreleased` 且默认返回 `true`。同步历史入口传入命令的直接返回值；异步历史入口把完成 Signal 的零、单、二至 16 参数 payload 分别规范化为 `null`、单值和 `Array` 后传入，超过 16 个参数时告警并只保留前 16 个。
 - `Gf.set_architecture()` 改为原子提交候选架构：Installer 和三阶段初始化成功前，`Gf` facade 只暴露既有已提交架构或空状态；pending assignment 被更新赋值、尚无已提交架构时由 `Gf.create_architecture()` 创建的默认架构，或 Gf 退出场景树替代时，会取消其异步作用域并 dispose 未提交候选。函数签名不变，但依赖 Installer 期间 facade 指向候选、或依赖被替代候选仍可复用的代码需要迁移。
 - `GFBindableProperty.mutate()` 的 callback 必须返回完整 replacement；void/in-place-only mutator 不再是有效写法。集合 helper 的 `value_changed` 参数改为独立 before/after 快照。
 - `GFBindableProperty.subscribe()`、`subscribe_token()`、`subscribe_owned()` 与 `subscribe_method()` 的每次调用都会创建独立订阅；相同参数不再复用既有 token。
@@ -170,6 +172,7 @@
 
 ### 📘 升级指南 (Migration Guide)
 
+- 既有 `GFUndoableCommand` 若不重入历史写操作则无需迁移：两个历史结果 hook 默认成功，`null` 返回值和无参数完成 Signal 保持原行为。只有撤销或重做可能进入“已完成但业务失败”终态的命令才需要覆盖对应 hook；异步 hook 应按 `null`、单值或最多 16 项的多值 `Array` 读取规范化完成 payload，并返回明确的 `bool`，更多字段应封装成单个 Result 或 `Dictionary`。`execute()`、`undo()`、`should_record()` 和结果 hook 现在统一处于非重入历史操作内；原先从这些回调嵌套执行、记录、清空、修改容量或恢复历史的项目代码，应改为在外层历史 API 完成后由项目队列提交后续操作。
 - 项目 Installer 必须改为通过 `install(architecture, scope)` 的显式 `architecture` 参数或 `install_bindings(binder, scope)` 的 `binder` 注册候选模块，不要在 `Gf.set_architecture()` 提交前使用 `Gf.register_*()`、`Gf.create_binder()` 或 `Gf.get_*()` 指向候选。异步 Installer 在每个 `await` 后检查 `scope.is_cancel_requested()` 并用 `scope.register_cleanup()` 释放临时资源；assignment 被替代并返回 `false` 后应创建新的 `GFArchitecture` 重试，不复用已经 dispose 的候选。释放回调和项目自定义等待器应通过 `is_disposing()` / `is_disposed()` 拒绝向终结中的架构提交新工作。
 - `GFNodeContext` 的父级 Architecture identity 与首次 READY generation 现在按每轮入树固定。不要在 child 场景分支仍活动时调用其 owned Architecture 的 `set_parent_architecture()`，也不要让父级失败后原地重试或热替换全局父级；需要绑定新父级或新 generation 时，应让对应 child 分支退出并重新进入，或重建该场景分支。
 - 把 `property.mutate(func(value): value[...] = ...)` 改为显式返回 replacement；标量同样返回新值。依赖集合 helper 把 old/new 指向同一对象的监听器应改为消费真实 before/after 快照。

--- a/docs/zh/kernel/messaging/command-history/async-constraints.md
+++ b/docs/zh/kernel/messaging/command-history/async-constraints.md
@@ -11,10 +11,21 @@ await history.redo_async()
 
 同步版本 `undo_last()` / `redo()` 会保持原有立即返回的行为，适合纯数据命令。
 
-异步版本会在命令返回 `Signal` 时等待完成后再移动撤销/重做栈。
+异步版本会在命令返回 `Signal` 时等待真实终态，再把完成参数规范化后传给对应结果 hook：
+
+- Signal 无参数时传入 `null`；
+- 只有一个参数时直接传入该值；
+- 有两个至 16 个参数时传入保持发射顺序的 `Array`；
+- 超过 16 个参数时发出 warning，并只保留前 16 个。
+
+需要携带更多字段时，应把它们封装进单个类型化 Result 或 `Dictionary` payload 后再发射，不要依赖超宽 Signal 参数列表。
+
+`is_undo_successful(result)` 或 `is_redo_successful(result)` 返回 `true` 后，历史工具才会移动命令并执行容量裁剪；返回 `false` 时，命令回到来源栈原位置，另一侧栈完全不变。默认 hook 返回 `true`，所以无参数 Signal 和未声明失败语义的命令保持默认成功。
 
 `GFCommandHistoryUtility.async_stall_warning_seconds` 是停滞告警阈值，不是 timeout 或 cancellation。超过阈值后历史工具只发出一次 warning，并继续持有处理锁，直到命令 Signal 进入真实终态；因此迟到完成不会让 world state 与撤销/重做栈分叉。设为 `0` 可关闭告警，但不会关闭等待。
 
-异步命令执行期间，历史工具会拒绝新的执行、记录、清空或恢复请求并输出 warning。若项目必须在截止时间取消副作用，应让命令自身使用 `GFCancellationToken` 或显式 terminal operation，并在命令完成后再让历史栈推进；历史层不会伪装成底层取消器。
+处理锁会一直覆盖 Signal 等待、结果 hook 和最终栈提交，不会在 hook 前提前释放。期间历史工具会拒绝新的执行、记录、撤销、重做、清空、容量修改或恢复请求；结果 hook 不应重入历史写操作。来源命令在成功提交前仍保留在原栈，因此只读历史查询和序列化始终观察最近一次完整提交。相同非重入规则也适用于同步命令的 `execute()` / `undo()`、`should_record()` 和结果 hook。`init()` / `dispose()` 会使旧操作的 lifecycle generation 失效，旧异步 continuation 返回后不会把命令恢复或提交到新一代历史栈。
+
+若项目必须在截止时间取消副作用，应让命令自身使用 `GFCancellationToken` 或显式 terminal operation，并在命令完成后再让历史栈推进；历史层不会伪装成底层取消器。
 
 需要排队的高频操作应放入项目层队列或 `GFCommandSequence`。

--- a/docs/zh/kernel/messaging/command-history/index.md
+++ b/docs/zh/kernel/messaging/command-history/index.md
@@ -8,9 +8,26 @@
 
 `GFCommandHistoryUtility` 只管理历史栈和调用顺序。每个命令如何执行、撤销、保存快照和恢复状态，仍由命令类自己负责。
 
+`undo()` 或重做阶段的 `execute()` 进入终态，并不一定代表业务状态已经成功变更。命令可以覆盖 `is_undo_successful(result)` 与 `is_redo_successful(result)` 报告终态结果；只有 hook 返回 `true`，历史工具才会把命令原子地移动到另一侧栈。返回 `false` 时，历史 API 同样返回 `false`，命令保持在来源栈原位置，另一侧栈的身份、顺序与容量均不改变。
+
+```gdscript
+class_name RestoreDocumentCommand
+extends GFUndoableCommand
+
+func undo() -> Variant:
+	return _restore_document()
+
+func is_undo_successful(undo_result: Variant) -> bool:
+	return GFVariantData.to_bool(undo_result, false)
+```
+
+两个 hook 默认返回 `true`，因此未覆盖它们的既有命令以及返回 `null` 的命令继续采用成功语义。
+
+通过 `execute_command()`、撤销或重做进入的命令回调统一运行在非重入历史操作内，包括命令的 `execute()` / `undo()`、`should_record()` 和两个结果 hook。回调返回前，新的执行、记录、撤销、重做、清空、容量修改和历史恢复请求都会被拒绝；需要触发后续命令时，应把意图交给项目层队列，并在当前历史 API 完成后再执行。只读计数、历史副本和序列化仍可使用，并始终观察最近一次完整提交的栈，不暴露等待中或 hook 内的临时移动。
+
 ## 阅读入口
 
 - [序列化与恢复](persistence.md)：`serialize_history()`、`deserialize_history()`、命令构建器和历史容量。
-- [异步撤销与重做](async-constraints.md)：Signal 等待、异步超时、并发操作拒绝和项目层排队。
+- [异步撤销与重做](async-constraints.md)：Signal 终态 payload、停滞告警、原子处理锁、并发操作拒绝和项目层排队。
 
 命令历史、快照历史和流程编排的更多用法，可继续阅读 [本地存储、编码、同步与快照](../../../standard/utilities/io/storage-snapshot/index.md) 与 [撤销历史与指令序列](../../../standard/input-flow/command-sequence/index.md)。

--- a/docs/zh/reference/api/classes/GFCommandHistoryUtility.md
+++ b/docs/zh/reference/api/classes/GFCommandHistoryUtility.md
@@ -95,12 +95,13 @@ var async_stall_warning_seconds: float = 30.0:
 ### `is_processing_async`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var is_processing_async: bool:
 ```
 
-当前是否正在等待一条异步命令完成。
+当前是否正在处理一条异步命令的等待、终态判断或历史栈提交。
 
 ## 方法
 
@@ -175,56 +176,60 @@ func execute_command(cmd: GFUndoableCommand) -> Variant:
 ### `undo_last`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func undo_last() -> bool:
 ```
 
-撤销最后一条命令。
+撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。 `is_undo_successful()` 返回 `false` 时，命令保留在撤销栈原位置，重做栈不变。
 
-返回：成功撤销时返回 `true`。
+返回：成功提交撤销历史时返回 `true`，否则返回 `false`。
 
 <a id="member-gfcommandhistoryutility-methods-undo_last_async"></a>
 
 ### `undo_last_async`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func undo_last_async() -> bool:
 ```
 
-异步撤销最后一条命令。
+异步撤销最后一条命令，并仅在结果 hook 成功时提交历史栈移动。 Signal 完成参数会规范化后传入 `is_undo_successful()`：无参数为 null，一个参数为该值， 两个至 16 个参数为保持发射顺序的 Array；超过 16 个时告警并只保留前 16 个。 结果 hook 返回 `false` 时，命令保留在撤销栈原位置，重做栈不变。
 
-返回：成功撤销时返回 `true`。
+返回：成功提交撤销历史时返回 `true`，否则返回 `false`。
 
 <a id="member-gfcommandhistoryutility-methods-redo"></a>
 
 ### `redo`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func redo() -> bool:
 ```
 
-重做最近被撤销的命令。
+重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。 `is_redo_successful()` 返回 `false` 时，命令保留在重做栈原位置，撤销栈不变。
 
-返回：成功重做时返回 `true`。
+返回：成功提交重做历史时返回 `true`，否则返回 `false`。
 
 <a id="member-gfcommandhistoryutility-methods-redo_async"></a>
 
 ### `redo_async`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func redo_async() -> bool:
 ```
 
-异步重做最近被撤销的命令。
+异步重做最近被撤销的命令，并仅在结果 hook 成功时提交历史栈移动。 Signal 完成参数会规范化后传入 `is_redo_successful()`：无参数为 null，一个参数为该值， 两个至 16 个参数为保持发射顺序的 Array；超过 16 个时告警并只保留前 16 个。 结果 hook 返回 `false` 时，命令保留在重做栈原位置，撤销栈不变。
 
-返回：成功重做时返回 `true`。
+返回：成功提交重做历史时返回 `true`，否则返回 `false`。
 
 <a id="member-gfcommandhistoryutility-methods-clear"></a>
 

--- a/docs/zh/reference/api/classes/GFUndoableCommand.md
+++ b/docs/zh/reference/api/classes/GFUndoableCommand.md
@@ -19,6 +19,8 @@
 | 方法 | [`execute`](#member-gfundoablecommand-methods-execute) | `func execute() -> Variant:` |
 | 方法 | [`undo`](#member-gfundoablecommand-methods-undo) | `func undo() -> Variant:` |
 | 方法 | [`should_record`](#member-gfundoablecommand-methods-should_record) | `func should_record(_execute_result: Variant) -> bool:` |
+| 方法 | [`is_undo_successful`](#member-gfundoablecommand-methods-is_undo_successful) | `func is_undo_successful(_undo_result: Variant) -> bool:` |
+| 方法 | [`is_redo_successful`](#member-gfundoablecommand-methods-is_redo_successful) | `func is_redo_successful(_execute_result: Variant) -> bool:` |
 | 方法 | [`set_snapshot`](#member-gfundoablecommand-methods-set_snapshot) | `func set_snapshot(data: Variant) -> bool:` |
 | 方法 | [`get_snapshot`](#member-gfundoablecommand-methods-get_snapshot) | `func get_snapshot() -> Variant:` |
 
@@ -97,6 +99,56 @@ func should_record(_execute_result: Variant) -> bool:
 结构：
 
 - `_execute_result`: Variant returned by execute().
+
+<a id="member-gfundoablecommand-methods-is_undo_successful"></a>
+
+### `is_undo_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_undo_successful(_undo_result: Variant) -> bool:
+```
+
+判断一次 undo() 的终态结果是否成功。 该 hook 运行在非重入历史操作内，不得执行、记录、清空、调整容量或恢复历史。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_undo_result` | 同步返回值，或异步完成 Signal 的规范化 payload；异步最多捕获 16 个参数。 |
+
+返回：返回 false 时，GFCommandHistoryUtility 会保留原撤销栈位置并报告失败。
+
+结构：
+
+- `_undo_result`: Direct undo() result, null for a no-argument completion Signal, one emitted value, or an Array containing the first 2 to 16 emitted values.
+
+<a id="member-gfundoablecommand-methods-is_redo_successful"></a>
+
+### `is_redo_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_redo_successful(_execute_result: Variant) -> bool:
+```
+
+判断一次重做 execute() 的终态结果是否成功。 该 hook 运行在非重入历史操作内，不得执行、记录、清空、调整容量或恢复历史。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_execute_result` | 同步返回值，或异步完成 Signal 的规范化 payload；异步最多捕获 16 个参数。 |
+
+返回：返回 false 时，GFCommandHistoryUtility 会保留原重做栈位置并报告失败。
+
+结构：
+
+- `_execute_result`: Direct execute() result, null for a no-argument completion Signal, one emitted value, or an Array containing the first 2 to 16 emitted values.
 
 <a id="member-gfundoablecommand-methods-set_snapshot"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 71 | 996 | [Kernel](#module-kernel) |
-| Standard | 434 | 6859 | [Standard](#module-standard) |
+| Standard | 434 | 6861 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -322,7 +322,7 @@
 | [`GFSequenceStep`](GFSequenceStep.md#gfsequencestep) | 协议与扩展点 (`protocol`) | `Resource` | 4 | `addons/gf/standard/sequence/gf_sequence_step.gd` |
 | [`GFState`](GFState.md#gfstate) | 协议与扩展点 (`protocol`) | `RefCounted` | 26 | `addons/gf/standard/state_machine/pure/gf_state.gd` |
 | [`GFStorageBackend`](GFStorageBackend.md#gfstoragebackend) | 协议与扩展点 (`protocol`) | `RefCounted` | 17 | `addons/gf/standard/utilities/storage/gf_storage_backend.gd` |
-| [`GFUndoableCommand`](GFUndoableCommand.md#gfundoablecommand) | 协议与扩展点 (`protocol`) | `GFCommand` | 6 | `addons/gf/standard/command/gf_undoable_command.gd` |
+| [`GFUndoableCommand`](GFUndoableCommand.md#gfundoablecommand) | 协议与扩展点 (`protocol`) | `GFCommand` | 8 | `addons/gf/standard/command/gf_undoable_command.gd` |
 | [`GFValidationRule`](GFValidationRule.md#gfvalidationrule) | 协议与扩展点 (`protocol`) | `Resource` | 14 | `addons/gf/standard/foundation/validation/gf_validation_rule.gd` |
 | [`GFAnalyticsConfig`](GFAnalyticsConfig.md#gfanalyticsconfig) | 资源定义 (`resource_definition`) | `Resource` | 19 | `addons/gf/standard/utilities/analytics/gf_analytics_config.gd` |
 | [`GFAnalyticsEventSchema`](GFAnalyticsEventSchema.md#gfanalyticseventschema) | 资源定义 (`resource_definition`) | `Resource` | 8 | `addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -6,15 +6,15 @@
 
 - 源码根目录：`addons/gf`
 - 公开类：`779`
-- 公开成员：`11300`
-- 公开方法：`6989`
+- 公开成员：`11302`
+- 公开方法：`6991`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 71 | 996 | 720 | [kernel.md](kernel.md) |
-| Standard | 434 | 6859 | 4356 | [standard.md](standard.md) |
+| Standard | 434 | 6861 | 4358 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -7,7 +7,7 @@
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
 | [运行时服务](#category-runtime_service) | 187 | 3342 | 2259 |
-| [协议与扩展点](#category-protocol) | 24 | 335 | 264 |
+| [协议与扩展点](#category-protocol) | 24 | 337 | 266 |
 | [资源定义](#category-resource_definition) | 117 | 1505 | 771 |
 | [运行时句柄](#category-runtime_handle) | 44 | 744 | 484 |
 | [值对象](#category-value_object) | 38 | 698 | 442 |

--- a/tests/gf_core/standard/utilities/history/test_gf_command_history_utility.gd
+++ b/tests/gf_core/standard/utilities/history/test_gf_command_history_utility.gd
@@ -134,7 +134,7 @@ func test_undo_last_empty_stack_returns_false() -> void:
 
 
 ## 验证同步 undo 遇到异步命令时会回滚撤销栈并提示使用异步接口。
-func test_undo_last_rejects_async_command_and_restores_stack() -> void:
+func test_undo_last_rejects_async_command_and_preserves_stack() -> void:
 	var cmd: ManualAsyncCommand = ManualAsyncCommand.new()
 	_history.record(cmd)
 
@@ -145,6 +145,38 @@ func test_undo_last_rejects_async_command_and_restores_stack() -> void:
 	assert_eq(_history.undo_count, 1, "异步命令被拒绝后应放回撤销栈。")
 	assert_eq(_history.redo_count, 0, "异步命令被拒绝后不应进入重做栈。")
 	assert_push_warning("[GFCommandHistoryUtility] undo_last() 不支持异步命令，请使用 await undo_last_async()。")
+
+
+func test_failed_sync_undo_preserves_both_stack_orders() -> void:
+	_history.max_history_size = 0
+	var failing_cmd: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var redo_first: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var redo_second: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var redo_third: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	_history.record(failing_cmd)
+	_history.record(redo_first)
+	_history.record(redo_second)
+	_history.record(redo_third)
+	assert_true(_history.undo_last(), "测试前置撤销第三条命令应成功。")
+	assert_true(_history.undo_last(), "测试前置撤销第二条命令应成功。")
+	assert_true(_history.undo_last(), "测试前置撤销第一条命令应成功。")
+	_history.max_history_size = 3
+	failing_cmd.undo_success = false
+	var undo_before: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_before: Array[GFUndoableCommand] = _history.get_redo_history()
+
+	var result: bool = _history.undo_last()
+
+	assert_false(result, "命令报告撤销失败时 undo_last 应返回 false。")
+	var undo_after: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_after: Array[GFUndoableCommand] = _history.get_redo_history()
+	assert_eq(undo_after.size(), undo_before.size(), "失败撤销不得改变撤销栈深度。")
+	if undo_after.size() == undo_before.size():
+		assert_same(undo_after[0], undo_before[0], "失败撤销必须把命令恢复到原撤销栈位置。")
+	assert_eq(redo_after.size(), redo_before.size(), "失败撤销不得触发重做栈容量裁剪。")
+	if redo_after.size() == redo_before.size():
+		for index: int in range(redo_before.size()):
+			assert_same(redo_after[index], redo_before[index], "失败撤销不得改变重做栈顺序。")
 
 
 # --- 测试：redo ---
@@ -183,7 +215,7 @@ func test_redo_empty_stack_returns_false() -> void:
 
 
 ## 验证同步 redo 遇到异步命令时会回滚重做栈并提示使用异步接口。
-func test_redo_rejects_async_command_and_restores_stack() -> void:
+func test_redo_rejects_async_command_and_preserves_stack() -> void:
 	var counter: CounterState = CounterState.new()
 	var cmd: AsyncCounterCommand = AsyncCounterCommand.new(counter, 5, 0)
 	_history.record(cmd)
@@ -197,6 +229,36 @@ func test_redo_rejects_async_command_and_restores_stack() -> void:
 	assert_push_warning("[GFCommandHistoryUtility] redo() 不支持异步命令，请使用 await redo_async()。")
 
 
+func test_failed_sync_redo_preserves_both_stack_orders() -> void:
+	_history.max_history_size = 0
+	var undo_first: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var undo_second: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var undo_third: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var failing_cmd: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	_history.record(undo_first)
+	_history.record(undo_second)
+	_history.record(undo_third)
+	_history.record(failing_cmd)
+	assert_true(_history.undo_last(), "测试前置撤销失败命令应成功。")
+	_history.max_history_size = 3
+	failing_cmd.redo_success = false
+	var undo_before: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_before: Array[GFUndoableCommand] = _history.get_redo_history()
+
+	var result: bool = _history.redo()
+
+	assert_false(result, "命令报告重做失败时 redo 应返回 false。")
+	var undo_after: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_after: Array[GFUndoableCommand] = _history.get_redo_history()
+	assert_eq(undo_after.size(), undo_before.size(), "失败重做不得触发撤销栈容量裁剪。")
+	if undo_after.size() == undo_before.size():
+		for index: int in range(undo_before.size()):
+			assert_same(undo_after[index], undo_before[index], "失败重做不得改变撤销栈顺序。")
+	assert_eq(redo_after.size(), redo_before.size(), "失败重做不得改变重做栈深度。")
+	if redo_after.size() == redo_before.size():
+		assert_same(redo_after[0], redo_before[0], "失败重做必须把命令恢复到原重做栈位置。")
+
+
 ## 验证 undo_last_async 会等待异步撤销命令完成后再移动到重做栈。
 func test_undo_last_async_awaits_async_command() -> void:
 	var counter: CounterState = CounterState.new(10)
@@ -206,16 +268,115 @@ func test_undo_last_async_awaits_async_command() -> void:
 	var result: bool = await _history.undo_last_async()
 
 	assert_true(result, "异步撤销完成后应返回 true。")
+	assert_true(cmd.undo_hook_called, "无参数完成 Signal 仍应调用默认成功 hook。")
+	assert_true(cmd.observed_undo_payload == null, "无参数完成 Signal 应规范化为 null。")
 	assert_eq(counter.value, 0, "异步 undo 完成后应恢复指定值。")
 	assert_eq(_history.redo_count, 1, "异步 undo 完成后应推入重做栈。")
+
+
+func test_failed_async_undo_preserves_stacks_and_holds_lock_through_hook() -> void:
+	_history.max_history_size = 0
+	var failing_cmd: AsyncUndoOutcomeCommand = AsyncUndoOutcomeCommand.new(_history, false)
+	var redo_first: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var redo_second: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var redo_third: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	_history.record(failing_cmd)
+	_history.record(redo_first)
+	_history.record(redo_second)
+	_history.record(redo_third)
+	assert_true(_history.undo_last(), "测试前置撤销第三条命令应成功。")
+	assert_true(_history.undo_last(), "测试前置撤销第二条命令应成功。")
+	assert_true(_history.undo_last(), "测试前置撤销第一条命令应成功。")
+	_history.max_history_size = 3
+	var undo_before: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_before: Array[GFUndoableCommand] = _history.get_redo_history()
+
+	var result: bool = await _history.undo_last_async()
+
+	assert_false(result, "异步命令报告撤销失败时 undo_last_async 应返回 false。")
+	assert_eq(typeof(failing_cmd.observed_payload), TYPE_BOOL, "单参数完成 Signal 应保留参数类型。")
+	assert_false(GFVariantData.to_bool(failing_cmd.observed_payload, true), "单参数完成 Signal 应直接传给撤销结果 hook。")
+	assert_true(failing_cmd.hook_saw_async_lock, "撤销结果 hook 执行期间必须继续持有异步历史锁。")
+	assert_false(_history.is_processing_async, "异步撤销终态提交后必须释放历史锁。")
+	var undo_after: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_after: Array[GFUndoableCommand] = _history.get_redo_history()
+	assert_eq(undo_after.size(), undo_before.size(), "失败异步撤销不得改变撤销栈深度。")
+	if undo_after.size() == undo_before.size():
+		assert_same(undo_after[0], undo_before[0], "失败异步撤销必须保持原撤销栈位置。")
+	assert_eq(redo_after.size(), redo_before.size(), "失败异步撤销不得触发重做栈容量裁剪。")
+	if redo_after.size() == redo_before.size():
+		for index: int in range(redo_before.size()):
+			assert_same(redo_after[index], redo_before[index], "失败异步撤销不得改变重做栈顺序。")
+
+
+func test_sync_outcome_hook_cannot_clear_or_reenter_history() -> void:
+	var cmd: ReentrantUndoOutcomeCommand = ReentrantUndoOutcomeCommand.new(_history)
+	var redo_cmd: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	assert_true(cmd.set_snapshot({ "id": "undo_source" }), "测试命令快照应可保存。")
+	assert_true(redo_cmd.set_snapshot({ "id": "redo_source" }), "测试重做命令快照应可保存。")
+	_history.record(cmd)
+	_history.record(redo_cmd)
+	assert_true(_history.undo_last(), "测试前置撤销应生成非空重做栈。")
+	_history.max_history_size = 3
+	var undo_before: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_before: Array[GFUndoableCommand] = _history.get_redo_history()
+	var serialized_before: Dictionary = _history.serialize_full_history()
+
+	var result: bool = _history.undo_last()
+
+	assert_false(result, "失败结果 hook 外层撤销应返回 false。")
+	assert_false(cmd.reentrant_undo_result, "结果 hook 内不得重入另一条撤销操作。")
+	assert_eq(cmd.nested_execute_count, 0, "结果 hook 内的嵌套 execute_command 不得执行业务命令。")
+	assert_true(cmd.nested_execute_result == null, "被拒绝的嵌套 execute_command 应返回 null。")
+	assert_eq(cmd.observed_max_history_size, 3, "结果 hook 内不得修改历史容量。")
+	assert_push_warning("[GFCommandHistoryUtility] 当前正在处理历史操作，忽略新的历史记录。")
+	assert_push_warning("[GFCommandHistoryUtility] 当前正在处理历史操作，忽略新的执行请求。")
+	assert_push_warning("[GFCommandHistoryUtility] 当前正在处理历史操作，忽略容量修改请求。")
+	assert_push_warning("[GFCommandHistoryUtility] 当前正在处理历史操作，忽略清空请求。")
+	assert_eq(cmd.observed_serialized_history, serialized_before, "结果 hook 内序列化必须观察到提交前完整历史。")
+	_assert_same_history_ids(cmd.observed_undo_history_ids, undo_before, "结果 hook 内撤销栈必须保持提交前身份与顺序。")
+	_assert_same_history_ids(cmd.observed_redo_history_ids, redo_before, "结果 hook 内重做栈必须保持提交前身份与顺序。")
+	var undo_after: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_after: Array[GFUndoableCommand] = _history.get_redo_history()
+	assert_eq(undo_after.size(), undo_before.size(), "hook 内 clear 与重入不得改变撤销栈。")
+	if undo_after.size() == undo_before.size():
+		assert_same(undo_after[0], undo_before[0], "失败命令应回到原撤销栈位置。")
+	assert_eq(redo_after.size(), redo_before.size(), "hook 内 clear 与重入不得改变重做栈。")
+	if redo_after.size() == redo_before.size():
+		assert_same(redo_after[0], redo_before[0], "既有重做命令的身份与顺序必须保留。")
+	assert_false(undo_after.has(cmd.nested_record_command), "结果 hook 内的 record 请求不得写入历史。")
+
+
+func test_dispose_in_async_outcome_hook_does_not_commit_stale_generation() -> void:
+	var replacement: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var cmd: AsyncUndoOutcomeCommand = AsyncUndoOutcomeCommand.new(_history, false)
+	cmd.dispose_in_hook = true
+	cmd.replacement_after_dispose = replacement
+	_history.record(cmd)
+
+	var result: bool = await _history.undo_last_async()
+
+	assert_false(result, "hook 切换生命周期后旧异步撤销必须返回 false。")
+	assert_true(cmd.hook_saw_async_lock, "dispose 前的结果 hook 仍应观察到异步锁。")
+	assert_false(_history.is_processing_async, "dispose 切代后不得遗留旧异步锁。")
+	var undo_history: Array[GFUndoableCommand] = _history.get_undo_history()
+	assert_eq(undo_history.size(), 1, "新生命周期写入的历史不得被旧操作覆盖。")
+	if undo_history.size() == 1:
+		assert_same(undo_history[0], replacement, "旧操作不得把失败命令恢复进新生命周期。")
+	assert_eq(_history.redo_count, 0, "旧操作不得向新生命周期的重做栈提交。")
 
 
 ## 验证异步撤销过程中不会允许第二次撤销污染栈顺序。
 func test_undo_last_async_blocks_reentrant_history_mutation() -> void:
 	var first_cmd: CounterCommand = CounterCommand.new(CounterState.new())
 	var second_cmd: ManualAsyncCommand = ManualAsyncCommand.new()
+	assert_true(first_cmd.set_snapshot({ "id": "first" }), "第一条测试命令快照应可保存。")
+	assert_true(second_cmd.set_snapshot({ "id": "second" }), "第二条测试命令快照应可保存。")
 	_history.record(first_cmd)
 	_history.record(second_cmd)
+	var undo_before: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_before: Array[GFUndoableCommand] = _history.get_redo_history()
+	var serialized_before: Dictionary = _history.serialize_full_history()
 
 	@warning_ignore("missing_await")
 	@warning_ignore("return_value_discarded")
@@ -226,11 +387,15 @@ func test_undo_last_async_blocks_reentrant_history_mutation() -> void:
 
 	assert_true(second_cmd.undo_called, "第一条异步 undo 应已开始执行。")
 	assert_false(sync_result, "异步 undo 未完成时，同步 undo 应被拒绝。")
-	assert_eq(_history.undo_count, 1, "被锁保护期间不应继续弹出更早的命令。")
+	assert_eq(_history.undo_count, 2, "异步等待期间来源栈必须保持提交前深度。")
+	_assert_same_history(_history.get_undo_history(), undo_before, "异步等待期间撤销栈身份与顺序必须不变。")
+	_assert_same_history(_history.get_redo_history(), redo_before, "异步等待期间重做栈身份与顺序必须不变。")
+	assert_eq(_history.serialize_full_history(), serialized_before, "异步等待期间序列化必须保留完整提交前历史。")
 
 	second_cmd.complete()
 	await get_tree().process_frame
 
+	assert_eq(_history.undo_count, 1, "异步 undo 成功后才应从来源栈移除命令。")
 	assert_eq(_history.redo_count, 1, "异步 undo 完成后才应写入 redo 栈。")
 
 
@@ -246,10 +411,10 @@ func test_async_stall_warning_keeps_history_locked_until_late_completion() -> vo
 		await get_tree().process_frame
 
 	assert_true(_history.is_processing_async, "告警阈值不能被当成异步命令终态。")
-	assert_eq(_history.undo_count, 0, "命令等待期间不得提前放回 undo 栈。")
+	assert_eq(_history.undo_count, 1, "命令等待期间必须保留在来源 undo 栈。")
 	assert_eq(_history.redo_count, 0, "命令等待期间不得提前写入 redo 栈。")
 	_history.record(CounterCommand.new(CounterState.new()))
-	assert_eq(_history.undo_count, 0, "迟到完成前新的历史 mutation 必须继续被锁拒绝。")
+	assert_eq(_history.undo_count, 1, "迟到完成前新的历史 mutation 必须继续被锁拒绝。")
 
 	cmd.complete()
 	await get_tree().process_frame
@@ -288,8 +453,48 @@ func test_redo_async_awaits_async_command() -> void:
 	var result: bool = await _history.redo_async()
 
 	assert_true(result, "异步重做完成后应返回 true。")
+	assert_true(cmd.redo_hook_called, "无参数完成 Signal 仍应调用默认重做成功 hook。")
+	assert_true(cmd.observed_redo_payload == null, "无参数完成 Signal 应规范化为 null。")
 	assert_eq(counter.value, 20, "异步 redo 完成后应应用指定值。")
 	assert_eq(_history.undo_count, 1, "异步 redo 完成后应推回撤销栈。")
+
+
+func test_failed_async_redo_preserves_stacks_and_normalizes_multi_payload() -> void:
+	_history.max_history_size = 0
+	var undo_first: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var undo_second: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var undo_third: ConditionalOutcomeCommand = ConditionalOutcomeCommand.new()
+	var failing_cmd: AsyncRedoOutcomeCommand = AsyncRedoOutcomeCommand.new(_history, false, "redo_rejected")
+	_history.record(undo_first)
+	_history.record(undo_second)
+	_history.record(undo_third)
+	_history.record(failing_cmd)
+	assert_true(_history.undo_last(), "测试前置撤销失败命令应成功。")
+	_history.max_history_size = 3
+	var undo_before: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_before: Array[GFUndoableCommand] = _history.get_redo_history()
+
+	var result: bool = await _history.redo_async()
+
+	assert_false(result, "异步命令报告重做失败时 redo_async 应返回 false。")
+	assert_true(failing_cmd.observed_payload is Array, "多参数完成 Signal 应规范化为 Array。")
+	var observed_payload: Array = GFVariantData.as_array(failing_cmd.observed_payload)
+	assert_eq(
+		observed_payload,
+		[false, "redo_rejected"],
+		"多参数完成 Signal 应以保持顺序的 Array 传给重做结果 hook。"
+	)
+	assert_true(failing_cmd.hook_saw_async_lock, "重做结果 hook 执行期间必须继续持有异步历史锁。")
+	assert_false(_history.is_processing_async, "异步重做终态提交后必须释放历史锁。")
+	var undo_after: Array[GFUndoableCommand] = _history.get_undo_history()
+	var redo_after: Array[GFUndoableCommand] = _history.get_redo_history()
+	assert_eq(undo_after.size(), undo_before.size(), "失败异步重做不得触发撤销栈容量裁剪。")
+	if undo_after.size() == undo_before.size():
+		for index: int in range(undo_before.size()):
+			assert_same(undo_after[index], undo_before[index], "失败异步重做不得改变撤销栈顺序。")
+	assert_eq(redo_after.size(), redo_before.size(), "失败异步重做不得改变重做栈深度。")
+	if redo_after.size() == redo_before.size():
+		assert_same(redo_after[0], redo_before[0], "失败异步重做必须保持原重做栈位置。")
 
 
 # --- 测试：clear 与辅助方法 ---
@@ -486,6 +691,30 @@ func test_snapshot_rejects_runtime_references_transactionally() -> void:
 	assert_eq(preserved_snapshot, { "value": 7 }, "无效快照不应覆盖最近一次有效快照。")
 
 
+func _assert_same_history(
+	actual: Array[GFUndoableCommand],
+	expected: Array[GFUndoableCommand],
+	message: String
+) -> void:
+	assert_eq(actual.size(), expected.size(), "%s（数量）" % message)
+	if actual.size() != expected.size():
+		return
+	for index: int in range(expected.size()):
+		assert_same(actual[index], expected[index], "%s（索引 %d）" % [message, index])
+
+
+func _assert_same_history_ids(
+	actual: Array[int],
+	expected: Array[GFUndoableCommand],
+	message: String
+) -> void:
+	assert_eq(actual.size(), expected.size(), "%s（数量）" % message)
+	if actual.size() != expected.size():
+		return
+	for index: int in range(expected.size()):
+		assert_eq(actual[index], expected[index].get_instance_id(), "%s（索引 %d）" % [message, index])
+
+
 # --- 内部类 ---
 
 class CounterState:
@@ -518,6 +747,10 @@ class AsyncCounterCommand:
 
 	signal completed
 
+	var undo_hook_called: bool = false
+	var redo_hook_called: bool = false
+	var observed_undo_payload: Variant = "not_called"
+	var observed_redo_payload: Variant = "not_called"
 	var _counter: CounterState
 	var _execute_value: int
 	var _undo_value: int
@@ -534,6 +767,16 @@ class AsyncCounterCommand:
 	func undo() -> Variant:
 		call_deferred("_finish_undo")
 		return completed
+
+	func is_undo_successful(undo_result: Variant) -> bool:
+		undo_hook_called = true
+		observed_undo_payload = undo_result
+		return super.is_undo_successful(undo_result)
+
+	func is_redo_successful(execute_result: Variant) -> bool:
+		redo_hook_called = true
+		observed_redo_payload = execute_result
+		return super.is_redo_successful(execute_result)
 
 	func _finish_execute() -> void:
 		_counter.value = _execute_value
@@ -564,6 +807,129 @@ class ManualAsyncCommand:
 		completed.emit()
 
 
+class AsyncUndoOutcomeCommand:
+	extends GFUndoableCommand
+
+	signal undo_completed(success: bool)
+
+	var observed_payload: Variant = null
+	var hook_saw_async_lock: bool = false
+	var dispose_in_hook: bool = false
+	var replacement_after_dispose: GFUndoableCommand = null
+	var _history_ref: WeakRef
+	var _undo_success: bool
+
+	func _init(history: GFCommandHistoryUtility, undo_success: bool) -> void:
+		_history_ref = weakref(history)
+		_undo_success = undo_success
+
+	func undo() -> Variant:
+		call_deferred("_finish_undo")
+		return undo_completed
+
+	func is_undo_successful(undo_result: Variant) -> bool:
+		observed_payload = undo_result
+		var history_value: Variant = _history_ref.get_ref()
+		var history: GFCommandHistoryUtility = null
+		if history_value is GFCommandHistoryUtility:
+			history = history_value
+		hook_saw_async_lock = history != null and history.is_processing_async
+		if dispose_in_hook and history != null:
+			history.dispose()
+			if replacement_after_dispose != null:
+				history.record(replacement_after_dispose)
+		return GFVariantData.to_bool(undo_result, false)
+
+	func _finish_undo() -> void:
+		undo_completed.emit(_undo_success)
+
+
+class AsyncRedoOutcomeCommand:
+	extends GFUndoableCommand
+
+	signal redo_completed(success: bool, reason: String)
+
+	var observed_payload: Variant = null
+	var hook_saw_async_lock: bool = false
+	var _history_ref: WeakRef
+	var _redo_success: bool
+	var _reason: String
+
+	func _init(history: GFCommandHistoryUtility, redo_success: bool, reason: String) -> void:
+		_history_ref = weakref(history)
+		_redo_success = redo_success
+		_reason = reason
+
+	func execute() -> Variant:
+		call_deferred("_finish_redo")
+		return redo_completed
+
+	func undo() -> Variant:
+		return true
+
+	func is_redo_successful(execute_result: Variant) -> bool:
+		observed_payload = execute_result
+		var history_value: Variant = _history_ref.get_ref()
+		var history: GFCommandHistoryUtility = null
+		if history_value is GFCommandHistoryUtility:
+			history = history_value
+		hook_saw_async_lock = history != null and history.is_processing_async
+		if not (execute_result is Array):
+			return false
+		var payload: Array = execute_result
+		return not payload.is_empty() and GFVariantData.to_bool(payload[0], false)
+
+	func _finish_redo() -> void:
+		redo_completed.emit(_redo_success, _reason)
+
+
+class ReentrantUndoOutcomeCommand:
+	extends GFUndoableCommand
+
+	var reentrant_undo_result: bool = true
+	var nested_execute_result: Variant = "not_called"
+	var nested_execute_count: int = -1
+	var nested_record_command: GFUndoableCommand = null
+	var observed_max_history_size: int = -1
+	var observed_undo_history_ids: Array[int] = []
+	var observed_redo_history_ids: Array[int] = []
+	var observed_serialized_history: Dictionary = {}
+	var _history_ref: WeakRef
+
+	func _init(history: GFCommandHistoryUtility) -> void:
+		_history_ref = weakref(history)
+		nested_record_command = CounterCommand.new(CounterState.new())
+
+	func undo() -> Variant:
+		return false
+
+	func is_undo_successful(_undo_result: Variant) -> bool:
+		var history_value: Variant = _history_ref.get_ref()
+		var history: GFCommandHistoryUtility = null
+		if history_value is GFCommandHistoryUtility:
+			history = history_value
+		if history != null:
+			observed_undo_history_ids = _history_instance_ids(history.get_undo_history())
+			observed_redo_history_ids = _history_instance_ids(history.get_redo_history())
+			observed_serialized_history = history.serialize_full_history()
+			history.record(nested_record_command)
+			var nested_counter: CounterState = CounterState.new()
+			var nested_execute_command: CounterCommand = CounterCommand.new(nested_counter)
+			nested_execute_result = history.call("execute_command", nested_execute_command)
+			nested_execute_count = nested_counter.value
+			history.max_history_size = history.max_history_size + 1
+			observed_max_history_size = history.max_history_size
+			history.clear()
+			reentrant_undo_result = history.undo_last()
+		return false
+
+	static func _history_instance_ids(history: Array[GFUndoableCommand]) -> Array[int]:
+		var instance_ids: Array[int] = []
+		for command: GFUndoableCommand in history:
+			instance_ids.append(command.get_instance_id())
+		return instance_ids
+
+
 class InjectedHistoryCommand:
 	extends GFUndoableCommand
 
@@ -589,3 +955,22 @@ class ConditionalRecordCommand:
 
 	func should_record(_execute_result: Variant) -> bool:
 		return should_store
+
+
+class ConditionalOutcomeCommand:
+	extends GFUndoableCommand
+
+	var undo_success: bool = true
+	var redo_success: bool = true
+
+	func execute() -> Variant:
+		return redo_success
+
+	func undo() -> Variant:
+		return undo_success
+
+	func is_undo_successful(undo_result: Variant) -> bool:
+		return GFVariantData.to_bool(undo_result, false)
+
+	func is_redo_successful(execute_result: Variant) -> bool:
+		return GFVariantData.to_bool(execute_result, false)


### PR DESCRIPTION
## Summary

Add a terminal-success contract to undoable commands and commit undo/redo stack transitions only after the command reports success. Failed synchronous and asynchronous transitions now leave both history stacks atomically unchanged.

Closes #39

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: failed undo/redo returns `false` without advancing the history cursor; successful and default-success commands retain the existing result.
- API or extension contract: adds public `GFUndoableCommand.is_undo_successful()` and `is_redo_successful()`, both `@since unreleased` and defaulting to `true`.
- Persisted data, package, protocol, or ProjectSettings impact: none.
- Failure, cancellation, rollback, concurrency, and ownership impact: sync/async operations use one non-reentrant transaction lock; source-stack identity is verified before atomic commit; lifecycle invalidation prevents stale continuations from restoring or committing history.
- Compatibility and migration: existing commands require no migration. Commands that can fail at terminal completion should override the appropriate success hook. Async payload normalization is null / one value / Array of up to 16 values.

## Verification

- [x] Focused tests cover the changed behavior and failure path: command-history GUT 36/36, 174 assertions.
- [x] Exit-leak regression is clean: exact reentrant-hook test 1/1, 22 assertions; ObjectDB/resource/RID leaks all 0.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only` — 22/22.
- [x] GDScript warning and LSP gates are clean — 1224 files, 0 diagnostics.
- [x] Generated API, reference, and AI knowledge output is fresh.
- [x] Clean-head local Full on the final code tree — 35/35 checks; GUT 5045/5045 with 39150 assertions; lifecycle 0 orphan / 0 unhandled warning.
- [x] Ready PR CI completed through `GF repository policy`, Full validation, and `GF merge gate`.
- [x] All review feedback was handled; no unresolved review threads remain.

## Documentation and Release

- [x] Command-history guides and `[未发布]` changelog are updated.
- [x] Development version remains unchanged; new API is marked `@since unreleased`.
- [x] This PR does not create a tag or publish a release.
