### PR TITLE
Harden event, grid, and adapter contracts

### DIFF
--- a/addons/gf/kernel/core/gf.gd
+++ b/addons/gf/kernel/core/gf.gd
@@ -981,6 +981,36 @@ func listen_owned(listener_owner: Object, event_type: Script, listener: GFEventL
 	if arch != null:
 		arch.register_event_owned(listener_owner, event_type, listener, priority)
 
+
+## 快捷订阅类型事件并返回可取消句柄。
+##
+## listener 携带 owner 时句柄会绑定该 owner 生命周期。`once` 订阅会在首个
+## 回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event_type: 要订阅的事件脚本类型。
+## [br]
+## @param listener: 事件监听器契约。
+## [br]
+## @param priority: 监听器优先级，数值越大越先执行。
+## [br]
+## @param once: 是否在首个回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；全局架构不可用时返回非活动句柄。
+func subscribe(
+	event_type: Script,
+	listener: GFEventListener,
+	priority: int = 0,
+	once: bool = false
+) -> GFSubscriptionToken:
+	var arch: GFArchitecture = _get_architecture_or_null("subscribe")
+	if arch == null:
+		return GFSubscriptionToken.new()
+	return arch.subscribe_event(event_type, listener, priority, once)
+
 ## 快捷注册可赋值类型事件监听。
 ## [br]
 ## @api public
@@ -1019,6 +1049,36 @@ func listen_assignable_owned(
 	var arch: GFArchitecture = _get_architecture_or_null("listen_assignable_owned")
 	if arch != null:
 		arch.register_assignable_event_owned(listener_owner, base_event_type, listener, priority)
+
+
+## 快捷订阅可赋值类型事件并返回可取消句柄。
+##
+## listener 携带 owner 时句柄会绑定该 owner 生命周期。监听基类脚本时也会
+## 收到其派生脚本实例；`once` 在首个匹配回调开始前生效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param base_event_type: 要订阅的基类事件脚本类型。
+## [br]
+## @param listener: 事件监听器契约。
+## [br]
+## @param priority: 监听器优先级，数值越大越先执行。
+## [br]
+## @param once: 是否在首个匹配回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；全局架构不可用时返回非活动句柄。
+func subscribe_assignable(
+	base_event_type: Script,
+	listener: GFEventListener,
+	priority: int = 0,
+	once: bool = false
+) -> GFSubscriptionToken:
+	var arch: GFArchitecture = _get_architecture_or_null("subscribe_assignable")
+	if arch == null:
+		return GFSubscriptionToken.new()
+	return arch.subscribe_assignable_event(base_event_type, listener, priority, once)
 
 ## 快捷注销类型事件监听（别名：unlisten）。
 ## [br]
@@ -1109,6 +1169,33 @@ func listen_simple_owned(listener_owner: Object, event_id: StringName, listener:
 	var arch: GFArchitecture = _get_architecture_or_null("listen_simple_owned")
 	if arch != null:
 		arch.register_simple_event_owned(listener_owner, event_id, listener)
+
+
+## 快捷订阅轻量事件并返回可取消句柄。
+##
+## listener 携带 owner 时句柄会绑定该 owner 生命周期。`once` 订阅会在首个
+## 回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event_id: 简单事件标识符。
+## [br]
+## @param listener: 简单事件监听器契约。
+## [br]
+## @param once: 是否在首个回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；全局架构不可用时返回非活动句柄。
+func subscribe_simple(
+	event_id: StringName,
+	listener: GFEventListener,
+	once: bool = false
+) -> GFSubscriptionToken:
+	var arch: GFArchitecture = _get_architecture_or_null("subscribe_simple")
+	if arch == null:
+		return GFSubscriptionToken.new()
+	return arch.subscribe_simple_event(event_id, listener, once)
 
 ## 快捷注销轻量事件监听（别名：unlisten_simple）。
 ## [br]

--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -617,6 +617,35 @@ func register_event_owned(owner: Object, event_type: Script, listener: GFEventLi
 	_event_system.register_owned(owner, event_type, listener, priority)
 
 
+## 订阅脚本类型事件并返回可取消句柄。
+##
+## listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once` 订阅会在
+## 首个回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event_type: 要订阅的脚本类型。
+## [br]
+## @param listener: 事件监听器契约。
+## [br]
+## @param priority: 回调优先级，数值越大越先执行，默认为 0。
+## [br]
+## @param once: 是否在首个回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。
+func subscribe_event(
+	event_type: Script,
+	listener: GFEventListener,
+	priority: int = 0,
+	once: bool = false
+) -> GFSubscriptionToken:
+	if not _can_mutate_runtime("subscribe_event"):
+		return GFSubscriptionToken.new()
+	return _event_system.subscribe(event_type, listener, priority, once)
+
+
 ## 为脚本类型注册可赋值事件监听器。
 ## 监听基类事件时，也会收到继承自该脚本类型的事件实例。
 ## [br]
@@ -657,6 +686,35 @@ func register_assignable_event_owned(
 	if not _can_mutate_runtime("register_assignable_event_owned"):
 		return
 	_event_system.register_assignable_owned(owner, base_event_type, listener, priority)
+
+
+## 订阅可赋值类型事件并返回可取消句柄。
+##
+## listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。监听基类脚本时，
+## 订阅也会收到其派生脚本实例；`once` 在首个匹配回调开始前生效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param base_event_type: 要订阅的基类脚本类型。
+## [br]
+## @param listener: 事件监听器契约。
+## [br]
+## @param priority: 回调优先级，数值越大越先执行，默认为 0。
+## [br]
+## @param once: 是否在首个匹配回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。
+func subscribe_assignable_event(
+	base_event_type: Script,
+	listener: GFEventListener,
+	priority: int = 0,
+	once: bool = false
+) -> GFSubscriptionToken:
+	if not _can_mutate_runtime("subscribe_assignable_event"):
+		return GFSubscriptionToken.new()
+	return _event_system.subscribe_assignable(base_event_type, listener, priority, once)
 
 
 ## 为脚本类型注销事件监听器。
@@ -754,6 +812,32 @@ func register_simple_event_owned(owner: Object, event_id: StringName, listener: 
 	if not _can_mutate_runtime("register_simple_event_owned"):
 		return
 	_event_system.register_simple_owned(owner, event_id, listener)
+
+
+## 订阅轻量级 StringName 事件并返回可取消句柄。
+##
+## listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once` 订阅会在
+## 首个回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event_id: StringName 事件标识符。
+## [br]
+## @param listener: 简单事件监听器契约。
+## [br]
+## @param once: 是否在首个回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。
+func subscribe_simple_event(
+	event_id: StringName,
+	listener: GFEventListener,
+	once: bool = false
+) -> GFSubscriptionToken:
+	if not _can_mutate_runtime("subscribe_simple_event"):
+		return GFSubscriptionToken.new()
+	return _event_system.subscribe_simple(event_id, listener, once)
 
 
 ## 注销轻量级 StringName 事件监听器。

--- a/addons/gf/kernel/core/gf_lifetime_subscription.gd
+++ b/addons/gf/kernel/core/gf_lifetime_subscription.gd
@@ -104,6 +104,14 @@ func owner_is_released() -> bool:
 	return _owner_id != 0 and get_owner() == null
 
 
+# --- 框架内部方法 ---
+
+# 由订阅源在订阅自动结束时解除 owner 监听并使句柄失效。
+func _deactivate_from_source() -> bool:
+	_disconnect_owner_signal()
+	return super._deactivate_from_source()
+
+
 # --- 私有/辅助方法 ---
 
 func _set_owner(owner: Object) -> void:

--- a/addons/gf/kernel/core/gf_subscription_token.gd
+++ b/addons/gf/kernel/core/gf_subscription_token.gd
@@ -79,3 +79,14 @@ func is_active() -> bool:
 ## @return 创建订阅时传入的诊断标签。
 func get_debug_label() -> String:
 	return _debug_label
+
+
+# --- 框架内部方法 ---
+
+# 由订阅源在订阅自动结束时使句柄失效，但不再次执行取消回调。
+func _deactivate_from_source() -> bool:
+	if not _active:
+		return false
+	_active = false
+	_cancel_callback = Callable()
+	return true

--- a/addons/gf/kernel/core/gf_type_event_system.gd
+++ b/addons/gf/kernel/core/gf_type_event_system.gd
@@ -22,6 +22,9 @@ const DEFAULT_MAX_DISPATCH_DEPTH: int = 64
 const _INSTANCE_GUARD = preload("res://addons/gf/kernel/core/gf_instance_guard.gd")
 const _SCRIPT_TYPE_INSPECTOR = preload("res://addons/gf/kernel/core/gf_script_type_inspector.gd")
 const _GF_VARIANT_ACCESS_SCRIPT = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
+const _TRACK_TYPE: StringName = &"type"
+const _TRACK_ASSIGNABLE: StringName = &"assignable"
+const _TRACK_SIMPLE: StringName = &"simple"
 
 
 # --- 公共变量 ---
@@ -70,7 +73,18 @@ var _dispatch_depth: int = 0
 var _max_dispatch_depth_observed: int = 0
 var _dispatch_sequence: int = 0
 var _listener_order_counter: int = 0
+var _subscription_id_counter: int = 0
 var _dispatch_trace: Array[Dictionary] = []
+
+
+# --- Godot 生命周期方法 ---
+
+func _notification(what: int) -> void:
+	if what != NOTIFICATION_PREDELETE:
+		return
+	_type_track.clear_all()
+	_assignable_type_track.clear_all()
+	_simple_track.clear_all()
 
 
 # --- 公共方法 (类型事件) ---
@@ -131,6 +145,46 @@ func register_owned(owner: Object, event_type: Script, listener: GFEventListener
 	register(event_type, listener.with_owner(owner), priority)
 
 
+## 订阅特定脚本类型事件并返回可取消句柄。
+##
+## 每次调用都会创建独立的稳定订阅身份；即使回调和 owner 相同，取消一个句柄也不会影响其它订阅。
+## `once` 为 true 时，订阅会在首个回调开始前失效，因此嵌套派发不会再次调用它。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event_type: 要订阅的脚本类型。
+## [br]
+## @param listener: 事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。
+## [br]
+## @param priority: 回调优先级，数值越大越先执行，默认为 0。
+## [br]
+## @param once: 是否在首个回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；参数无效时返回非活动句柄。
+func subscribe(
+	event_type: Script,
+	listener: GFEventListener,
+	priority: int = 0,
+	once: bool = false
+) -> GFSubscriptionToken:
+	if event_type == null:
+		push_error("[GFTypeEventSystem] subscribe 失败：event_type 为空。")
+		return GFSubscriptionToken.new()
+	if not _validate_listener(listener, 1, "类型事件回调", "事件实例"):
+		return GFSubscriptionToken.new()
+	return _subscribe_type_listener(
+		_type_track,
+		_TRACK_TYPE,
+		event_type,
+		listener,
+		priority,
+		once,
+		false
+	)
+
+
 ## 注销特定脚本类型的事件监听器。
 ## [br]
 ## @api public
@@ -146,6 +200,7 @@ func unregister(event_type: Script, listener: GFEventListener) -> void:
 	var callback: Callable = _get_listener_callback(listener)
 	if _type_dispatch_depth > 0:
 		_type_track.remove_pending_add(event_type, callback, 0, true)
+		_deactivate_matching_subscription_tokens(_type_track, event_type, callback, 0, true)
 		_type_track.queue_remove(event_type, callback, 0, true)
 		return
 
@@ -173,6 +228,7 @@ func unregister_owned(owner: Object, event_type: Script, listener: GFEventListen
 	var callback: Callable = _get_listener_callback(listener)
 	if _type_dispatch_depth > 0:
 		_type_track.remove_pending_add(event_type, callback, owner_id, true)
+		_deactivate_matching_subscription_tokens(_type_track, event_type, callback, owner_id, true)
 		_type_track.queue_remove(event_type, callback, owner_id, true)
 		return
 
@@ -244,6 +300,46 @@ func register_assignable_owned(
 	register_assignable(base_event_type, listener.with_owner(owner), priority)
 
 
+## 订阅可赋值类型事件并返回可取消句柄。
+##
+## 监听基类脚本时也会收到其派生脚本实例。每次调用都创建独立订阅身份，
+## `once` 会在首个匹配事件的用户回调开始前使句柄失效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param base_event_type: 要订阅的基类脚本类型。
+## [br]
+## @param listener: 事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。
+## [br]
+## @param priority: 回调优先级，数值越大越先执行，默认为 0。
+## [br]
+## @param once: 是否在首个匹配回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；参数无效时返回非活动句柄。
+func subscribe_assignable(
+	base_event_type: Script,
+	listener: GFEventListener,
+	priority: int = 0,
+	once: bool = false
+) -> GFSubscriptionToken:
+	if base_event_type == null:
+		push_error("[GFTypeEventSystem] subscribe_assignable 失败：base_event_type 为空。")
+		return GFSubscriptionToken.new()
+	if not _validate_listener(listener, 1, "可赋值事件回调", "事件实例"):
+		return GFSubscriptionToken.new()
+	return _subscribe_type_listener(
+		_assignable_type_track,
+		_TRACK_ASSIGNABLE,
+		base_event_type,
+		listener,
+		priority,
+		once,
+		true
+	)
+
+
 ## 注销可赋值类型事件监听器。
 ## [br]
 ## @api public
@@ -259,6 +355,13 @@ func unregister_assignable(base_event_type: Script, listener: GFEventListener) -
 	var callback: Callable = _get_listener_callback(listener)
 	if _type_dispatch_depth > 0:
 		_assignable_type_track.remove_pending_add(base_event_type, callback, 0, true)
+		_deactivate_matching_subscription_tokens(
+			_assignable_type_track,
+			base_event_type,
+			callback,
+			0,
+			true
+		)
 		_assignable_type_track.queue_remove(base_event_type, callback, 0, true)
 		return
 
@@ -286,6 +389,13 @@ func unregister_assignable_owned(owner: Object, base_event_type: Script, listene
 	var callback: Callable = _get_listener_callback(listener)
 	if _type_dispatch_depth > 0:
 		_assignable_type_track.remove_pending_add(base_event_type, callback, owner_id, true)
+		_deactivate_matching_subscription_tokens(
+			_assignable_type_track,
+			base_event_type,
+			callback,
+			owner_id,
+			true
+		)
 		_assignable_type_track.queue_remove(base_event_type, callback, owner_id, true)
 		return
 
@@ -390,6 +500,68 @@ func register_simple_owned(owner: Object, event_id: StringName, listener: GFEven
 	register_simple(event_id, listener.with_owner(owner))
 
 
+## 订阅轻量级 StringName 事件并返回可取消句柄。
+##
+## 每次调用都会创建独立的稳定订阅身份；`once` 为 true 时，订阅会在首个
+## 用户回调开始前失效，因此同一回调中的嵌套派发不会再次调用它。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param event_id: StringName 事件标识符。
+## [br]
+## @param listener: 简单事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。
+## [br]
+## @param once: 是否在首个回调开始前自动取消订阅。
+## [br]
+## @return 可幂等取消的订阅句柄；参数无效时返回非活动句柄。
+func subscribe_simple(
+	event_id: StringName,
+	listener: GFEventListener,
+	once: bool = false
+) -> GFSubscriptionToken:
+	if not _validate_simple_event_id(event_id, "subscribe_simple"):
+		return GFSubscriptionToken.new()
+	if not _validate_listener(listener, 1, "简单事件回调", "payload"):
+		return GFSubscriptionToken.new()
+
+	var callback: Callable = listener.get_callback()
+	var owner: Object = listener.get_owner()
+	var subscription_id: int = _next_subscription_id()
+	var subscription_token: GFSubscriptionToken = _create_subscription_token(
+		_TRACK_SIMPLE,
+		event_id,
+		subscription_id,
+		owner,
+		listener.get_debug_label()
+	)
+	var subscription_token_ref: WeakRef = weakref(subscription_token)
+	if _simple_dispatch_depth > 0:
+		_simple_track.queue_add(
+			event_id,
+			callback,
+			0,
+			_make_owner_ref(owner),
+			_owner_instance_id(owner),
+			_next_listener_order(),
+			subscription_id,
+			once,
+			subscription_token_ref
+		)
+	else:
+		_add_simple_listener_entry(
+			event_id,
+			callback,
+			owner,
+			_next_listener_order(),
+			subscription_id,
+			once,
+			subscription_token_ref
+		)
+	return subscription_token
+
+
 ## 注销轻量级 StringName 事件监听器。
 ## [br]
 ## @api public
@@ -405,6 +577,7 @@ func unregister_simple(event_id: StringName, listener: GFEventListener) -> void:
 	var callback: Callable = _get_listener_callback(listener)
 	if _simple_dispatch_depth > 0:
 		_simple_track.remove_pending_add(event_id, callback, 0, true)
+		_deactivate_matching_subscription_tokens(_simple_track, event_id, callback, 0, true)
 		_simple_track.queue_remove(event_id, callback, 0, true)
 		return
 
@@ -432,6 +605,7 @@ func unregister_simple_owned(owner: Object, event_id: StringName, listener: GFEv
 	var callback: Callable = _get_listener_callback(listener)
 	if _simple_dispatch_depth > 0:
 		_simple_track.remove_pending_add(event_id, callback, owner_id, true)
+		_deactivate_matching_subscription_tokens(_simple_track, event_id, callback, owner_id, true)
 		_simple_track.queue_remove(event_id, callback, owner_id, true)
 		return
 
@@ -476,20 +650,29 @@ func send_simple(event_id: StringName, payload: Variant = null) -> void:
 			break
 
 		var callback: Callable = entry.callable
+		var subscription_id: int = _entry_subscription_id(entry)
 
+		if (
+			subscription_id != 0
+			and _simple_track.has_pending_subscription_remove(event_id, subscription_id)
+		):
+			continue
 		if _entry_owner_is_released(entry):
+			_deactivate_subscription_token_from_entry(entry)
 			_simple_track.queue_remove(event_id, callback, _entry_owner_id(entry), true)
 			has_pending_removes = true
 			continue
 		if has_pending_owner_removes and _is_pending_owner_remove(entry, _simple_track.pending_owner_removes):
 			continue
 		if not callback.is_valid() or (callback.get_object() != null and not is_instance_valid(callback.get_object())):
+			_deactivate_subscription_token_from_entry(entry)
 			_simple_track.queue_remove(event_id, callback, _entry_owner_id(entry), true)
 			has_pending_removes = true
 			continue
 		if has_pending_removes and _simple_track.has_pending_remove(event_id, callback, _entry_owner_id(entry), true):
 			continue
 
+		_retire_once_subscription_before_dispatch(_simple_track, event_id, entry)
 		callback.call(payload)
 
 		if _clear_requested_simple:
@@ -519,6 +702,8 @@ func unregister_owner(owner: Object) -> void:
 	if _type_dispatch_depth > 0:
 		_type_track.remove_pending_adds_for_owner_id(owner_id)
 		_assignable_type_track.remove_pending_adds_for_owner_id(owner_id)
+		_deactivate_owner_subscription_tokens(_type_track, owner_id)
+		_deactivate_owner_subscription_tokens(_assignable_type_track, owner_id)
 		_type_track.append_unique_owner_remove(owner_id)
 		_assignable_type_track.append_unique_owner_remove(owner_id)
 	else:
@@ -527,6 +712,7 @@ func unregister_owner(owner: Object) -> void:
 
 	if _simple_dispatch_depth > 0:
 		_simple_track.remove_pending_adds_for_owner_id(owner_id)
+		_deactivate_owner_subscription_tokens(_simple_track, owner_id)
 		_simple_track.append_unique_owner_remove(owner_id)
 	else:
 		_remove_owner_from_simple_listeners(owner_id)
@@ -572,7 +758,8 @@ func get_debug_stats() -> Dictionary:
 
 ## 获取事件监听器诊断明细。
 ## [br]
-## 默认只返回每条轨道的数量统计；传入 `{ "include_entries": true }` 时会附带每个监听器的事件 key、owner 状态、优先级和 Callable 状态。
+## 默认只返回每条轨道的数量统计；传入 `{ "include_entries": true }` 时会附带每个监听器的
+## 事件 key、owner 状态、优先级、Callable 状态，以及订阅记录的稳定身份和 once 标记。
 ## [br]
 ## @api public
 ## [br]
@@ -584,7 +771,7 @@ func get_debug_stats() -> Dictionary:
 ## [br]
 ## @return 监听器诊断报告。
 ## [br]
-## @schema return: Dictionary containing listener counts, stale owner counts, track summaries, and optional entry rows.
+## @schema return: Dictionary containing listener counts, stale owner counts, track summaries, and optional entry rows with subscription_id and once.
 func get_listener_diagnostics(options: Dictionary = {}) -> Dictionary:
 	var include_entries: bool = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "include_entries", false)
 	var type_track: Dictionary = _collect_track_diagnostics("type", _type_track, include_entries)
@@ -679,6 +866,195 @@ func _get_type_track(assignable: bool) -> EventListenerTrack:
 	return _assignable_type_track if assignable else _type_track
 
 
+func _subscribe_type_listener(
+	track: EventListenerTrack,
+	track_kind: StringName,
+	event_type: Script,
+	listener: GFEventListener,
+	priority: int,
+	once: bool,
+	assignable: bool
+) -> GFSubscriptionToken:
+	var callback: Callable = listener.get_callback()
+	var owner: Object = listener.get_owner()
+	var subscription_id: int = _next_subscription_id()
+	var subscription_token: GFSubscriptionToken = _create_subscription_token(
+		track_kind,
+		event_type,
+		subscription_id,
+		owner,
+		listener.get_debug_label()
+	)
+	var subscription_token_ref: WeakRef = weakref(subscription_token)
+	if _type_dispatch_depth > 0:
+		track.queue_add(
+			event_type,
+			callback,
+			priority,
+			_make_owner_ref(owner),
+			_owner_instance_id(owner),
+			_next_listener_order(),
+			subscription_id,
+			once,
+			subscription_token_ref
+		)
+	else:
+		_add_listener_entry(
+			track.listeners,
+			event_type,
+			callback,
+			priority,
+			owner,
+			_next_listener_order(),
+			assignable,
+			subscription_id,
+			once,
+			subscription_token_ref
+		)
+	return subscription_token
+
+
+func _create_subscription_token(
+	track_kind: StringName,
+	event_key: Variant,
+	subscription_id: int,
+	owner: Object,
+	listener_label: String
+) -> GFSubscriptionToken:
+	var cancel_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+		self,
+		&"_cancel_subscription"
+	)
+	var cancel_callback: Callable = func() -> void:
+		var _cancel_report: Dictionary = cancel_invocation.invoke([
+			track_kind,
+			event_key,
+			subscription_id,
+		])
+	var debug_label: String = "event:%s:%s#%d" % [
+		String(track_kind),
+		_track_key_debug_string(event_key),
+		subscription_id,
+	]
+	if not listener_label.is_empty():
+		debug_label += ":%s" % listener_label
+	if owner != null:
+		return GFLifetimeSubscription.new(owner, cancel_callback, debug_label)
+	return GFSubscriptionToken.new(cancel_callback, debug_label)
+
+
+func _cancel_subscription(
+	track_kind: StringName,
+	event_key: Variant,
+	subscription_id: int
+) -> void:
+	if subscription_id == 0:
+		return
+	var track: EventListenerTrack = _get_track_by_kind(track_kind)
+	if track == null:
+		return
+	if track.remove_pending_add_by_subscription_id(subscription_id):
+		return
+	if _get_track_dispatch_depth(track_kind) > 0:
+		track.queue_subscription_remove(event_key, subscription_id)
+		return
+	if not track.listeners.has(event_key):
+		return
+
+	var listeners: Array = _get_registry_array(track.listeners, event_key)
+	_remove_entry_by_subscription_id(
+		listeners,
+		subscription_id,
+		_event_type_from_key(event_key),
+		track_kind == _TRACK_ASSIGNABLE
+	)
+	_erase_listener_key_if_empty(track.listeners, event_key)
+
+
+func _get_track_by_kind(track_kind: StringName) -> EventListenerTrack:
+	match track_kind:
+		_TRACK_TYPE:
+			return _type_track
+		_TRACK_ASSIGNABLE:
+			return _assignable_type_track
+		_TRACK_SIMPLE:
+			return _simple_track
+	return null
+
+
+func _get_track_dispatch_depth(track_kind: StringName) -> int:
+	return _simple_dispatch_depth if track_kind == _TRACK_SIMPLE else _type_dispatch_depth
+
+
+func _retire_once_subscription_before_dispatch(
+	track: EventListenerTrack,
+	event_key: Variant,
+	entry: Dictionary
+) -> void:
+	var subscription_id: int = _entry_subscription_id(entry)
+	if subscription_id == 0 or not _entry_is_once(entry):
+		return
+	_deactivate_subscription_token_from_entry(entry)
+	track.queue_subscription_remove(event_key, subscription_id)
+
+
+func _deactivate_matching_subscription_tokens(
+	track: EventListenerTrack,
+	event_key: Variant,
+	callback: Callable,
+	owner_id: int,
+	owner_filter_enabled: bool
+) -> void:
+	if not track.listeners.has(event_key):
+		return
+	var listeners: Array = _get_registry_array(track.listeners, event_key)
+	for entry_variant: Variant in listeners:
+		var entry: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(entry_variant)
+		if _get_callable_option(entry, "callable") != callback:
+			continue
+		if owner_filter_enabled and _entry_owner_id(entry) != owner_id:
+			continue
+		_deactivate_subscription_token_from_entry(entry)
+
+
+func _deactivate_owner_subscription_tokens(track: EventListenerTrack, owner_id: int) -> void:
+	for event_key: Variant in track.listeners.keys():
+		var listeners: Array = _get_registry_array(track.listeners, event_key)
+		for entry_variant: Variant in listeners:
+			var entry: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(entry_variant)
+			if _entry_owner_id(entry) == owner_id:
+				_deactivate_subscription_token_from_entry(entry)
+
+
+func _deactivate_subscription_token_from_entry(entry: Dictionary) -> void:
+	var subscription_token_ref: WeakRef = _get_subscription_token_ref(entry)
+	if subscription_token_ref == null:
+		return
+	var token_value: Variant = subscription_token_ref.get_ref()
+	if token_value is GFSubscriptionToken:
+		var subscription_token: GFSubscriptionToken = token_value
+		var _deactivated: bool = subscription_token._deactivate_from_source()
+
+
+func _get_subscription_token_ref(entry: Dictionary) -> WeakRef:
+	var token_ref_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		entry,
+		"subscription_token_ref"
+	)
+	if token_ref_value is WeakRef:
+		var subscription_token_ref: WeakRef = token_ref_value
+		return subscription_token_ref
+	return null
+
+
+func _entry_subscription_id(entry: Dictionary) -> int:
+	return _GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "subscription_id", 0)
+
+
+func _entry_is_once(entry: Dictionary) -> bool:
+	return _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(entry, "once", false)
+
+
 func _is_pending_owner_remove(entry: Dictionary, pending_owner_ids: Array[int]) -> bool:
 	var owner_id: int = _entry_owner_id(entry)
 	return owner_id != 0 and pending_owner_ids.has(owner_id)
@@ -691,15 +1067,19 @@ func _add_listener_entry(
 	priority: int,
 	owner: Object,
 	order: int,
-	assignable: bool
+	assignable: bool,
+	subscription_id: int = 0,
+	once: bool = false,
+	subscription_token_ref: WeakRef = null
 ) -> void:
 	if not registry.has(event_type):
 		registry[event_type] = []
 	var listeners: Array = _get_registry_array(registry, event_type)
 
-	for entry: Dictionary in listeners:
-		if _listener_entry_matches(entry, on_event, owner):
-			return
+	if subscription_id == 0:
+		for entry: Dictionary in listeners:
+			if _listener_entry_matches(entry, on_event, owner):
+				return
 
 	var new_entry: Dictionary = {
 		"callable": on_event,
@@ -707,6 +1087,9 @@ func _add_listener_entry(
 		"owner_ref": _make_owner_ref(owner),
 		"owner_id": _owner_instance_id(owner),
 		"order": order,
+		"subscription_id": subscription_id,
+		"once": once,
+		"subscription_token_ref": subscription_token_ref,
 	}
 	var inserted: bool = false
 	for i: int in range(listeners.size()):
@@ -728,21 +1111,28 @@ func _add_simple_listener_entry(
 	event_id: StringName,
 	on_event: Callable,
 	owner: Object,
-	order: int
+	order: int,
+	subscription_id: int = 0,
+	once: bool = false,
+	subscription_token_ref: WeakRef = null
 ) -> void:
 	if not _simple_event_listeners.has(event_id):
 		_simple_event_listeners[event_id] = []
 	var listeners: Array = _get_registry_array(_simple_event_listeners, event_id)
 
-	for entry: Dictionary in listeners:
-		if _listener_entry_matches(entry, on_event, owner):
-			return
+	if subscription_id == 0:
+		for entry: Dictionary in listeners:
+			if _listener_entry_matches(entry, on_event, owner):
+				return
 
 	listeners.append({
 		"callable": on_event,
 		"owner_ref": _make_owner_ref(owner),
 		"owner_id": _owner_instance_id(owner),
 		"order": order,
+		"subscription_id": subscription_id,
+		"once": once,
+		"subscription_token_ref": subscription_token_ref,
 	})
 
 
@@ -789,17 +1179,26 @@ func _dispatch_type_listener_entries(event_instance: Object, listeners: Array[Di
 		var event_type: Script = _get_script_option(entry, "event_type")
 		var assignable: bool = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(entry, "assignable", false)
 		var track: EventListenerTrack = _get_type_track(assignable)
+		var subscription_id: int = _entry_subscription_id(entry)
+		if (
+			subscription_id != 0
+			and track.has_pending_subscription_remove(event_type, subscription_id)
+		):
+			continue
 		if _entry_owner_is_released(entry):
+			_deactivate_subscription_token_from_entry(entry)
 			_append_pending_type_remove(event_type, callback, assignable, _entry_owner_id(entry), true)
 			continue
 		if _is_pending_owner_remove(entry, track.pending_owner_removes):
 			continue
 		if not callback.is_valid() or (callback.get_object() != null and not is_instance_valid(callback.get_object())):
+			_deactivate_subscription_token_from_entry(entry)
 			_append_pending_type_remove(event_type, callback, assignable, _entry_owner_id(entry), true)
 			continue
 		if track.has_pending_remove(event_type, callback, _entry_owner_id(entry), true):
 			continue
 
+		_retire_once_subscription_before_dispatch(track, event_type, entry)
 		callback.call(event_instance)
 
 		if (
@@ -963,6 +1362,8 @@ func _make_listener_diagnostic_entry(
 		"callable_method": String(callback.get_method()) if callback.is_valid() else "",
 		"priority": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "priority", 0),
 		"order": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "order", 0),
+		"subscription_id": _entry_subscription_id(entry),
+		"once": _entry_is_once(entry),
 	}
 
 
@@ -1038,14 +1439,23 @@ func _flush_listener_track_removes(track: EventListenerTrack, assignable: bool) 
 		if not track.listeners.has(key):
 			continue
 		var listeners: Array = _get_registry_array(track.listeners, key)
-		_remove_entry_by_callable(
-			listeners,
-			_get_callable_option(pending, "callable"),
-			_event_type_from_key(key),
-			assignable,
-			_get_pending_owner_id(pending),
-			_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(pending, "owner_filter_enabled", true)
-		)
+		var subscription_id: int = _entry_subscription_id(pending)
+		if subscription_id != 0:
+			_remove_entry_by_subscription_id(
+				listeners,
+				subscription_id,
+				_event_type_from_key(key),
+				assignable
+			)
+		else:
+			_remove_entry_by_callable(
+				listeners,
+				_get_callable_option(pending, "callable"),
+				_event_type_from_key(key),
+				assignable,
+				_get_pending_owner_id(pending),
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(pending, "owner_filter_enabled", true)
+			)
 		_erase_listener_key_if_empty(track.listeners, key)
 	track.pending_removes.clear()
 
@@ -1061,9 +1471,11 @@ func _flush_type_track_adds(track: EventListenerTrack, assignable: bool) -> void
 		var owner_ref: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(pending, "owner_ref")
 		var binding_owner: Object = _owner_from_ref(owner_ref)
 		if owner_ref != null and binding_owner == null:
+			_deactivate_subscription_token_from_entry(pending)
 			continue
 		var event_type: Script = _get_script_option(pending, track.key_field)
 		if event_type == null:
+			_deactivate_subscription_token_from_entry(pending)
 			continue
 		_add_listener_entry(
 			track.listeners,
@@ -1072,7 +1484,10 @@ func _flush_type_track_adds(track: EventListenerTrack, assignable: bool) -> void
 			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(pending, "priority", 0),
 			binding_owner,
 			_pending_listener_order(pending),
-			assignable
+			assignable,
+			_entry_subscription_id(pending),
+			_entry_is_once(pending),
+			_get_subscription_token_ref(pending)
 		)
 	track.pending_adds.clear()
 
@@ -1082,13 +1497,20 @@ func _flush_simple_track_adds() -> void:
 		var owner_ref: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(pending, "owner_ref")
 		var binding_owner: Object = _owner_from_ref(owner_ref)
 		if owner_ref != null and binding_owner == null:
+			_deactivate_subscription_token_from_entry(pending)
 			continue
 		var event_id: StringName = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(pending, _simple_track.key_field, &"")
+		if event_id == &"":
+			_deactivate_subscription_token_from_entry(pending)
+			continue
 		_add_simple_listener_entry(
 			event_id,
 			_get_callable_option(pending, "callable"),
 			binding_owner,
-			_pending_listener_order(pending)
+			_pending_listener_order(pending),
+			_entry_subscription_id(pending),
+			_entry_is_once(pending),
+			_get_subscription_token_ref(pending)
 		)
 	_simple_track.pending_adds.clear()
 
@@ -1124,10 +1546,30 @@ func _remove_entry_by_callable(
 	for i: int in range(listeners.size() - 1, -1, -1):
 		var entry: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(listeners[i])
 		if entry.callable == on_event and (not owner_filter_enabled or _entry_owner_id(entry) == owner_id):
+			_deactivate_subscription_token_from_entry(entry)
 			listeners.remove_at(i)
 			removed = true
 	if removed and event_type != null:
 		_invalidate_type_dispatch_cache_for_event(event_type, assignable)
+
+
+func _remove_entry_by_subscription_id(
+	listeners: Array,
+	subscription_id: int,
+	event_type: Script = null,
+	assignable: bool = false
+) -> void:
+	if subscription_id == 0:
+		return
+	for i: int in range(listeners.size() - 1, -1, -1):
+		var entry: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(listeners[i])
+		if _entry_subscription_id(entry) != subscription_id:
+			continue
+		_deactivate_subscription_token_from_entry(entry)
+		listeners.remove_at(i)
+		if event_type != null:
+			_invalidate_type_dispatch_cache_for_event(event_type, assignable)
+		return
 
 
 func _remove_entries_by_owner_id(
@@ -1140,6 +1582,7 @@ func _remove_entries_by_owner_id(
 	for i: int in range(listeners.size() - 1, -1, -1):
 		var entry: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(listeners[i])
 		if _entry_owner_id(entry) == owner_id:
+			_deactivate_subscription_token_from_entry(entry)
 			listeners.remove_at(i)
 			removed = true
 	if removed and event_type != null:
@@ -1202,6 +1645,8 @@ func _owner_id_from_ref(owner_ref_variant: Variant) -> int:
 
 
 func _listener_entry_matches(entry: Dictionary, on_event: Callable, owner: Object) -> bool:
+	if _entry_subscription_id(entry) != 0:
+		return false
 	if entry.callable != on_event:
 		return false
 	var owner_id: int = _owner_instance_id(owner)
@@ -1213,6 +1658,11 @@ func _listener_entry_matches(entry: Dictionary, on_event: Callable, owner: Objec
 func _next_listener_order() -> int:
 	_listener_order_counter += 1
 	return _listener_order_counter
+
+
+func _next_subscription_id() -> int:
+	_subscription_id_counter += 1
+	return _subscription_id_counter
 
 
 func _pending_listener_order(pending: Dictionary) -> int:
@@ -1281,6 +1731,7 @@ func _compact_released_owner_entries(track: EventListenerTrack, assignable: bool
 			if not _entry_owner_is_released(entry):
 				continue
 			compacted_count += 1
+			_deactivate_subscription_token_from_entry(entry)
 			var callback: Callable = _get_callable_option(entry, "callable")
 			if defer_remove:
 				track.queue_remove(key, callback, _entry_owner_id(entry), true)
@@ -1353,13 +1804,22 @@ class EventListenerTrack:
 	## @param owner_id: 监听 owner 实例 ID。
 	## [br]
 	## @param order: 注册顺序。
+	## [br]
+	## @param subscription_id: 可取消订阅的稳定身份；普通 register 为 0。
+	## [br]
+	## @param once: 是否在首个回调开始前移除。
+	## [br]
+	## @param subscription_token_ref: 订阅句柄弱引用。
 	func queue_add(
 		key: Variant,
 		on_event: Callable,
 		priority: int,
 		owner_ref: WeakRef,
 		owner_id: int,
-		order: int
+		order: int,
+		subscription_id: int = 0,
+		once: bool = false,
+		subscription_token_ref: WeakRef = null
 	) -> void:
 		var pending: Dictionary = {
 			"callable": on_event,
@@ -1367,6 +1827,9 @@ class EventListenerTrack:
 			"owner_ref": owner_ref,
 			"owner_id": owner_id,
 			"order": order,
+			"subscription_id": subscription_id,
+			"once": once,
+			"subscription_token_ref": subscription_token_ref,
 		}
 		pending[key_field] = key
 		pending_adds.append(pending)
@@ -1394,6 +1857,26 @@ class EventListenerTrack:
 			"callable": on_event,
 			"owner_id": owner_id,
 			"owner_filter_enabled": owner_filter_enabled,
+		}
+		pending[key_field] = key
+		pending_removes.append(pending)
+
+	## 暂存按稳定身份注销订阅。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @param key: 监听轨道键。
+	## [br]
+	## @schema key: Script or StringName listener key matching key_field.
+	## [br]
+	## @param subscription_id: 要注销的稳定订阅身份。
+	func queue_subscription_remove(key: Variant, subscription_id: int) -> void:
+		if subscription_id == 0 or has_pending_subscription_remove(key, subscription_id):
+			return
+		var pending: Dictionary = {
+			"subscription_id": subscription_id,
 		}
 		pending[key_field] = key
 		pending_removes.append(pending)
@@ -1430,7 +1913,29 @@ class EventListenerTrack:
 				and pending_callable == on_event
 				and (not owner_filter_enabled or pending_owner_id == owner_id)
 			):
+				_deactivate_entry_subscription(pending)
 				pending_adds.remove_at(i)
+
+	## 按稳定身份移除同一派发周期内尚未落地的订阅。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @param subscription_id: 要移除的稳定订阅身份。
+	## [br]
+	## @return 是否移除了 pending 订阅。
+	func remove_pending_add_by_subscription_id(subscription_id: int) -> bool:
+		if subscription_id == 0:
+			return false
+		for i: int in range(pending_adds.size() - 1, -1, -1):
+			var pending: Dictionary = pending_adds[i]
+			if _get_subscription_id_from_entry(pending) != subscription_id:
+				continue
+			_deactivate_entry_subscription(pending)
+			pending_adds.remove_at(i)
+			return true
+		return false
 
 	## 移除指定 owner 在同一派发周期内尚未落地的注册。
 	## [br]
@@ -1445,6 +1950,7 @@ class EventListenerTrack:
 			var pending: Dictionary = pending_variant
 			var pending_owner_id: int = _get_owner_id_from_pending(pending)
 			if pending_owner_id == owner_id:
+				_deactivate_entry_subscription(pending)
 				pending_adds.remove_at(i)
 
 	## 查询指定监听是否已暂存注销。
@@ -1487,6 +1993,31 @@ class EventListenerTrack:
 				return true
 		return false
 
+	## 查询指定稳定身份是否已暂存注销。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @param key: 监听轨道键。
+	## [br]
+	## @schema key: Script or StringName listener key matching key_field.
+	## [br]
+	## @param subscription_id: 要查询的稳定订阅身份。
+	## [br]
+	## @return 已暂存注销时返回 true。
+	func has_pending_subscription_remove(key: Variant, subscription_id: int) -> bool:
+		if subscription_id == 0:
+			return false
+		for pending: Dictionary in pending_removes:
+			var pending_key: Variant = pending[key_field] if pending.has(key_field) else null
+			if (
+				pending_key == key
+				and _get_subscription_id_from_entry(pending) == subscription_id
+			):
+				return true
+		return false
+
 	func _get_owner_id_from_pending(pending: Dictionary) -> int:
 		if not pending.has("owner_id"):
 			return 0
@@ -1512,6 +2043,15 @@ class EventListenerTrack:
 	## [br]
 	## @api framework_internal
 	func clear_all() -> void:
+		for key: Variant in listeners.keys():
+			var listener_entries_value: Variant = listeners[key]
+			if not (listener_entries_value is Array):
+				continue
+			var listener_entries: Array = listener_entries_value
+			for entry_variant: Variant in listener_entries:
+				if entry_variant is Dictionary:
+					var entry: Dictionary = entry_variant
+					_deactivate_entry_subscription(entry)
 		listeners.clear()
 		clear_pending()
 
@@ -1519,6 +2059,32 @@ class EventListenerTrack:
 	## [br]
 	## @api framework_internal
 	func clear_pending() -> void:
+		for pending: Dictionary in pending_adds:
+			_deactivate_entry_subscription(pending)
 		pending_adds.clear()
 		pending_removes.clear()
 		pending_owner_removes.clear()
+
+	func _get_subscription_id_from_entry(entry: Dictionary) -> int:
+		if not entry.has("subscription_id"):
+			return 0
+		var subscription_id_value: Variant = entry["subscription_id"]
+		if subscription_id_value is int:
+			var subscription_id: int = subscription_id_value
+			return subscription_id
+		if subscription_id_value is float:
+			var subscription_id_float: float = subscription_id_value
+			return int(subscription_id_float)
+		return 0
+
+	func _deactivate_entry_subscription(entry: Dictionary) -> void:
+		if not entry.has("subscription_token_ref"):
+			return
+		var token_ref_value: Variant = entry["subscription_token_ref"]
+		if not (token_ref_value is WeakRef):
+			return
+		var subscription_token_ref: WeakRef = token_ref_value
+		var token_value: Variant = subscription_token_ref.get_ref()
+		if token_value is GFSubscriptionToken:
+			var subscription_token: GFSubscriptionToken = token_value
+			var _deactivated: bool = subscription_token._deactivate_from_source()

--- a/addons/gf/standard/foundation/math/gf_grid_occupancy.gd
+++ b/addons/gf/standard/foundation/math/gf_grid_occupancy.gd
@@ -2,6 +2,8 @@
 ##
 ## 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。
 ## 它不负责路径查找、碰撞或胜负规则。
+## 占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态，
+## 但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。
 ## [br]
 ## @api public
 ## [br]
@@ -59,17 +61,40 @@ signal cell_reserved(receiver: Variant, cell: Vector2i)
 signal reservation_released(receiver: Variant, cell: Vector2i)
 
 
+# --- 常量 ---
+
+const _INVALID_CELL: Vector2i = Vector2i(-1, -1)
+const _NOTIFICATION_CELL_OCCUPIED: StringName = &"cell_occupied"
+const _NOTIFICATION_CELL_RELEASED: StringName = &"cell_released"
+const _NOTIFICATION_CELL_RESERVED: StringName = &"cell_reserved"
+const _NOTIFICATION_RESERVATION_RELEASED: StringName = &"reservation_released"
+
+
 # --- 公共变量 ---
 
-## 网格尺寸。小于等于 0 的维度会让所有格子视为越界。
+## 网格尺寸，默认为 [constant Vector2i.ZERO]。小于等于 0 的维度会让所有格子视为越界。
+## 直接赋值会像 configure() 一样清空现有占用与预约；通知期间的赋值会失败关闭。
 ## [br]
 ## @api public
-var grid_size: Vector2i = Vector2i.ZERO
+## [br]
+## @since 10.0.0
+var grid_size: Vector2i:
+	get:
+		return _grid_size
+	set(value):
+		_set_grid_size(value)
 
-## 单格允许的最大占用数量。
+## 单格允许的最大占用数量，默认为 1，最小为 1。
+## 直接赋值会像 configure() 一样清空现有占用与预约；通知期间的赋值会失败关闭。
 ## [br]
 ## @api public
-var max_occupants_per_cell: int = 1
+## [br]
+## @since 10.0.0
+var max_occupants_per_cell: int:
+	get:
+		return _max_occupants_per_cell
+	set(value):
+		_set_max_occupants_per_cell(value)
 
 
 # --- 私有变量 ---
@@ -79,13 +104,16 @@ var _receiver_records: Dictionary = {}
 var _cell_reservations: Dictionary = {}
 var _receiver_reservations: Dictionary = {}
 var _reservation_records: Dictionary = {}
+var _grid_size: Vector2i = Vector2i.ZERO
+var _max_occupants_per_cell: int = 1
+var _mutation_in_progress: bool = false
 
 
 # --- Godot 生命周期方法 ---
 
 func _init(p_grid_size: Vector2i = Vector2i.ZERO, p_max_occupants_per_cell: int = 1) -> void:
-	grid_size = p_grid_size
-	max_occupants_per_cell = maxi(p_max_occupants_per_cell, 1)
+	_grid_size = p_grid_size
+	_max_occupants_per_cell = maxi(p_max_occupants_per_cell, 1)
 
 
 # --- 公共方法 ---
@@ -98,9 +126,13 @@ func _init(p_grid_size: Vector2i = Vector2i.ZERO, p_max_occupants_per_cell: int 
 ## [br]
 ## @param p_max_occupants_per_cell: 单格最大占用数量。
 func configure(p_grid_size: Vector2i, p_max_occupants_per_cell: int = 1) -> void:
-	grid_size = p_grid_size
-	max_occupants_per_cell = maxi(p_max_occupants_per_cell, 1)
-	clear()
+	if not _begin_mutation(&"configure"):
+		return
+
+	_grid_size = p_grid_size
+	_max_occupants_per_cell = maxi(p_max_occupants_per_cell, 1)
+	_clear_records()
+	_finish_mutation([])
 
 
 ## 检查格子是否在边界内。
@@ -126,8 +158,7 @@ func is_in_bounds(cell: Vector2i) -> bool:
 ## [br]
 ## @return 可占用时返回 true。
 func can_occupy(receiver: Variant, cell: Vector2i) -> bool:
-	prune_invalid_receivers()
-	return _can_occupy_after_prune(receiver, cell)
+	return _can_occupy_current(receiver, cell)
 
 
 ## 获取当前被占用的格子快照。
@@ -138,8 +169,7 @@ func can_occupy(receiver: Variant, cell: Vector2i) -> bool:
 ## [br]
 ## @return 被至少一个接收者占用的格子数组，按 y/x 稳定顺序返回。
 func get_occupied_cells() -> Array[Vector2i]:
-	prune_invalid_receivers()
-	return _collect_cells_with_keys(_cell_occupants)
+	return _collect_occupied_cells()
 
 
 ## 获取当前被预约的格子快照。
@@ -150,8 +180,7 @@ func get_occupied_cells() -> Array[Vector2i]:
 ## [br]
 ## @return 被接收者预约的格子数组，按 y/x 稳定顺序返回。
 func get_reserved_cells() -> Array[Vector2i]:
-	prune_invalid_receivers()
-	return _collect_cells_with_keys(_cell_reservations)
+	return _collect_reserved_cells()
 
 
 ## 获取指定接收者当前可占用的格子。
@@ -166,7 +195,6 @@ func get_reserved_cells() -> Array[Vector2i]:
 ## [br]
 ## @return 当前可被该接收者占用的格子数组，按 y/x 稳定顺序返回。
 func get_occupiable_cells(receiver: Variant) -> Array[Vector2i]:
-	prune_invalid_receivers()
 	var result: Array[Vector2i] = []
 	if grid_size.x <= 0 or grid_size.y <= 0:
 		return result
@@ -174,7 +202,7 @@ func get_occupiable_cells(receiver: Variant) -> Array[Vector2i]:
 	for y: int in range(grid_size.y):
 		for x: int in range(grid_size.x):
 			var cell: Vector2i = Vector2i(x, y)
-			if _can_occupy_after_prune(receiver, cell):
+			if _can_occupy_current(receiver, cell):
 				result.append(cell)
 	return result
 
@@ -191,22 +219,31 @@ func get_occupiable_cells(receiver: Variant) -> Array[Vector2i]:
 ## [br]
 ## @return 成功时返回 true。
 func occupy(receiver: Variant, cell: Vector2i) -> bool:
-	if not can_occupy(receiver, cell):
+	if not _begin_mutation(&"occupy"):
+		return false
+
+	var notifications: Array[Dictionary] = []
+	_prune_invalid_records(notifications)
+	if not _can_occupy_current(receiver, cell):
+		_finish_mutation(notifications)
 		return false
 
 	var receiver_key: String = _make_receiver_key(receiver)
-	var current_cell: Vector2i = get_receiver_cell(receiver)
+	var current_record: Dictionary = _get_record(_receiver_records, receiver_key)
+	var current_cell: Vector2i = _get_record_cell(current_record)
 	if current_cell == cell:
+		_finish_mutation(notifications)
 		return true
-	if current_cell != Vector2i(-1, -1):
-		release(receiver)
+	if current_cell != _INVALID_CELL:
+		_remove_occupancy_by_key(receiver_key, notifications, true)
 
 	var occupants: Array = _get_or_create_occupant_keys(cell)
 	if not occupants.has(receiver_key):
 		occupants.append(receiver_key)
 
 	_receiver_records[receiver_key] = _make_receiver_record(receiver, cell)
-	cell_occupied.emit(receiver, cell)
+	_append_notification(notifications, _NOTIFICATION_CELL_OCCUPIED, receiver, cell)
+	_finish_mutation(notifications)
 	return true
 
 
@@ -218,16 +255,13 @@ func occupy(receiver: Variant, cell: Vector2i) -> bool:
 ## [br]
 ## @schema receiver: Variant receiver identity stored by value or weak Object reference.
 func release(receiver: Variant) -> void:
-	var receiver_key: String = _make_receiver_key(receiver)
-	var record: Dictionary = _get_record(_receiver_records, receiver_key)
-	if record.is_empty():
+	if not _begin_mutation(&"release"):
 		return
 
-	var cell: Vector2i = _get_record_cell(record)
-	_release_cell_occupant_key(cell, receiver_key)
-
-	_erase_dictionary_key(_receiver_records, receiver_key)
-	cell_released.emit(receiver, cell)
+	var notifications: Array[Dictionary] = []
+	var receiver_key: String = _make_receiver_key(receiver)
+	_remove_occupancy_by_key(receiver_key, notifications, true)
+	_finish_mutation(notifications)
 
 
 ## 释放指定格子的所有占用。
@@ -236,11 +270,14 @@ func release(receiver: Variant) -> void:
 ## [br]
 ## @param cell: 格子坐标。
 func release_cell(cell: Vector2i) -> void:
+	if not _begin_mutation(&"release_cell"):
+		return
+
+	var notifications: Array[Dictionary] = []
 	var occupants: Array = _get_occupant_keys(cell).duplicate()
 	for receiver_key: String in occupants:
-		var record: Dictionary = _get_record(_receiver_records, receiver_key)
-		if not record.is_empty():
-			release(_record_to_receiver(record))
+		_remove_occupancy_by_key(receiver_key, notifications, true)
+	_finish_mutation(notifications)
 
 
 ## 预约格子，防止其他接收者抢占。
@@ -255,15 +292,32 @@ func release_cell(cell: Vector2i) -> void:
 ## [br]
 ## @return 成功时返回 true。
 func reserve_cell(receiver: Variant, cell: Vector2i) -> bool:
-	if not can_occupy(receiver, cell):
+	if not _begin_mutation(&"reserve_cell"):
+		return false
+
+	var notifications: Array[Dictionary] = []
+	_prune_invalid_records(notifications)
+	if not _can_occupy_current(receiver, cell):
+		_finish_mutation(notifications)
 		return false
 
 	var receiver_key: String = _make_receiver_key(receiver)
-	release_reservation(receiver)
+	var current_cell: Vector2i = _get_dictionary_vector2i(
+		_receiver_reservations,
+		receiver_key,
+		_INVALID_CELL
+	)
+	if current_cell == cell and _cell_has_valid_reservation(cell):
+		_finish_mutation(notifications)
+		return true
+	if current_cell != _INVALID_CELL:
+		_remove_reservation_by_key(receiver_key, notifications, true)
+
 	_cell_reservations[cell] = receiver_key
 	_receiver_reservations[receiver_key] = cell
 	_reservation_records[receiver_key] = _make_receiver_record(receiver, cell)
-	cell_reserved.emit(receiver, cell)
+	_append_notification(notifications, _NOTIFICATION_CELL_RESERVED, receiver, cell)
+	_finish_mutation(notifications)
 	return true
 
 
@@ -277,13 +331,41 @@ func reserve_cell(receiver: Variant, cell: Vector2i) -> bool:
 ## [br]
 ## @return 成功时返回 true。
 func confirm_reservation(receiver: Variant) -> bool:
-	var receiver_key: String = _make_receiver_key(receiver)
-	if not _receiver_reservations.has(receiver_key):
+	if not _begin_mutation(&"confirm_reservation"):
 		return false
 
-	var cell: Vector2i = _get_dictionary_vector2i(_receiver_reservations, receiver_key, Vector2i(-1, -1))
-	release_reservation(receiver)
-	return occupy(receiver, cell)
+	var notifications: Array[Dictionary] = []
+	_prune_invalid_records(notifications)
+	var receiver_key: String = _make_receiver_key(receiver)
+	if not _receiver_reservations.has(receiver_key):
+		_finish_mutation(notifications)
+		return false
+
+	var cell: Vector2i = _get_dictionary_vector2i(
+		_receiver_reservations,
+		receiver_key,
+		_INVALID_CELL
+	)
+	if not _can_occupy_current(receiver, cell):
+		_finish_mutation(notifications)
+		return false
+
+	_remove_reservation_by_key(receiver_key, notifications, true)
+	var current_record: Dictionary = _get_record(_receiver_records, receiver_key)
+	var current_cell: Vector2i = _get_record_cell(current_record)
+	if current_cell == cell:
+		_finish_mutation(notifications)
+		return true
+	if current_cell != _INVALID_CELL:
+		_remove_occupancy_by_key(receiver_key, notifications, true)
+
+	var occupants: Array = _get_or_create_occupant_keys(cell)
+	if not occupants.has(receiver_key):
+		occupants.append(receiver_key)
+	_receiver_records[receiver_key] = _make_receiver_record(receiver, cell)
+	_append_notification(notifications, _NOTIFICATION_CELL_OCCUPIED, receiver, cell)
+	_finish_mutation(notifications)
+	return true
 
 
 ## 释放接收者预约。
@@ -294,15 +376,13 @@ func confirm_reservation(receiver: Variant) -> bool:
 ## [br]
 ## @schema receiver: Variant receiver identity stored by value or weak Object reference.
 func release_reservation(receiver: Variant) -> void:
-	var receiver_key: String = _make_receiver_key(receiver)
-	if not _receiver_reservations.has(receiver_key):
+	if not _begin_mutation(&"release_reservation"):
 		return
 
-	var cell: Vector2i = _get_dictionary_vector2i(_receiver_reservations, receiver_key, Vector2i(-1, -1))
-	_erase_dictionary_key(_receiver_reservations, receiver_key)
-	_erase_dictionary_key(_cell_reservations, cell)
-	_erase_dictionary_key(_reservation_records, receiver_key)
-	reservation_released.emit(receiver, cell)
+	var notifications: Array[Dictionary] = []
+	var receiver_key: String = _make_receiver_key(receiver)
+	_remove_reservation_by_key(receiver_key, notifications, true)
+	_finish_mutation(notifications)
 
 
 ## 检查格子是否有占用。
@@ -324,7 +404,7 @@ func is_cell_occupied(cell: Vector2i) -> bool:
 ## [br]
 ## @return 被预约时返回 true。
 func is_cell_reserved(cell: Vector2i) -> bool:
-	return _cell_reservations.has(cell)
+	return _cell_has_valid_reservation(cell)
 
 
 ## 获取格子中的所有接收者。
@@ -337,11 +417,10 @@ func is_cell_reserved(cell: Vector2i) -> bool:
 ## [br]
 ## @schema return: Array receiver values restored from occupancy records.
 func get_cell_occupants(cell: Vector2i) -> Array[Variant]:
-	prune_invalid_receivers()
 	var result: Array[Variant] = []
 	for receiver_key: String in _get_occupant_keys(cell):
 		var record: Dictionary = _get_record(_receiver_records, receiver_key)
-		if not record.is_empty():
+		if _record_is_valid(record) and _get_record_cell(record) == cell:
 			result.append(_record_to_receiver(record))
 	return result
 
@@ -373,10 +452,9 @@ func get_receiver_cell(receiver: Variant) -> Vector2i:
 	var receiver_key: String = _make_receiver_key(receiver)
 	var record: Dictionary = _get_record(_receiver_records, receiver_key)
 	if record.is_empty():
-		return Vector2i(-1, -1)
+		return _INVALID_CELL
 	if not _record_is_valid(record):
-		release(receiver)
-		return Vector2i(-1, -1)
+		return _INVALID_CELL
 	return _get_record_cell(record)
 
 
@@ -384,37 +462,105 @@ func get_receiver_cell(receiver: Variant) -> Vector2i:
 ## [br]
 ## @api public
 func prune_invalid_receivers() -> void:
-	var keys_to_release: Array[String] = []
-	for receiver_key: String in _receiver_records.keys():
-		var record: Dictionary = _get_record(_receiver_records, receiver_key)
-		if not _record_is_valid(record):
-			keys_to_release.append(receiver_key)
+	if not _begin_mutation(&"prune_invalid_receivers"):
+		return
 
-	for receiver_key: String in keys_to_release:
-		_release_by_key(receiver_key, true)
-
-	var reservation_keys_to_release: Array[String] = []
-	for receiver_key: String in _reservation_records.keys():
-		var record: Dictionary = _get_record(_reservation_records, receiver_key)
-		if not _record_is_valid(record):
-			reservation_keys_to_release.append(receiver_key)
-
-	for receiver_key: String in reservation_keys_to_release:
-		_release_reservation_by_key(receiver_key)
+	var notifications: Array[Dictionary] = []
+	_prune_invalid_records(notifications)
+	_finish_mutation(notifications)
 
 
 ## 清空占用和预约。
 ## [br]
 ## @api public
 func clear() -> void:
+	if not _begin_mutation(&"clear"):
+		return
+
+	_clear_records()
+	_finish_mutation([])
+
+
+# --- 私有/辅助方法 ---
+
+func _begin_mutation(operation_name: StringName) -> bool:
+	if _mutation_in_progress:
+		push_error(
+			"[GFGridOccupancy] %s 被拒绝：占用事务通知期间不允许重入修改。"
+			% operation_name
+		)
+		return false
+
+	_mutation_in_progress = true
+	return true
+
+
+func _set_grid_size(value: Vector2i) -> void:
+	if value == _grid_size:
+		return
+	if not _begin_mutation(&"grid_size"):
+		return
+	_grid_size = value
+	_clear_records()
+	_finish_mutation([])
+
+
+func _set_max_occupants_per_cell(value: int) -> void:
+	var normalized_value: int = maxi(value, 1)
+	if normalized_value == _max_occupants_per_cell:
+		return
+	if not _begin_mutation(&"max_occupants_per_cell"):
+		return
+	_max_occupants_per_cell = normalized_value
+	_clear_records()
+	_finish_mutation([])
+
+
+func _finish_mutation(notifications: Array[Dictionary]) -> void:
+	for notification_data: Dictionary in notifications:
+		var notification_name: StringName = GFVariantData.get_option_string_name(
+			notification_data,
+			"name"
+		)
+		var receiver: Variant = GFVariantData.get_option_value(notification_data, "receiver")
+		var cell: Vector2i = _get_dictionary_vector2i(
+			notification_data,
+			"cell",
+			_INVALID_CELL
+		)
+		match notification_name:
+			_NOTIFICATION_CELL_OCCUPIED:
+				cell_occupied.emit(receiver, cell)
+			_NOTIFICATION_CELL_RELEASED:
+				cell_released.emit(receiver, cell)
+			_NOTIFICATION_CELL_RESERVED:
+				cell_reserved.emit(receiver, cell)
+			_NOTIFICATION_RESERVATION_RELEASED:
+				reservation_released.emit(receiver, cell)
+
+	_mutation_in_progress = false
+
+
+func _append_notification(
+	notifications: Array[Dictionary],
+	notification_name: StringName,
+	receiver: Variant,
+	cell: Vector2i
+) -> void:
+	notifications.append({
+		"name": notification_name,
+		"receiver": receiver,
+		"cell": cell,
+	})
+
+
+func _clear_records() -> void:
 	_cell_occupants.clear()
 	_receiver_records.clear()
 	_cell_reservations.clear()
 	_receiver_reservations.clear()
 	_reservation_records.clear()
 
-
-# --- 私有/辅助方法 ---
 
 func _get_occupant_keys(cell: Vector2i) -> Array:
 	return GFVariantData.as_array(GFVariantData.get_option_value(_cell_occupants, cell, []))
@@ -431,7 +577,7 @@ func _get_or_create_occupant_keys(cell: Vector2i) -> Array:
 	return new_occupants
 
 
-func _can_occupy_after_prune(receiver: Variant, cell: Vector2i) -> bool:
+func _can_occupy_current(receiver: Variant, cell: Vector2i) -> bool:
 	if not is_in_bounds(cell):
 		return false
 
@@ -440,16 +586,25 @@ func _can_occupy_after_prune(receiver: Variant, cell: Vector2i) -> bool:
 		return false
 
 	var reserved_by: String = GFVariantData.get_option_string(_cell_reservations, cell, "")
-	if not reserved_by.is_empty() and reserved_by != receiver_key:
+	if (
+		not reserved_by.is_empty()
+		and _reservation_is_valid_for_cell(reserved_by, cell)
+		and reserved_by != receiver_key
+	):
 		return false
 
-	var occupants: Array = _get_occupant_keys(cell)
-	if occupants.has(receiver_key):
-		return true
-	return occupants.size() < max_occupants_per_cell
+	var valid_occupant_count: int = 0
+	for occupant_key: String in _get_occupant_keys(cell):
+		var record: Dictionary = _get_record(_receiver_records, occupant_key)
+		if not _record_is_valid(record) or _get_record_cell(record) != cell:
+			continue
+		if occupant_key == receiver_key:
+			return true
+		valid_occupant_count += 1
+	return valid_occupant_count < max_occupants_per_cell
 
 
-func _collect_cells_with_keys(source: Dictionary) -> Array[Vector2i]:
+func _collect_occupied_cells() -> Array[Vector2i]:
 	var result: Array[Vector2i] = []
 	if grid_size.x <= 0 or grid_size.y <= 0:
 		return result
@@ -457,9 +612,52 @@ func _collect_cells_with_keys(source: Dictionary) -> Array[Vector2i]:
 	for y: int in range(grid_size.y):
 		for x: int in range(grid_size.x):
 			var cell: Vector2i = Vector2i(x, y)
-			if source.has(cell):
+			if _cell_has_valid_occupant(cell):
 				result.append(cell)
 	return result
+
+
+func _collect_reserved_cells() -> Array[Vector2i]:
+	var result: Array[Vector2i] = []
+	if grid_size.x <= 0 or grid_size.y <= 0:
+		return result
+
+	for y: int in range(grid_size.y):
+		for x: int in range(grid_size.x):
+			var cell: Vector2i = Vector2i(x, y)
+			if _cell_has_valid_reservation(cell):
+				result.append(cell)
+	return result
+
+
+func _cell_has_valid_occupant(cell: Vector2i) -> bool:
+	for receiver_key: String in _get_occupant_keys(cell):
+		var record: Dictionary = _get_record(_receiver_records, receiver_key)
+		if _record_is_valid(record) and _get_record_cell(record) == cell:
+			return true
+	return false
+
+
+func _cell_has_valid_reservation(cell: Vector2i) -> bool:
+	var receiver_key: String = GFVariantData.get_option_string(
+		_cell_reservations,
+		cell,
+		""
+	)
+	return _reservation_is_valid_for_cell(receiver_key, cell)
+
+
+func _reservation_is_valid_for_cell(receiver_key: String, cell: Vector2i) -> bool:
+	if receiver_key.is_empty():
+		return false
+
+	var record: Dictionary = _get_record(_reservation_records, receiver_key)
+	if not _record_is_valid(record) or _get_record_cell(record) != cell:
+		return false
+	return (
+		_get_dictionary_vector2i(_receiver_reservations, receiver_key, _INVALID_CELL)
+		== cell
+	)
 
 
 func _make_receiver_key(receiver: Variant) -> String:
@@ -505,7 +703,32 @@ func _record_is_valid(record: Dictionary) -> bool:
 	return true
 
 
-func _release_by_key(receiver_key: String, emit_cell_signal: bool = false) -> void:
+func _prune_invalid_records(notifications: Array[Dictionary]) -> void:
+	var occupancy_keys: Array[String] = []
+	for receiver_key: String in _receiver_records.keys():
+		var record: Dictionary = _get_record(_receiver_records, receiver_key)
+		if not _record_is_valid(record):
+			occupancy_keys.append(receiver_key)
+
+	for receiver_key: String in occupancy_keys:
+		_remove_reservation_by_key(receiver_key, notifications, true)
+		_remove_occupancy_by_key(receiver_key, notifications, true)
+
+	var reservation_keys: Array[String] = []
+	for receiver_key: String in _reservation_records.keys():
+		var record: Dictionary = _get_record(_reservation_records, receiver_key)
+		if not _record_is_valid(record):
+			reservation_keys.append(receiver_key)
+
+	for receiver_key: String in reservation_keys:
+		_remove_reservation_by_key(receiver_key, notifications, true)
+
+
+func _remove_occupancy_by_key(
+	receiver_key: String,
+	notifications: Array[Dictionary],
+	emit_notification: bool
+) -> void:
 	var record: Dictionary = _get_record(_receiver_records, receiver_key)
 	if record.is_empty():
 		return
@@ -515,25 +738,44 @@ func _release_by_key(receiver_key: String, emit_cell_signal: bool = false) -> vo
 	_release_cell_occupant_key(cell, receiver_key)
 
 	_erase_dictionary_key(_receiver_records, receiver_key)
-	_release_reservation_by_key(receiver_key)
-	if emit_cell_signal:
-		cell_released.emit(receiver, cell)
+	if emit_notification:
+		_append_notification(
+			notifications,
+			_NOTIFICATION_CELL_RELEASED,
+			receiver,
+			cell
+		)
 
 
-func _release_reservation_by_key(receiver_key: String) -> void:
+func _remove_reservation_by_key(
+	receiver_key: String,
+	notifications: Array[Dictionary],
+	emit_notification: bool
+) -> void:
 	if not _receiver_reservations.has(receiver_key):
 		_erase_dictionary_key(_reservation_records, receiver_key)
 		return
 
-	var cell: Vector2i = _get_dictionary_vector2i(_receiver_reservations, receiver_key, Vector2i(-1, -1))
+	var cell: Vector2i = _get_dictionary_vector2i(
+		_receiver_reservations,
+		receiver_key,
+		_INVALID_CELL
+	)
 	var record: Dictionary = _get_record(_reservation_records, receiver_key)
 	var receiver: Variant = null
 	if not record.is_empty():
 		receiver = _record_to_receiver(record)
 	_erase_dictionary_key(_receiver_reservations, receiver_key)
-	_erase_dictionary_key(_cell_reservations, cell)
+	if GFVariantData.get_option_string(_cell_reservations, cell, "") == receiver_key:
+		_erase_dictionary_key(_cell_reservations, cell)
 	_erase_dictionary_key(_reservation_records, receiver_key)
-	reservation_released.emit(receiver, cell)
+	if emit_notification:
+		_append_notification(
+			notifications,
+			_NOTIFICATION_RESERVATION_RELEASED,
+			receiver,
+			cell
+		)
 
 
 func _get_record(records: Dictionary, receiver_key: String) -> Dictionary:
@@ -541,7 +783,7 @@ func _get_record(records: Dictionary, receiver_key: String) -> Dictionary:
 
 
 func _get_record_cell(record: Dictionary) -> Vector2i:
-	return _get_dictionary_vector2i(record, "cell", Vector2i(-1, -1))
+	return _get_dictionary_vector2i(record, "cell", _INVALID_CELL)
 
 
 func _release_cell_occupant_key(cell: Vector2i, receiver_key: String) -> void:

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "1fb53ddb3599ee632af501562e0789f8d06af57361f7c5df546847e6514025bb",
+  "source_digest": "310fe1c262bca2ddeb5d73faf0f5f7bbd62feb16faec18c22610fec75d357fa8",
   "class_count": 755,
   "package_count": 52,
   "packages": [
@@ -2252,6 +2252,13 @@
         },
         {
           "kind": "func",
+          "name": "subscribe_event",
+          "signature": "func subscribe_event( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken",
+          "summary": "订阅脚本类型事件并返回可取消句柄。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "register_assignable_event",
           "signature": "func register_assignable_event(base_event_type: Script, listener: GFEventListener, priority: int = 0) -> void",
           "summary": "为脚本类型注册可赋值事件监听器。",
@@ -2262,6 +2269,13 @@
           "name": "register_assignable_event_owned",
           "signature": "func register_assignable_event_owned( owner: Object, base_event_type: Script, listener: GFEventListener, priority: int = 0 ) -> void",
           "summary": "为脚本类型注册带拥有者的可赋值事件监听器。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "subscribe_assignable_event",
+          "signature": "func subscribe_assignable_event( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken",
+          "summary": "订阅可赋值类型事件并返回可取消句柄。",
           "visibility": "public"
         },
         {
@@ -2304,6 +2318,13 @@
           "name": "register_simple_event_owned",
           "signature": "func register_simple_event_owned(owner: Object, event_id: StringName, listener: GFEventListener) -> void",
           "summary": "注册带拥有者的轻量级 StringName 事件监听器。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "subscribe_simple_event",
+          "signature": "func subscribe_simple_event( event_id: StringName, listener: GFEventListener, once: bool = false ) -> GFSubscriptionToken",
+          "summary": "订阅轻量级 StringName 事件并返回可取消句柄。",
           "visibility": "public"
         },
         {
@@ -33296,15 +33317,15 @@
         {
           "kind": "var",
           "name": "grid_size",
-          "signature": "var grid_size: Vector2i = Vector2i.ZERO",
-          "summary": "网格尺寸。小于等于 0 的维度会让所有格子视为越界。",
+          "signature": "var grid_size: Vector2i",
+          "summary": "网格尺寸，默认为 [constant Vector2i.ZERO]。小于等于 0 的维度会让所有格子视为越界。",
           "visibility": "public"
         },
         {
           "kind": "var",
           "name": "max_occupants_per_cell",
-          "signature": "var max_occupants_per_cell: int = 1",
-          "summary": "单格允许的最大占用数量。",
+          "signature": "var max_occupants_per_cell: int",
+          "summary": "单格允许的最大占用数量，默认为 1，最小为 1。",
           "visibility": "public"
         },
         {
@@ -83169,6 +83190,13 @@
         },
         {
           "kind": "func",
+          "name": "subscribe",
+          "signature": "func subscribe( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken",
+          "summary": "订阅特定脚本类型事件并返回可取消句柄。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "unregister",
           "signature": "func unregister(event_type: Script, listener: GFEventListener) -> void",
           "summary": "注销特定脚本类型的事件监听器。",
@@ -83193,6 +83221,13 @@
           "name": "register_assignable_owned",
           "signature": "func register_assignable_owned( owner: Object, base_event_type: Script, listener: GFEventListener, priority: int = 0 ) -> void",
           "summary": "注册带 owner 的可赋值类型事件监听器。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "subscribe_assignable",
+          "signature": "func subscribe_assignable( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken",
+          "summary": "订阅可赋值类型事件并返回可取消句柄。",
           "visibility": "public"
         },
         {
@@ -83228,6 +83263,13 @@
           "name": "register_simple_owned",
           "signature": "func register_simple_owned(owner: Object, event_id: StringName, listener: GFEventListener) -> void",
           "summary": "注册带 owner 的轻量级 StringName 事件监听器。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "subscribe_simple",
+          "signature": "func subscribe_simple( event_id: StringName, listener: GFEventListener, once: bool = false ) -> GFSubscriptionToken",
+          "summary": "订阅轻量级 StringName 事件并返回可取消句柄。",
           "visibility": "public"
         },
         {

--- a/addons/gf/tools/ai_developer/knowledge/capabilities.json
+++ b/addons/gf/tools/ai_developer/knowledge/capabilities.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.5.0",
+  "catalog_version": "1.6.0",
   "capabilities": [
     {
       "id": "architecture",
@@ -25,12 +25,12 @@
     {
       "id": "assets-content",
       "title": "Assets, resource identity, and content",
-      "summary": "Async resource handles, stable resource keys, catalogs, preload plans, and optional content packages.",
-      "keywords": ["asset", "resource", "load", "cache", "preload", "catalog", "content package", "dlc"],
+      "summary": "Async resource handles, stable resource keys, catalogs, preload plans, optional content packages, and auditable generated-artifact export plans.",
+      "keywords": ["asset", "resource", "load", "cache", "preload", "catalog", "content package", "dlc", "artifact export", "thumbnail", "screenshot", "atlas"],
       "packages": ["gf.standard.assets", "gf.extension.content_package"],
-      "primary_classes": ["GFAssetUtility", "GFAssetHandle", "GFResourceResolverUtility", "GFAssetCatalogRuntime", "GFAssetCatalogMount", "GFContentPackageQuery", "GFContentPackageAssetCatalogProvider"],
-      "recipes": ["owned-resource-load", "content-package"],
-      "boundary": "Projects define content taxonomy and distribution policy; GF provides identity, lifecycle, plans, and diagnostics."
+      "primary_classes": ["GFAssetUtility", "GFAssetHandle", "GFResourceResolverUtility", "GFAssetCatalogRuntime", "GFAssetCatalogMount", "GFContentPackageQuery", "GFContentPackageAssetCatalogProvider", "GFContentPackageExportPlan"],
+      "recipes": ["owned-resource-load", "content-package", "external-artifact-export"],
+      "boundary": "Projects define content taxonomy, materialization, target adapters, and distribution policy; GF provides identity, lifecycle, plans, and diagnostics."
     },
     {
       "id": "config-data",

--- a/addons/gf/tools/ai_developer/knowledge/recipes.json
+++ b/addons/gf/tools/ai_developer/knowledge/recipes.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.5.0",
+  "catalog_version": "1.6.0",
   "recipes": [
     {
       "id": "project-feature",
@@ -138,13 +138,17 @@
       "primary_classes": ["GFPlatformAdapter", "GFPlatformContractDescriptor", "GFPlatformAdapterConformance", "GFNetworkLobbyBackend", "GFNetworkLobbyService", "GFMultiplayerPeerNetworkBackend"],
       "steps": [
         "Declare provider-neutral contract methods, request/result schemas, byte budgets, capability requirements, concurrency, cancellation support, and sensitive fields.",
-        "Keep Steam, Epic, console, or service SDK calls inside the adapter.",
+        "Keep every provider SDK call inside the project-owned adapter and correlate the GF handle before invoking a provider that may complete synchronously.",
+        "For native or GDExtension-backed providers, choose script_only, optional, or required mode; freeze the descriptor and exact platform, architecture, and build-configuration artifact matrix with hashes, sizes, immutable sources, licenses, Godot floor, and reload policy.",
+        "Keep detection side-effect free and fail closed on absent, ambiguous, stale, mismatched, or partially readable native evidence; never treat a runtime class name or filename as integrity proof.",
+        "Declare call and callback threads, copy worker callbacks into a bounded plain-data ingress queue, and pump them onto the main thread before touching Godot objects, GF handles, signals, or owner state.",
         "Map every lobby call to a GFNetworkLobbyOperationHandle by request ID and normalize initialization, cancellation, timeout, provider shutdown, and late callbacks.",
         "Publish launch and invite callbacks as deduplicated GFPlatformActivationIntent records; adopt provider MultiplayerPeer instances with explicit owned or borrowed lifecycle.",
-        "Run GFPlatformAdapterConformance and fault-inject unavailable SDK, invalid schemas, concurrency, cancellation, timeout, duplicate terminal callbacks, disconnect, and ownership transfer.",
+        "Pin native dependencies for offline reproduction, declare permissions and redaction, separate editor-only from runtime artifacts, and run load, request, cancellation, bounded worker shutdown, and integrity checks against every actual exported target.",
+        "Run GFPlatformAdapterConformance and fault-inject unavailable SDK, invalid schemas, concurrency, cancellation, timeout, duplicate or late callbacks, denied permissions, secret-shaped errors, disconnect, and ownership transfer.",
         "Let project code own lobby visibility, matchmaking, authority, UI, product policy, and fallback."
       ],
-      "avoid": ["Provider IDs leaking into portable domain models", "Uncorrelated callback-only completion", "A GFSteamManager-style global business facade"]
+      "avoid": ["Provider IDs leaking into portable domain models", "Uncorrelated callback-only completion", "Side-effecting native availability probes", "Worker callbacks touching Godot or GF objects", "Mutable or network-only native build inputs", "Editor-only success accepted as runtime proof", "A provider-specific global business facade"]
     },
     {
       "id": "platform-storage-adapter",
@@ -244,6 +248,44 @@
         "Test missing content, duplicate keys, priority ties, provider removal, stale mounts, dependency cycles, and owner disposal."
       ],
       "avoid": ["Download URLs embedded in runtime content records", "Gameplay rules keyed to physical file paths", "Global mounts without a lifecycle owner"]
+    },
+    {
+      "id": "external-artifact-export",
+      "title": "Export generated artifacts through a project adapter",
+      "package_requirements": {"all_of": ["gf.extension.content_package", "gf.standard.debug", "gf.standard.spatial"], "any_of": []},
+      "primary_classes": ["GFThumbnailRenderer", "GFScreenshotUtility", "GFRectPacking2D", "GFGeneratedArtifactReport", "GFContentPackageExportPlan"],
+      "required_api_members": [
+        {
+          "class_name": "GFThumbnailRenderer",
+          "members": ["submit_render_request", "cancel_render_task"]
+        },
+        {
+          "class_name": "GFScreenshotUtility",
+          "members": ["capture_viewport_image", "save_image"]
+        },
+        {
+          "class_name": "GFRectPacking2D",
+          "members": ["pack_fixed", "pack_square"]
+        },
+        {
+          "class_name": "GFGeneratedArtifactReport",
+          "members": ["save_text", "make_report", "summarize_reports"]
+        },
+        {
+          "class_name": "GFContentPackageExportPlan",
+          "members": ["add_entry", "get_validation_report", "get_artifact_report", "get_preflight_report"]
+        }
+      ],
+      "steps": [
+        "Freeze a project-owned export request with stable artifact IDs, stable input ordering, finite image count, resolution and atlas budgets, a bounded staging root, and an explicit cancellation owner.",
+        "Render asset previews through GFThumbnailRenderer and capture Viewport images through GFScreenshotUtility; reject null Images and release preview nodes and render tasks with the owning tool session.",
+        "Plan placements through GFRectPacking2D, fail the batch when any input is unplaced, and keep pixel copying, padding, atlas materialization, and metadata semantics in the project tool.",
+        "Save binary Images through GFScreenshotUtility.save_image, save text mappings through GFGeneratedArtifactReport.save_text with allowed_roots, normalize binary results through make_report, and summarize every produced or skipped artifact.",
+        "Build GFContentPackageExportPlan from a manifest or catalog, add the generated outputs, and require plan, artifact-integrity, and project compatibility preflight reports to pass before handoff.",
+        "Let a project-owned target adapter consume only the frozen plan, reports, and staging artifacts while it owns target schemas, authentication, rate limits, idempotency, retries, upload or file output, receipts, and cleanup.",
+        "Test dry-run, cancellation, empty images, budget overflow, unplaced inputs, duplicate archive paths, write failures, integrity mismatch, partial adapter failure, idempotent retry, and credential absence from reports."
+      ],
+      "avoid": ["A business-specific generator added to GF", "Upload or target authentication inside a renderer or export plan", "Publishing partial or unreported staging output", "Credentials or remote business state copied into generic artifact reports"]
     },
     {
       "id": "input-context",

--- a/addons/gf/tools/ai_developer/templates/adapters/platform/README.md
+++ b/addons/gf/tools/ai_developer/templates/adapters/platform/README.md
@@ -11,6 +11,9 @@ package. Do not place provider SDK code under `res://addons/gf`.
   `GFPlatformContractMethodDescriptor`.
 - Put request/result schemas, byte budgets, capability requirements,
   concurrency, cancellation support, and sensitive fields in the descriptor.
+- Treat every provider callback as untrusted input. Correlate it to one active
+  request, validate its result schema, and redact it before publishing a GF
+  result, lifecycle event, activation intent, diagnostic, or log entry.
 - Extend `GFNetworkLobbyBackend` only for lobby operations. Correlate every SDK
   callback with the `request_id` and handle supplied to `_dispatch_operation`.
 - When the SDK exposes a Godot `MultiplayerPeer`, pass it to
@@ -26,13 +29,115 @@ package. Do not place provider SDK code under `res://addons/gf`.
   `GFCompatibilityPreflight.require_godot_version()`,
   `require_framework_version()`, and `require_package()`.
 
+## Native mode and fail-closed probing
+
+Choose exactly one native mode in `metadata.native_boundary.mode`:
+
+- `script_only`: remove the native artifacts and prove that no native payload
+  belonging to this Adapter is included in exported builds.
+- `optional`: an absent native provider leaves the Adapter unregistered and
+  publishes no provider capability.
+- `required`: an absent, mismatched, or unverifiable provider fails
+  initialization with a stable, redacted reason. It must not silently select a
+  script fallback or a different native binary.
+
+Packaging and CI verify descriptor and library bytes before execution. A
+runtime probe is side-effect free: first match the declared
+`platform + architecture + build_configuration` target, then query the expected
+resource or registered class. Do not instantiate or initialize a native type
+only to detect it. `ClassDB.class_exists()` is an availability fact after engine
+loading, not proof of provenance, integrity, compatibility, or permission.
+Required evidence that is missing, stale, ambiguous, or only partially readable
+must fail closed.
+
+## Native artifact matrix
+
+Record the `.gdextension` descriptor and every selectable native library in
+`compatibility_profile.json`. Each native library entry declares one exact
+target tuple, immutable source version, license identifier, byte size, SHA-256,
+and `editor` or `runtime` export scope. Reject duplicate tuples, undeclared
+filename fallbacks, placeholder hashes, missing files, hash mismatches, and a
+descriptor whose library mapping disagrees with the profile.
+
+Record the exact Godot compatibility floor and reloadability policy. A
+non-reloadable extension requires an editor or process restart; an Adapter must
+not claim hot-reload support merely because a script can be reloaded.
+
+## Threading and callback pump
+
+Declare the SDK call thread and callback thread. Native worker callbacks may
+copy bounded plain data into a project-owned ingress queue, but must not touch
+`Object`, `Node`, `Resource`, a GF request handle, or emit a signal off the main
+thread. Drain that ingress through a bounded main-thread callback pump. A
+project may use `GFMainThreadDispatchQueue` when its owning package is declared,
+or provide an equivalent project-owned pump.
+
+Associate the provider call ID with the GF handle before an SDK call that may
+complete synchronously. Apply backpressure to both the provider and callback
+queues, validate copied payloads again on the main thread, and ignore late or
+duplicate callbacks after the request has reached a terminal state.
+
+## Shutdown and cancellation
+
+Shutdown is idempotent and ordered:
+
+1. Stop accepting new requests and native callbacks.
+2. Give each pending GF handle exactly one local cancellation terminal state.
+3. Request provider cancellation at most once, then detach provider callbacks.
+4. Drop or drain Adapter-owned callback records without invoking released
+   owners.
+5. Join Adapter-owned workers with a documented bounded timeout.
+6. Release the provider only after callbacks can no longer arrive.
+
+A join timeout or callback source that cannot be quiesced is a shutdown failure,
+not a successful unload. Cancellation never waits indefinitely for a provider
+acknowledgement, and a late acknowledgement cannot create a second terminal
+result.
+
+## Permissions and sensitive data
+
+List native permissions and external resources explicitly. Permission denial,
+unavailable elevation, or a forbidden interactive prompt produces a stable
+typed failure; headless, export, and background paths must never open an
+implicit permission dialog. Do not bypass operating-system policy or expand
+access after initialization.
+
+Keep credentials, account tokens, payment data, device or network identifiers,
+and raw provider errors out of compatibility metadata, activation intents, and
+logs. Declare request fields that require redaction as `sensitive_fields`, copy
+only the minimum result data needed by the contract, and test diagnostics with
+representative secret-shaped values.
+
+## Reproducible supply chain
+
+Pin native source and transitive dependencies to immutable versions, record
+checksums and licenses, and keep credentials outside build inputs. Acceptance
+must be repeatable offline from reviewed, locked inputs; mutable branches,
+implicit package-manager resolution, build-time downloads, and locally
+discovered binaries are rejection conditions. Record the resulting artifact
+hashes and sizes in the compatibility profile instead of trusting filenames.
+
+## Editor and export boundary
+
+Declare every artifact as editor-only or runtime. Editor tooling and debug-only
+libraries must not leak into a release export; required runtime descriptors and
+libraries must be selected by each export preset. Run the load, request,
+cancellation, and shutdown matrix against the exported artifact on every
+declared target tuple. An Adapter that works only inside the editor has not
+passed runtime acceptance.
+
 ## Failure matrix
 
 Test every row independently from the real project UI and gameplay:
 
 | Condition | Required outcome |
 | --- | --- |
-| SDK/plugin absent | Initialization fails with a stable, redacted reason. |
+| Required SDK/plugin absent | Initialization fails with a stable, redacted reason and publishes no capability. |
+| Optional SDK/plugin absent | Adapter remains unregistered and publishes no partial capability. |
+| Probe has side effects | Rejected; detection must not instantiate or initialize the provider. |
+| Target tuple undeclared or ambiguous | Rejected before a native class or library is selected. |
+| Descriptor/library missing, stale, or hash-mismatched | Rejected by packaging or preflight; no filename fallback. |
+| Unsupported Godot floor or reload policy | Rejected with an explicit restart or compatibility action. |
 | SDK initialized twice | One initialization completion; no duplicate callbacks. |
 | Unknown contract or method | Rejected before an SDK call. |
 | Invalid request/result schema | Typed failure; no malformed value escapes. |
@@ -40,7 +145,14 @@ Test every row independently from the real project UI and gameplay:
 | User cancellation | Local terminal result first; provider cancellation requested once. |
 | Timeout | Local `timed_out` result; late provider callback ignored. |
 | Duplicate provider callback | First terminal result wins. |
-| Shutdown with pending calls | Every handle reaches one cancellation terminal state. |
+| Worker-thread callback | Bounded plain data is pumped to the main thread before GF or Godot objects are touched. |
+| Callback after shutdown begins | Callback is detached or dropped; no released owner is invoked. |
+| Shutdown with pending calls | Every handle reaches one cancellation terminal state and owned workers join within budget. |
+| Permission denied or prompt unavailable | Stable typed failure; no implicit elevation or headless prompt. |
+| Secret-shaped request or provider error | Public result, diagnostics, and logs remain redacted. |
+| Mutable or network-only build input | Acceptance fails until an immutable offline-reproducible input is supplied. |
+| Editor-only artifact in runtime export | Export acceptance fails. |
+| Required runtime artifact missing from export | Export acceptance fails before provider initialization. |
 | Duplicate activation event | One queued intent per Adapter; duplicate is observable as dropped. |
 | Borrowed MultiplayerPeer release | External peer remains open. |
 | Owned MultiplayerPeer release | Backend closes the peer exactly once. |

--- a/addons/gf/tools/ai_developer/templates/adapters/platform/adapter_contract_test.gd.txt
+++ b/addons/gf/tools/ai_developer/templates/adapters/platform/adapter_contract_test.gd.txt
@@ -29,6 +29,16 @@ func test_adapter_failure_matrix() -> void:
 	fail_test("Replace this sentinel with the complete adapter failure matrix.")
 
 
+func test_native_adapter_acceptance_matrix() -> void:
+	# For script_only mode, prove that exported builds contain no native payload.
+	# Otherwise verify the side-effect-free probe, exact platform/architecture/build
+	# tuples, descriptor and library hashes, immutable offline build inputs, Godot
+	# floor, reload policy, permission denial, worker-to-main callback pump, bounded
+	# queue pressure, cancellation, shutdown order, late callbacks, worker joins,
+	# redaction, and the installed/exported runtime artifact.
+	fail_test("Replace this sentinel with the native Adapter acceptance matrix.")
+
+
 func _make_adapter_with_fake_provider() -> ProjectPlatformAdapter:
 	var adapter: ProjectPlatformAdapter = ProjectPlatformAdapter.new()
 	var capabilities: GFPlatformCapabilitySet = GFPlatformCapabilitySet.new().configure(

--- a/addons/gf/tools/ai_developer/templates/adapters/platform/compatibility_profile.json
+++ b/addons/gf/tools/ai_developer/templates/adapters/platform/compatibility_profile.json
@@ -8,9 +8,92 @@
     {"id": "gf.standard.platform", "version": ""},
     {"id": "gf.extension.network", "version": ""}
   ],
-  "artifacts": [],
+  "artifacts": [
+    {
+      "id": "project.sample_adapter.descriptor",
+      "path": "res://adapters/platform/sample/project_sample.gdextension",
+      "kind": "gdextension_descriptor",
+      "sha256": "replace-with-64-lowercase-sha256",
+      "size_bytes": 0,
+      "metadata": {
+        "export_scope": "runtime",
+        "minimum_godot_version": "4.5.0",
+        "reloadable": false
+      }
+    },
+    {
+      "id": "project.sample_adapter.windows_x86_64_debug",
+      "path": "res://adapters/platform/sample/bin/project_sample.windows.debug.x86_64.dll",
+      "kind": "native_library",
+      "sha256": "replace-with-64-lowercase-sha256",
+      "size_bytes": 0,
+      "metadata": {
+        "platform": "windows",
+        "architecture": "x86_64",
+        "build_configuration": "debug",
+        "export_scope": "runtime",
+        "source_id": "project.sample_native",
+        "source_version": "replace-with-exact-immutable-version",
+        "license_id": "replace-with-license-identifier"
+      }
+    },
+    {
+      "id": "project.sample_adapter.windows_x86_64_release",
+      "path": "res://adapters/platform/sample/bin/project_sample.windows.release.x86_64.dll",
+      "kind": "native_library",
+      "sha256": "replace-with-64-lowercase-sha256",
+      "size_bytes": 0,
+      "metadata": {
+        "platform": "windows",
+        "architecture": "x86_64",
+        "build_configuration": "release",
+        "export_scope": "runtime",
+        "source_id": "project.sample_native",
+        "source_version": "replace-with-exact-immutable-version",
+        "license_id": "replace-with-license-identifier"
+      }
+    }
+  ],
   "metadata": {
     "adapter_id": "project.sample_adapter",
-    "contract_versions": {"project.platform.sample": "1.0.0"}
+    "contract_versions": {"project.platform.sample": "1.0.0"},
+    "native_boundary": {
+      "mode": "required",
+      "descriptor_path": "res://adapters/platform/sample/project_sample.gdextension",
+      "availability_probe": {
+        "kind": "class_db",
+        "class_name": "ProjectSampleNative",
+        "side_effect_free": true
+      },
+      "call_thread": "replace-with-main-or-worker",
+      "callback_thread": "replace-with-main-or-worker",
+      "callback_pump": "replace-with-project-owned-main-thread-pump",
+      "shutdown_timeout_msec": 1000,
+      "permissions": [],
+      "editor_only": false,
+      "export_targets": [
+        {
+          "platform": "windows",
+          "architecture": "x86_64",
+          "build_configuration": "debug"
+        },
+        {
+          "platform": "windows",
+          "architecture": "x86_64",
+          "build_configuration": "release"
+        }
+      ],
+      "dependency_lock_path": "res://adapters/platform/sample/native-dependencies.lock.json",
+      "offline_rebuild_verified": false
+    },
+    "native_dependencies": [
+      {
+        "id": "project.sample_native",
+        "version": "replace-with-exact-immutable-version",
+        "source": "replace-with-immutable-source-identity",
+        "sha256": "replace-with-64-lowercase-sha256",
+        "license_id": "replace-with-license-identifier"
+      }
+    ]
   }
 }

--- a/addons/gf/tools/ai_developer/templates/adapters/platform/lobby_backend.gd.txt
+++ b/addons/gf/tools/ai_developer/templates/adapters/platform/lobby_backend.gd.txt
@@ -47,6 +47,8 @@ func on_provider_lobby_succeeded(
 	provider_call_id: String,
 	lobby: GFNetworkLobbyDescriptor
 ) -> void:
+	# Native worker callbacks must copy bounded plain data into a project-owned
+	# main-thread pump before invoking any on_provider_* entry point.
 	var handle: GFNetworkLobbyOperationHandle = _take_handle(provider_call_id)
 	if handle != null:
 		var _completed: bool = _succeed_operation(handle, {"lobby": lobby})
@@ -90,6 +92,8 @@ func on_provider_cancelled(provider_call_id: String) -> void:
 
 
 func _close() -> void:
+	# Before clearing state: stop callback ingress, request cancellation once,
+	# detach callbacks, and join Backend-owned workers within a bounded timeout.
 	_calls.clear()
 	_provider = null
 

--- a/addons/gf/tools/ai_developer/templates/adapters/platform/platform_adapter.gd.txt
+++ b/addons/gf/tools/ai_developer/templates/adapters/platform/platform_adapter.gd.txt
@@ -44,12 +44,16 @@ func _dispatch(
 
 
 func on_provider_succeeded(provider_call_id: String, value: Dictionary) -> void:
+	# Native worker callbacks must copy bounded plain data into a project-owned
+	# main-thread pump before invoking this method.
 	var handle: GFPlatformRequestHandle = _take_handle(provider_call_id)
 	if handle != null:
 		var _completed: bool = _succeed_request(handle, value)
 
 
 func on_provider_failed(provider_call_id: String, error_code: StringName) -> void:
+	# Translate provider errors to stable, redacted contract status on the main
+	# thread; do not expose raw native error text or sensitive identifiers.
 	var handle: GFPlatformRequestHandle = _take_handle(provider_call_id)
 	if handle != null:
 		var _completed: bool = _fail_request(
@@ -66,12 +70,16 @@ func _cancel_request(handle: GFPlatformRequestHandle, _reason: StringName) -> vo
 
 
 func on_provider_cancelled(provider_call_id: String) -> void:
+	# Provider cancellation acknowledgement follows the same main-thread pump
+	# boundary as success and failure callbacks.
 	var handle: GFPlatformRequestHandle = _take_handle(provider_call_id)
 	if handle != null:
 		var _released: bool = _release_request(handle)
 
 
 func _shutdown() -> void:
+	# Before clearing state: stop callback ingress, request cancellation once,
+	# detach callbacks, and join Adapter-owned workers within a bounded timeout.
 	_provider_calls.clear()
 	_provider = null
 

--- a/docs/api_catalog/classes/GFArchitecture.xml
+++ b/docs/api_catalog/classes/GFArchitecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="bdd882b7f99f10f4ea4874059aa0cc3fdc97fcbc6b89dc1c328c15bef9636b44">
+<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="d9e6a4f9f161bba088597788f2f672d85d91453af891c45c22ca5d86f4dbc6a8">
 	<description>GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。
 生命周期遵循三阶段初始化协议：
 阶段一 (init)       ：所有模块执行自身内部变量初始化。
@@ -380,6 +380,21 @@ query 缺少 execute() 方法时会输出 warning 并返回 null。</description
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
+		<member kind="method" name="subscribe_event">
+			<signature>func subscribe_event( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -&gt; GFSubscriptionToken:</signature>
+			<description>订阅脚本类型事件并返回可取消句柄。
+listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once` 订阅会在
+首个回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">event_type: 要订阅的脚本类型。</tag>
+				<tag name="param">listener: 事件监听器契约。</tag>
+				<tag name="param">priority: 回调优先级，数值越大越先执行，默认为 0。</tag>
+				<tag name="param">once: 是否在首个回调开始前自动取消订阅。</tag>
+				<tag name="return">可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="register_assignable_event">
 			<signature>func register_assignable_event(base_event_type: Script, listener: GFEventListener, priority: int = 0) -&gt; void:</signature>
 			<description>为脚本类型注册可赋值事件监听器。
@@ -402,6 +417,21 @@ query 缺少 execute() 方法时会输出 warning 并返回 null。</description
 				<tag name="param">listener: 事件监听器契约。</tag>
 				<tag name="param">priority: 回调优先级，数值越大越先执行，默认为 0。</tag>
 				<tag name="since">8.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="subscribe_assignable_event">
+			<signature>func subscribe_assignable_event( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -&gt; GFSubscriptionToken:</signature>
+			<description>订阅可赋值类型事件并返回可取消句柄。
+listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。监听基类脚本时，
+订阅也会收到其派生脚本实例；`once` 在首个匹配回调开始前生效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">base_event_type: 要订阅的基类脚本类型。</tag>
+				<tag name="param">listener: 事件监听器契约。</tag>
+				<tag name="param">priority: 回调优先级，数值越大越先执行，默认为 0。</tag>
+				<tag name="param">once: 是否在首个匹配回调开始前自动取消订阅。</tag>
+				<tag name="return">可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_event">
@@ -466,6 +496,20 @@ query 缺少 execute() 方法时会输出 warning 并返回 null。</description
 				<tag name="param">event_id: StringName 事件标识符。</tag>
 				<tag name="param">listener: 简单事件监听器契约。</tag>
 				<tag name="since">8.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="subscribe_simple_event">
+			<signature>func subscribe_simple_event( event_id: StringName, listener: GFEventListener, once: bool = false ) -&gt; GFSubscriptionToken:</signature>
+			<description>订阅轻量级 StringName 事件并返回可取消句柄。
+listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once` 订阅会在
+首个回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">event_id: StringName 事件标识符。</tag>
+				<tag name="param">listener: 简单事件监听器契约。</tag>
+				<tag name="param">once: 是否在首个回调开始前自动取消订阅。</tag>
+				<tag name="return">可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_simple_event">

--- a/docs/api_catalog/classes/GFGridOccupancy.xml
+++ b/docs/api_catalog/classes/GFGridOccupancy.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFGridOccupancy" path="addons/gf/standard/foundation/math/gf_grid_occupancy.gd" module="standard" extends="RefCounted" classDigest="3cc9e7beadd77b6773ba1023ee640250f989e391eba62e6b9cdb829fd4e4a626">
+<class name="GFGridOccupancy" path="addons/gf/standard/foundation/math/gf_grid_occupancy.gd" module="standard" extends="RefCounted" classDigest="feba97fe54b6fe04063104c48b3f9aa19a9cc5cf344e3e25bf11cd1cd90f4910">
 	<description>GFGridOccupancy: 网格占用与预约数据结构。
 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。
-它不负责路径查找、碰撞或胜负规则。</description>
+它不负责路径查找、碰撞或胜负规则。
+占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态，
+但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -54,17 +56,21 @@
 	<constants />
 	<properties>
 		<member kind="property" name="grid_size">
-			<signature>var grid_size: Vector2i = Vector2i.ZERO</signature>
-			<description>网格尺寸。小于等于 0 的维度会让所有格子视为越界。</description>
+			<signature>var grid_size: Vector2i:</signature>
+			<description>网格尺寸，默认为 [constant Vector2i.ZERO]。小于等于 0 的维度会让所有格子视为越界。
+直接赋值会像 configure() 一样清空现有占用与预约；通知期间的赋值会失败关闭。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="max_occupants_per_cell">
-			<signature>var max_occupants_per_cell: int = 1</signature>
-			<description>单格允许的最大占用数量。</description>
+			<signature>var max_occupants_per_cell: int:</signature>
+			<description>单格允许的最大占用数量，默认为 1，最小为 1。
+直接赋值会像 configure() 一样清空现有占用与预约；通知期间的赋值会失败关闭。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
 	</properties>

--- a/docs/api_catalog/classes/GFTypeEventSystem.xml
+++ b/docs/api_catalog/classes/GFTypeEventSystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTypeEventSystem" path="addons/gf/kernel/core/gf_type_event_system.gd" module="kernel" extends="Object" classDigest="2e6678a20ca661133fb422de8edba0a0d3b79ad0f7bd2aca13bfe5a4f813fbb3">
+<class name="GFTypeEventSystem" path="addons/gf/kernel/core/gf_type_event_system.gd" module="kernel" extends="Object" classDigest="a836475360b2334f14fc0fd604daad64bcae2aa5bc4402159c721c0e683ebcda">
 	<description>GFTypeEventSystem: 基于类型和 StringName 的双轨事件系统。
 轨道一（类型事件）：使用 Script 类型作为键，以对象实例为载体分发事件。
 轨道二（简单事件）：使用 StringName 作为键，以 Variant 为 payload 分发事件。</description>
@@ -67,6 +67,21 @@
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
+		<member kind="method" name="subscribe">
+			<signature>func subscribe( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -&gt; GFSubscriptionToken:</signature>
+			<description>订阅特定脚本类型事件并返回可取消句柄。
+每次调用都会创建独立的稳定订阅身份；即使回调和 owner 相同，取消一个句柄也不会影响其它订阅。
+`once` 为 true 时，订阅会在首个回调开始前失效，因此嵌套派发不会再次调用它。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">event_type: 要订阅的脚本类型。</tag>
+				<tag name="param">listener: 事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。</tag>
+				<tag name="param">priority: 回调优先级，数值越大越先执行，默认为 0。</tag>
+				<tag name="param">once: 是否在首个回调开始前自动取消订阅。</tag>
+				<tag name="return">可幂等取消的订阅句柄；参数无效时返回非活动句柄。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="unregister">
 			<signature>func unregister(event_type: Script, listener: GFEventListener) -&gt; void:</signature>
 			<description>注销特定脚本类型的事件监听器。</description>
@@ -110,6 +125,21 @@
 				<tag name="param">listener: 事件监听器契约。</tag>
 				<tag name="param">priority: 回调优先级，数值越大越先执行，默认为 0。</tag>
 				<tag name="since">8.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="subscribe_assignable">
+			<signature>func subscribe_assignable( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -&gt; GFSubscriptionToken:</signature>
+			<description>订阅可赋值类型事件并返回可取消句柄。
+监听基类脚本时也会收到其派生脚本实例。每次调用都创建独立订阅身份，
+`once` 会在首个匹配事件的用户回调开始前使句柄失效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">base_event_type: 要订阅的基类脚本类型。</tag>
+				<tag name="param">listener: 事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。</tag>
+				<tag name="param">priority: 回调优先级，数值越大越先执行，默认为 0。</tag>
+				<tag name="param">once: 是否在首个匹配回调开始前自动取消订阅。</tag>
+				<tag name="return">可幂等取消的订阅句柄；参数无效时返回非活动句柄。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_assignable">
@@ -160,6 +190,20 @@
 				<tag name="param">event_id: StringName 事件标识符。</tag>
 				<tag name="param">listener: 简单事件监听器契约。</tag>
 				<tag name="since">8.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="subscribe_simple">
+			<signature>func subscribe_simple( event_id: StringName, listener: GFEventListener, once: bool = false ) -&gt; GFSubscriptionToken:</signature>
+			<description>订阅轻量级 StringName 事件并返回可取消句柄。
+每次调用都会创建独立的稳定订阅身份；`once` 为 true 时，订阅会在首个
+用户回调开始前失效，因此同一回调中的嵌套派发不会再次调用它。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">event_id: StringName 事件标识符。</tag>
+				<tag name="param">listener: 简单事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。</tag>
+				<tag name="param">once: 是否在首个回调开始前自动取消订阅。</tag>
+				<tag name="return">可幂等取消的订阅句柄；参数无效时返回非活动句柄。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_simple">
@@ -213,13 +257,14 @@
 		<member kind="method" name="get_listener_diagnostics">
 			<signature>func get_listener_diagnostics(options: Dictionary = {}) -&gt; Dictionary:</signature>
 			<description>获取事件监听器诊断明细。
-默认只返回每条轨道的数量统计；传入 `{ "include_entries": true }` 时会附带每个监听器的事件 key、owner 状态、优先级和 Callable 状态。</description>
+默认只返回每条轨道的数量统计；传入 `{ "include_entries": true }` 时会附带每个监听器的
+事件 key、owner 状态、优先级、Callable 状态，以及订阅记录的稳定身份和 once 标记。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">options: 诊断选项。</tag>
 				<tag name="return">监听器诊断报告。</tag>
 				<tag name="schema">options: Dictionary，可包含 include_entries。</tag>
-				<tag name="schema">return: Dictionary containing listener counts, stale owner counts, track summaries, and optional entry rows.</tag>
+				<tag name="schema">return: Dictionary containing listener counts, stale owner counts, track summaries, and optional entry rows with subscription_id and once.</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="6c607d1065ccb57dbc1536778f9865fa9d93e52b75b42720539a933831438bb2" classCount="779" methodCount="6991">
-	<module id="kernel" label="Kernel" classCount="71" methodCount="720">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="1361253ef33667c4fc00b9e0bd89b7c78e56b24a885c281b310a8f4069a52815" classCount="779" methodCount="6997">
+	<module id="kernel" label="Kernel" classCount="71" methodCount="726">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
 		<class name="GFAsyncCompletion" path="classes/GFAsyncCompletion.xml" sourcePath="addons/gf/kernel/core/gf_async_completion.gd" extends="RefCounted" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -27,9 +27,10 @@
 ### 🚀 新增特性 (Added)
 
 - 新增 `GFWeakMethodInvocation` 框架级弱方法调用原语，以及 `GFMainThreadDispatchQueue.post_method()` 和 `GFDeferredMutationQueue.record_method()`：长期记录只保存 owner 的弱引用、初始实例 ID 和方法名，调用参数只在执行时传入；队列安全入口不持久化任意参数或 metadata，并把 owner 释放、方法缺失、预检失败与真实业务返回值明确分离。
+- `GFTypeEventSystem` 新增 exact、assignable 与 simple 三类 token 订阅：每次订阅拥有独立稳定身份，可通过 `GFSubscriptionToken` 幂等取消；一次性订阅会在用户回调前退休，owner 清理、显式注销和事件系统清空也会同步使 token 失效。`GFArchitecture` 与 `Gf` 提供对应入口，而 `GFController` 的长期 desired binding 继续采用生命周期重建语义，不会让一次性订阅在架构切换后复活。
 - 新增平台 Contract Descriptor、Activation Intent 有界去重队列与 `GFPlatformAdapterConformance`，让外部 SDK Adapter 可以声明请求/结果 Schema、字节预算、能力、并发、取消和敏感字段，并在不调用 SDK 时完成静态覆盖审查。
 - Network Lobby 升级为带唯一请求关联、单终态、取消、单调超时和迟到 callback 防护的类型化操作模型；新增可显式接管 owned/borrowed `MultiplayerPeer` 的通用 Backend，以及区分未知值的传输指标快照与有界采样历史。
-- AI Developer Kit 新增 Platform Adapter、Lobby Backend、契约测试、兼容性 Profile 和故障矩阵模板，并更新 Network / Platform capability 与 Recipe，使 AI 默认生成 Provider 中立且可验证的 Adapter 边界。
+- AI Developer Kit 新增 Platform Adapter、Lobby Backend、契约测试、兼容性 Profile 和故障矩阵模板，并补齐原生模式、无副作用探针、descriptor/二进制目标矩阵、完整性与来源证据、线程和主线程回调泵、关闭/取消、权限脱敏、离线可复现依赖及真实导出包验收，使 AI 默认生成 Provider 中立且可验证的 Adapter 边界。
 - `GFThumbnailRenderer` 与 `GFThumbnailRenderRequest` 支持 `CanvasItem` 的 `Image` / `ImageTexture` 缩略图请求，统一覆盖 `Node2D` 和 `Control`。调用方可以显式提供内容 `Rect2`，也可以让渲染器保守估算 Sprite、Control、Polygon、Line、AnimatedSprite 和 2D 粒子范围。
 - 新增可选包 `gf.standard.spatial.canvas` 与运行时 `Control` `GFSpatialCanvas2D`：提供世界/画布变换、焦点缩放、有界平移、稳定网格吸附、带精确命中 Hook 的候选查询、隔离选择结果和项目校验的放置会话；条目、选择、查询候选与网格绘制均受可降低但不可突破的绝对预算约束，GF 不拥有项目节点、占位规则或最终业务命令。
 - 新增 `GFAssetCollection`，用稳定 `collection_id` 和有序 `asset_ids` 描述可序列化资源集合，并通过 `GFValidationReport` 报告空 ID、重复 ID 和目录缺失项。
@@ -52,7 +53,8 @@
 
 ### 🔄 机制更改 (Changed)
 
-- AI Developer Capability / Recipe 知识目录同步升级到 `1.5.0`，补齐可伸缩 UI 集合、渲染反馈编排、命令历史、有界运行时工作与网格路径发现边界；能力搜索统一标点、连字符和下划线，目录完整性检查新增包、类、Recipe 与类所属包依赖闭包的交叉复核。
+- AI Developer Capability / Recipe 知识目录同步升级到 `1.6.0`，补齐可伸缩 UI 集合、渲染反馈编排、命令历史、有界运行时工作、网格路径发现与通用外部产物导出边界；新导出配方只组合缩略图、截图、矩形打包、产物报告和内容包计划，最终格式、认证、幂等、重试与写出仍归项目 Adapter。能力搜索统一标点、连字符和下划线，目录完整性检查新增包、类、Recipe 与类所属包依赖闭包的交叉复核。
+- TurnBased 使用指南明确 `GFTurnAction` 只调度一次性行动请求、项目自有 `GFUndoableCommand` 唯一修改或恢复权威状态、`GFActionQueueSystem` 只编排提交后的视觉与音频表现；三者由项目 Coordinator/Installer 按需组合，不新增跨扩展耦合类型，也不把反向 Tween 当作撤销事实源。
 - Architecture assignment、Installer、动态模块注册/替换和 `GFNodeContext` 安装统一采用 generation/scope 驱动的 prepare / commit / rollback 事务；候选未提交前不会通过全局 facade 暴露，旧异步 continuation 和生命周期回调重入不能覆盖最新状态。
 - `GFBindableProperty` 的集合 helper 现在发出独立的修改前/后快照，`mutate()` 统一采用“回调返回完整 replacement”的标量/集合契约；失效且未曾入树的 Node binding 会在下一次发射时剪枝。
 - `GFCancellationSource` 收敛为主线程、一次性终结的取消拥有者：token、节点和 timeout 注册会冻结 metadata，重复注册与 self-link 明确失败，timeout replacement 会停止旧 timer，组合创建不再返回部分绑定结果。
@@ -93,6 +95,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFGridOccupancy` 在移动占用、移动预约、确认预约或批量释放的同步信号回调中发生重入写入时，外层后续提交可能突破格子容量、丢失预约或留下不一致反向索引的问题；所有内部映射现在先按单次事务完整提交，再发出通知，通知期的方法与配置属性写入均明确失败关闭。`grid_size` / `max_occupants_per_cell` 的实际变更会清空既有记录并保持容量至少为 1；查询改为只读过滤失效对象，清理索引和释放通知由显式 `prune_invalid_receivers()` 或下一次写事务负责。
 - 修复 `GFCommandHistoryUtility` 在命令已进入终态但业务撤销/重做失败时仍推进历史游标的问题；`GFUndoableCommand` 新增默认成功的 `is_undo_successful()` / `is_redo_successful()` hook，同步与异步入口只在 hook 成功后复核来源栈顶身份并原子移动栈。异步 Signal 的零、单、二至 16 参数终态分别规范化为 `null`、单值和 `Array`，处理锁贯穿命令回调、等待、hook 与提交；等待和 hook 内的只读查询仍观察最近一次完整提交，失败不触碰任一栈的身份、顺序或容量，生命周期切代后的旧 continuation 也不会回填新历史。
 - 修复 Interaction Sensor 对类型化 Receiver 派发时绕过项目 `receive_interaction()` 覆写，以及自定义 sender 的 2D/3D 碰撞广播在规范化报告前发出公开信号的问题；公开覆写继续参与派发，返回值和信号报告统一保持 JSON-safe。
 - 修复 Audio backend 接管 `Master`、`BGM` 等本地同名总线时，duck、生命周期恢复和 mix snapshot 的逐总线 fallback 仍会静默写入 `AudioServer` 的问题；总线所有权和 backend identity 现在贯穿捕获、应用与恢复，只有 backend 明确拒绝的字段才进入本地回退。
@@ -136,6 +139,7 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
+- `GFTypeEventSystem` 新增 `subscribe()`、`subscribe_assignable()` 与 `subscribe_simple()`；`GFArchitecture` 新增 `subscribe_event()`、`subscribe_assignable_event()` 与 `subscribe_simple_event()`；`Gf` 新增同名三类快捷订阅入口。上述入口均返回 `GFSubscriptionToken`，接受 `once`，带 owner 的 `GFEventListener` 实际返回 `GFLifetimeSubscription`。`GFSubscriptionToken` 与 `GFLifetimeSubscription` 新增仅供订阅源使用的自动失效内部入口。
 - `GFUndoableCommand` 新增 `is_undo_successful(_undo_result)` 与 `is_redo_successful(_execute_result)`，均标记为 `@since unreleased` 且默认返回 `true`。同步历史入口传入命令的直接返回值；异步历史入口把完成 Signal 的零、单、二至 16 参数 payload 分别规范化为 `null`、单值和 `Array` 后传入，超过 16 个参数时告警并只保留前 16 个。
 - `Gf.set_architecture()` 改为原子提交候选架构：Installer 和三阶段初始化成功前，`Gf` facade 只暴露既有已提交架构或空状态；pending assignment 被更新赋值、尚无已提交架构时由 `Gf.create_architecture()` 创建的默认架构，或 Gf 退出场景树替代时，会取消其异步作用域并 dispose 未提交候选。函数签名不变，但依赖 Installer 期间 facade 指向候选、或依赖被替代候选仍可复用的代码需要迁移。
 - `GFBindableProperty.mutate()` 的 callback 必须返回完整 replacement；void/in-place-only mutator 不再是有效写法。集合 helper 的 `value_changed` 参数改为独立 before/after 快照。
@@ -174,6 +178,7 @@
 
 ### 📘 升级指南 (Migration Guide)
 
+- `GFGridOccupancy` 的查询不再隐式回收已释放 `Object` 或发出释放信号；依赖该副作用的调用方应在明确的维护边界调用 `prune_invalid_receivers()`，或让下一次占用/预约写事务负责清理。运行期修改 `grid_size` 或 `max_occupants_per_cell` 现在会像重新配置一样清空既有记录；需要保留棋盘状态时，应先导出项目自己的稳定状态，再按新配置显式重建。
 - 既有 `GFUndoableCommand` 若不重入历史写操作则无需迁移：两个历史结果 hook 默认成功，`null` 返回值和无参数完成 Signal 保持原行为。只有撤销或重做可能进入“已完成但业务失败”终态的命令才需要覆盖对应 hook；异步 hook 应按 `null`、单值或最多 16 项的多值 `Array` 读取规范化完成 payload，并返回明确的 `bool`，更多字段应封装成单个 Result 或 `Dictionary`。`execute()`、`undo()`、`should_record()` 和结果 hook 现在统一处于非重入历史操作内；原先从这些回调嵌套执行、记录、清空、修改容量或恢复历史的项目代码，应改为在外层历史 API 完成后由项目队列提交后续操作。
 - 项目 Installer 必须改为通过 `install(architecture, scope)` 的显式 `architecture` 参数或 `install_bindings(binder, scope)` 的 `binder` 注册候选模块，不要在 `Gf.set_architecture()` 提交前使用 `Gf.register_*()`、`Gf.create_binder()` 或 `Gf.get_*()` 指向候选。异步 Installer 在每个 `await` 后检查 `scope.is_cancel_requested()` 并用 `scope.register_cleanup()` 释放临时资源；assignment 被替代并返回 `false` 后应创建新的 `GFArchitecture` 重试，不复用已经 dispose 的候选。释放回调和项目自定义等待器应通过 `is_disposing()` / `is_disposed()` 拒绝向终结中的架构提交新工作。
 - `GFNodeContext` 的父级 Architecture identity 与首次 READY generation 现在按每轮入树固定。不要在 child 场景分支仍活动时调用其 owned Architecture 的 `set_parent_architecture()`，也不要让父级失败后原地重试或热替换全局父级；需要绑定新父级或新 generation 时，应让对应 child 分支退出并重新进入，或重建该场景分支。

--- a/docs/zh/editor/tools/ai-developer.md
+++ b/docs/zh/editor/tools/ai-developer.md
@@ -156,6 +156,8 @@ Steam、微信小游戏、Epic、主机平台、云服务、支付和广告 SDK 
 
 Kit 的 `templates/adapters/platform/` 提供 Platform contract、Lobby Backend、契约测试、兼容性 Profile 和故障矩阵起点。Agent 应先用 `GFPlatformContractDescriptor` 声明 Schema 与预算，用 `GFPlatformAdapterConformance` 做无 SDK 静态审查，再实现 Provider callback 映射；Provider 返回 Godot Peer 时采用 `GFMultiplayerPeerNetworkBackend` 并显式选择 owned/borrowed，不能生成平台命名的 GF Core Manager。
 
+原生或 GDExtension-backed Adapter 还必须通过独立的原生边界验收：Profile 固定 descriptor、二进制哈希与 `platform + architecture + build_configuration` 矩阵；运行时只做无副作用可用性探测，必需能力缺失、目标歧义或证据不完整时 fail closed。后台回调只能先复制有界纯数据，再经主线程 callback pump 接触 Godot/GF 对象；关闭流程依次停止入口、取消句柄、解绑回调、有界等待自有线程并释放 Provider。依赖来源必须锁定且可离线复现，权限拒绝与敏感字段必须稳定失败并脱敏，编辑器专属产物不能进入运行时导出，所有声明目标都要在实际导出包中复跑加载、取消与关闭验收。
+
 ## 反馈状态机
 
 项目开发暴露的问题按以下状态推进：

--- a/docs/zh/extensions/content-package/index.md
+++ b/docs/zh/extensions/content-package/index.md
@@ -126,6 +126,31 @@ var report := plan.get_validation_report()
 
 从 catalog 构建多包计划时，每个包的 archive path 会自动加上稳定 package ID 作用域，依赖条目也保留实际 owner package ID。这样两个包可以拥有相同相对路径而不会在归档中碰撞；单 manifest 计划仍按调用方传入的 `archive_root` 组织。
 
+### 项目侧外部产物导出配方
+
+项目需要生成预览图、截图、图集和映射文件，再交给外部目标时，可以在项目编辑器工具或独立插件中组合现有机制。这个配方不增加业务生成器，也不让 Content Package 承担写出或上传。
+
+| 组件 | 负责 | 不负责 |
+| --- | --- | --- |
+| `GFThumbnailRenderer` | 把 `CanvasItem`、`Node3D` 或 `Mesh` 渲染为短生命周期 `Image`，并为批量预览提供可取消任务 | 保存文件、拼图、目标平台命名或上传 |
+| `GFScreenshotUtility` | 捕获 Viewport，或把已有 `Image` 保存为 PNG、JPEG、WebP，并返回保存记录 | 解释素材业务类型或决定发布策略 |
+| `GFRectPacking2D` | 在显式数量和容器预算内计算图集放置矩形 | 复制像素、创建纹理资源或写入文件 |
+| `GFGeneratedArtifactReport` | 记录产物路径、状态、所有权和 dry-run 结果，并汇总批次 | 替代二进制写入器、内容校验或远端回执 |
+| `GFContentPackageExportPlan` | 收集源路径与归档路径，并生成计划、完整性和兼容性预检报告 | 创建归档、签名、联网、写入目标或启用内容 |
+
+推荐流程如下：
+
+1. 项目工具先冻结一份导出请求：稳定 artifact ID、稳定输入顺序、最大图片数量、分辨率、图集尺寸、暂存根目录和取消 owner 都必须显式给出。
+2. 资源预览通过 `GFThumbnailRenderer` 生成，Viewport 画面通过 `GFScreenshotUtility` 捕获；两类结果都先收束为 `Image`。空图像、已取消任务或超出预算应直接阻断本批次。
+3. 项目按稳定 ID 排序尺寸，再调用 `GFRectPacking2D.pack_fixed()` 或 `pack_square()`。只要存在未放置项，就报告失败；像素复制、边距填充和 atlas `Image` 创建仍由项目 materializer 实现。
+4. 二进制图像用 `GFScreenshotUtility.save_image()` 写入受控的 `res://` 或 `user://` 暂存根；映射 JSON 等文本用 `GFGeneratedArtifactReport.save_text()` 写入，并设置 `allowed_roots`。二进制保存记录可通过 `make_report()` 归一化，再用 `summarize_reports()` 汇总，避免未报告的部分产物进入后续步骤。
+5. 从 manifest 或 catalog 建立 `GFContentPackageExportPlan`，再用 `add_entry()` 把已生成的 atlas 和映射文件加入计划。只有计划校验、artifact 完整性报告和项目要求的 preflight 全部通过，才把不可变暂存集合交给下一层。
+6. 项目自有目标 Adapter 负责目标格式、认证、限流、幂等键、重试、上传或文件写出以及失败清理。Adapter 只消费已冻结的计划、报告和暂存产物；凭据、远端对象 ID 和业务发布状态不得写入通用产物报告。
+
+至少覆盖 dry-run、取消、空图像、超量输入、无法放置、重复归档路径、写入失败、完整性不匹配、Adapter 部分失败和幂等重试。编辑器预览节点与渲染任务归属当前工具会话，暂存文件归属项目生成目录，远端回执则由项目持久化边界管理。
+
+相关细节见[编辑器访问器与缩略图](../../kernel/architecture/editor-accessors.md)、[截图捕获与批量保存](../../standard/utilities/runtime/debug-observability/debug-visual-inspection/screenshots.md)、[2D 矩形打包](../../standard/foundation/grid-spatial/rect-packing-2d.md)和[编辑器命令、动作与工具协议](../../editor/tool-protocols.md)。
+
 ## 使用边界
 
 - Content Package 不内置 `quest`、`item`、`biome`、`npc`、`skin` 等业务字段；这些字段应由项目 schema 或独立插件解释。

--- a/docs/zh/extensions/network-turnbased/turn-flow.md
+++ b/docs/zh/extensions/network-turnbased/turn-flow.md
@@ -33,3 +33,22 @@ flow.advance_phase()
 默认排序规则是 `priority` 降序，然后 `sort_value` 降序。需要项目自定义排序时，可向 `resolve_actions(order_resolver)` 传入比较回调。阶段和行动如果返回 Signal，系统会通过 `signal_timeout_seconds` 和当前流程 serial 做安全等待；`stop()` 或超时后不会继续调用旧阶段的 `exit()`，也不会把旧行动标记为 resolved。`resolve_actions()` 在上一批行动仍等待时会拒绝重入，避免同一批行动被重复解析。
 
 参与者对象可能在流程中被释放。`GFTurnContext.cleanup_invalid_actors()` 可显式移除失效参与者并清空失效的 `current_actor`，`GFTurnFlowSystem` 在推进和解析边界也会同步清理当前上下文。项目仍然应在行动效果层处理目标失效、死亡、离场或替换这类业务语义；TurnBased 只负责不让无效 Object 引用继续驱动通用流程。
+
+## 与权威状态和表现队列的组合边界
+
+需要同时支持回合排序、撤销重做和有序表现时，应由项目自己的 Coordinator 或 Installer 组合三种机制。GF 内置扩展不会互相探测，也不会把这套可选组合固化成新的跨扩展类型。
+
+| 机制 | 在组合中的职责 | 不应承担的职责 |
+| --- | --- | --- |
+| `GFTurnAction` | 保存一次性行动请求，参与入队、排序、取消和解析时机调度 | 直接充当权威状态、撤销快照或表现队列 |
+| 项目自有 `GFUndoableCommand` | 校验业务前置条件，在修改前保存纯数据快照，并原子修改或恢复权威 Model | 决定回合排序，或用 Tween、节点状态代替权威数据 |
+| `GFActionQueueSystem` | 在权威命令成功提交后，按顺序、并行组或命名流播放视觉、音频和等待动作 | 提交玩法状态、决定命令是否成功，或充当撤销栈 |
+
+推荐的项目侧顺序是：
+
+1. `GFTurnFlowSystem` 选择并解析一个 `GFTurnAction`；项目行动只把稳定输入交给 Coordinator。
+2. Coordinator 创建新的项目 `GFUndoableCommand`，通过 `GFCommandHistoryUtility` 的同步或异步入口提交权威状态。命令失败时由项目保留失败结果，不把表现完成误当成业务成功。
+3. 命令成功后，Coordinator 从已提交结果构建 `GFVisualAction`，再交给 `GFActionQueueSystem`。表现动作读取结果快照或当前只读状态，不回写权威 Model。
+4. 撤销或重做仍只经过命令历史；界面和场景表现根据恢复后的权威状态重新同步，或由项目追加补偿表现。反向播放 Tween 不能替代状态恢复。
+
+参见[可撤销命令历史](../../standard/input-flow/command-sequence/undo-history.md)和[视觉动作与入队](../action-queue/visual-actions/index.md)。如果项目不需要撤销或演出，只使用对应机制即可，不要为了统一形态创建空命令、空行动或空表现步骤。

--- a/docs/zh/kernel/messaging/events/owner-lifecycle.md
+++ b/docs/zh/kernel/messaging/events/owner-lifecycle.md
@@ -43,6 +43,34 @@ func _exit_tree() -> void:
 
 `Gf.listen()` / `Gf.listen_simple()` 没有 owner 归属，只适合 AutoLoad、全局常驻服务或明确手动管理生命周期的监听；动态节点、临时 Utility、关卡局部模块应使用 owner 绑定写法。
 
+## 可取消与一次性订阅
+
+需要由调用方持有取消权，或只处理首个匹配事件时，使用返回 `GFSubscriptionToken` 的 `Gf.subscribe()`、`Gf.subscribe_assignable()` 和 `Gf.subscribe_simple()`。每次调用都会建立独立订阅身份；即使多个订阅复用同一个 Callable，取消其中一个 token 也不会移除其余订阅。
+
+```gdscript
+var _damage_subscription: GFSubscriptionToken
+
+
+func _ready() -> void:
+	_damage_subscription = Gf.subscribe(
+		DamagePayload,
+		GFEventListener.from_method(self, &"_on_first_damage", 1),
+		100,
+		true
+	)
+
+
+func close_panel() -> void:
+	if _damage_subscription != null:
+		_damage_subscription.cancel()
+```
+
+`once = true` 的订阅会在用户回调开始前从当前轨道退休，因此回调内部再次发送同类事件也不会重入同一个一次性订阅。`cancel()` 是幂等的；一次性派发、owner 清理、显式 unregister 或事件系统 `clear()` 已经结束订阅时，token 会自动变为非活动状态，后续 `cancel()` 返回 `false`。
+
+`GFEventListener.from_method(owner, ...)` 已携带 owner，事件系统会返回绑定该 owner 的 `GFLifetimeSubscription` 实例；Node 离树时会自动取消。无 owner 的订阅必须由调用方保留 token 并明确取消。直接持有 `GFArchitecture` 时，对应入口为 `subscribe_event()`、`subscribe_assignable_event()` 和 `subscribe_simple_event()`。
+
+`GFController` 等需要在架构替换或重新入树后重建长期绑定的模块，继续使用现有 `register_event()` 系列生命周期 API；一次性 token 表达一次具体订阅，不应在协调层失效后被自动“复活”。
+
 ## 清理时序
 
 如果在事件回调中调用 `Gf.unlisten_owner()`，框架会延迟到最外层派发结束后统一合并清理，并会在当前派发中跳过该 owner 后续尚未执行的 exact、assignable 与 simple 监听器。

--- a/docs/zh/reference/api/classes/GFArchitecture.md
+++ b/docs/zh/reference/api/classes/GFArchitecture.md
@@ -57,14 +57,17 @@
 | 方法 | [`send_event`](#member-gfarchitecture-methods-send_event) | `func send_event(event_instance: Object) -> void:` |
 | 方法 | [`register_event`](#member-gfarchitecture-methods-register_event) | `func register_event(event_type: Script, listener: GFEventListener, priority: int = 0) -> void:` |
 | 方法 | [`register_event_owned`](#member-gfarchitecture-methods-register_event_owned) | `func register_event_owned(owner: Object, event_type: Script, listener: GFEventListener, priority: int = 0) -> void:` |
+| 方法 | [`subscribe_event`](#member-gfarchitecture-methods-subscribe_event) | `func subscribe_event( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:` |
 | 方法 | [`register_assignable_event`](#member-gfarchitecture-methods-register_assignable_event) | `func register_assignable_event(base_event_type: Script, listener: GFEventListener, priority: int = 0) -> void:` |
 | 方法 | [`register_assignable_event_owned`](#member-gfarchitecture-methods-register_assignable_event_owned) | `func register_assignable_event_owned( owner: Object, base_event_type: Script, listener: GFEventListener, priority: int = 0 ) -> void:` |
+| 方法 | [`subscribe_assignable_event`](#member-gfarchitecture-methods-subscribe_assignable_event) | `func subscribe_assignable_event( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:` |
 | 方法 | [`unregister_event`](#member-gfarchitecture-methods-unregister_event) | `func unregister_event(event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_event_owned`](#member-gfarchitecture-methods-unregister_event_owned) | `func unregister_event_owned(owner: Object, event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_assignable_event`](#member-gfarchitecture-methods-unregister_assignable_event) | `func unregister_assignable_event(base_event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_assignable_event_owned`](#member-gfarchitecture-methods-unregister_assignable_event_owned) | `func unregister_assignable_event_owned(owner: Object, base_event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`register_simple_event`](#member-gfarchitecture-methods-register_simple_event) | `func register_simple_event(event_id: StringName, listener: GFEventListener) -> void:` |
 | 方法 | [`register_simple_event_owned`](#member-gfarchitecture-methods-register_simple_event_owned) | `func register_simple_event_owned(owner: Object, event_id: StringName, listener: GFEventListener) -> void:` |
+| 方法 | [`subscribe_simple_event`](#member-gfarchitecture-methods-subscribe_simple_event) | `func subscribe_simple_event( event_id: StringName, listener: GFEventListener, once: bool = false ) -> GFSubscriptionToken:` |
 | 方法 | [`unregister_simple_event`](#member-gfarchitecture-methods-unregister_simple_event) | `func unregister_simple_event(event_id: StringName, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_simple_event_owned`](#member-gfarchitecture-methods-unregister_simple_event_owned) | `func unregister_simple_event_owned(owner: Object, event_id: StringName, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_owner_events`](#member-gfarchitecture-methods-unregister_owner_events) | `func unregister_owner_events(owner: Object) -> void:` |
@@ -779,6 +782,30 @@ func register_event_owned(owner: Object, event_type: Script, listener: GFEventLi
 | `listener` | 事件监听器契约。 |
 | `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
 
+<a id="member-gfarchitecture-methods-subscribe_event"></a>
+
+### `subscribe_event`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func subscribe_event( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:
+```
+
+订阅脚本类型事件并返回可取消句柄。 listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once` 订阅会在 首个回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `event_type` | 要订阅的脚本类型。 |
+| `listener` | 事件监听器契约。 |
+| `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
+| `once` | 是否在首个回调开始前自动取消订阅。 |
+
+返回：可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。
+
 <a id="member-gfarchitecture-methods-register_assignable_event"></a>
 
 ### `register_assignable_event`
@@ -821,6 +848,30 @@ func register_assignable_event_owned( owner: Object, base_event_type: Script, li
 | `base_event_type` | 要监听的基类脚本类型。 |
 | `listener` | 事件监听器契约。 |
 | `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
+
+<a id="member-gfarchitecture-methods-subscribe_assignable_event"></a>
+
+### `subscribe_assignable_event`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func subscribe_assignable_event( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:
+```
+
+订阅可赋值类型事件并返回可取消句柄。 listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。监听基类脚本时， 订阅也会收到其派生脚本实例；`once` 在首个匹配回调开始前生效。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `base_event_type` | 要订阅的基类脚本类型。 |
+| `listener` | 事件监听器契约。 |
+| `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
+| `once` | 是否在首个匹配回调开始前自动取消订阅。 |
+
+返回：可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。
 
 <a id="member-gfarchitecture-methods-unregister_event"></a>
 
@@ -944,6 +995,29 @@ func register_simple_event_owned(owner: Object, event_id: StringName, listener: 
 | `owner` | 监听器拥有者。 |
 | `event_id` | StringName 事件标识符。 |
 | `listener` | 简单事件监听器契约。 |
+
+<a id="member-gfarchitecture-methods-subscribe_simple_event"></a>
+
+### `subscribe_simple_event`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func subscribe_simple_event( event_id: StringName, listener: GFEventListener, once: bool = false ) -> GFSubscriptionToken:
+```
+
+订阅轻量级 StringName 事件并返回可取消句柄。 listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once` 订阅会在 首个回调开始前失效，保证嵌套事件派发不会重复进入同一订阅。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `event_id` | StringName 事件标识符。 |
+| `listener` | 简单事件监听器契约。 |
+| `once` | 是否在首个回调开始前自动取消订阅。 |
+
+返回：可幂等取消的订阅句柄；架构不可修改或参数无效时返回非活动句柄。
 
 <a id="member-gfarchitecture-methods-unregister_simple_event"></a>
 

--- a/docs/zh/reference/api/classes/GFGridOccupancy.md
+++ b/docs/zh/reference/api/classes/GFGridOccupancy.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`3.17.0`
 
-网格占用与预约数据结构。 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。 它不负责路径查找、碰撞或胜负规则。
+网格占用与预约数据结构。 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。 它不负责路径查找、碰撞或胜负规则。 占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态， 但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。
 
 ## 成员概览
 
@@ -19,8 +19,8 @@
 | 信号 | [`cell_released`](#member-gfgridoccupancy-signals-cell_released) | `signal cell_released(receiver: Variant, cell: Vector2i)` |
 | 信号 | [`cell_reserved`](#member-gfgridoccupancy-signals-cell_reserved) | `signal cell_reserved(receiver: Variant, cell: Vector2i)` |
 | 信号 | [`reservation_released`](#member-gfgridoccupancy-signals-reservation_released) | `signal reservation_released(receiver: Variant, cell: Vector2i)` |
-| 属性 | [`grid_size`](#member-gfgridoccupancy-properties-grid_size) | `var grid_size: Vector2i = Vector2i.ZERO` |
-| 属性 | [`max_occupants_per_cell`](#member-gfgridoccupancy-properties-max_occupants_per_cell) | `var max_occupants_per_cell: int = 1` |
+| 属性 | [`grid_size`](#member-gfgridoccupancy-properties-grid_size) | `var grid_size: Vector2i:` |
+| 属性 | [`max_occupants_per_cell`](#member-gfgridoccupancy-properties-max_occupants_per_cell) | `var max_occupants_per_cell: int:` |
 | 方法 | [`configure`](#member-gfgridoccupancy-methods-configure) | `func configure(p_grid_size: Vector2i, p_max_occupants_per_cell: int = 1) -> void:` |
 | 方法 | [`is_in_bounds`](#member-gfgridoccupancy-methods-is_in_bounds) | `func is_in_bounds(cell: Vector2i) -> bool:` |
 | 方法 | [`can_occupy`](#member-gfgridoccupancy-methods-can_occupy) | `func can_occupy(receiver: Variant, cell: Vector2i) -> bool:` |
@@ -142,24 +142,26 @@ signal reservation_released(receiver: Variant, cell: Vector2i)
 ### `grid_size`
 
 - API：`public`
+- 首次版本：`10.0.0`
 
 ```gdscript
-var grid_size: Vector2i = Vector2i.ZERO
+var grid_size: Vector2i:
 ```
 
-网格尺寸。小于等于 0 的维度会让所有格子视为越界。
+网格尺寸，默认为 [constant Vector2i.ZERO]。小于等于 0 的维度会让所有格子视为越界。 直接赋值会像 configure() 一样清空现有占用与预约；通知期间的赋值会失败关闭。
 
 <a id="member-gfgridoccupancy-properties-max_occupants_per_cell"></a>
 
 ### `max_occupants_per_cell`
 
 - API：`public`
+- 首次版本：`10.0.0`
 
 ```gdscript
-var max_occupants_per_cell: int = 1
+var max_occupants_per_cell: int:
 ```
 
-单格允许的最大占用数量。
+单格允许的最大占用数量，默认为 1，最小为 1。 直接赋值会像 configure() 一样清空现有占用与预约；通知期间的赋值会失败关闭。
 
 ## 方法
 

--- a/docs/zh/reference/api/classes/GFTypeEventSystem.md
+++ b/docs/zh/reference/api/classes/GFTypeEventSystem.md
@@ -21,15 +21,18 @@
 | 属性 | [`max_trace_entries`](#member-gftypeeventsystem-properties-max_trace_entries) | `var max_trace_entries: int = 64:` |
 | 方法 | [`register`](#member-gftypeeventsystem-methods-register) | `func register(event_type: Script, listener: GFEventListener, priority: int = 0) -> void:` |
 | 方法 | [`register_owned`](#member-gftypeeventsystem-methods-register_owned) | `func register_owned(owner: Object, event_type: Script, listener: GFEventListener, priority: int = 0) -> void:` |
+| 方法 | [`subscribe`](#member-gftypeeventsystem-methods-subscribe) | `func subscribe( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:` |
 | 方法 | [`unregister`](#member-gftypeeventsystem-methods-unregister) | `func unregister(event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_owned`](#member-gftypeeventsystem-methods-unregister_owned) | `func unregister_owned(owner: Object, event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`register_assignable`](#member-gftypeeventsystem-methods-register_assignable) | `func register_assignable(base_event_type: Script, listener: GFEventListener, priority: int = 0) -> void:` |
 | 方法 | [`register_assignable_owned`](#member-gftypeeventsystem-methods-register_assignable_owned) | `func register_assignable_owned( owner: Object, base_event_type: Script, listener: GFEventListener, priority: int = 0 ) -> void:` |
+| 方法 | [`subscribe_assignable`](#member-gftypeeventsystem-methods-subscribe_assignable) | `func subscribe_assignable( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:` |
 | 方法 | [`unregister_assignable`](#member-gftypeeventsystem-methods-unregister_assignable) | `func unregister_assignable(base_event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_assignable_owned`](#member-gftypeeventsystem-methods-unregister_assignable_owned) | `func unregister_assignable_owned(owner: Object, base_event_type: Script, listener: GFEventListener) -> void:` |
 | 方法 | [`send`](#member-gftypeeventsystem-methods-send) | `func send(event_instance: Object) -> void:` |
 | 方法 | [`register_simple`](#member-gftypeeventsystem-methods-register_simple) | `func register_simple(event_id: StringName, listener: GFEventListener) -> void:` |
 | 方法 | [`register_simple_owned`](#member-gftypeeventsystem-methods-register_simple_owned) | `func register_simple_owned(owner: Object, event_id: StringName, listener: GFEventListener) -> void:` |
+| 方法 | [`subscribe_simple`](#member-gftypeeventsystem-methods-subscribe_simple) | `func subscribe_simple( event_id: StringName, listener: GFEventListener, once: bool = false ) -> GFSubscriptionToken:` |
 | 方法 | [`unregister_simple`](#member-gftypeeventsystem-methods-unregister_simple) | `func unregister_simple(event_id: StringName, listener: GFEventListener) -> void:` |
 | 方法 | [`unregister_simple_owned`](#member-gftypeeventsystem-methods-unregister_simple_owned) | `func unregister_simple_owned(owner: Object, event_id: StringName, listener: GFEventListener) -> void:` |
 | 方法 | [`send_simple`](#member-gftypeeventsystem-methods-send_simple) | `func send_simple(event_id: StringName, payload: Variant = null) -> void:` |
@@ -138,6 +141,30 @@ func register_owned(owner: Object, event_type: Script, listener: GFEventListener
 | `listener` | 事件监听器契约。 |
 | `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
 
+<a id="member-gftypeeventsystem-methods-subscribe"></a>
+
+### `subscribe`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func subscribe( event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:
+```
+
+订阅特定脚本类型事件并返回可取消句柄。 每次调用都会创建独立的稳定订阅身份；即使回调和 owner 相同，取消一个句柄也不会影响其它订阅。 `once` 为 true 时，订阅会在首个回调开始前失效，因此嵌套派发不会再次调用它。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `event_type` | 要订阅的脚本类型。 |
+| `listener` | 事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。 |
+| `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
+| `once` | 是否在首个回调开始前自动取消订阅。 |
+
+返回：可幂等取消的订阅句柄；参数无效时返回非活动句柄。
+
 <a id="member-gftypeeventsystem-methods-unregister"></a>
 
 ### `unregister`
@@ -221,6 +248,30 @@ func register_assignable_owned( owner: Object, base_event_type: Script, listener
 | `base_event_type` | 要监听的基类脚本类型。 |
 | `listener` | 事件监听器契约。 |
 | `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
+
+<a id="member-gftypeeventsystem-methods-subscribe_assignable"></a>
+
+### `subscribe_assignable`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func subscribe_assignable( base_event_type: Script, listener: GFEventListener, priority: int = 0, once: bool = false ) -> GFSubscriptionToken:
+```
+
+订阅可赋值类型事件并返回可取消句柄。 监听基类脚本时也会收到其派生脚本实例。每次调用都创建独立订阅身份， `once` 会在首个匹配事件的用户回调开始前使句柄失效。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `base_event_type` | 要订阅的基类脚本类型。 |
+| `listener` | 事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。 |
+| `priority` | 回调优先级，数值越大越先执行，默认为 0。 |
+| `once` | 是否在首个匹配回调开始前自动取消订阅。 |
+
+返回：可幂等取消的订阅句柄；参数无效时返回非活动句柄。
 
 <a id="member-gftypeeventsystem-methods-unregister_assignable"></a>
 
@@ -321,6 +372,29 @@ func register_simple_owned(owner: Object, event_id: StringName, listener: GFEven
 | `owner` | 监听 owner。 |
 | `event_id` | StringName 事件标识符。 |
 | `listener` | 简单事件监听器契约。 |
+
+<a id="member-gftypeeventsystem-methods-subscribe_simple"></a>
+
+### `subscribe_simple`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func subscribe_simple( event_id: StringName, listener: GFEventListener, once: bool = false ) -> GFSubscriptionToken:
+```
+
+订阅轻量级 StringName 事件并返回可取消句柄。 每次调用都会创建独立的稳定订阅身份；`once` 为 true 时，订阅会在首个 用户回调开始前失效，因此同一回调中的嵌套派发不会再次调用它。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `event_id` | StringName 事件标识符。 |
+| `listener` | 简单事件监听器契约；其中携带的 owner 决定返回句柄的生命周期绑定。 |
+| `once` | 是否在首个回调开始前自动取消订阅。 |
+
+返回：可幂等取消的订阅句柄；参数无效时返回非活动句柄。
 
 <a id="member-gftypeeventsystem-methods-unregister_simple"></a>
 
@@ -433,7 +507,7 @@ func get_debug_stats() -> Dictionary:
 func get_listener_diagnostics(options: Dictionary = {}) -> Dictionary:
 ```
 
-获取事件监听器诊断明细。 默认只返回每条轨道的数量统计；传入 `{ "include_entries": true }` 时会附带每个监听器的事件 key、owner 状态、优先级和 Callable 状态。
+获取事件监听器诊断明细。 默认只返回每条轨道的数量统计；传入 `{ "include_entries": true }` 时会附带每个监听器的 事件 key、owner 状态、优先级、Callable 状态，以及订阅记录的稳定身份和 once 标记。
 
 参数：
 
@@ -446,7 +520,7 @@ func get_listener_diagnostics(options: Dictionary = {}) -> Dictionary:
 结构：
 
 - `options`: Dictionary，可包含 include_entries。
-- `return`: Dictionary containing listener counts, stale owner counts, track summaries, and optional entry rows.
+- `return`: Dictionary containing listener counts, stale owner counts, track summaries, and optional entry rows with subscription_id and once.
 
 <a id="member-gftypeeventsystem-methods-compact_released_owner_listeners"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -6,7 +6,7 @@
 
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
-| Kernel | 71 | 996 | [Kernel](#module-kernel) |
+| Kernel | 71 | 1002 | [Kernel](#module-kernel) |
 | Standard | 434 | 6861 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
@@ -35,7 +35,7 @@
 
 | 类 | 类别 | 继承 | 成员 | 源文件 |
 |---|---|---|---:|---|
-| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 113 | `addons/gf/kernel/core/gf_architecture.gd` |
+| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 116 | `addons/gf/kernel/core/gf_architecture.gd` |
 | [`GFDependencyGraphTools`](GFDependencyGraphTools.md#gfdependencygraphtools) | 运行时服务 (`runtime_service`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_dependency_graph_tools.gd` |
 | [`GFExtensionCatalog`](GFExtensionCatalog.md#gfextensioncatalog) | 运行时服务 (`runtime_service`) | `RefCounted` | 5 | `addons/gf/kernel/extension/gf_extension_catalog.gd` |
 | [`GFExtensionManifestDiscovery`](GFExtensionManifestDiscovery.md#gfextensionmanifestdiscovery) | 运行时服务 (`runtime_service`) | `RefCounted` | 2 | `addons/gf/kernel/extension/gf_extension_manifest_discovery.gd` |
@@ -48,7 +48,7 @@
 | [`GFProjectReferenceScanner`](GFProjectReferenceScanner.md#gfprojectreferencescanner) | 运行时服务 (`runtime_service`) | `RefCounted` | 17 | `addons/gf/kernel/core/gf_project_reference_scanner.gd` |
 | [`GFProjectSettingsTools`](GFProjectSettingsTools.md#gfprojectsettingstools) | 运行时服务 (`runtime_service`) | `RefCounted` | 2 | `addons/gf/kernel/core/gf_project_settings_tools.gd` |
 | [`GFReportValueCodec`](GFReportValueCodec.md#gfreportvaluecodec) | 运行时服务 (`runtime_service`) | `RefCounted` | 9 | `addons/gf/kernel/core/gf_report_value_codec.gd` |
-| [`GFTypeEventSystem`](GFTypeEventSystem.md#gftypeeventsystem) | 运行时服务 (`runtime_service`) | `Object` | 25 | `addons/gf/kernel/core/gf_type_event_system.gd` |
+| [`GFTypeEventSystem`](GFTypeEventSystem.md#gftypeeventsystem) | 运行时服务 (`runtime_service`) | `Object` | 28 | `addons/gf/kernel/core/gf_type_event_system.gd` |
 | [`GFBindBuilder`](GFBindBuilder.md#gfbindbuilder) | 协议与扩展点 (`protocol`) | `RefCounted` | 5 | `addons/gf/kernel/core/gf_bind_builder.gd` |
 | [`GFBindableProperty`](GFBindableProperty.md#gfbindableproperty) | 协议与扩展点 (`protocol`) | `RefCounted` | 22 | `addons/gf/kernel/core/gf_bindable_property.gd` |
 | [`GFBinder`](GFBinder.md#gfbinder) | 协议与扩展点 (`protocol`) | `RefCounted` | 4 | `addons/gf/kernel/core/gf_binder.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -6,14 +6,14 @@
 
 - 源码根目录：`addons/gf`
 - 公开类：`779`
-- 公开成员：`11302`
-- 公开方法：`6991`
+- 公开成员：`11308`
+- 公开方法：`6997`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
-| Kernel | 71 | 996 | 720 | [kernel.md](kernel.md) |
+| Kernel | 71 | 1002 | 726 | [kernel.md](kernel.md) |
 | Standard | 434 | 6861 | 4358 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |

--- a/docs/zh/reference/api/kernel.md
+++ b/docs/zh/reference/api/kernel.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 14 | 288 | 222 |
+| [运行时服务](#category-runtime_service) | 14 | 294 | 228 |
 | [协议与扩展点](#category-protocol) | 19 | 195 | 170 |
 | [资源定义](#category-resource_definition) | 2 | 45 | 15 |
 | [运行时句柄](#category-runtime_handle) | 9 | 86 | 70 |

--- a/docs/zh/standard/foundation/grid-spatial/occupancy-tile-spatial/grid-occupancy.md
+++ b/docs/zh/standard/foundation/grid-spatial/occupancy-tile-spatial/grid-occupancy.md
@@ -4,6 +4,8 @@
 
 它不负责地图生成、寻路策略、碰撞检测、棋子规则或胜负判定，因此可以用于推箱子、战棋、棋盘解谜、消除棋盘等不同项目。
 
+## 基本用法
+
 ```gdscript
 var occupancy := GFGridOccupancy.new(Vector2i(8, 8))
 
@@ -16,7 +18,9 @@ if occupancy.reserve_cell(player, Vector2i(2, 1)):
 var blocked := occupancy.is_cell_occupied(Vector2i(3, 1))
 ```
 
-批量查询入口可用于生成候选格、调试面板、保存运行时快照或构建可视化覆盖层。`get_occupied_cells()` 与 `get_reserved_cells()` 返回按 y/x 稳定排序的格子快照；`get_occupiable_cells(receiver)` 会按当前容量、边界和预约归属返回指定接收者可占用的格子。
+## 查询与事务边界
+
+批量查询入口可用于生成候选格、调试面板、保存运行时快照或构建可视化覆盖层。`get_occupied_cells()` 与 `get_reserved_cells()` 返回按 y/x 稳定排序的格子快照；`get_occupiable_cells(receiver)` 会按当前容量、边界和预约归属返回指定接收者可占用的格子。所有查询都是无副作用快照：它们会忽略已释放的对象记录，但不会清理索引或发出释放信号。
 
 ```gdscript
 var spawn_token := &"item_spawn"
@@ -26,6 +30,12 @@ if not candidates.is_empty():
 	occupancy.reserve_cell(spawn_token, cell)
 ```
 
-对象接收者使用弱引用记录，`prune_invalid_receivers()` 可清理已释放对象留下的占用或预约；失效对象释放占用时也会发出 `cell_released(null, cell)`，方便 UI 或棋盘缓存同步刷新。
+`occupy()`、`release_cell()`、`reserve_cell()` 与 `confirm_reservation()` 等写入入口以单次事务更新占用、预约和接收者反向索引，再同步发出对应信号。因此信号回调可以查询完整提交后的状态，但不能在同一通知调用栈中再次修改这个 `GFGridOccupancy`；重入写入会明确失败，`bool` 入口返回 `false`，`void` 入口保持无操作。需要连锁移动、批量放置或响应式规则时，应先在项目 `System` 中计算完整计划，再按确定顺序提交后续事务，而不是在占用信号里继续写入。
+
+`grid_size` 与 `max_occupants_per_cell` 的直接赋值同样属于写事务：值实际变化时会清空既有占用与预约，容量会钳制到至少 1；通知期间的直接赋值会失败关闭。需要同时修改两个配置时优先调用 `configure()`，避免分别赋值造成两次清理。
+
+## 生命周期与标识
+
+对象接收者使用弱引用记录。需要回收已释放对象留下的索引并通知缓存消费者时，显式调用 `prune_invalid_receivers()`，或等待下一次占用/预约事务在提交前执行清理；失效对象释放占用时会发出 `cell_released(null, cell)`。不要依赖任意查询触发清理信号。
 
 非 `Object` 接收者会以 `typeof + str(value)` 生成内部 key，推荐使用 `StringName`、`int`、稳定字符串或 `Object`，不要直接把 `Dictionary` / `Array` 当作长期唯一标识。

--- a/tests/gf_core/kernel/core/test_gf_type_event_system.gd
+++ b/tests/gf_core/kernel/core/test_gf_type_event_system.gd
@@ -87,6 +87,7 @@ class EventTestState:
 	var cb_b: Callable = Callable()
 	var late_cb: Callable = Callable()
 	var replacement: Callable = Callable()
+	var subscription_token: GFSubscriptionToken = null
 
 class SimpleReceiver:
 	var payload: Variant = null
@@ -708,6 +709,141 @@ func test_multiple_listeners() -> void:
 	assert_eq(state.count, 2, "两个监听器都应被调用。")
 
 
+func test_subscribe_returns_independently_cancellable_tokens() -> void:
+	var state: EventTestState = EventTestState.new()
+	var listener: GFEventListener = _type_listener(func(_event: SampleEventA) -> void:
+		state.count += 1
+	)
+	var first_token: GFSubscriptionToken = _system.subscribe(SampleEventA, listener)
+	var second_token: GFSubscriptionToken = _system.subscribe(SampleEventA, listener)
+
+	assert_true(first_token.is_active(), "第一个订阅 token 应处于活动状态。")
+	assert_true(second_token.is_active(), "第二个订阅 token 应处于活动状态。")
+	assert_true(first_token.cancel(), "首次取消应只移除对应稳定身份的订阅。")
+	assert_false(first_token.cancel(), "重复取消应保持幂等。")
+	assert_false(first_token.is_active(), "已取消 token 应立即失效。")
+	assert_true(second_token.is_active(), "取消第一个 token 不应影响相同回调的独立订阅。")
+
+	_system.send(SampleEventA.new())
+
+	assert_eq(state.count, 1, "相同回调的另一个独立订阅仍应收到事件。")
+	assert_true(second_token.cancel(), "剩余订阅仍应可独立取消。")
+
+
+func test_once_subscription_is_removed_before_nested_type_dispatch() -> void:
+	var state: EventTestState = EventTestState.new()
+	var listener: GFEventListener = _type_listener(func(_event: SampleEventA) -> void:
+		state.count += 1
+		state.called = state.subscription_token != null and not state.subscription_token.is_active()
+		_system.send(SampleEventA.new())
+	)
+	state.subscription_token = _system.subscribe(SampleEventA, listener, 0, true)
+
+	_system.send(SampleEventA.new())
+
+	assert_eq(state.count, 1, "一次性订阅必须在嵌套派发前移除，不能重入第二次。")
+	assert_true(state.called, "一次性订阅 token 应在用户回调开始前失效。")
+	assert_false(state.subscription_token.is_active(), "一次性派发完成后 token 应保持失效。")
+	assert_false(state.subscription_token.cancel(), "自动失效后 cancel 应保持幂等并返回 false。")
+
+
+func test_once_assignable_subscription_accepts_only_first_matching_event() -> void:
+	var state: EventTestState = EventTestState.new()
+	var subscription_token: GFSubscriptionToken = _system.subscribe_assignable(
+		SampleEventA,
+		_type_listener(func(_event: SampleEventA) -> void:
+			state.count += 1,
+		),
+		0,
+		true
+	)
+
+	_system.send(SampleEventChild.new())
+	_system.send(SampleEventA.new())
+
+	assert_eq(state.count, 1, "可赋值一次性订阅应只接收首个匹配事件。")
+	assert_false(subscription_token.is_active(), "首个匹配事件后可赋值订阅 token 应失效。")
+
+
+func test_cancel_during_dispatch_skips_pending_listener_by_subscription_id() -> void:
+	var state: EventTestState = EventTestState.new()
+	state.subscription_token = _system.subscribe(
+		SampleEventA,
+		_type_listener(func(_event: SampleEventA) -> void:
+			state.count += 1,
+		)
+	)
+	_system.register(
+		SampleEventA,
+		_type_listener(func(_event: SampleEventA) -> void:
+			assert_true(state.subscription_token.cancel(), "派发中的 token.cancel 应立即使目标订阅失效。"),
+		),
+		10
+	)
+
+	_system.send(SampleEventA.new())
+
+	assert_eq(state.count, 0, "派发中取消的较低优先级订阅不应在本轮继续执行。")
+	assert_false(state.subscription_token.is_active(), "派发中取消后 token 应保持失效。")
+	assert_false(state.subscription_token.cancel(), "派发中取消后的重复 cancel 应保持幂等。")
+
+
+func test_unregister_owner_deactivates_owned_subscription_token() -> void:
+	var listener_owner: RefCounted = RefCounted.new()
+	var state: EventTestState = EventTestState.new()
+	var listener: GFEventListener = _type_listener(func(_event: SampleEventA) -> void:
+		state.count += 1
+	).with_owner(listener_owner)
+	var subscription_token: GFSubscriptionToken = _system.subscribe(SampleEventA, listener)
+
+	assert_true(subscription_token is GFLifetimeSubscription, "带 owner 的监听器应返回生命周期订阅 token。")
+	assert_true(subscription_token.is_active(), "owner 清理前订阅应处于活动状态。")
+
+	_system.unregister_owner(listener_owner)
+	_system.send(SampleEventA.new())
+
+	assert_eq(state.count, 0, "owner 清理后订阅不应收到事件。")
+	assert_false(subscription_token.is_active(), "owner 清理应使订阅 token 自动失效。")
+	assert_false(subscription_token.cancel(), "owner 清理后的 cancel 应保持幂等。")
+
+
+func test_clear_deactivates_subscription_tokens() -> void:
+	var type_token: GFSubscriptionToken = _system.subscribe(
+		SampleEventA,
+		_type_listener(func(_event: SampleEventA) -> void:
+			pass,
+		)
+	)
+	var simple_token: GFSubscriptionToken = _system.subscribe_simple(
+		&"clear_subscription",
+		_simple_listener(func(_payload: Variant) -> void:
+			pass,
+		)
+	)
+
+	_system.clear()
+
+	assert_false(type_token.is_active(), "clear 应使类型事件订阅 token 失效。")
+	assert_false(simple_token.is_active(), "clear 应使简单事件订阅 token 失效。")
+	assert_false(type_token.cancel(), "clear 后类型订阅 cancel 应保持幂等。")
+	assert_false(simple_token.cancel(), "clear 后简单订阅 cancel 应保持幂等。")
+
+
+func test_source_release_deactivates_subscription_token() -> void:
+	var source: GFTypeEventSystem = GFTypeEventSystem.new()
+	var subscription_token: GFSubscriptionToken = source.subscribe(
+		SampleEventA,
+		_type_listener(func(_event: SampleEventA) -> void:
+			pass,
+		)
+	)
+
+	source = null
+
+	assert_false(subscription_token.is_active(), "事件源释放前必须使仍被持有的订阅 token 失效。")
+	assert_false(subscription_token.cancel(), "事件源释放后的 cancel 应保持幂等并返回 false。")
+
+
 ## 验证 clear 后，send 不再触发任何回调。
 func test_clear() -> void:
 	var state: EventTestState = EventTestState.new()
@@ -762,6 +898,47 @@ func test_send_simple_register_and_send() -> void:
 	_system.send_simple(event_id, 99)
 
 	assert_eq(_GF_VARIANT_ACCESS_SCRIPT.to_int(state.payload), 99, "简单事件回调应接收到正确的 payload。")
+
+
+func test_once_simple_subscription_is_removed_before_nested_dispatch() -> void:
+	var state: EventTestState = EventTestState.new()
+	var event_id: StringName = &"once_nested_simple"
+	var listener: GFEventListener = _simple_listener(func(_payload: Variant) -> void:
+		state.count += 1
+		state.called = state.subscription_token != null and not state.subscription_token.is_active()
+		_system.send_simple(event_id)
+	)
+	state.subscription_token = _system.subscribe_simple(event_id, listener, true)
+
+	_system.send_simple(event_id)
+
+	assert_eq(state.count, 1, "简单事件一次性订阅必须在嵌套派发前移除。")
+	assert_true(state.called, "简单事件一次性 token 应在用户回调开始前失效。")
+	assert_false(state.subscription_token.cancel(), "自动失效后 cancel 应保持幂等。")
+
+
+func test_cancel_pending_subscription_prevents_later_registration() -> void:
+	var state: EventTestState = EventTestState.new()
+	var outer_listener: GFEventListener = _type_listener(func(_event: SampleEventA) -> void:
+		if state.subscription_token != null:
+			return
+		state.subscription_token = _system.subscribe(
+			SampleEventA,
+			_type_listener(func(_late_event: SampleEventA) -> void:
+				state.count += 10,
+			)
+		)
+		assert_true(state.subscription_token.cancel(), "派发中新增的 pending 订阅应可立即取消。")
+		assert_false(state.subscription_token.cancel(), "pending 订阅重复取消应保持幂等。")
+	)
+	_system.register(SampleEventA, outer_listener)
+
+	_system.send(SampleEventA.new())
+	_system.send(SampleEventA.new())
+
+	assert_eq(state.count, 0, "派发中创建后取消的订阅不应在后续派发中落地。")
+	assert_not_null(state.subscription_token, "回调应创建 pending 订阅 token。")
+	assert_false(state.subscription_token.is_active(), "已取消的 pending 订阅 token 应保持失效。")
 
 
 func test_register_simple_rejects_empty_event_id() -> void:

--- a/tests/gf_core/standard/foundation/math/test_gf_grid_occupancy.gd
+++ b/tests/gf_core/standard/foundation/math/test_gf_grid_occupancy.gd
@@ -28,6 +28,39 @@ func test_occupy_moves_receiver_between_cells() -> void:
 	assert_eq(grid.get_receiver_cell(actor), Vector2i(1, 0), "接收者当前位置应更新。")
 
 
+func test_occupy_move_commits_before_notifications_and_rejects_reentrant_mutation() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(3, 1))
+	var actor_a: Object = _make_object()
+	var actor_b: Object = _make_object()
+	var source_cell: Vector2i = Vector2i.ZERO
+	var target_cell: Vector2i = Vector2i(1, 0)
+	var nested_results: Array[bool] = []
+	var observed_cells: Array[Vector2i] = []
+
+	assert_true(grid.occupy(actor_a, source_cell), "外层接收者应能建立初始占用。")
+	var release_callback: Callable = func(
+		_receiver: Variant,
+		released_cell: Vector2i
+	) -> void:
+		if released_cell != source_cell:
+			return
+		observed_cells.append(grid.get_receiver_cell(actor_a))
+		nested_results.append(grid.occupy(actor_b, target_cell))
+	var connect_error: Error = grid.cell_released.connect(
+		release_callback
+	) as Error
+	assert_eq(connect_error, OK, "测试应能监听格子释放通知。")
+
+	assert_true(grid.occupy(actor_a, target_cell), "外层移动事务应成功提交。")
+
+	assert_eq(observed_cells, [target_cell], "通知回调必须观察到已经完整提交的外层状态。")
+	assert_eq(nested_results, [false], "通知期的重入写入必须失败关闭。")
+	assert_push_error_count(1, "被拒绝的重入写入应报告一次明确错误。")
+	assert_false(grid.is_cell_occupied(source_cell), "外层移动后旧格子应为空。")
+	assert_eq(grid.get_cell_occupants(target_cell), [actor_a], "目标格不得因重入超过容量。")
+	grid.cell_released.disconnect(release_callback)
+
+
 func test_reservation_blocks_other_receivers_and_can_confirm() -> void:
 	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(3, 3))
 	var actor_a: Object = _make_object()
@@ -40,6 +73,64 @@ func test_reservation_blocks_other_receivers_and_can_confirm() -> void:
 	assert_false(grid.is_cell_reserved(Vector2i(2, 1)), "确认后预约记录应释放。")
 
 
+func test_confirm_reservation_is_atomic_against_release_notification_reentry() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1))
+	var actor_a: Object = _make_object()
+	var actor_b: Object = _make_object()
+	var target_cell: Vector2i = Vector2i(1, 0)
+	var nested_results: Array[bool] = []
+
+	assert_true(grid.reserve_cell(actor_a, target_cell), "外层接收者应能预约目标格。")
+	var release_callback: Callable = func(
+		_receiver: Variant,
+		released_cell: Vector2i
+	) -> void:
+		if released_cell == target_cell:
+			nested_results.append(grid.occupy(actor_b, target_cell))
+	var connect_error: Error = grid.reservation_released.connect(
+		release_callback
+	) as Error
+	assert_eq(connect_error, OK, "测试应能监听预约释放通知。")
+
+	assert_true(grid.confirm_reservation(actor_a), "确认预约应原子提交为占用。")
+
+	assert_eq(nested_results, [false], "预约释放通知不得允许其他接收者抢占提交中的目标格。")
+	assert_push_error_count(1, "被拒绝的确认期重入应报告一次明确错误。")
+	assert_false(grid.is_cell_reserved(target_cell), "确认后预约记录应被清理。")
+	assert_eq(grid.get_cell_occupants(target_cell), [actor_a], "预约所有者应成为唯一占用者。")
+	grid.reservation_released.disconnect(release_callback)
+
+
+func test_reservation_move_is_atomic_against_release_notification_reentry() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(3, 1))
+	var actor_a: Object = _make_object()
+	var actor_b: Object = _make_object()
+	var source_cell: Vector2i = Vector2i.ZERO
+	var target_cell: Vector2i = Vector2i(1, 0)
+	var nested_results: Array[bool] = []
+
+	assert_true(grid.reserve_cell(actor_a, source_cell), "外层接收者应能建立初始预约。")
+	var release_callback: Callable = func(
+		_receiver: Variant,
+		released_cell: Vector2i
+	) -> void:
+		if released_cell == source_cell:
+			nested_results.append(grid.reserve_cell(actor_b, target_cell))
+	var connect_error: Error = grid.reservation_released.connect(
+		release_callback
+	) as Error
+	assert_eq(connect_error, OK, "测试应能监听预约释放通知。")
+
+	assert_true(grid.reserve_cell(actor_a, target_cell), "外层预约移动应成功提交。")
+
+	assert_eq(nested_results, [false], "预约移动通知期的重入写入必须失败关闭。")
+	assert_push_error_count(1, "被拒绝的预约移动重入应报告一次明确错误。")
+	grid.release_reservation(actor_b)
+	assert_true(grid.is_cell_reserved(target_cell), "被拒绝的接收者不得残留可破坏预约的反向记录。")
+	assert_true(grid.confirm_reservation(actor_a), "外层接收者应能确认目标预约。")
+	grid.reservation_released.disconnect(release_callback)
+
+
 func test_max_occupants_per_cell_allows_shared_cells() -> void:
 	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 2), 2)
 
@@ -47,6 +138,66 @@ func test_max_occupants_per_cell_allows_shared_cells() -> void:
 	assert_true(grid.occupy("b", Vector2i.ZERO), "容量允许时第二个值接收者应能共享格子。")
 	assert_false(grid.occupy("c", Vector2i.ZERO), "超过容量后不应继续占用。")
 	assert_eq(grid.get_cell_occupants(Vector2i.ZERO).size(), 2, "格子中应只有两个接收者。")
+
+
+func test_release_cell_is_atomic_against_reentrant_occupy() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(1, 1), 2)
+	var nested_results: Array[bool] = []
+
+	assert_true(grid.occupy("a", Vector2i.ZERO), "第一个接收者应能占用格子。")
+	assert_true(grid.occupy("b", Vector2i.ZERO), "第二个接收者应能共享格子。")
+	var release_callback: Callable = func(
+		_receiver: Variant,
+		_released_cell: Vector2i
+	) -> void:
+		if not nested_results.is_empty():
+			return
+		nested_results.append(grid.occupy("c", Vector2i.ZERO))
+	var connect_error: Error = grid.cell_released.connect(
+		release_callback
+	) as Error
+	assert_eq(connect_error, OK, "测试应能监听批量释放通知。")
+
+	grid.release_cell(Vector2i.ZERO)
+
+	assert_eq(nested_results, [false], "批量释放通知期的重入占用必须失败关闭。")
+	assert_push_error_count(1, "被拒绝的批量释放重入应报告一次明确错误。")
+	assert_true(grid.get_cell_occupants(Vector2i.ZERO).is_empty(), "批量释放必须留下完整的空格状态。")
+	grid.cell_released.disconnect(release_callback)
+
+
+func test_configuration_property_writes_are_rejected_during_notification() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1), 2)
+	var configuration_callback: Callable = func(
+		_receiver: Variant,
+		_cell: Vector2i
+	) -> void:
+		grid.grid_size = Vector2i.ZERO
+		grid.max_occupants_per_cell = 0
+	var connect_error: Error = grid.cell_occupied.connect(
+		configuration_callback
+	) as Error
+	assert_eq(connect_error, OK, "测试应能监听格子占用通知。")
+
+	assert_true(grid.occupy("actor", Vector2i.ZERO), "外层占用事务应成功提交。")
+
+	assert_eq(grid.grid_size, Vector2i(2, 1), "通知期不得直接改写网格尺寸。")
+	assert_eq(grid.max_occupants_per_cell, 2, "通知期不得直接改写格子容量。")
+	assert_eq(grid.get_cell_occupants(Vector2i.ZERO), ["actor"], "被拒绝的配置写入不得破坏已提交占用。")
+	assert_push_error_count(2, "两个被拒绝的配置写入都应报告明确错误。")
+	grid.cell_occupied.disconnect(configuration_callback)
+
+
+func test_configuration_property_write_clears_existing_records() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1), 2)
+	assert_true(grid.occupy("actor", Vector2i.ZERO), "修改配置前应存在占用记录。")
+	assert_true(grid.reserve_cell("reservation", Vector2i(1, 0)), "修改配置前应存在预约记录。")
+
+	grid.max_occupants_per_cell = 1
+
+	assert_eq(grid.max_occupants_per_cell, 1, "直接配置赋值应规范化并提交新容量。")
+	assert_true(grid.get_occupied_cells().is_empty(), "直接配置赋值必须清空旧占用，避免容量失配。")
+	assert_true(grid.get_reserved_cells().is_empty(), "直接配置赋值必须清空旧预约，避免双向索引失配。")
 
 
 func test_occupied_and_reserved_cell_snapshots_are_stable() -> void:
@@ -97,6 +248,69 @@ func test_prune_invalid_receiver_releases_stale_reservation() -> void:
 	grid.prune_invalid_receivers()
 
 	assert_false(grid.is_cell_reserved(cell), "对象释放后预约应能被清理。")
+
+
+func test_queries_ignore_invalid_receiver_without_cleanup_side_effects() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1))
+	var receiver: Node = Node.new()
+	var released_count: Array[int] = [0]
+	var release_callback: Callable = func(
+		_released_receiver: Variant,
+		_released_cell: Vector2i
+	) -> void:
+		released_count[0] += 1
+	var connect_error: Error = grid.cell_released.connect(
+		release_callback
+	) as Error
+	assert_eq(connect_error, OK, "测试应能监听格子释放通知。")
+	assert_true(grid.occupy(receiver, Vector2i.ZERO), "对象接收者应能建立占用。")
+
+	receiver.free()
+	receiver = null
+
+	assert_false(grid.is_cell_occupied(Vector2i.ZERO), "查询应忽略已释放对象。")
+	assert_true(grid.get_occupied_cells().is_empty(), "批量查询应过滤已释放对象。")
+	assert_eq(released_count[0], 0, "只读查询不得清理索引或发出释放通知。")
+
+	grid.prune_invalid_receivers()
+
+	assert_eq(released_count[0], 1, "显式清理应发出唯一释放通知。")
+
+
+func test_prune_keeps_reservation_release_before_occupancy_release() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1))
+	var receiver: Node = Node.new()
+	var notification_order: Array[String] = []
+	var reservation_callback: Callable = func(
+		_released_receiver: Variant,
+		_released_cell: Vector2i
+	) -> void:
+		notification_order.append("reservation")
+	var occupancy_callback: Callable = func(
+		_released_receiver: Variant,
+		_released_cell: Vector2i
+	) -> void:
+		notification_order.append("occupancy")
+	var reservation_connect_error: Error = grid.reservation_released.connect(
+		reservation_callback
+	) as Error
+	var occupancy_connect_error: Error = grid.cell_released.connect(
+		occupancy_callback
+	) as Error
+	assert_eq(reservation_connect_error, OK, "测试应能监听预约释放通知。")
+	assert_eq(occupancy_connect_error, OK, "测试应能监听占用释放通知。")
+	assert_true(grid.occupy(receiver, Vector2i.ZERO), "对象接收者应能建立占用。")
+	assert_true(grid.reserve_cell(receiver, Vector2i(1, 0)), "同一接收者应能预约另一个格子。")
+
+	receiver.free()
+	receiver = null
+	grid.prune_invalid_receivers()
+
+	assert_eq(
+		notification_order,
+		["reservation", "occupancy"],
+		"同一失效接收者的预约应先于占用释放通知。"
+	)
 
 
 func test_prune_invalid_receiver_emits_cell_released() -> void:

--- a/tests/gf_core/tools/ai_developer/fixtures/evaluation_cases.json
+++ b/tests/gf_core/tools/ai_developer/fixtures/evaluation_cases.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.5.0",
+  "catalog_version": "1.6.0",
   "catalog_api_requirements": [
     {
       "catalog": "capability",
@@ -18,6 +18,54 @@
       "members": [
         "is_undo_successful",
         "is_redo_successful"
+      ]
+    },
+    {
+      "catalog": "recipe",
+      "record_id": "external-artifact-export",
+      "class_name": "GFThumbnailRenderer",
+      "members": [
+        "submit_render_request",
+        "cancel_render_task"
+      ]
+    },
+    {
+      "catalog": "recipe",
+      "record_id": "external-artifact-export",
+      "class_name": "GFScreenshotUtility",
+      "members": [
+        "capture_viewport_image",
+        "save_image"
+      ]
+    },
+    {
+      "catalog": "recipe",
+      "record_id": "external-artifact-export",
+      "class_name": "GFRectPacking2D",
+      "members": [
+        "pack_fixed",
+        "pack_square"
+      ]
+    },
+    {
+      "catalog": "recipe",
+      "record_id": "external-artifact-export",
+      "class_name": "GFGeneratedArtifactReport",
+      "members": [
+        "save_text",
+        "make_report",
+        "summarize_reports"
+      ]
+    },
+    {
+      "catalog": "recipe",
+      "record_id": "external-artifact-export",
+      "class_name": "GFContentPackageExportPlan",
+      "members": [
+        "add_entry",
+        "get_validation_report",
+        "get_artifact_report",
+        "get_preflight_report"
       ]
     }
   ],
@@ -232,6 +280,10 @@
     {
       "query": "GFObjectPoolUtility",
       "expected_id": "runtime-performance"
+    },
+    {
+      "query": "artifact export atlas",
+      "expected_id": "assets-content"
     }
   ],
   "recipe_cases": [
@@ -242,6 +294,16 @@
     {
       "recipe_id": "content-package",
       "expected_class": "GFAssetCatalogRuntime"
+    },
+    {
+      "recipe_id": "external-artifact-export",
+      "expected_class": "GFContentPackageExportPlan",
+      "expected_step_fragment": "project-owned target adapter"
+    },
+    {
+      "recipe_id": "platform-lobby-adapter",
+      "expected_class": "GFPlatformAdapter",
+      "expected_step_fragment": "native or GDExtension-backed providers"
     },
     {
       "recipe_id": "ui-route-operation",

--- a/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
+++ b/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
@@ -632,6 +632,11 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 	def test_new_recipe_package_readiness_matches_declared_requirements(self) -> None:
 		scalable_group = [["gf.standard.ui", "gf.standard.ui.state"]]
 		render_group = [["gf.extension.feedback", "gf.standard.assets", "gf.standard.display"]]
+		artifact_packages = [
+			"gf.extension.content_package",
+			"gf.standard.debug",
+			"gf.standard.spatial",
+		]
 		cases = [
 			{
 				"recipe_id": "bounded-runtime-work",
@@ -720,6 +725,27 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 				"missing_all_of": [],
 				"any_of": render_group,
 				"unsatisfied_any_of": render_group,
+			},
+			{
+				"recipe_id": "external-artifact-export",
+				"available": artifact_packages,
+				"satisfied": True,
+				"all_of": artifact_packages,
+				"missing_all_of": [],
+				"any_of": [],
+				"unsatisfied_any_of": [],
+			},
+			{
+				"recipe_id": "external-artifact-export",
+				"available": [
+					"gf.extension.content_package",
+					"gf.standard.spatial",
+				],
+				"satisfied": False,
+				"all_of": artifact_packages,
+				"missing_all_of": ["gf.standard.debug"],
+				"any_of": [],
+				"unsatisfied_any_of": [],
 			},
 		]
 
@@ -1800,30 +1826,216 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 
 	def test_platform_adapter_templates_are_strictly_validated(self) -> None:
 		self.assertEqual(build_gf_ai_developer_kit.validate_platform_adapter_templates(), [])
-		with tempfile.TemporaryDirectory(prefix="gf-ai-adapter-template-") as temporary:
-			template_root = Path(temporary) / "platform"
+		template_root = build_gf_ai_developer_kit.PLATFORM_ADAPTER_TEMPLATE_ROOT
+		readme_text = (template_root / "README.md").read_text(encoding="utf-8")
+		contract_test_text = (template_root / "adapter_contract_test.gd.txt").read_text(
+			encoding="utf-8"
+		)
+		platform_adapter_text = (template_root / "platform_adapter.gd.txt").read_text(
+			encoding="utf-8"
+		)
+		lobby_backend_text = (template_root / "lobby_backend.gd.txt").read_text(
+			encoding="utf-8"
+		)
+		profile = json.loads(
+			(template_root / "compatibility_profile.json").read_text(encoding="utf-8")
+		)
+		for heading in (
+			"## Native mode and fail-closed probing",
+			"## Native artifact matrix",
+			"## Threading and callback pump",
+			"## Shutdown and cancellation",
+			"## Permissions and sensitive data",
+			"## Reproducible supply chain",
+			"## Editor and export boundary",
+		):
+			self.assertIn(heading, readme_text)
+		self.assertIn("test_native_adapter_acceptance_matrix", contract_test_text)
+		self.assertIn(
+			"Replace this sentinel with the native Adapter acceptance matrix.",
+			contract_test_text,
+		)
+		self.assertIn("main-thread pump", platform_adapter_text)
+		self.assertIn("main-thread pump", lobby_backend_text)
+		self.assertIn("bounded timeout", platform_adapter_text)
+		self.assertIn("bounded timeout", lobby_backend_text)
+
+		native_boundary = profile["metadata"]["native_boundary"]
+		self.assertIn(native_boundary["mode"], ("script_only", "optional", "required"))
+		availability_probe = native_boundary["availability_probe"]
+		self.assertIn(availability_probe["kind"], ("class_db", "resource"))
+		self.assertTrue(availability_probe["side_effect_free"])
+		if availability_probe["kind"] == "class_db":
+			self.assertIn("class_name", availability_probe)
+		else:
+			self.assertIn("resource_path", availability_probe)
+		self.assertIn("call_thread", native_boundary)
+		self.assertIn("callback_thread", native_boundary)
+		self.assertIn("callback_pump", native_boundary)
+		self.assertGreater(native_boundary["shutdown_timeout_msec"], 0)
+		self.assertIn("permissions", native_boundary)
+		self.assertIn("editor_only", native_boundary)
+		self.assertIn("dependency_lock_path", native_boundary)
+		self.assertIn("offline_rebuild_verified", native_boundary)
+
+		artifacts = profile["artifacts"]
+		descriptor_artifacts = [
+			item for item in artifacts if item.get("kind") == "gdextension_descriptor"
+		]
+		native_libraries = [
+			item for item in artifacts if item.get("kind") == "native_library"
+		]
+		self.assertEqual(len(descriptor_artifacts), 1)
+		self.assertGreaterEqual(len(native_libraries), 2)
+		descriptor = descriptor_artifacts[0]
+		self.assertEqual(descriptor["path"], native_boundary["descriptor_path"])
+		self.assertIn("minimum_godot_version", descriptor["metadata"])
+		self.assertIn("reloadable", descriptor["metadata"])
+		target_tuples = set()
+		for artifact in native_libraries:
+			metadata = artifact["metadata"]
+			target_tuple = (
+				metadata["platform"],
+				metadata["architecture"],
+				metadata["build_configuration"],
+			)
+			self.assertNotIn(target_tuple, target_tuples)
+			target_tuples.add(target_tuple)
+			self.assertIn(metadata["export_scope"], ("editor", "runtime"))
+			self.assertIn("source_version", metadata)
+			self.assertIn("license_id", metadata)
+			self.assertIn("sha256", artifact)
+			self.assertIn("size_bytes", artifact)
+		declared_export_targets = {
+			(
+				item["platform"],
+				item["architecture"],
+				item["build_configuration"],
+			)
+			for item in native_boundary["export_targets"]
+		}
+		self.assertEqual(target_tuples, declared_export_targets)
+
+		native_dependencies = profile["metadata"]["native_dependencies"]
+		self.assertTrue(native_dependencies)
+		for dependency in native_dependencies:
+			self.assertIn("version", dependency)
+			self.assertIn("source", dependency)
+			self.assertIn("sha256", dependency)
+			self.assertIn("license_id", dependency)
+
+		with tempfile.TemporaryDirectory(prefix="gf-ai-native-profile-test-") as temporary:
+			copied_template_root = Path(temporary) / "platform"
 			shutil.copytree(
 				build_gf_ai_developer_kit.PLATFORM_ADAPTER_TEMPLATE_ROOT,
-				template_root,
+				copied_template_root,
 			)
-			(template_root / "platform_adapter.gd.txt").write_text(
+			copied_profile_path = copied_template_root / "compatibility_profile.json"
+			resource_profile = json.loads(copied_profile_path.read_text(encoding="utf-8"))
+			resource_probe = resource_profile["metadata"]["native_boundary"]["availability_probe"]
+			resource_probe["kind"] = "resource"
+			resource_probe.pop("class_name")
+			resource_probe["resource_path"] = resource_profile["metadata"]["native_boundary"][
+				"descriptor_path"
+			]
+			copied_profile_path.write_text(
+				json.dumps(resource_profile, ensure_ascii=False, indent=2) + "\n",
+				encoding="utf-8",
+			)
+			self.assertEqual(
+				build_gf_ai_developer_kit.validate_platform_adapter_templates(
+					copied_template_root
+				),
+				[],
+			)
+
+			resource_probe.pop("resource_path")
+			copied_profile_path.write_text(
+				json.dumps(resource_profile, ensure_ascii=False, indent=2) + "\n",
+				encoding="utf-8",
+			)
+			issues = build_gf_ai_developer_kit.validate_platform_adapter_templates(
+				copied_template_root
+			)
+			self.assertTrue(
+				any("resource_path" in issue for issue in issues),
+				issues,
+			)
+
+			script_only_profile = json.loads(
+				(template_root / "compatibility_profile.json").read_text(encoding="utf-8")
+			)
+			script_only_profile["metadata"]["native_boundary"]["mode"] = "script_only"
+			copied_profile_path.write_text(
+				json.dumps(script_only_profile, ensure_ascii=False, indent=2) + "\n",
+				encoding="utf-8",
+			)
+			issues = build_gf_ai_developer_kit.validate_platform_adapter_templates(
+				copied_template_root
+			)
+			self.assertTrue(
+				any("script_only native mode" in issue for issue in issues),
+				issues,
+			)
+
+			invalid_hash_profile = json.loads(
+				(template_root / "compatibility_profile.json").read_text(encoding="utf-8")
+			)
+			invalid_hash_profile["artifacts"][0]["sha256"] = "not-a-digest"
+			copied_profile_path.write_text(
+				json.dumps(invalid_hash_profile, ensure_ascii=False, indent=2) + "\n",
+				encoding="utf-8",
+			)
+			issues = build_gf_ai_developer_kit.validate_platform_adapter_templates(
+				copied_template_root
+			)
+			self.assertTrue(any("sha256" in issue for issue in issues), issues)
+
+			invalid_path_profile = json.loads(
+				(template_root / "compatibility_profile.json").read_text(encoding="utf-8")
+			)
+			invalid_path_profile["artifacts"][0][
+				"path"
+			] = "res://adapters/platform/../outside.gdextension"
+			invalid_path_profile["metadata"]["native_boundary"][
+				"descriptor_path"
+			] = "res://adapters/platform/../outside.gdextension"
+			copied_profile_path.write_text(
+				json.dumps(invalid_path_profile, ensure_ascii=False, indent=2) + "\n",
+				encoding="utf-8",
+			)
+			issues = build_gf_ai_developer_kit.validate_platform_adapter_templates(
+				copied_template_root
+			)
+			self.assertTrue(
+				any("canonical cross-platform" in issue for issue in issues),
+				issues,
+			)
+
+		with tempfile.TemporaryDirectory(prefix="gf-ai-adapter-template-") as temporary:
+			copied_template_root = Path(temporary) / "platform"
+			shutil.copytree(
+				build_gf_ai_developer_kit.PLATFORM_ADAPTER_TEMPLATE_ROOT,
+				copied_template_root,
+			)
+			(copied_template_root / "platform_adapter.gd.txt").write_text(
 				"extends RefCounted\n",
 				encoding="utf-8",
 			)
 			issues = build_gf_ai_developer_kit.validate_platform_adapter_templates(
-				template_root
+				copied_template_root
 			)
 			self.assertTrue(
 				any("platform_adapter.gd.txt" in issue for issue in issues),
 				issues,
 			)
 
-			(template_root / "compatibility_profile.json").write_text(
+			(copied_template_root / "compatibility_profile.json").write_text(
 				'{"profile_id":"broken","godot_version":NaN}',
 				encoding="utf-8",
 			)
 			issues = build_gf_ai_developer_kit.validate_platform_adapter_templates(
-				template_root
+				copied_template_root
 			)
 			self.assertTrue(
 				any("compatibility profile is invalid" in issue for issue in issues),

--- a/tools/build_gf_ai_developer_kit.py
+++ b/tools/build_gf_ai_developer_kit.py
@@ -28,10 +28,16 @@ PLUGIN_NAME = "gf-ai-developer"
 ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
 BLOCKED_PARTS = {"__pycache__", ".git", ".godot"}
 BLOCKED_SUFFIXES = {".pyc", ".pyo", ".tmp", ".log"}
+NATIVE_HASH_PLACEHOLDER = "replace-with-64-lowercase-sha256"
+NATIVE_THREAD_PLACEHOLDER = "replace-with-main-or-worker"
 
 sys.path.insert(0, str(ADDON_ROOT))
 try:
-	from gf_ai.paths import read_json_object as read_strict_json_object
+	from gf_ai.paths import (
+		is_reserved_framework_resource_path,
+		normalize_portable_ownership_path,
+		read_json_object as read_strict_json_object,
+	)
 finally:
 	sys.path.pop(0)
 
@@ -333,6 +339,11 @@ def validate_platform_adapter_templates(
 			"GFPlatformAdapterConformance.inspect()",
 			"GFMultiplayerPeerNetworkBackend.adopt_peer()",
 			"provider cancellation requested once",
+			"## Native mode and fail-closed probing",
+			"## Native artifact matrix",
+			"## Threading and callback pump",
+			"## Reproducible supply chain",
+			"## Editor and export boundary",
 		),
 		"platform_adapter.gd.txt": (
 			"extends GFPlatformAdapter",
@@ -350,6 +361,8 @@ def validate_platform_adapter_templates(
 			"GFPlatformAdapterConformance.inspect",
 			"test_adapter_failure_matrix",
 			"Replace this sentinel with the complete adapter failure matrix.",
+			"test_native_adapter_acceptance_matrix",
+			"Replace this sentinel with the native Adapter acceptance matrix.",
 		),
 	}
 	for relative_path, required_fragments in required_text.items():
@@ -402,6 +415,7 @@ def validate_platform_adapter_templates(
 			for contract_id, version in contract_versions.items()
 		):
 			issues.append("Platform adapter contract_versions must map stable IDs to exact SemVer.")
+		issues.extend(_validate_platform_native_profile(profile))
 
 	try:
 		recipes = read_strict_json_object(ADDON_ROOT / "knowledge/recipes.json")
@@ -421,6 +435,24 @@ def validate_platform_adapter_templates(
 		for package_id in ("gf.standard.platform", "gf.extension.network"):
 			if package_id not in all_of:
 				issues.append(f"platform-lobby-adapter recipe must require package: {package_id}.")
+		platform_steps = " ".join(
+			str(step)
+			for step in (
+				platform_recipe.get("steps", [])
+				if isinstance(platform_recipe, dict)
+				else []
+			)
+		)
+		for fragment in (
+			"native or GDExtension-backed providers",
+			"bounded plain-data ingress queue",
+			"actual exported target",
+		):
+			if fragment not in platform_steps:
+				issues.append(
+					"platform-lobby-adapter recipe is missing native acceptance guidance: "
+					f"{fragment}."
+				)
 		capabilities = read_strict_json_object(ADDON_ROOT / "knowledge/capabilities.json")
 		platform_capability = next(
 			(
@@ -435,6 +467,275 @@ def validate_platform_adapter_templates(
 	except (OSError, ValueError) as exc:
 		issues.append(f"Platform adapter catalog contract validation failed: {exc}")
 	return issues
+
+
+def _validate_platform_native_profile(profile: dict[str, Any]) -> list[str]:
+	issues: list[str] = []
+	metadata = profile.get("metadata")
+	if not isinstance(metadata, dict):
+		return ["Platform adapter compatibility profile requires metadata."]
+	native_boundary = metadata.get("native_boundary")
+	if not isinstance(native_boundary, dict):
+		return ["Platform adapter compatibility profile requires native_boundary metadata."]
+
+	mode = native_boundary.get("mode")
+	if mode not in {"script_only", "optional", "required"}:
+		issues.append(
+			"Platform adapter native_boundary.mode must be script_only, optional, or required."
+		)
+
+	artifacts_value = profile.get("artifacts")
+	if not isinstance(artifacts_value, list):
+		issues.append("Platform adapter compatibility profile artifacts must be an array.")
+		artifacts: list[dict[str, Any]] = []
+	else:
+		artifacts = [item for item in artifacts_value if isinstance(item, dict)]
+		if len(artifacts) != len(artifacts_value):
+			issues.append("Platform adapter compatibility profile artifacts must contain objects.")
+
+	artifact_ids: set[str] = set()
+	artifact_paths: set[str] = set()
+	descriptor_artifacts: list[dict[str, Any]] = []
+	native_libraries: list[dict[str, Any]] = []
+	library_targets: set[tuple[str, str, str]] = set()
+	for artifact in artifacts:
+		artifact_id = artifact.get("id")
+		path = artifact.get("path")
+		kind = artifact.get("kind")
+		if not isinstance(artifact_id, str) or not artifact_id.strip():
+			issues.append("Every native artifact requires a stable non-empty id.")
+		elif artifact_id in artifact_ids:
+			issues.append(f"Native artifact id is duplicated: {artifact_id}.")
+		else:
+			artifact_ids.add(artifact_id)
+		if not _is_project_owned_native_path(path):
+			issues.append(
+				f"Native artifact {artifact_id!r} requires a canonical cross-platform "
+				"project-owned res:// path."
+			)
+		elif path in artifact_paths:
+			issues.append(f"Native artifact path is duplicated: {path}.")
+		else:
+			artifact_paths.add(path)
+		if kind not in {"gdextension_descriptor", "native_library"}:
+			issues.append(f"Native artifact {artifact_id!r} has unsupported kind: {kind!r}.")
+
+		sha256 = artifact.get("sha256")
+		hash_is_placeholder = sha256 == NATIVE_HASH_PLACEHOLDER
+		if not hash_is_placeholder and (
+			not isinstance(sha256, str)
+			or re.fullmatch(r"[0-9a-f]{64}", sha256) is None
+		):
+			issues.append(
+				f"Native artifact {artifact_id!r} sha256 must be a lowercase digest or explicit template placeholder."
+			)
+		size_bytes = artifact.get("size_bytes")
+		if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0:
+			issues.append(f"Native artifact {artifact_id!r} size_bytes must be a non-negative integer.")
+		elif hash_is_placeholder and size_bytes != 0:
+			issues.append(
+				f"Unverified native artifact {artifact_id!r} must retain size_bytes = 0."
+			)
+		elif not hash_is_placeholder and size_bytes <= 0:
+			issues.append(
+				f"Verified native artifact {artifact_id!r} requires a positive size_bytes value."
+			)
+
+		artifact_metadata = artifact.get("metadata")
+		if not isinstance(artifact_metadata, dict):
+			issues.append(f"Native artifact {artifact_id!r} requires metadata.")
+			continue
+		if artifact_metadata.get("export_scope") not in {"editor", "runtime"}:
+			issues.append(
+				f"Native artifact {artifact_id!r} export_scope must be editor or runtime."
+			)
+		if kind == "gdextension_descriptor":
+			descriptor_artifacts.append(artifact)
+			minimum_godot_version = artifact_metadata.get("minimum_godot_version")
+			if (
+				not isinstance(minimum_godot_version, str)
+				or re.fullmatch(r"\d+\.\d+\.\d+", minimum_godot_version) is None
+			):
+				issues.append(
+					f"Native descriptor {artifact_id!r} requires an exact minimum_godot_version."
+				)
+			if not isinstance(artifact_metadata.get("reloadable"), bool):
+				issues.append(f"Native descriptor {artifact_id!r} requires a bool reloadable policy.")
+		elif kind == "native_library":
+			native_libraries.append(artifact)
+			target_values = tuple(
+				artifact_metadata.get(field_name)
+				for field_name in ("platform", "architecture", "build_configuration")
+			)
+			if any(not isinstance(value, str) or not value.strip() for value in target_values):
+				issues.append(
+					f"Native library {artifact_id!r} requires an exact platform/architecture/build_configuration tuple."
+				)
+			else:
+				target = (target_values[0], target_values[1], target_values[2])
+				if target in library_targets:
+					issues.append(f"Native library target tuple is duplicated: {target}.")
+				library_targets.add(target)
+			for field_name in ("source_id", "source_version", "license_id"):
+				value = artifact_metadata.get(field_name)
+				if not isinstance(value, str) or not value.strip():
+					issues.append(
+						f"Native library {artifact_id!r} requires non-empty {field_name}."
+					)
+
+	if mode == "script_only":
+		if artifacts:
+			issues.append("script_only native mode must not declare native artifacts.")
+	else:
+		if len(descriptor_artifacts) != 1:
+			issues.append("optional and required native modes require exactly one descriptor artifact.")
+		if not native_libraries:
+			issues.append("optional and required native modes require at least one native library.")
+
+	descriptor_path = native_boundary.get("descriptor_path")
+	if mode != "script_only":
+		if not _is_project_owned_native_path(descriptor_path):
+			issues.append(
+				"Native boundary descriptor_path must be a canonical cross-platform "
+				"project-owned res:// path."
+			)
+		elif len(descriptor_artifacts) == 1 and descriptor_artifacts[0].get("path") != descriptor_path:
+			issues.append("Native boundary descriptor_path must match the descriptor artifact.")
+
+	probe = native_boundary.get("availability_probe")
+	if not isinstance(probe, dict):
+		issues.append("Native boundary requires an availability_probe object.")
+	else:
+		probe_kind = probe.get("kind")
+		if probe_kind not in {"class_db", "resource"}:
+			issues.append("Native availability_probe.kind must be class_db or resource.")
+		elif probe_kind == "class_db":
+			if not isinstance(probe.get("class_name"), str) or not probe["class_name"].strip():
+				issues.append("class_db availability probes require class_name.")
+		elif not _is_project_owned_native_path(probe.get("resource_path")):
+			issues.append(
+				"resource availability probes require a canonical cross-platform "
+				"project-owned res:// resource_path."
+			)
+		if probe.get("side_effect_free") is not True:
+			issues.append("Native availability probes must declare side_effect_free = true.")
+
+	for field_name in ("call_thread", "callback_thread"):
+		thread_name = native_boundary.get(field_name)
+		if thread_name not in {"main", "worker", NATIVE_THREAD_PLACEHOLDER}:
+			issues.append(
+				f"Native boundary {field_name} must be main, worker, or the explicit template placeholder."
+			)
+	callback_pump = native_boundary.get("callback_pump")
+	if not isinstance(callback_pump, str) or not callback_pump.strip():
+		issues.append("Native boundary requires a non-empty callback_pump.")
+	shutdown_timeout_msec = native_boundary.get("shutdown_timeout_msec")
+	if (
+		isinstance(shutdown_timeout_msec, bool)
+		or not isinstance(shutdown_timeout_msec, int)
+		or shutdown_timeout_msec <= 0
+	):
+		issues.append("Native boundary shutdown_timeout_msec must be a positive integer.")
+	permissions = native_boundary.get("permissions")
+	if not isinstance(permissions, list) or any(
+		not isinstance(permission, str) or not permission.strip()
+		for permission in permissions
+	):
+		issues.append("Native boundary permissions must be an array of stable non-empty strings.")
+	if not isinstance(native_boundary.get("editor_only"), bool):
+		issues.append("Native boundary editor_only must be bool.")
+	dependency_lock_path = native_boundary.get("dependency_lock_path")
+	if (
+		mode != "script_only"
+		and not _is_project_owned_native_path(dependency_lock_path)
+	):
+		issues.append(
+			"Native boundary dependency_lock_path must be a canonical cross-platform "
+			"project-owned res:// path."
+		)
+	if not isinstance(native_boundary.get("offline_rebuild_verified"), bool):
+		issues.append("Native boundary offline_rebuild_verified must be bool.")
+
+	export_targets_value = native_boundary.get("export_targets")
+	if not isinstance(export_targets_value, list):
+		issues.append("Native boundary export_targets must be an array.")
+		export_targets: set[tuple[str, str, str]] = set()
+	else:
+		export_targets = set()
+		for target_value in export_targets_value:
+			if not isinstance(target_value, dict):
+				issues.append("Native boundary export_targets must contain objects.")
+				continue
+			target_values = tuple(
+				target_value.get(field_name)
+				for field_name in ("platform", "architecture", "build_configuration")
+			)
+			if any(not isinstance(value, str) or not value.strip() for value in target_values):
+				issues.append(
+					"Every native export target requires platform, architecture, and build_configuration."
+				)
+				continue
+			target = (target_values[0], target_values[1], target_values[2])
+			if target in export_targets:
+				issues.append(f"Native export target tuple is duplicated: {target}.")
+			export_targets.add(target)
+	if mode == "script_only" and export_targets:
+		issues.append("script_only native mode must not declare native export targets.")
+	elif mode in {"optional", "required"} and export_targets != library_targets:
+		issues.append("Native export targets must exactly match declared native library tuples.")
+
+	dependencies_value = metadata.get("native_dependencies")
+	if mode == "script_only":
+		if dependencies_value not in (None, []):
+			issues.append("script_only native mode must not declare native_dependencies.")
+	elif not isinstance(dependencies_value, list) or not dependencies_value:
+		issues.append("Native modes require a non-empty native_dependencies array.")
+	else:
+		dependency_ids: set[str] = set()
+		for dependency in dependencies_value:
+			if not isinstance(dependency, dict):
+				issues.append("native_dependencies must contain objects.")
+				continue
+			dependency_id = dependency.get("id")
+			if not isinstance(dependency_id, str) or not dependency_id.strip():
+				issues.append("Every native dependency requires a stable non-empty id.")
+			elif dependency_id in dependency_ids:
+				issues.append(f"Native dependency id is duplicated: {dependency_id}.")
+			else:
+				dependency_ids.add(dependency_id)
+			for field_name in ("version", "source", "license_id"):
+				value = dependency.get(field_name)
+				if not isinstance(value, str) or not value.strip():
+					issues.append(
+						f"Native dependency {dependency_id!r} requires non-empty {field_name}."
+					)
+			sha256 = dependency.get("sha256")
+			if sha256 != NATIVE_HASH_PLACEHOLDER and (
+				not isinstance(sha256, str)
+				or re.fullmatch(r"[0-9a-f]{64}", sha256) is None
+			):
+				issues.append(
+					f"Native dependency {dependency_id!r} sha256 must be a lowercase digest or explicit template placeholder."
+				)
+		for artifact in native_libraries:
+			artifact_metadata = artifact.get("metadata")
+			if (
+				isinstance(artifact_metadata, dict)
+				and artifact_metadata.get("source_id") not in dependency_ids
+			):
+				issues.append(
+					f"Native library {artifact.get('id')!r} source_id must reference native_dependencies."
+				)
+	return issues
+
+
+def _is_project_owned_native_path(value: Any) -> bool:
+	if not isinstance(value, str):
+		return False
+	return (
+		normalize_portable_ownership_path(value) == value
+		and not is_reserved_framework_resource_path(value)
+	)
 
 
 def build_plugin_archive(output: Path, version: str) -> None:


### PR DESCRIPTION
## Summary

- Add independently cancellable and one-shot exact, assignable, and simple event subscriptions across `GFTypeEventSystem`, `GFArchitecture`, and `Gf`, with stable token identity and explicit owner/source lifecycle retirement.
- Make `GFGridOccupancy` mutations commit before synchronous notifications and fail closed on notification-time reentry, while keeping query APIs side-effect free.
- Strengthen the native Platform Adapter acceptance template with target-mode matrices, canonical path gates, integrity/provenance evidence, thread pumping, cancellation/shutdown, offline dependency, permission/redaction, and real artifact acceptance requirements.
- Add a generic external artifact export recipe composed from `GFThumbnailRenderer`, `GFScreenshotUtility`, `GFRectPacking2D`, `GFGeneratedArtifactReport`, and `GFContentPackageExportPlan`; no business-specific generator is introduced.
- Document the project-side composition boundary: `GFTurnAction` schedules, a project `GFUndoableCommand` changes authoritative state, and `GFActionQueueSystem` drives presentation.

## Behavior changes

- `GFGridOccupancy` queries no longer prune released objects or emit release signals. Callers that require cleanup should invoke `prune_invalid_receivers()` explicitly or rely on the next write transaction.
- Changing `grid_size` or `max_occupants_per_cell` clears existing occupancy and reservation state so configuration and indexes cannot diverge.
- Reentrant writes against the same `GFGridOccupancy` instance during notifications now fail closed. Project code should calculate chained moves first and commit them in a later transaction.
- The event subscription APIs are additive; existing long-lived registration APIs remain available.
- Native Adapter acceptance fails closed when required target evidence or exported artifact proof is missing.

## Validation

- `python tools/gf_maintenance.py check --suite full`: 35/35 checks passed; all 8 parallel shards passed (framework GUT/LSP/static, package editor/local/network/Godot CI/contract).
- `python tools/gf_maintenance.py check --suite quick`: 22/22 checks passed.
- Focused event GUT: 71/71 passed with a clean lifecycle gate.
- Focused Grid GUT: 15/15 passed with zero ObjectDB/resource exit leaks.
- AI Developer tooling: 68/68 tests passed.
- API baseline diff against 9.0.1 passed.
- Multi-track change audit found no remaining blocker, major, or minor findings.
- Final log hygiene passed.