### PR TITLE
Add explicit settings, property, and shader contracts

### DIFF
--- a/addons/gf/extensions/action_queue/actions/gf_shader_parameter_action.gd
+++ b/addons/gf/extensions/action_queue/actions/gf_shader_parameter_action.gd
@@ -82,6 +82,8 @@ var restore_initial_value_on_finish: bool = false
 
 var _active_tween: Tween = null
 var _active_material: ShaderMaterial = null
+var _active_parameter_name: StringName = &""
+var _active_target_value: Variant = null
 var _duration: float = 0.2
 var _initial_value: Variant = null
 var _has_initial_value: bool = false
@@ -116,10 +118,25 @@ func execute() -> Variant:
 	_clear_active_tween()
 	_reset_completion_state()
 	_active_material = null
+	_active_parameter_name = &""
+	_active_target_value = null
+	var execution_parameter_name: StringName = parameter_name
+	var execution_target_value: Variant = GFVariantData.duplicate_variant(
+		target_value
+	)
 	var source_material: ShaderMaterial = _resolve_shader_material()
-	if source_material == null or not _has_shader_parameter(source_material):
+	if (
+		source_material == null
+		or not _accepts_shader_parameter(
+			source_material,
+			execution_parameter_name,
+			execution_target_value
+		)
+	):
 		return null
 
+	_active_parameter_name = execution_parameter_name
+	_active_target_value = execution_target_value
 	_capture_initial_value(source_material)
 	var tween_host: Node = null
 	if duration > 0.0:
@@ -134,7 +151,7 @@ func execute() -> Variant:
 	if _active_material == null:
 		return null
 	if duration <= 0.0:
-		_set_shader_parameter(target_value)
+		_set_shader_parameter(_active_target_value)
 		_restore_initial_value_on_finish()
 		return null
 
@@ -142,7 +159,7 @@ func execute() -> Variant:
 	var tweener: MethodTweener = _active_tween.tween_method(
 		Callable(self, "_set_shader_parameter"),
 		_initial_value,
-		target_value,
+		_active_target_value,
 		duration
 	)
 	var _set_ease_result_128: Variant = tweener.set_trans(transition_type).set_ease(ease_type)
@@ -184,7 +201,7 @@ func resume() -> void:
 func finish() -> void:
 	if is_instance_valid(_active_tween):
 		_clear_active_tween()
-		_set_shader_parameter(target_value)
+		_set_shader_parameter(_active_target_value)
 		_restore_initial_value_on_finish()
 		_emit_completed_once()
 		return
@@ -245,43 +262,65 @@ func _activate_shader_material(material: ShaderMaterial) -> ShaderMaterial:
 	return duplicated_material
 
 
-func _has_shader_parameter(material: ShaderMaterial) -> bool:
-	if parameter_name == &"":
+func _accepts_shader_parameter(
+	material: ShaderMaterial,
+	execution_parameter_name: StringName,
+	execution_target_value: Variant
+) -> bool:
+	if execution_parameter_name == &"":
 		push_warning("[GFShaderParameterAction] Shader 参数名为空。")
 		return false
 	if material.shader == null:
 		push_warning("[GFShaderParameterAction] ShaderMaterial 缺少 Shader。")
 		return false
 
-	for uniform_value: Variant in material.shader.get_shader_uniform_list():
-		if not (uniform_value is Dictionary):
-			continue
-		var uniform: Dictionary = uniform_value
-		if GFVariantData.get_option_string(uniform, "name") == String(parameter_name):
-			return true
-
-	push_warning("[GFShaderParameterAction] Shader 参数不存在：%s。" % String(parameter_name))
-	return false
+	var interface_snapshot: GFShaderInterfaceSnapshot = (
+		GFShaderInterfaceSnapshot.capture(material.shader)
+	)
+	if (
+		interface_snapshot == null
+		or not interface_snapshot.has_uniform(execution_parameter_name)
+	):
+		push_warning(
+			"[GFShaderParameterAction] Shader 参数不存在：%s。"
+			% String(execution_parameter_name)
+		)
+		return false
+	if not interface_snapshot.accepts_parameter_value(
+		execution_parameter_name,
+		execution_target_value
+	):
+		push_warning(
+			"[GFShaderParameterAction] Shader 参数值类型不符合声明：%s。"
+			% String(execution_parameter_name)
+		)
+		return false
+	return true
 
 
 func _capture_initial_value(material: ShaderMaterial) -> void:
-	_initial_value = GFVariantData.duplicate_variant(material.get_shader_parameter(parameter_name))
+	_initial_value = GFVariantData.duplicate_variant(
+		material.get_shader_parameter(_active_parameter_name)
+	)
 	_has_initial_value = true
 
 
 func _can_tween_parameter_value() -> bool:
 	if not _has_initial_value:
 		return false
-	if _values_are_tween_compatible(_initial_value, target_value):
+	if _values_are_tween_compatible(_initial_value, _active_target_value):
 		return true
-	push_warning("[GFShaderParameterAction] Shader 参数值类型不兼容：%s。" % String(parameter_name))
+	push_warning(
+		"[GFShaderParameterAction] Shader 参数值类型不兼容：%s。"
+		% String(_active_parameter_name)
+	)
 	return false
 
 
 func _set_shader_parameter(value: Variant) -> void:
 	if _active_material == null:
 		return
-	_active_material.set_shader_parameter(parameter_name, value)
+	_active_material.set_shader_parameter(_active_parameter_name, value)
 
 
 func _restore_initial_value_on_cancel() -> void:
@@ -297,7 +336,10 @@ func _restore_initial_value_on_finish() -> void:
 func _restore_initial_value() -> void:
 	if _active_material == null or not _has_initial_value:
 		return
-	_active_material.set_shader_parameter(parameter_name, GFVariantData.duplicate_variant(_initial_value))
+	_active_material.set_shader_parameter(
+		_active_parameter_name,
+		GFVariantData.duplicate_variant(_initial_value)
+	)
 
 
 func _get_tween_host() -> Node:

--- a/addons/gf/kernel/core/gf_object_property_tools.gd
+++ b/addons/gf/kernel/core/gf_object_property_tools.gd
@@ -188,9 +188,98 @@ static func read_property(
 	return object.get_indexed(property_path)
 
 
+## 零写入验证对象属性路径，并计算真实写入会使用的规范化值。
+##
+## 该方法与 write_property() 共享路径、可写性、类型和转换规则，但不会调用
+## Object.set_indexed()。事务或批处理可先准备全部条目，再决定是否开始写入。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param object: 目标对象。
+## [br]
+## @param property_path: 属性路径。
+## [br]
+## @param value: 请求写入的值。
+## [br]
+## @param options: 可选项，支持 check_writable、check_type、coerce_value。
+## [br]
+## @schema value: Variant value requested for assignment.
+## [br]
+## @schema options: Dictionary with optional bool keys check_writable, check_type, and coerce_value.
+## [br]
+## @return 准备结果字典，包含 ok、error、property_name、old_value 与规范化 new_value。
+## [br]
+## @schema return: Dictionary { ok: bool, error: String, property_name: StringName, old_value: Variant, new_value: Variant }.
+static func prepare_property_write(
+	object: Object,
+	property_path: NodePath,
+	value: Variant,
+	options: Dictionary = {}
+) -> Dictionary:
+	if not is_instance_valid(object):
+		return _make_write_result(false, "Object is null.")
+	if property_path.is_empty():
+		return _make_write_result(false, "Property path is empty.")
+
+	var root_property: StringName = get_root_property_name(property_path)
+	var property_info: Dictionary = get_property_info(object, root_property)
+	if property_info.is_empty():
+		return _make_write_result(
+			false,
+			"Missing property: %s" % String(root_property),
+			root_property
+		)
+	if (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "check_writable", true)
+		and not is_property_writable(property_info)
+	):
+		return _make_write_result(
+			false,
+			"Property is not writable: %s" % String(root_property),
+			root_property
+		)
+	if not _property_path_can_resolve(object, property_path):
+		return _make_write_result(
+			false,
+			"Property path cannot be resolved: %s" % String(property_path),
+			root_property
+		)
+
+	var old_value: Variant = object.get_indexed(property_path)
+	var property_type: int = _get_effective_property_type(
+		property_path,
+		property_info,
+		old_value
+	)
+	if (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "check_type", true)
+		and not value_matches_property_type(value, property_type)
+	):
+		return _make_write_result(
+			false,
+			"Property type mismatch: %s" % String(root_property),
+			root_property,
+			old_value
+		)
+	var value_to_write: Variant = value
+	if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "coerce_value", true):
+		value_to_write = coerce_property_value(value, property_type)
+	return _make_write_result(
+		true,
+		"",
+		root_property,
+		old_value,
+		value_to_write
+	)
+
+
 ## 写入对象属性路径。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 ## [br]
 ## @param object: 目标对象。
 ## [br]
@@ -213,28 +302,28 @@ static func write_property(
 	value: Variant,
 	options: Dictionary = {}
 ) -> Dictionary:
-	if not is_instance_valid(object):
-		return _make_write_result(false, "Object is null.")
-	if property_path.is_empty():
-		return _make_write_result(false, "Property path is empty.")
+	var preparation: Dictionary = prepare_property_write(
+		object,
+		property_path,
+		value,
+		options
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		return preparation
 
-	var root_property: StringName = get_root_property_name(property_path)
-	var property_info: Dictionary = get_property_info(object, root_property)
-	if property_info.is_empty():
-		return _make_write_result(false, "Missing property: %s" % String(root_property), root_property)
-	if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "check_writable", true) and not is_property_writable(property_info):
-		return _make_write_result(false, "Property is not writable: %s" % String(root_property), root_property)
-	if not _property_path_can_resolve(object, property_path):
-		return _make_write_result(false, "Property path cannot be resolved: %s" % String(property_path), root_property)
-
-	var old_value: Variant = object.get_indexed(property_path)
-	var property_type: int = _get_effective_property_type(property_path, property_info, old_value)
-	var value_to_write: Variant = value
-	if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "check_type", true) and not value_matches_property_type(value, property_type):
-		return _make_write_result(false, "Property type mismatch: %s" % String(root_property), root_property, old_value)
-	if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "coerce_value", true):
-		value_to_write = coerce_property_value(value, property_type)
-
+	var root_property: StringName = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+		preparation,
+		"property_name",
+		get_root_property_name(property_path)
+	)
+	var old_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		preparation,
+		"old_value"
+	)
+	var value_to_write: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		preparation,
+		"new_value"
+	)
 	object.set_indexed(property_path, value_to_write)
 	var applied_value: Variant = object.get_indexed(property_path)
 	if not _GF_VARIANT_ACCESS_SCRIPT.values_equal(applied_value, value_to_write):
@@ -248,10 +337,11 @@ static func write_property(
 	return _make_write_result(true, "", root_property, old_value, applied_value)
 
 
-## 按精确 StringName 写入对象的直接属性，不把 `/` 或 `:` 解释为 NodePath 分隔符。
-## 写入后会读取属性并验证请求值确实落地；动态 `_set()` 拒绝或静默忽略时返回失败。
+## 零写入验证对象的精确直接属性，并计算真实写入会使用的规范化值。
+##
+## 属性名不会被解释为 NodePath；包含 `/` 或 `:` 的动态属性名会保持原样。
 ## [br]
-## @api public
+## @api framework_internal
 ## [br]
 ## @since unreleased
 ## [br]
@@ -263,14 +353,14 @@ static func write_property(
 ## [br]
 ## @schema value: Variant value requested for direct property assignment.
 ## [br]
-## @param options: 与 write_property() 相同的校验和转换选项。
+## @param options: 与 write_direct_property() 相同的校验和转换选项。
 ## [br]
 ## @schema options: Dictionary with optional bool keys check_writable, check_type, and coerce_value.
 ## [br]
-## @return 写入结果字典。
+## @return 准备结果字典。
 ## [br]
 ## @schema return: Dictionary { ok: bool, error: String, property_name: StringName, old_value: Variant, new_value: Variant }.
-static func write_direct_property(
+static func prepare_direct_property_write(
 	object: Object,
 	property_name: StringName,
 	value: Variant,
@@ -304,7 +394,6 @@ static func write_direct_property(
 		"type",
 		TYPE_NIL
 	)
-	var value_to_write: Variant = value
 	if (
 		_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "check_type", true)
 		and not value_matches_property_type(value, property_type)
@@ -315,9 +404,63 @@ static func write_direct_property(
 			property_name,
 			old_value
 		)
+	var value_to_write: Variant = value
 	if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "coerce_value", true):
 		value_to_write = coerce_property_value(value, property_type)
+	return _make_write_result(
+		true,
+		"",
+		property_name,
+		old_value,
+		value_to_write
+	)
 
+
+## 按精确 StringName 写入对象的直接属性，不把 `/` 或 `:` 解释为 NodePath 分隔符。
+## 写入后会读取属性并验证请求值确实落地；动态 `_set()` 拒绝或静默忽略时返回失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param object: 目标对象。
+## [br]
+## @param property_name: 精确直接属性名。
+## [br]
+## @param value: 请求写入的值。
+## [br]
+## @schema value: Variant value requested for direct property assignment.
+## [br]
+## @param options: 与 write_property() 相同的校验和转换选项。
+## [br]
+## @schema options: Dictionary with optional bool keys check_writable, check_type, and coerce_value.
+## [br]
+## @return 写入结果字典。
+## [br]
+## @schema return: Dictionary { ok: bool, error: String, property_name: StringName, old_value: Variant, new_value: Variant }.
+static func write_direct_property(
+	object: Object,
+	property_name: StringName,
+	value: Variant,
+	options: Dictionary = {}
+) -> Dictionary:
+	var preparation: Dictionary = prepare_direct_property_write(
+		object,
+		property_name,
+		value,
+		options
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		return preparation
+
+	var old_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		preparation,
+		"old_value"
+	)
+	var value_to_write: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		preparation,
+		"new_value"
+	)
 	object.set(property_name, value_to_write)
 	var applied_value: Variant = object.get(property_name)
 	if not _GF_VARIANT_ACCESS_SCRIPT.values_equal(applied_value, value_to_write):

--- a/addons/gf/kernel/editor/gf_editor_command.gd
+++ b/addons/gf/kernel/editor/gf_editor_command.gd
@@ -65,6 +65,8 @@ var _configuration_sealed: bool = false
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @return Godot 错误码。
 func execute() -> Error:
 	if not can_execute():
@@ -75,7 +77,7 @@ func execute() -> Error:
 	_last_execute_error = error
 	if error == OK:
 		_executed = true
-		_seal_configuration()
+		_seal_configuration_for_execution()
 	return error
 
 
@@ -137,9 +139,9 @@ func add_to_undo_manager(undo_manager: Object, execute_immediately: bool = true)
 		var commit_error_value: int = commit_result
 		var commit_error: Error = commit_error_value as Error
 		if commit_error == OK:
-			_seal_configuration()
+			_seal_configuration_for_execution()
 		return commit_error
-	_seal_configuration()
+	_seal_configuration_for_execution()
 	return OK
 
 
@@ -258,7 +260,16 @@ func _can_change_configuration(field_name: String) -> bool:
 	return false
 
 
-# --- 私有/辅助方法 ---
-
-func _seal_configuration() -> void:
+## 冻结命令配置。
+##
+## 会在命令成功执行或注册到 UndoRedo 后由基类调用。可能发生部分写入的事务子类
+## 应在第一笔实际写入前主动调用，确保失败恢复仍使用不可变配置与首次快照。
+## [br]
+## @api protected
+## [br]
+## @since unreleased
+func _seal_configuration_for_execution() -> void:
 	_configuration_sealed = true
+
+
+# --- 私有/辅助方法 ---

--- a/addons/gf/kernel/editor/gf_editor_property_batch_command.gd
+++ b/addons/gf/kernel/editor/gf_editor_property_batch_command.gd
@@ -1,0 +1,1496 @@
+@tool
+
+## GFEditorPropertyBatchCommand: 通用多目标属性事务命令。
+##
+## 对调用方显式提供的 Object 属性先做全量零写入预检，再按稳定顺序提交。
+## 任一写入或最终状态验证失败时，会按相反顺序恢复本次尝试前的全部目标属性。
+## 命令只保证显式属性值边界，不代理 setter 的外部副作用、文件保存或业务事务。
+## [br]
+## @api public
+## [br]
+## @category editor_api
+## [br]
+## @since unreleased
+## [br]
+## @layer kernel/editor
+class_name GFEditorPropertyBatchCommand
+extends GFEditorCommand
+
+
+# --- 常量 ---
+
+## 尚未验证或执行。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_PENDING: StringName = &"pending"
+
+## 全量预检通过。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_READY: StringName = &"ready"
+
+## 属性事务已提交。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_COMMITTED: StringName = &"committed"
+
+## 属性事务已撤销。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_REVERTED: StringName = &"reverted"
+
+## 未完整补偿的事务已恢复到该次操作开始前状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_RECOVERED: StringName = &"recovered"
+
+## 全量预检失败，未开始写入。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_PREFLIGHT_FAILED: StringName = &"preflight_failed"
+
+## 提交失败，且已恢复本次尝试前状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_APPLY_FAILED: StringName = &"apply_failed"
+
+## 撤销失败，且已恢复撤销前状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_REVERT_FAILED: StringName = &"revert_failed"
+
+## 补偿写入未完整恢复属性状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"
+
+const _SELECTOR_DIRECT: StringName = &"direct"
+const _SELECTOR_PATH: StringName = &"indexed_path"
+const _GF_OBJECT_PROPERTY_TOOLS_SCRIPT = preload(
+	"res://addons/gf/kernel/core/gf_object_property_tools.gd"
+)
+const _GF_VARIANT_ACCESS_SCRIPT = preload(
+	"res://addons/gf/kernel/core/gf_variant_access.gd"
+)
+
+
+# --- 私有变量 ---
+
+var _changes: Array[Dictionary] = []
+var _execution_entries: Array[Dictionary] = []
+var _first_snapshots: Array = []
+var _duplicate_resources: bool = false
+var _has_first_snapshot: bool = false
+var _recovery_required: bool = false
+var _operation_in_progress: bool = false
+var _pending_recovery_values: Array = []
+var _pending_recovery_reverse_order: bool = true
+var _last_transaction_report: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 配置属性事务。
+##
+## 每个 change 必须包含 target、new_value，以及且仅包含 property_name 或
+## property_path。property_name 表示精确直接属性名；property_path 使用 Godot
+## indexed path 语义。可选 metadata 会复制到条目和错误报告。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param changes: 属性变更数组。
+## [br]
+## @param options: 配置选项。
+## [br]
+## @schema changes: Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。
+## [br]
+## @schema options: Dictionary，可包含 command_name、metadata 和 duplicate_resources。
+## [br]
+## @return 当前命令。
+func configure(
+	changes: Array[Dictionary],
+	options: Dictionary = {}
+) -> GFEditorPropertyBatchCommand:
+	if not _can_change_configuration("configure"):
+		return self
+	_duplicate_resources = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		options,
+		"duplicate_resources",
+		false
+	)
+	_changes = _copy_configured_changes(changes)
+	command_name = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		options,
+		"command_name",
+		"Edit Object Properties"
+	)
+	metadata = _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(options, "metadata")
+	_execution_entries.clear()
+	_first_snapshots.clear()
+	_has_first_snapshot = false
+	_recovery_required = false
+	_pending_recovery_values.clear()
+	_pending_recovery_reverse_order = true
+	_last_transaction_report.clear()
+	return self
+
+
+## 零写入验证全部属性变更。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 结构化事务报告。
+## [br]
+## @schema return: Dictionary，包含 ok、status、phase、error、requested_count、applied_count、unchanged_count、attempted_count、rollback_count、failed_count、failed_index、rolled_back、recovery_required、entries、issues 和 metadata。
+func validate() -> Dictionary:
+	var report: Dictionary = _build_config_preflight()
+	_set_last_report(report)
+	return _copy_report(report)
+
+
+## 获取最近一次预检、提交、撤销或恢复报告。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 结构化事务报告副本。
+## [br]
+## @schema return: Dictionary，形状与 validate() 返回值相同。
+func get_transaction_report() -> Dictionary:
+	if _last_transaction_report.is_empty():
+		return _make_report(
+			true,
+			STATUS_PENDING,
+			&"pending",
+			OK,
+			[],
+			[]
+		)
+	return _copy_report(_last_transaction_report)
+
+
+## 恢复最近一次未完整补偿的操作。
+##
+## 恢复目标是该次失败 apply、redo 或 undo 开始前的 attempt guard，而不是固定的
+## 首次 undo 基线。undo 补偿失败时，恢复成功后命令仍保持 executed，调用方可再
+## 次调用 revert() 完成真正撤销。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Godot 错误码。
+func recover() -> Error:
+	if _operation_in_progress or not _recovery_required:
+		return ERR_UNAVAILABLE
+	_operation_in_progress = true
+	var error: Error = _recover_pending_guard()
+	_operation_in_progress = false
+	return error
+
+
+## 当前命令是否允许执行。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 配置完整、目标可写且没有待恢复残余状态时返回 true。
+func can_execute() -> bool:
+	if _operation_in_progress:
+		_set_last_report(_make_unavailable_report(&"busy", "Property transaction is busy."))
+		return false
+	if is_executed():
+		_set_last_report(
+			_make_unavailable_report(
+				&"already_executed",
+				"Property transaction is already executed."
+			)
+		)
+		return false
+	if _recovery_required:
+		_set_last_report(
+			_make_unavailable_report(
+				&"recovery_required",
+				"Property transaction must be recovered before execute."
+			)
+		)
+		return false
+	var report: Dictionary = _build_config_preflight()
+	_set_last_report(report)
+	return _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "ok")
+
+
+## 首次执行未成功但留下残余状态时，允许显式调用 revert() 重试恢复。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 存在首次快照且需要恢复时返回 true。
+func can_revert_before_execute() -> bool:
+	return _has_first_snapshot and _recovery_required
+
+
+# --- 可重写钩子 / 虚方法 ---
+
+## 执行属性事务。
+## [br]
+## @api protected
+## [br]
+## @since unreleased
+## [br]
+## @return Godot 错误码。
+func _do_it() -> Error:
+	if _operation_in_progress:
+		return ERR_UNAVAILABLE
+	_operation_in_progress = true
+	var error: Error = _execute_transaction()
+	_operation_in_progress = false
+	return error
+
+
+## 撤销属性事务，或恢复首次执行失败留下的残余状态。
+## [br]
+## @api protected
+## [br]
+## @since unreleased
+## [br]
+## @return Godot 错误码。
+func _undo_it() -> Error:
+	if _operation_in_progress:
+		return ERR_UNAVAILABLE
+	if not _has_first_snapshot:
+		return ERR_UNAVAILABLE
+	_operation_in_progress = true
+	if _recovery_required:
+		if is_executed():
+			_set_last_report(
+				_make_unavailable_report(
+					&"recover_before_revert",
+					"Recover the failed undo attempt before retrying revert."
+				)
+			)
+			_operation_in_progress = false
+			return ERR_UNAVAILABLE
+		var recovery_error: Error = _recover_pending_guard()
+		_operation_in_progress = false
+		return recovery_error
+	var preparation: Dictionary = _prepare_execution_values(
+		_first_snapshots,
+		&"revert"
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		var failed_report: Dictionary = _copy_report(preparation)
+		failed_report["status"] = STATUS_REVERT_FAILED
+		failed_report["recovery_required"] = _recovery_required
+		_set_last_report(failed_report)
+		_operation_in_progress = false
+		return ERR_INVALID_DATA
+	var entries: Array[Dictionary] = _get_report_entries(preparation)
+	var error: Error = _run_transition(
+		entries,
+		STATUS_REVERTED,
+		STATUS_REVERT_FAILED,
+		&"revert",
+		true
+	)
+	_operation_in_progress = false
+	return error
+
+
+# --- 私有/辅助方法 ---
+
+func _execute_transaction() -> Error:
+	var preparation: Dictionary
+	if _has_first_snapshot:
+		preparation = _prepare_execution_values(
+			_get_execution_new_values(),
+			&"apply"
+		)
+	else:
+		preparation = _build_config_preflight()
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		_set_last_report(preparation)
+		return ERR_INVALID_DATA
+
+	var entries: Array[Dictionary] = _get_report_entries(preparation)
+	if not _has_first_snapshot:
+		_capture_first_snapshot(entries)
+		_seal_configuration_for_execution()
+	return _run_transition(
+		entries,
+		STATUS_COMMITTED,
+		STATUS_APPLY_FAILED,
+		&"apply",
+		false
+	)
+
+
+func _recover_pending_guard() -> Error:
+	if not _recovery_required or _pending_recovery_values.is_empty():
+		return ERR_UNAVAILABLE
+	var desired_values: Array = _duplicate_value_array(
+		_pending_recovery_values
+	)
+	var recovery_reverse_order: bool = _pending_recovery_reverse_order
+	var preparation: Dictionary = _prepare_execution_values(
+		desired_values,
+		&"recovery"
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		var failed_report: Dictionary = _copy_report(preparation)
+		failed_report["status"] = STATUS_ROLLBACK_FAILED
+		failed_report["recovery_required"] = true
+		_set_last_report(failed_report)
+		return ERR_INVALID_DATA
+	var entries: Array[Dictionary] = _get_report_entries(preparation)
+	var error: Error = _run_transition(
+		entries,
+		STATUS_RECOVERED,
+		STATUS_ROLLBACK_FAILED,
+		&"recovery",
+		recovery_reverse_order
+	)
+	if error != OK:
+		_set_pending_recovery(
+			desired_values,
+			recovery_reverse_order
+		)
+		var failure_report: Dictionary = get_transaction_report()
+		failure_report["recovery_required"] = true
+		_set_last_report(failure_report)
+	return error
+
+
+func _build_config_preflight() -> Dictionary:
+	var entries: Array[Dictionary] = []
+	var issues: Array[Dictionary] = []
+	if _changes.is_empty():
+		issues.append(
+			_make_issue(
+				-1,
+				&"missing_changes",
+				"Property transaction has no changes.",
+				&"preflight"
+			)
+		)
+	for index: int in range(_changes.size()):
+		var prepared: Dictionary = _prepare_configured_change(
+			_changes[index],
+			index,
+			&"preflight"
+		)
+		if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(prepared, "ok"):
+			var entry_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+				prepared,
+				"entry"
+			)
+			if entry_value is Dictionary:
+				var entry: Dictionary = entry_value
+				entries.append(entry)
+		else:
+			var issue_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+				prepared,
+				"issue"
+			)
+			if issue_value is Dictionary:
+				var issue: Dictionary = issue_value
+				issues.append(issue)
+	_append_overlap_issues(entries, issues)
+	var ok: bool = issues.is_empty()
+	return _make_report(
+		ok,
+		STATUS_READY if ok else STATUS_PREFLIGHT_FAILED,
+		&"preflight",
+		OK if ok else ERR_INVALID_DATA,
+		entries,
+		issues
+	)
+
+
+func _prepare_configured_change(
+	change: Dictionary,
+	index: int,
+	phase: StringName
+) -> Dictionary:
+	var metadata_value: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+		change,
+		"metadata"
+	)
+	var target_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		change,
+		"target"
+	)
+	if not (target_value is Object):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"invalid_target",
+				"Property transaction target is not an Object.",
+				phase,
+				change
+			)
+		)
+	var target: Object = target_value
+	if not is_instance_valid(target):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"invalid_target",
+				"Property transaction target is no longer valid.",
+				phase,
+				change
+			)
+		)
+	if not _has_option_key(change, &"new_value"):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"missing_new_value",
+				"Property transaction change is missing new_value.",
+				phase,
+				change
+			)
+		)
+
+	var has_property_name: bool = _has_option_key(change, &"property_name")
+	var has_property_path: bool = _has_option_key(change, &"property_path")
+	if has_property_name == has_property_path:
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"invalid_selector",
+				"Change must contain exactly one of property_name or property_path.",
+				phase,
+				change
+			)
+		)
+
+	var new_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		change,
+		"new_value"
+	)
+	var preparation: Dictionary
+	var entry: Dictionary = {
+		"index": index,
+		"target": target,
+		"metadata": metadata_value.duplicate(true),
+		"status": STATUS_READY,
+	}
+	if has_property_name:
+		var property_name: StringName = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+			change,
+			"property_name",
+			&""
+		)
+		if property_name == &"":
+			return _make_prepare_failure(
+				_make_issue(
+					index,
+					&"invalid_selector",
+					"Direct property name is empty.",
+					phase,
+					change
+				)
+			)
+		preparation = _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.prepare_direct_property_write(
+			target,
+			property_name,
+			new_value
+		)
+		entry["selector_mode"] = _SELECTOR_DIRECT
+		entry["property_name"] = property_name
+		entry["root_property"] = property_name
+		entry["root_selector"] = true
+	else:
+		var raw_path: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			change,
+			"property_path"
+		)
+		var property_path: NodePath = NodePath("")
+		if raw_path is NodePath:
+			property_path = raw_path
+		elif raw_path is String or raw_path is StringName:
+			property_path = NodePath(_GF_VARIANT_ACCESS_SCRIPT.to_text(raw_path))
+		if property_path.is_empty():
+			return _make_prepare_failure(
+				_make_issue(
+					index,
+					&"invalid_selector",
+					"Indexed property path is empty or invalid.",
+					phase,
+					change
+				)
+			)
+		preparation = _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.prepare_property_write(
+			target,
+			property_path,
+			new_value
+		)
+		entry["selector_mode"] = _SELECTOR_PATH
+		entry["property_path"] = property_path
+		var selector_components: PackedStringArray = (
+			_make_property_selector_components(property_path)
+		)
+		entry["selector_components"] = selector_components
+		entry["root_property"] = (
+			_GF_OBJECT_PROPERTY_TOOLS_SCRIPT.get_root_property_name(property_path)
+		)
+		entry["root_selector"] = selector_components.size() == 1
+
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"property_preflight_failed",
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+					preparation,
+					"error",
+					"Property preflight failed."
+				),
+				phase,
+				entry
+			)
+		)
+	entry["old_value"] = _duplicate_value(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_value(preparation, "old_value"),
+		false
+	)
+	entry["new_value"] = _duplicate_value(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_value(preparation, "new_value"),
+		false
+	)
+	return {
+		"ok": true,
+		"entry": entry,
+	}
+
+
+func _prepare_execution_values(
+	desired_values: Array,
+	phase: StringName
+) -> Dictionary:
+	var entries: Array[Dictionary] = []
+	var issues: Array[Dictionary] = []
+	if desired_values.size() != _execution_entries.size():
+		issues.append(
+			_make_issue(
+				-1,
+				&"snapshot_mismatch",
+				"Property transaction snapshot count does not match entries.",
+				phase
+			)
+		)
+	else:
+		for index: int in range(_execution_entries.size()):
+			var prepared: Dictionary = _prepare_execution_entry(
+				_execution_entries[index],
+				desired_values[index],
+				phase
+			)
+			if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(prepared, "ok"):
+				var entry_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+					prepared,
+					"entry"
+				)
+				if entry_value is Dictionary:
+					var entry: Dictionary = entry_value
+					entries.append(entry)
+			else:
+				var issue_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+					prepared,
+					"issue"
+				)
+				if issue_value is Dictionary:
+					var issue: Dictionary = issue_value
+					issues.append(issue)
+	var ok: bool = issues.is_empty()
+	return _make_report(
+		ok,
+		STATUS_READY if ok else STATUS_PREFLIGHT_FAILED,
+		phase,
+		OK if ok else ERR_INVALID_DATA,
+		entries,
+		issues
+	)
+
+
+func _prepare_execution_entry(
+	template: Dictionary,
+	desired_value: Variant,
+	phase: StringName
+) -> Dictionary:
+	var target_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		template,
+		"target"
+	)
+	var index: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+		template,
+		"index",
+		-1
+	)
+	if not (target_value is Object):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"invalid_target",
+				"Property transaction target is not an Object.",
+				phase,
+				template
+			)
+		)
+	var target: Object = target_value
+	if not is_instance_valid(target):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"invalid_target",
+				"Property transaction target is no longer valid.",
+				phase,
+				template
+			)
+		)
+
+	var selector_mode: StringName = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+		template,
+		"selector_mode"
+	)
+	var preparation: Dictionary
+	if selector_mode == _SELECTOR_DIRECT:
+		preparation = _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.prepare_direct_property_write(
+			target,
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				template,
+				"property_name"
+			),
+			desired_value
+		)
+	else:
+		var property_path_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			template,
+			"property_path"
+		)
+		if not (property_path_value is NodePath):
+			return _make_prepare_failure(
+				_make_issue(
+					index,
+					&"invalid_selector",
+					"Stored indexed property path is invalid.",
+					phase,
+					template
+				)
+			)
+		var property_path: NodePath = property_path_value
+		preparation = _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.prepare_property_write(
+			target,
+			property_path,
+			desired_value
+		)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "ok"):
+		return _make_prepare_failure(
+			_make_issue(
+				index,
+				&"property_preflight_failed",
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+					preparation,
+					"error",
+					"Property preflight failed."
+				),
+				phase,
+				template
+			)
+		)
+	var entry: Dictionary = template.duplicate(true)
+	entry["old_value"] = _duplicate_value(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_value(preparation, "old_value"),
+		false
+	)
+	entry["new_value"] = _duplicate_value(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_value(preparation, "new_value"),
+		false
+	)
+	entry["status"] = STATUS_READY
+	return {
+		"ok": true,
+		"entry": entry,
+	}
+
+
+func _run_transition(
+	entries: Array[Dictionary],
+	success_status: StringName,
+	failure_status: StringName,
+	phase: StringName,
+	reverse_order: bool
+) -> Error:
+	var recovery_before: bool = _recovery_required
+	var attempt_guard: Array = []
+	var desired_values: Array = []
+	var report_entries: Array[Dictionary] = _copy_dictionary_array(entries)
+	for entry: Dictionary in entries:
+		attempt_guard.append(
+			_duplicate_value(
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_value(entry, "old_value"),
+				false
+			)
+		)
+		desired_values.append(
+			_duplicate_value(
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_value(entry, "new_value"),
+				false
+			)
+		)
+
+	var issues: Array[Dictionary] = []
+	var attempted_count: int = 0
+	var changed_count: int = 0
+	var unchanged_count: int = 0
+	var order: Array[int] = _make_index_order(entries.size(), reverse_order)
+	for entry_index: int in order:
+		var entry: Dictionary = entries[entry_index]
+		if _values_equal(attempt_guard[entry_index], desired_values[entry_index]):
+			report_entries[entry_index]["status"] = &"unchanged"
+			unchanged_count += 1
+			continue
+		attempted_count += 1
+		var write_result: Dictionary = _write_entry(
+			entry,
+			desired_values[entry_index]
+		)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(write_result, "ok"):
+			report_entries[entry_index]["status"] = &"failed"
+			issues.append(
+				_make_issue(
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "index", -1),
+					&"property_write_failed",
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+						write_result,
+						"error",
+						"Property write failed."
+					),
+					phase,
+					entry
+				)
+			)
+			break
+		report_entries[entry_index]["status"] = (
+			&"reverted" if phase == &"revert" else &"applied"
+		)
+		changed_count += 1
+
+	if issues.is_empty():
+		issues.append_array(
+			_collect_state_issues(
+				entries,
+				desired_values,
+				phase,
+				&"final_state_mismatch"
+			)
+		)
+	if not issues.is_empty():
+		var rollback: Dictionary = _restore_attempt_guard(
+			entries,
+			attempt_guard,
+			not reverse_order
+		)
+		var rollback_issues: Array[Dictionary] = _get_report_issues(rollback)
+		issues.append_array(rollback_issues)
+		var rolled_back: bool = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			rollback,
+			"ok"
+		)
+		if rolled_back:
+			if recovery_before:
+				_recovery_required = true
+			else:
+				_clear_pending_recovery()
+			for entry_index: int in range(report_entries.size()):
+				if (
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+						report_entries[entry_index],
+						"status"
+					)
+					in [&"applied", &"reverted"]
+				):
+					report_entries[entry_index]["status"] = &"rolled_back"
+		else:
+			_set_pending_recovery(
+				attempt_guard,
+				not reverse_order
+			)
+		_set_last_report(
+			_make_report(
+				false,
+				failure_status if rolled_back else STATUS_ROLLBACK_FAILED,
+				phase,
+				FAILED,
+				report_entries,
+				issues,
+				{
+					"applied_count": 0,
+					"unchanged_count": unchanged_count,
+					"attempted_count": attempted_count,
+					"rollback_count": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+						rollback,
+						"rollback_count"
+					),
+					"rolled_back": rolled_back,
+					"recovery_required": _recovery_required,
+				}
+			)
+		)
+		return FAILED
+
+	_clear_pending_recovery()
+	_set_last_report(
+		_make_report(
+			true,
+			success_status,
+			phase,
+			OK,
+			report_entries,
+			[],
+			{
+				"applied_count": changed_count,
+				"unchanged_count": unchanged_count,
+				"attempted_count": attempted_count,
+				"rollback_count": 0,
+				"rolled_back": false,
+				"recovery_required": false,
+			}
+		)
+	)
+	return OK
+
+
+func _restore_attempt_guard(
+	entries: Array[Dictionary],
+	attempt_guard: Array,
+	reverse_order: bool
+) -> Dictionary:
+	var issues: Array[Dictionary] = []
+	var rollback_count: int = 0
+	var order: Array[int] = _make_index_order(entries.size(), reverse_order)
+	for entry_index: int in order:
+		var entry: Dictionary = entries[entry_index]
+		var read_result: Dictionary = _read_entry(entry)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(read_result, "ok"):
+			issues.append(
+				_make_issue(
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "index", -1),
+					&"rollback_read_failed",
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+						read_result,
+						"error",
+						"Rollback could not read property."
+					),
+					&"rollback",
+					entry
+				)
+			)
+			continue
+		if _values_equal(
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_value(read_result, "value"),
+			attempt_guard[entry_index]
+		):
+			continue
+		var write_result: Dictionary = _write_entry(
+			entry,
+			attempt_guard[entry_index]
+		)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(write_result, "ok"):
+			issues.append(
+				_make_issue(
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "index", -1),
+					&"rollback_write_failed",
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+						write_result,
+						"error",
+						"Rollback property write failed."
+					),
+					&"rollback",
+					entry
+				)
+			)
+			continue
+		rollback_count += 1
+	issues.append_array(
+		_collect_state_issues(
+			entries,
+			attempt_guard,
+			&"rollback",
+			&"rollback_state_mismatch"
+		)
+	)
+	return {
+		"ok": issues.is_empty(),
+		"rollback_count": rollback_count,
+		"issues": issues,
+	}
+
+
+func _collect_state_issues(
+	entries: Array[Dictionary],
+	expected_values: Array,
+	phase: StringName,
+	kind: StringName
+) -> Array[Dictionary]:
+	var issues: Array[Dictionary] = []
+	for entry_index: int in range(entries.size()):
+		var entry: Dictionary = entries[entry_index]
+		var read_result: Dictionary = _read_entry(entry)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(read_result, "ok"):
+			issues.append(
+				_make_issue(
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "index", -1),
+					kind,
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+						read_result,
+						"error",
+						"Property state could not be verified."
+					),
+					phase,
+					entry
+				)
+			)
+			continue
+		var actual_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			read_result,
+			"value"
+		)
+		if _values_equal(actual_value, expected_values[entry_index]):
+			continue
+		var issue: Dictionary = _make_issue(
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(entry, "index", -1),
+			kind,
+			"Property state does not match the transaction expectation.",
+			phase,
+			entry
+		)
+		issue["actual_value"] = _duplicate_value(actual_value, false)
+		issue["expected_value"] = _duplicate_value(
+			expected_values[entry_index],
+			false
+		)
+		issues.append(issue)
+	return issues
+
+
+func _write_entry(entry: Dictionary, value: Variant) -> Dictionary:
+	var target_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		entry,
+		"target"
+	)
+	if not (target_value is Object):
+		return {
+			"ok": false,
+			"error": "Property transaction target is invalid.",
+		}
+	var target: Object = target_value
+	if not is_instance_valid(target):
+		return {
+			"ok": false,
+			"error": "Property transaction target is no longer valid.",
+		}
+	if (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+			entry,
+			"selector_mode"
+		)
+		== _SELECTOR_DIRECT
+	):
+		return _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.write_direct_property(
+			target,
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				entry,
+				"property_name"
+			),
+			_duplicate_value(value, false)
+		)
+	var property_path_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		entry,
+		"property_path"
+	)
+	if not (property_path_value is NodePath):
+		return {
+			"ok": false,
+			"error": "Stored indexed property path is invalid.",
+		}
+	var property_path: NodePath = property_path_value
+	return _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.write_property(
+		target,
+		property_path,
+		_duplicate_value(value, false)
+	)
+
+
+func _read_entry(entry: Dictionary) -> Dictionary:
+	var target_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		entry,
+		"target"
+	)
+	if not (target_value is Object):
+		return {
+			"ok": false,
+			"error": "Property transaction target is invalid.",
+		}
+	var target: Object = target_value
+	if not is_instance_valid(target):
+		return {
+			"ok": false,
+			"error": "Property transaction target is no longer valid.",
+		}
+	if (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+			entry,
+			"selector_mode"
+		)
+		== _SELECTOR_DIRECT
+	):
+		var property_name: StringName = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				entry,
+				"property_name"
+			)
+		)
+		if not _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.has_property(
+			target,
+			property_name
+		):
+			return {
+				"ok": false,
+				"error": "Direct property is no longer available.",
+			}
+		return {
+			"ok": true,
+			"value": target.get(property_name),
+		}
+	var property_path_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		entry,
+		"property_path"
+	)
+	if not (property_path_value is NodePath):
+		return {
+			"ok": false,
+			"error": "Stored indexed property path is invalid.",
+		}
+	var property_path: NodePath = property_path_value
+	var missing_marker: RefCounted = RefCounted.new()
+	var value: Variant = _GF_OBJECT_PROPERTY_TOOLS_SCRIPT.read_property(
+		target,
+		property_path,
+		missing_marker
+	)
+	if is_same(value, missing_marker):
+		return {
+			"ok": false,
+			"error": "Indexed property path is no longer available.",
+		}
+	return {
+		"ok": true,
+		"value": value,
+	}
+
+
+func _capture_first_snapshot(entries: Array[Dictionary]) -> void:
+	_execution_entries = _copy_dictionary_array(entries)
+	_first_snapshots.clear()
+	for entry: Dictionary in entries:
+		_first_snapshots.append(
+			_duplicate_value(
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_value(entry, "old_value"),
+				false
+			)
+		)
+	_has_first_snapshot = true
+
+
+func _get_execution_new_values() -> Array:
+	var values: Array = []
+	for entry: Dictionary in _execution_entries:
+		values.append(
+			_duplicate_value(
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_value(entry, "new_value"),
+				false
+			)
+		)
+	return values
+
+
+func _set_pending_recovery(values: Array, reverse_order: bool) -> void:
+	_pending_recovery_values = _duplicate_value_array(values)
+	_pending_recovery_reverse_order = reverse_order
+	_recovery_required = true
+
+
+func _clear_pending_recovery() -> void:
+	_pending_recovery_values.clear()
+	_pending_recovery_reverse_order = true
+	_recovery_required = false
+
+
+func _duplicate_value_array(values: Array) -> Array:
+	var result: Array = []
+	for value: Variant in values:
+		result.append(_duplicate_value(value, false))
+	return result
+
+
+func _append_overlap_issues(
+	entries: Array[Dictionary],
+	issues: Array[Dictionary]
+) -> void:
+	for right_index: int in range(entries.size()):
+		var right: Dictionary = entries[right_index]
+		for left_index: int in range(right_index):
+			var left: Dictionary = entries[left_index]
+			if not _selectors_overlap(left, right):
+				continue
+			issues.append(
+				_make_issue(
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(right, "index", -1),
+					&"overlapping_selector",
+					"Property transaction selectors overlap on the same target.",
+					&"preflight",
+					right
+				)
+			)
+			break
+
+
+func _selectors_overlap(left: Dictionary, right: Dictionary) -> bool:
+	var left_target: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		left,
+		"target"
+	)
+	var right_target: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		right,
+		"target"
+	)
+	if not (left_target is Object) or not (right_target is Object):
+		return false
+	var left_object: Object = left_target
+	var right_object: Object = right_target
+	if left_object.get_instance_id() != right_object.get_instance_id():
+		return false
+	if (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(left, "root_property")
+		!= _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+			right,
+			"root_property"
+		)
+	):
+		return false
+	if (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(left, "root_selector")
+		or _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(right, "root_selector")
+	):
+		return true
+	var left_components: PackedStringArray = (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_packed_string_array(
+			left,
+			"selector_components"
+		)
+	)
+	var right_components: PackedStringArray = (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_packed_string_array(
+			right,
+			"selector_components"
+		)
+	)
+	if left_components.is_empty() or right_components.is_empty():
+		return false
+	var shared_component_count: int = mini(
+		left_components.size(),
+		right_components.size()
+	)
+	for component_index: int in range(shared_component_count):
+		if left_components[component_index] != right_components[component_index]:
+			return false
+	return true
+
+
+func _make_property_selector_components(
+	property_path: NodePath
+) -> PackedStringArray:
+	var components: PackedStringArray = PackedStringArray()
+	if property_path.get_name_count() > 0:
+		var _append_root_name: bool = components.append(
+			String(property_path.get_name(0))
+		)
+	for subname_index: int in range(property_path.get_subname_count()):
+		var _append_subname: bool = components.append(
+			String(property_path.get_subname(subname_index))
+		)
+	return components
+
+
+func _copy_configured_changes(changes: Array[Dictionary]) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for change: Dictionary in changes:
+		var copied: Dictionary = {}
+		if _has_option_key(change, &"target"):
+			copied["target"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+				change,
+				"target"
+			)
+		if _has_option_key(change, &"property_name"):
+			copied["property_name"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+				change,
+				"property_name"
+			)
+		if _has_option_key(change, &"property_path"):
+			copied["property_path"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+				change,
+				"property_path"
+			)
+		if _has_option_key(change, &"new_value"):
+			copied["new_value"] = _duplicate_value(
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+					change,
+					"new_value"
+				),
+				_duplicate_resources
+			)
+		copied["metadata"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+			change,
+			"metadata"
+		).duplicate(true)
+		result.append(copied)
+	return result
+
+
+func _make_prepare_failure(issue: Dictionary) -> Dictionary:
+	return {
+		"ok": false,
+		"issue": issue,
+	}
+
+
+func _make_issue(
+	index: int,
+	kind: StringName,
+	message: String,
+	phase: StringName,
+	entry: Dictionary = {}
+) -> Dictionary:
+	var issue: Dictionary = {
+		"index": index,
+		"kind": kind,
+		"message": message,
+		"phase": phase,
+		"target": _GF_VARIANT_ACCESS_SCRIPT.get_option_value(entry, "target"),
+		"metadata": _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+			entry,
+			"metadata"
+		).duplicate(true),
+	}
+	if _has_option_key(entry, &"property_name"):
+		issue["property_name"] = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				entry,
+				"property_name"
+			)
+		)
+	if _has_option_key(entry, &"property_path"):
+		issue["property_path"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			entry,
+			"property_path"
+		)
+	return issue
+
+
+func _make_unavailable_report(kind: StringName, message: String) -> Dictionary:
+	return _make_report(
+		false,
+		STATUS_PREFLIGHT_FAILED,
+		&"preflight",
+		ERR_UNAVAILABLE,
+		[],
+		[_make_issue(-1, kind, message, &"preflight")],
+		{
+			"recovery_required": _recovery_required,
+		}
+	)
+
+
+func _make_report(
+	ok: bool,
+	status: StringName,
+	phase: StringName,
+	error: Error,
+	entries: Array[Dictionary],
+	issues: Array[Dictionary],
+	details: Dictionary = {}
+) -> Dictionary:
+	return {
+		"ok": ok,
+		"status": status,
+		"phase": phase,
+		"error": error,
+		"requested_count": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			details,
+			"requested_count",
+			_changes.size()
+		),
+		"applied_count": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			details,
+			"applied_count"
+		),
+		"unchanged_count": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			details,
+			"unchanged_count"
+		),
+		"attempted_count": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			details,
+			"attempted_count"
+		),
+		"rollback_count": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			details,
+			"rollback_count"
+		),
+		"failed_count": _count_failed_indices(issues),
+		"failed_index": _get_first_failed_index(issues),
+		"rolled_back": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			details,
+			"rolled_back"
+		),
+		"recovery_required": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			details,
+			"recovery_required",
+			_recovery_required
+		),
+		"entries": _copy_dictionary_array(entries),
+		"issues": _copy_dictionary_array(issues),
+		"metadata": metadata.duplicate(true),
+	}
+
+
+func _count_failed_indices(issues: Array[Dictionary]) -> int:
+	var failed_indices: Dictionary = {}
+	for issue: Dictionary in issues:
+		var index: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			issue,
+			"index",
+			-1
+		)
+		failed_indices[index] = true
+	return failed_indices.size()
+
+
+func _get_first_failed_index(issues: Array[Dictionary]) -> int:
+	if issues.is_empty():
+		return -1
+	return _GF_VARIANT_ACCESS_SCRIPT.get_option_int(issues[0], "index", -1)
+
+
+func _get_report_entries(report: Dictionary) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var entries_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		report,
+		"entries"
+	)
+	if not (entries_value is Array):
+		return result
+	var entries: Array = entries_value
+	for entry_value: Variant in entries:
+		if entry_value is Dictionary:
+			var entry: Dictionary = entry_value
+			result.append(entry)
+	return result
+
+
+func _get_report_issues(report: Dictionary) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var issues_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		report,
+		"issues"
+	)
+	if not (issues_value is Array):
+		return result
+	var issues: Array = issues_value
+	for issue_value: Variant in issues:
+		if issue_value is Dictionary:
+			var issue: Dictionary = issue_value
+			result.append(issue)
+	return result
+
+
+func _make_index_order(count: int, reverse_order: bool) -> Array[int]:
+	var result: Array[int] = []
+	if reverse_order:
+		for index: int in range(count - 1, -1, -1):
+			result.append(index)
+	else:
+		for index: int in range(count):
+			result.append(index)
+	return result
+
+
+func _copy_dictionary_array(values: Array[Dictionary]) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for value: Dictionary in values:
+		result.append(value.duplicate(true))
+	return result
+
+
+func _copy_report(report: Dictionary) -> Dictionary:
+	return report.duplicate(true)
+
+
+func _set_last_report(report: Dictionary) -> void:
+	_last_transaction_report = _copy_report(report)
+
+
+func _duplicate_value(value: Variant, duplicate_resources: bool) -> Variant:
+	return _GF_VARIANT_ACCESS_SCRIPT.duplicate_variant(
+		value,
+		true,
+		duplicate_resources
+	)
+
+
+func _values_equal(left: Variant, right: Variant) -> bool:
+	return _GF_VARIANT_ACCESS_SCRIPT.values_equal(
+		left,
+		right,
+		{
+			"match_string_names": true,
+		}
+	)
+
+
+func _has_option_key(options: Dictionary, key: Variant) -> bool:
+	if options.has(key):
+		return true
+	if key is StringName:
+		var string_name_key: StringName = key
+		return options.has(String(string_name_key))
+	if key is String:
+		var string_key: String = key
+		return options.has(StringName(string_key))
+	return false

--- a/addons/gf/kernel/editor/gf_editor_property_batch_command.gd
+++ b/addons/gf/kernel/editor/gf_editor_property_batch_command.gd
@@ -110,7 +110,7 @@ var _last_transaction_report: Dictionary = {}
 
 ## 配置属性事务。
 ##
-## 每个 change 必须包含 target、new_value，以及且仅包含 property_name 或
+## changes 必须至少包含一项。每个 change 必须包含 target、new_value，以及且仅包含 property_name 或
 ## property_path。property_name 表示精确直接属性名；property_path 使用 Godot
 ## indexed path 语义。可选 metadata 会复制到条目和错误报告。
 ## [br]
@@ -118,11 +118,11 @@ var _last_transaction_report: Dictionary = {}
 ## [br]
 ## @since unreleased
 ## [br]
-## @param changes: 属性变更数组。
+## @param changes: 非空属性变更数组。
 ## [br]
 ## @param options: 配置选项。
 ## [br]
-## @schema changes: Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。
+## @schema changes: 非空 Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。
 ## [br]
 ## @schema options: Dictionary，可包含 command_name、metadata 和 duplicate_resources。
 ## [br]

--- a/addons/gf/kernel/editor/gf_editor_property_batch_command.gd.uid
+++ b/addons/gf/kernel/editor/gf_editor_property_batch_command.gd.uid
@@ -1,0 +1,1 @@
+uid://ieay3ymptlu5

--- a/addons/gf/kernel/editor/gf_resource_table_editor.gd
+++ b/addons/gf/kernel/editor/gf_resource_table_editor.gd
@@ -24,9 +24,11 @@ extends VBoxContainer
 ## @param resource: 被选中的资源。
 signal resource_selected(resource: Resource)
 
-## 单元格值提交后发出。
+## 单元格值实际变化且整批事务成功后发出；空批次和规范化后同值的提交不发出。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 ## [br]
 ## @param resource: 被修改的资源。
 ## [br]
@@ -108,9 +110,12 @@ const _SCRIPT_TYPE_INSPECTOR = preload("res://addons/gf/kernel/core/gf_script_ty
 
 # --- 公共变量 ---
 
-## 提交单元格后是否自动保存已绑定路径的 Resource。
+## 是否自动保存成功事务中实际发生属性变化且已绑定路径的 Resource。
+## 空批次和规范化后同值的提交不会触发保存。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 var auto_save_committed_resources: bool = false
 
 ## 当前搜索过滤文本。为空时显示全部资源。
@@ -431,6 +436,9 @@ func duplicate_resource(row_index: int, deep: bool = false, insert_after: bool =
 
 
 ## 提交单元格值。
+##
+## 当规范化请求值与稳定当前值相同时返回成功，但不调用 setter、不发出
+## cell_value_committed、不自动保存，也不刷新表格。
 ## [br]
 ## @api public
 ## [br]
@@ -455,8 +463,13 @@ func commit_cell_value(row_index: int, property: StringName, new_value: Variant)
 
 
 ## 提交当前可见行的单元格值。
+##
+## 当规范化请求值与稳定当前值相同时返回成功，但不调用 setter、不发出
+## cell_value_committed、不自动保存，也不刷新表格。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 ## [br]
 ## @param visible_row_index: 过滤后的可见行索引。
 ## [br]
@@ -477,7 +490,10 @@ func commit_visible_cell_value(visible_row_index: int, property: StringName, new
 ## [br]
 ## 该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。
 ## 任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。
-## 成功后统一刷新表格；启用自动保存时同一 Resource 只保存一次。
+## 规范化后同值的条目计入 unchanged_count，不调用其 setter，也不发提交信号。
+## 仅当至少一项实际变化时统一刷新；启用自动保存时同一已变化 Resource 只保存一次。
+## 空变更数组返回 status = committed、error = OK 且全部计数为 0 的成功报告，
+## 不构造属性事务命令，也不触发信号、保存或刷新。
 ## [br]
 ## @api public
 ## [br]
@@ -497,8 +513,11 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ## 批量提交可见资源行单元格值。
 ## [br]
 ## 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。
-## 全部变更通过 GFEditorPropertyBatchCommand 原子提交；启用自动保存时同一 Resource
-## 只保存一次。
+## 全部变更通过 GFEditorPropertyBatchCommand 原子提交。规范化后同值的条目计入
+## unchanged_count，不调用其 setter，也不发提交信号。仅当至少一项实际变化时
+## 统一刷新；启用自动保存时同一已变化 Resource 只保存一次。
+## 空变更数组返回 status = committed、error = OK 且全部计数为 0 的成功报告，
+## 不构造属性事务命令，也不触发信号、保存或刷新。
 ## [br]
 ## @api public
 ## [br]
@@ -561,6 +580,17 @@ func _ensure_tree() -> void:
 func _commit_resource_cell_value_changes(changes: Array[Dictionary], use_visible_rows: bool) -> Dictionary:
 	var command_changes: Array[Dictionary] = []
 	var errors: Array[Dictionary] = []
+
+	if changes.is_empty():
+		return _make_resource_commit_batch_result(
+			0,
+			[],
+			[],
+			{
+				"status": GFEditorPropertyBatchCommand.STATUS_COMMITTED,
+				"error": OK,
+			}
+		)
 
 	for change_index: int in range(changes.size()):
 		var change: Dictionary = changes[change_index]
@@ -825,6 +855,13 @@ func _make_resource_committed_reports(
 			entry,
 			"new_value"
 		)
+		var entry_status: StringName = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				entry,
+				"status",
+				&""
+			)
+		)
 		var report: Dictionary = _make_resource_cell_commit_success(
 			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
 				entry_metadata,
@@ -839,7 +876,7 @@ func _make_resource_committed_reports(
 			),
 			old_value,
 			new_value,
-			not _GF_VARIANT_ACCESS_SCRIPT.values_equal(old_value, new_value)
+			entry_status == &"applied"
 		)
 		report["index"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
 			entry_metadata,

--- a/addons/gf/kernel/editor/gf_resource_table_editor.gd
+++ b/addons/gf/kernel/editor/gf_resource_table_editor.gd
@@ -434,6 +434,8 @@ func duplicate_resource(row_index: int, deep: bool = false, insert_after: bool =
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param row_index: 资源行索引。
 ## [br]
 ## @param property: 属性名。
@@ -444,20 +446,12 @@ func duplicate_resource(row_index: int, deep: bool = false, insert_after: bool =
 ## [br]
 ## @return 提交成功返回 true。
 func commit_cell_value(row_index: int, property: StringName, new_value: Variant) -> bool:
-	var report: Dictionary = _commit_resource_cell_value_internal(row_index, property, new_value, false)
-	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "ok"):
-		return false
-
-	var resource: Resource = _get_report_resource(report)
-	cell_value_committed.emit(
-		resource,
-		property,
-		_GF_VARIANT_ACCESS_SCRIPT.get_option_value(report, "old_value"),
-		_GF_VARIANT_ACCESS_SCRIPT.get_option_value(report, "new_value")
-	)
-	_save_resource_if_requested(resource)
-	refresh()
-	return true
+	var report: Dictionary = commit_cell_values([{
+		"row_index": row_index,
+		"property": property,
+		"new_value": new_value,
+	}])
+	return _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "ok")
 
 
 ## 提交当前可见行的单元格值。
@@ -481,8 +475,9 @@ func commit_visible_cell_value(visible_row_index: int, property: StringName, new
 
 ## 批量提交资源行单元格值。
 ## [br]
-## 该方法会先处理所有变更，再统一刷新表格；启用自动保存时同一 Resource 只保存一次。
-## 它不是事务，部分失败不会回滚已成功的变更。
+## 该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。
+## 任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。
+## 成功后统一刷新表格；启用自动保存时同一 Resource 只保存一次。
 ## [br]
 ## @api public
 ## [br]
@@ -494,7 +489,7 @@ func commit_visible_cell_value(visible_row_index: int, property: StringName, new
 ## [br]
 ## @schema changes: Array[Dictionary]，每项包含 row_index: int、property: StringName/String、new_value: Variant。
 ## [br]
-## @schema return: Dictionary，包含 ok、requested_count、applied_count、unchanged_count、failed_count、committed 和 errors。
+## @schema return: Dictionary，包含 ok、status、error、requested_count、applied_count、unchanged_count、failed_count、issue_count、rolled_back、recovery_required、committed、errors，以及需要显式恢复时的 transaction_command。
 func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 	return _commit_resource_cell_value_changes(changes, false)
 
@@ -502,7 +497,8 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ## 批量提交可见资源行单元格值。
 ## [br]
 ## 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。
-## 启用自动保存时同一 Resource 只保存一次；该方法不是事务，部分失败不会回滚已成功的变更。
+## 全部变更通过 GFEditorPropertyBatchCommand 原子提交；启用自动保存时同一 Resource
+## 只保存一次。
 ## [br]
 ## @api public
 ## [br]
@@ -514,7 +510,7 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ## [br]
 ## @schema changes: Array[Dictionary]，每项包含 visible_row_index: int、property: StringName/String、new_value: Variant。
 ## [br]
-## @schema return: Dictionary，包含 ok、requested_count、applied_count、unchanged_count、failed_count、committed 和 errors。
+## @schema return: Dictionary，包含 ok、status、error、requested_count、applied_count、unchanged_count、failed_count、issue_count、rolled_back、recovery_required、committed、errors，以及需要显式恢复时的 transaction_command。
 func commit_visible_cell_values(changes: Array[Dictionary]) -> Dictionary:
 	return _commit_resource_cell_value_changes(changes, true)
 
@@ -563,8 +559,7 @@ func _ensure_tree() -> void:
 
 
 func _commit_resource_cell_value_changes(changes: Array[Dictionary], use_visible_rows: bool) -> Dictionary:
-	var committed: Array[Dictionary] = []
-	var changed_reports: Array[Dictionary] = []
+	var command_changes: Array[Dictionary] = []
 	var errors: Array[Dictionary] = []
 
 	for change_index: int in range(changes.size()):
@@ -601,68 +596,266 @@ func _commit_resource_cell_value_changes(changes: Array[Dictionary], use_visible
 			continue
 
 		var new_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(change, "new_value")
-		var report: Dictionary = _commit_resource_cell_value_internal(row_index, property, new_value, true)
-		report["index"] = change_index
-		if use_visible_rows:
-			report["visible_row_index"] = visible_row_index
-
-		if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "ok"):
-			committed.append(report)
-			if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "changed"):
-				changed_reports.append(report)
-		else:
-			var reason: StringName = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(report, "reason", &"commit_failed")
-			var failure_context: Dictionary = {
-				"message": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(report, "message", String(reason)),
-			}
+		if row_index < 0 or row_index >= _resources.size():
+			var invalid_row_context: Dictionary = {}
 			if use_visible_rows:
-				failure_context["visible_row_index"] = visible_row_index
+				invalid_row_context["visible_row_index"] = visible_row_index
 			errors.append(_make_resource_commit_error(
 				change_index,
-				reason,
+				&"invalid_row_index",
 				row_index,
 				property,
-				failure_context
+				invalid_row_context
 			))
+			continue
+		if property == &"":
+			var missing_property_context: Dictionary = {}
+			if use_visible_rows:
+				missing_property_context["visible_row_index"] = visible_row_index
+			errors.append(_make_resource_commit_error(
+				change_index,
+				&"missing_property",
+				row_index,
+				property,
+				missing_property_context
+			))
+			continue
+		var resource: Resource = _resources[row_index]
+		if resource == null:
+			var missing_resource_context: Dictionary = {}
+			if use_visible_rows:
+				missing_resource_context["visible_row_index"] = visible_row_index
+			errors.append(_make_resource_commit_error(
+				change_index,
+				&"missing_resource",
+				row_index,
+				property,
+				missing_resource_context
+			))
+			continue
+		if not _OBJECT_PROPERTY_TOOLS.has_property(resource, property):
+			var unknown_property_context: Dictionary = {}
+			if use_visible_rows:
+				unknown_property_context["visible_row_index"] = visible_row_index
+			errors.append(_make_resource_commit_error(
+				change_index,
+				&"unknown_property",
+				row_index,
+				property,
+				unknown_property_context
+			))
+			continue
 
+		var change_metadata: Dictionary = {
+			"change_index": change_index,
+			"row_index": row_index,
+			"property": property,
+		}
+		if use_visible_rows:
+			change_metadata["visible_row_index"] = visible_row_index
+		command_changes.append({
+			"target": resource,
+			"property_name": property,
+			"new_value": new_value,
+			"metadata": change_metadata,
+		})
+
+	if not errors.is_empty():
+		return _make_resource_commit_batch_result(
+			changes.size(),
+			[],
+			errors,
+			{
+				"status": &"preflight_failed",
+				"error": ERR_INVALID_DATA,
+			}
+		)
+
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured_command: GFEditorPropertyBatchCommand = command.configure(
+		command_changes,
+		{
+			"command_name": "Edit Resource Table Cells",
+			"metadata": {
+				"source": &"GFResourceTableEditor",
+			},
+		}
+	)
+	var transaction_error: Error = command.execute()
+	var transaction_report: Dictionary = command.get_transaction_report()
+	if transaction_error != OK:
+		errors = _make_resource_transaction_errors(transaction_report)
+		if errors.is_empty():
+			errors.append(_make_resource_commit_error(
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+					transaction_report,
+					"failed_index",
+					-1
+				),
+				&"transaction_failed",
+				-1,
+				&"",
+				{
+					"message": "Resource property transaction failed.",
+				}
+			))
+		if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			transaction_report,
+			"recovery_required"
+		):
+			refresh()
+		return _make_resource_commit_batch_result(
+			changes.size(),
+			[],
+			errors,
+			transaction_report,
+			command
+		)
+
+	var committed: Array[Dictionary] = _make_resource_committed_reports(
+		transaction_report
+	)
+	var changed_reports: Array[Dictionary] = []
+	for report: Dictionary in committed:
+		if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "changed"):
+			changed_reports.append(report)
 	if not changed_reports.is_empty():
 		for report: Dictionary in changed_reports:
 			_emit_resource_cell_value_committed(report)
 		_save_changed_resources_if_requested(changed_reports)
 		refresh()
+	return _make_resource_commit_batch_result(
+		changes.size(),
+		committed,
+		[],
+		transaction_report,
+		command
+	)
 
-	return _make_resource_commit_batch_result(changes.size(), committed, errors)
+
+func _make_resource_transaction_errors(
+	transaction_report: Dictionary
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var issues_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		transaction_report,
+		"issues"
+	)
+	if not (issues_value is Array):
+		return result
+	var issues: Array = issues_value
+	for issue_value: Variant in issues:
+		if not (issue_value is Dictionary):
+			continue
+		var issue: Dictionary = issue_value
+		var issue_metadata: Dictionary = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(issue, "metadata")
+		)
+		var error_context: Dictionary = {
+			"message": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+				issue,
+				"message",
+				"Resource property transaction failed."
+			),
+		}
+		if _has_option_key(issue_metadata, &"visible_row_index"):
+			error_context["visible_row_index"] = (
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+					issue_metadata,
+					"visible_row_index",
+					-1
+				)
+			)
+		result.append(_make_resource_commit_error(
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+				issue_metadata,
+				"change_index",
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_int(issue, "index", -1)
+			),
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				issue,
+				"kind",
+				&"transaction_failed"
+			),
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+				issue_metadata,
+				"row_index",
+				-1
+			),
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				issue_metadata,
+				"property",
+				&""
+			),
+			error_context
+		))
+	return result
 
 
-func _commit_resource_cell_value_internal(
-	row_index: int,
-	property: StringName,
-	new_value: Variant,
-	skip_unchanged: bool
-) -> Dictionary:
-	if row_index < 0 or row_index >= _resources.size():
-		return _make_resource_cell_commit_failure(row_index, property, &"invalid_row_index")
-	if property == &"":
-		return _make_resource_cell_commit_failure(row_index, property, &"missing_property")
-
-	var resource: Resource = _resources[row_index]
-	if resource == null:
-		return _make_resource_cell_commit_failure(row_index, property, &"missing_resource")
-	if not _OBJECT_PROPERTY_TOOLS.has_property(resource, property):
-		return _make_resource_cell_commit_failure(row_index, property, &"unknown_property")
-
-	var old_value: Variant = _OBJECT_PROPERTY_TOOLS.read_property(resource, NodePath(String(property)))
-	if skip_unchanged and old_value == new_value:
-		return _make_resource_cell_commit_success(row_index, resource, property, old_value, new_value, false)
-
-	var property_path: NodePath = NodePath(String(property))
-	var result: Dictionary = _OBJECT_PROPERTY_TOOLS.write_property(resource, property_path, new_value)
-	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(result, "ok"):
-		return _make_resource_cell_commit_failure(row_index, property, &"write_failed")
-
-	var actual_value: Variant = _OBJECT_PROPERTY_TOOLS.read_property(resource, property_path)
-	var value_changed: bool = _GF_VARIANT_ACCESS_SCRIPT.to_bool(old_value != actual_value)
-	return _make_resource_cell_commit_success(row_index, resource, property, old_value, actual_value, value_changed)
+func _make_resource_committed_reports(
+	transaction_report: Dictionary
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var entries_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		transaction_report,
+		"entries"
+	)
+	if not (entries_value is Array):
+		return result
+	var entries: Array = entries_value
+	for entry_value: Variant in entries:
+		if not (entry_value is Dictionary):
+			continue
+		var entry: Dictionary = entry_value
+		var entry_metadata: Dictionary = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(entry, "metadata")
+		)
+		var resource_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			entry,
+			"target"
+		)
+		if not (resource_value is Resource):
+			continue
+		var resource: Resource = resource_value
+		var old_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			entry,
+			"old_value"
+		)
+		var new_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			entry,
+			"new_value"
+		)
+		var report: Dictionary = _make_resource_cell_commit_success(
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+				entry_metadata,
+				"row_index",
+				-1
+			),
+			resource,
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				entry_metadata,
+				"property",
+				&""
+			),
+			old_value,
+			new_value,
+			not _GF_VARIANT_ACCESS_SCRIPT.values_equal(old_value, new_value)
+		)
+		report["index"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			entry_metadata,
+			"change_index",
+			-1
+		)
+		if _has_option_key(entry_metadata, &"visible_row_index"):
+			report["visible_row_index"] = (
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+					entry_metadata,
+					"visible_row_index",
+					-1
+				)
+			)
+		result.append(report)
+	return result
 
 
 func _emit_resource_cell_value_committed(report: Dictionary) -> void:
@@ -693,22 +886,66 @@ func _save_changed_resources_if_requested(changed_reports: Array[Dictionary]) ->
 func _make_resource_commit_batch_result(
 	requested_count: int,
 	committed: Array[Dictionary],
-	errors: Array[Dictionary]
+	errors: Array[Dictionary],
+	transaction_report: Dictionary = {},
+	transaction_command: GFEditorPropertyBatchCommand = null
 ) -> Dictionary:
 	var applied_count: int = 0
 	for report: Dictionary in committed:
 		if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(report, "changed"):
 			applied_count += 1
 	var unchanged_count: int = committed.size() - applied_count
-	return {
+	var result: Dictionary = {
 		"ok": errors.is_empty(),
+		"status": _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+			transaction_report,
+			"status",
+			&"committed" if errors.is_empty() else &"preflight_failed"
+		),
+		"error": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			transaction_report,
+			"error",
+			OK if errors.is_empty() else ERR_INVALID_DATA
+		),
 		"requested_count": requested_count,
 		"applied_count": applied_count,
 		"unchanged_count": unchanged_count,
-		"failed_count": errors.size(),
+		"failed_count": _count_resource_commit_failed_indices(errors),
+		"issue_count": errors.size(),
+		"rolled_back": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			transaction_report,
+			"rolled_back"
+		),
+		"recovery_required": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			transaction_report,
+			"recovery_required"
+		),
 		"committed": committed,
 		"errors": errors,
 	}
+	if (
+		transaction_command != null
+		and _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			result,
+			"recovery_required"
+		)
+	):
+		result["transaction_command"] = transaction_command
+	return result
+
+
+func _count_resource_commit_failed_indices(
+	errors: Array[Dictionary]
+) -> int:
+	var failed_indices: Dictionary = {}
+	for error: Dictionary in errors:
+		var index: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			error,
+			"index",
+			-1
+		)
+		failed_indices[index] = true
+	return failed_indices.size()
 
 
 func _make_resource_cell_commit_success(
@@ -727,16 +964,6 @@ func _make_resource_cell_commit_success(
 		"property": property,
 		"old_value": old_value,
 		"new_value": new_value,
-	}
-
-
-func _make_resource_cell_commit_failure(row_index: int, property: StringName, reason: StringName) -> Dictionary:
-	return {
-		"ok": false,
-		"row_index": row_index,
-		"property": property,
-		"reason": reason,
-		"message": String(reason),
 	}
 
 

--- a/addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd
+++ b/addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd
@@ -1,0 +1,1051 @@
+## GFShaderInterfaceSnapshot: 可持久化的 Shader uniform 接口快照。
+##
+## 从 Shader 反射结果捕获稳定排序的 uniform 声明，并用同一份数据校验参数集合
+## 或比较接口漂移。快照只保存公开接口字段，不保存 shader 源码、材质当前值、
+## 渲染后端产物或项目视觉语义。直接 new() 的实例保持未配置，必须经 capture()
+## 或 from_dict() 建立后再使用。
+## [br]
+## @api public
+## [br]
+## @category resource_definition
+## [br]
+## @since unreleased
+class_name GFShaderInterfaceSnapshot
+extends Resource
+
+
+# --- 常量 ---
+
+## 当前快照字典 schema 版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const CURRENT_SCHEMA_VERSION: int = 1
+
+const _KIND_INTERFACE_MODE_INVALID: StringName = &"shader_interface_mode_invalid"
+const _KIND_INTERFACE_MODE_MISMATCH: StringName = &"shader_interface_mode_mismatch"
+const _KIND_INTERFACE_SCHEMA_VERSION_UNSUPPORTED: StringName = &"shader_interface_schema_version_unsupported"
+const _KIND_INTERFACE_SNAPSHOT_MISSING: StringName = &"shader_interface_snapshot_missing"
+const _KIND_PARAMETER_CLASS_MISMATCH: StringName = &"shader_parameter_class_mismatch"
+const _KIND_PARAMETER_DUPLICATE: StringName = &"shader_parameter_duplicate"
+const _KIND_PARAMETER_EXTRA: StringName = &"shader_parameter_extra"
+const _KIND_PARAMETER_MISSING: StringName = &"shader_parameter_missing"
+const _KIND_PARAMETER_NAME_INVALID: StringName = &"shader_parameter_name_invalid"
+const _KIND_PARAMETER_TYPE_MISMATCH: StringName = &"shader_parameter_type_mismatch"
+const _KIND_UNIFORM_DUPLICATE: StringName = &"shader_uniform_duplicate"
+const _KIND_UNIFORM_EXTRA: StringName = &"shader_uniform_extra"
+const _KIND_UNIFORM_INVALID: StringName = &"shader_uniform_invalid"
+const _KIND_UNIFORM_MISSING: StringName = &"shader_uniform_missing"
+const _KIND_UNIFORM_SIGNATURE_MISMATCH: StringName = &"shader_uniform_signature_mismatch"
+const _SEVERITY_ERROR: String = "error"
+const _SEVERITY_IGNORE: String = "ignore"
+const _SEVERITY_INFO: String = "info"
+const _SEVERITY_WARNING: String = "warning"
+const _SIGNATURE_FIELDS: PackedStringArray = [
+	"type",
+	"class_name",
+	"hint",
+	"hint_string",
+]
+
+
+# --- 私有变量 ---
+
+@export_storage var _configured: bool = false
+@export_storage var _schema_version: int = 0
+@export_storage var _shader_mode: int = -1
+@export_storage var _uniforms: Array[Dictionary] = []:
+	set(value):
+		_uniforms = _normalize_uniform_entries(value)
+
+
+# --- 公共方法 ---
+
+## 从 Shader 当前反射接口创建快照。
+## [br]
+## 参数分组提示不会进入快照；uniform 会按名称和签名稳定排序。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param shader: 要捕获的 Shader；为空时返回 null。
+## [br]
+## @return 新快照，或 null。
+static func capture(shader: Shader) -> GFShaderInterfaceSnapshot:
+	if shader == null:
+		return null
+
+	var uniform_entries: Array[Dictionary] = []
+	for uniform_value: Variant in shader.get_shader_uniform_list(false):
+		uniform_entries.append(_normalize_uniform_value(uniform_value))
+	return _make_snapshot(CURRENT_SCHEMA_VERSION, shader.get_mode(), uniform_entries)
+
+
+## 从字典创建快照。
+## [br]
+## 输入会被深复制并规范化，但不会强转字段类型；不支持的 schema、缺失数组和
+## 无效条目由 validate_definition() 报告。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param data: 快照字典。
+## [br]
+## @schema data: Dictionary，包含 schema_version、shader_mode 和 uniforms；uniform 字段为 name、type、class_name、hint、hint_string、usage。
+## [br]
+## @return 新快照。
+static func from_dict(data: Dictionary) -> GFShaderInterfaceSnapshot:
+	var uniform_entries: Array[Dictionary] = []
+	var uniforms_value: Variant = _get_field_value(data, "uniforms")
+	if uniforms_value is Array:
+		var uniform_values: Array = uniforms_value
+		for uniform_value: Variant in uniform_values:
+			uniform_entries.append(_normalize_uniform_value(uniform_value))
+	else:
+		uniform_entries.append(_make_invalid_uniform_entry())
+	return _make_snapshot(
+		_get_strict_int_field(data, "schema_version", 0),
+		_get_strict_int_field(data, "shader_mode", -1),
+		uniform_entries
+	)
+
+
+## 获取快照 schema 版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return schema 版本。
+func get_schema_version() -> int:
+	return _schema_version
+
+
+## 获取捕获时的 Shader 模式。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Shader.Mode 对应整数。
+func get_shader_mode() -> int:
+	return _shader_mode
+
+
+## 获取稳定排序的 uniform 条目深拷贝。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return uniform 条目数组。
+## [br]
+## @schema return: Array[Dictionary]，每项包含 name、type、class_name、hint、hint_string 和 usage。
+func get_uniforms() -> Array[Dictionary]:
+	return _duplicate_uniform_entries(_uniforms)
+
+
+## 获取稳定排序的 uniform 名。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return uniform 名数组。
+## [br]
+## @schema return: Array[StringName]，按名称稳定排序。
+func get_uniform_names() -> Array[StringName]:
+	var result: Array[StringName] = []
+	for uniform: Dictionary in _uniforms:
+		var parameter_name: StringName = GFVariantData.get_option_string_name(
+			uniform,
+			"name",
+			&""
+		)
+		if parameter_name != &"":
+			result.append(parameter_name)
+	return result
+
+
+## 检查接口是否声明 uniform。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param parameter_name: uniform 名。
+## [br]
+## @return 已声明时返回 true。
+func has_uniform(parameter_name: StringName) -> bool:
+	return not get_uniform(parameter_name).is_empty()
+
+
+## 获取 uniform 条目深拷贝。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param parameter_name: uniform 名。
+## [br]
+## @return uniform 条目；不存在时返回空字典。
+## [br]
+## @schema return: Dictionary，包含 name、type、class_name、hint、hint_string 和 usage。
+func get_uniform(parameter_name: StringName) -> Dictionary:
+	if parameter_name == &"":
+		return {}
+	for uniform: Dictionary in _uniforms:
+		if GFVariantData.get_option_string_name(uniform, "name", &"") == parameter_name:
+			return uniform.duplicate(true)
+	return {}
+
+
+## 检查一个值是否符合已声明 uniform 类型。
+## [br]
+## 数字类型严格匹配，不做 int/float 隐式转换；Object 参数会继续检查资源类。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param parameter_name: uniform 名。
+## [br]
+## @param value: 候选值。
+## [br]
+## @param options: 支持 allow_null_object，默认 true。
+## [br]
+## @schema value: Variant shader parameter value.
+## [br]
+## @schema options: Dictionary，allow_null_object 控制 TYPE_OBJECT uniform 是否接受 null。
+## [br]
+## @return 已声明且值兼容时返回 true。
+func accepts_parameter_value(
+	parameter_name: StringName,
+	value: Variant,
+	options: Dictionary = {}
+) -> bool:
+	if not validate_definition().is_ok():
+		return false
+	var uniform: Dictionary = get_uniform(parameter_name)
+	if uniform.is_empty():
+		return false
+	return _get_value_mismatch_kind(
+		uniform,
+		value,
+		GFVariantData.get_option_bool(options, "allow_null_object", true)
+	) == &""
+
+
+## 校验快照 schema、Shader 模式、uniform 字段和重复名称。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param options: 支持 subject 和 metadata。
+## [br]
+## @schema options: Dictionary，subject 覆盖报告主题，metadata 为调用方报告元数据。
+## [br]
+## @return 标准校验报告。
+func validate_definition(options: Dictionary = {}) -> GFValidationReport:
+	var report: GFValidationReport = _make_report(
+		options,
+		"Shader interface snapshot"
+	)
+	report.metadata["schema_version"] = _schema_version
+	report.metadata["shader_mode"] = _shader_mode
+	report.extra_fields["uniform_count"] = _uniforms.size()
+	if not _configured:
+		var _missing_snapshot_issue: RefCounted = report.add_error(
+			_KIND_INTERFACE_SNAPSHOT_MISSING,
+			"Shader interface snapshot has not been captured or imported."
+		)
+		return report
+
+	if _schema_version != CURRENT_SCHEMA_VERSION:
+		var _schema_issue: RefCounted = report.add_error(
+			_KIND_INTERFACE_SCHEMA_VERSION_UNSUPPORTED,
+			"Shader interface snapshot schema version is unsupported.",
+			_schema_version,
+			"schema_version",
+			{
+				"expected": CURRENT_SCHEMA_VERSION,
+				"actual": _schema_version,
+			}
+		)
+	if not _is_valid_shader_mode(_shader_mode):
+		var _mode_issue: RefCounted = report.add_error(
+			_KIND_INTERFACE_MODE_INVALID,
+			"Shader interface snapshot mode is invalid.",
+			_shader_mode,
+			"shader_mode"
+		)
+
+	var seen_names: Dictionary = {}
+	for uniform_index: int in range(_uniforms.size()):
+		var uniform: Dictionary = _uniforms[uniform_index]
+		var uniform_path: String = "uniforms[%d]" % uniform_index
+		if (
+			not _has_uniform_schema_fields(uniform)
+			or not _has_valid_uniform_field_types(uniform)
+		):
+			var _malformed_issue: RefCounted = report.add_error(
+				_KIND_UNIFORM_INVALID,
+				"Shader uniform entry fields do not match the snapshot schema.",
+				uniform_index,
+				uniform_path
+			)
+			continue
+
+		var parameter_name: StringName = GFVariantData.get_option_string_name(
+			uniform,
+			"name",
+			&""
+		)
+		var value_type: int = GFVariantData.get_option_int(uniform, "type", TYPE_NIL)
+		if parameter_name == &"" or value_type <= TYPE_NIL or value_type >= TYPE_MAX:
+			var _invalid_issue: RefCounted = report.add_error(
+				_KIND_UNIFORM_INVALID,
+				"Shader uniform entry must declare a non-empty name and valid Variant type.",
+				parameter_name,
+				uniform_path,
+				{
+					"type": value_type,
+				}
+			)
+			continue
+
+		var parameter_key: String = String(parameter_name)
+		if seen_names.has(parameter_key):
+			var _duplicate_issue: RefCounted = report.add_error(
+				_KIND_UNIFORM_DUPLICATE,
+				"Shader interface snapshot contains a duplicate uniform.",
+				parameter_name,
+				uniform_path
+			)
+		seen_names[parameter_key] = true
+	return report
+
+
+## 根据快照校验参数字典。
+## [br]
+## Profile 默认按部分覆盖处理，因此缺失 uniform 默认忽略；未知参数和错型值默认报错。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param parameters: uniform 名到参数值的映射。
+## [br]
+## @param options: 支持 subject、metadata、missing_severity、extra_severity、type_mismatch_severity 和 allow_null_object。
+## [br]
+## @schema parameters: Dictionary[StringName|String, Variant] shader parameter values.
+## [br]
+## @schema options: Dictionary，severity 可为 ignore、info、warning 或 error；missing 默认 ignore，extra/type mismatch 默认 error；allow_null_object 默认 true。
+## [br]
+## @return 标准校验报告。
+func validate_parameters(
+	parameters: Dictionary,
+	options: Dictionary = {}
+) -> GFValidationReport:
+	var report: GFValidationReport = _make_report(
+		options,
+		"Shader parameter contract"
+	)
+	var definition_report: GFValidationReport = validate_definition({
+		"subject": report.subject,
+	})
+	var _definition_merged: RefCounted = report.merge(definition_report, false)
+	if not definition_report.is_ok():
+		return report
+
+	var missing_severity: String = _get_severity_option(
+		options,
+		"missing_severity",
+		_SEVERITY_IGNORE
+	)
+	var extra_severity: String = _get_severity_option(
+		options,
+		"extra_severity",
+		_SEVERITY_ERROR
+	)
+	var type_mismatch_severity: String = _get_severity_option(
+		options,
+		"type_mismatch_severity",
+		_SEVERITY_ERROR
+	)
+	var allow_null_object: bool = GFVariantData.get_option_bool(
+		options,
+		"allow_null_object",
+		true
+	)
+	var normalized_parameters: Dictionary = {}
+	var parameter_names: PackedStringArray = PackedStringArray()
+	for raw_key: Variant in parameters.keys():
+		var parameter_name: StringName = _variant_to_parameter_name(raw_key)
+		if parameter_name == &"":
+			var _name_issue: RefCounted = report.add_error(
+				_KIND_PARAMETER_NAME_INVALID,
+				"Shader parameter names must be non-empty String or StringName values.",
+				GFVariantData.to_text(raw_key),
+				"parameters"
+			)
+			continue
+
+		var parameter_key: String = String(parameter_name)
+		if normalized_parameters.has(parameter_key):
+			var _duplicate_issue: RefCounted = report.add_error(
+				_KIND_PARAMETER_DUPLICATE,
+				"Shader parameter dictionary contains an equivalent duplicate name.",
+				parameter_name,
+				"parameters.%s" % parameter_key
+			)
+			continue
+		normalized_parameters[parameter_key] = parameters[raw_key]
+		var _name_appended: bool = parameter_names.append(parameter_key)
+	parameter_names.sort()
+
+	var declared_parameters: Dictionary = _uniform_map(_uniforms)
+	var missing_count: int = 0
+	var matched_count: int = 0
+	var type_mismatch_count: int = 0
+	for parameter_name: StringName in get_uniform_names():
+		var parameter_key: String = String(parameter_name)
+		if not normalized_parameters.has(parameter_key):
+			missing_count += 1
+			_add_issue_by_severity(
+				report,
+				missing_severity,
+				_KIND_PARAMETER_MISSING,
+				"Shader parameter is missing from the supplied values.",
+				parameter_name,
+				"parameters.%s" % parameter_key
+			)
+			continue
+
+		matched_count += 1
+		var uniform: Dictionary = GFVariantData.get_option_dictionary(
+			declared_parameters,
+			parameter_key
+		)
+		var parameter_value: Variant = normalized_parameters[parameter_key]
+		var mismatch_kind: StringName = _get_value_mismatch_kind(
+			uniform,
+			parameter_value,
+			allow_null_object
+		)
+		if mismatch_kind == &"":
+			continue
+		type_mismatch_count += 1
+		_add_issue_by_severity(
+			report,
+			type_mismatch_severity,
+			mismatch_kind,
+			"Shader parameter value does not match the declared uniform type.",
+			parameter_name,
+			"parameters.%s" % parameter_key,
+			_make_type_mismatch_metadata(uniform, parameter_value)
+		)
+
+	var extra_count: int = 0
+	for parameter_key: String in parameter_names:
+		if declared_parameters.has(parameter_key):
+			continue
+		extra_count += 1
+		_add_issue_by_severity(
+			report,
+			extra_severity,
+			_KIND_PARAMETER_EXTRA,
+			"Shader parameter is not declared by the interface snapshot.",
+			StringName(parameter_key),
+			"parameters.%s" % parameter_key
+		)
+
+	report.extra_fields["declared_count"] = declared_parameters.size()
+	report.extra_fields["supplied_count"] = parameters.size()
+	report.extra_fields["matched_count"] = matched_count
+	report.extra_fields["missing_count"] = missing_count
+	report.extra_fields["extra_count"] = extra_count
+	report.extra_fields["type_mismatch_count"] = type_mismatch_count
+	return report
+
+
+## 比较期望快照与实际快照。
+## [br]
+## 当前快照作为 expected；actual 缺失和签名变化默认报错，新增 uniform 默认 warning。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param actual: 实际接口快照。
+## [br]
+## @param options: 支持 subject、metadata、mode_mismatch_severity、missing_severity、extra_severity、signature_severity 和 usage_severity。
+## [br]
+## @schema options: Dictionary，severity 可为 ignore、info、warning 或 error；mode/missing/signature 默认 error，extra/usage 默认 warning。
+## [br]
+## @return 标准校验报告。
+func compare_with(
+	actual: GFShaderInterfaceSnapshot,
+	options: Dictionary = {}
+) -> GFValidationReport:
+	var report: GFValidationReport = _make_report(
+		options,
+		"Shader interface comparison"
+	)
+	if actual == null:
+		var _missing_snapshot_issue: RefCounted = report.add_error(
+			_KIND_INTERFACE_SNAPSHOT_MISSING,
+			"Actual shader interface snapshot is missing."
+		)
+		return report
+
+	var expected_definition: GFValidationReport = validate_definition()
+	var actual_definition: GFValidationReport = actual.validate_definition()
+	var _expected_merged: RefCounted = report.merge(expected_definition, false)
+	var _actual_merged: RefCounted = report.merge(actual_definition, false)
+	if not expected_definition.is_ok() or not actual_definition.is_ok():
+		return report
+
+	var mode_severity: String = _get_severity_option(
+		options,
+		"mode_mismatch_severity",
+		_SEVERITY_ERROR
+	)
+	var missing_severity: String = _get_severity_option(
+		options,
+		"missing_severity",
+		_SEVERITY_ERROR
+	)
+	var extra_severity: String = _get_severity_option(
+		options,
+		"extra_severity",
+		_SEVERITY_WARNING
+	)
+	var signature_severity: String = _get_severity_option(
+		options,
+		"signature_severity",
+		_SEVERITY_ERROR
+	)
+	var usage_severity: String = _get_severity_option(
+		options,
+		"usage_severity",
+		_SEVERITY_WARNING
+	)
+	if _shader_mode != actual.get_shader_mode():
+		_add_issue_by_severity(
+			report,
+			mode_severity,
+			_KIND_INTERFACE_MODE_MISMATCH,
+			"Shader interface modes differ.",
+			actual.get_shader_mode(),
+			"shader_mode",
+			{
+				"expected": _shader_mode,
+				"actual": actual.get_shader_mode(),
+			}
+		)
+
+	var expected_uniforms: Dictionary = _uniform_map(_uniforms)
+	var actual_uniforms: Dictionary = _uniform_map(actual.get_uniforms())
+	var expected_names: PackedStringArray = _sorted_dictionary_keys(expected_uniforms)
+	var actual_names: PackedStringArray = _sorted_dictionary_keys(actual_uniforms)
+	var matched_count: int = 0
+	var missing_count: int = 0
+	var extra_count: int = 0
+	var signature_mismatch_count: int = 0
+	for parameter_key: String in expected_names:
+		if not actual_uniforms.has(parameter_key):
+			missing_count += 1
+			_add_issue_by_severity(
+				report,
+				missing_severity,
+				_KIND_UNIFORM_MISSING,
+				"Expected shader uniform is missing from the actual interface.",
+				StringName(parameter_key),
+				"uniforms.%s" % parameter_key
+			)
+			continue
+
+		matched_count += 1
+		var expected_uniform: Dictionary = GFVariantData.get_option_dictionary(
+			expected_uniforms,
+			parameter_key
+		)
+		var actual_uniform: Dictionary = GFVariantData.get_option_dictionary(
+			actual_uniforms,
+			parameter_key
+		)
+		var changed_fields: Array[String] = _changed_uniform_fields(
+			expected_uniform,
+			actual_uniform,
+			_SIGNATURE_FIELDS
+		)
+		if not changed_fields.is_empty():
+			signature_mismatch_count += 1
+			_add_issue_by_severity(
+				report,
+				signature_severity,
+				_KIND_UNIFORM_SIGNATURE_MISMATCH,
+				"Shader uniform signature differs from the expected interface.",
+				StringName(parameter_key),
+				"uniforms.%s" % parameter_key,
+				_make_signature_mismatch_metadata(
+					expected_uniform,
+					actual_uniform,
+					changed_fields
+				)
+			)
+		if expected_uniform["usage"] != actual_uniform["usage"]:
+			signature_mismatch_count += 1
+			_add_issue_by_severity(
+				report,
+				usage_severity,
+				_KIND_UNIFORM_SIGNATURE_MISMATCH,
+				"Shader uniform usage flags differ from the expected interface.",
+				StringName(parameter_key),
+				"uniforms.%s" % parameter_key,
+				_make_signature_mismatch_metadata(
+					expected_uniform,
+					actual_uniform,
+					["usage"]
+				)
+			)
+
+	for parameter_key: String in actual_names:
+		if expected_uniforms.has(parameter_key):
+			continue
+		extra_count += 1
+		_add_issue_by_severity(
+			report,
+			extra_severity,
+			_KIND_UNIFORM_EXTRA,
+			"Actual shader interface declares an additional uniform.",
+			StringName(parameter_key),
+			"uniforms.%s" % parameter_key
+		)
+
+	report.extra_fields["expected_count"] = expected_uniforms.size()
+	report.extra_fields["actual_count"] = actual_uniforms.size()
+	report.extra_fields["matched_count"] = matched_count
+	report.extra_fields["missing_count"] = missing_count
+	report.extra_fields["extra_count"] = extra_count
+	report.extra_fields["signature_mismatch_count"] = signature_mismatch_count
+	return report
+
+
+## 将 Shader 当前接口与本快照比较。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param shader: 实际 Shader。
+## [br]
+## @param options: 传给 compare_with() 的报告和 severity 选项。
+## [br]
+## @schema options: Dictionary compare_with() options.
+## [br]
+## @return 标准校验报告。
+func validate_shader(
+	shader: Shader,
+	options: Dictionary = {}
+) -> GFValidationReport:
+	return compare_with(capture(shader), options)
+
+
+## 创建快照深拷贝。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新快照。
+func duplicate_snapshot() -> GFShaderInterfaceSnapshot:
+	return _make_snapshot(
+		_schema_version,
+		_shader_mode,
+		_uniforms,
+		_configured
+	)
+
+
+## 转换为稳定排序的快照字典。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 快照字典。
+## [br]
+## @schema return: Dictionary，包含 schema_version、shader_mode 和 uniforms。
+func to_dict() -> Dictionary:
+	return {
+		"schema_version": _schema_version,
+		"shader_mode": _shader_mode,
+		"uniforms": _duplicate_uniform_entries(_uniforms),
+	}
+
+
+# --- 私有/辅助方法 ---
+
+static func _make_snapshot(
+	schema_version: int,
+	shader_mode: int,
+	uniform_entries: Array[Dictionary],
+	configured: bool = true
+) -> GFShaderInterfaceSnapshot:
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.new()
+	snapshot._schema_version = schema_version
+	snapshot._shader_mode = shader_mode
+	snapshot._uniforms = uniform_entries
+	snapshot._configured = configured
+	return snapshot
+
+
+static func _normalize_uniform_entries(
+	uniform_entries: Array[Dictionary]
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for uniform: Dictionary in uniform_entries:
+		result.append(_normalize_uniform_value(uniform))
+	result.sort_custom(
+		func(left: Dictionary, right: Dictionary) -> bool:
+			return _uniform_sort_key(left) < _uniform_sort_key(right)
+	)
+	return result
+
+
+static func _normalize_uniform_value(value: Variant) -> Dictionary:
+	if not (value is Dictionary):
+		return _make_invalid_uniform_entry()
+	var uniform: Dictionary = value
+	if (
+		not _has_uniform_schema_fields(uniform)
+		or not _has_valid_uniform_field_types(uniform)
+	):
+		return _make_invalid_uniform_entry()
+
+	var name_value: Variant = _get_field_value(uniform, "name")
+	var type_value: Variant = _get_field_value(uniform, "type")
+	var class_name_value: Variant = _get_field_value(uniform, "class_name")
+	var hint_value: Variant = _get_field_value(uniform, "hint")
+	var hint_string_value: Variant = _get_field_value(uniform, "hint_string")
+	var usage_value: Variant = _get_field_value(uniform, "usage")
+
+	return {
+		"name": _to_strict_string_name(name_value),
+		"type": _to_strict_int(type_value),
+		"class_name": _to_strict_string_name(class_name_value),
+		"hint": _to_strict_int(hint_value),
+		"hint_string": _to_strict_string(hint_string_value),
+		"usage": _to_strict_int(usage_value),
+	}
+
+
+static func _make_invalid_uniform_entry() -> Dictionary:
+	return {
+		"name": &"",
+		"type": TYPE_NIL,
+		"class_name": &"",
+		"hint": PROPERTY_HINT_NONE,
+		"hint_string": "",
+		"usage": PROPERTY_USAGE_DEFAULT,
+	}
+
+
+static func _has_uniform_schema_fields(uniform: Dictionary) -> bool:
+	for field_name: String in [
+		"name",
+		"type",
+		"class_name",
+		"hint",
+		"hint_string",
+		"usage",
+	]:
+		if not _has_field(uniform, field_name):
+			return false
+	return true
+
+
+static func _has_valid_uniform_field_types(uniform: Dictionary) -> bool:
+	return (
+		_is_string_name_value(_get_field_value(uniform, "name"))
+		and typeof(_get_field_value(uniform, "type")) == TYPE_INT
+		and _is_string_name_value(_get_field_value(uniform, "class_name"))
+		and typeof(_get_field_value(uniform, "hint")) == TYPE_INT
+		and _is_string_value(_get_field_value(uniform, "hint_string"))
+		and typeof(_get_field_value(uniform, "usage")) == TYPE_INT
+	)
+
+
+static func _has_field(data: Dictionary, field_name: String) -> bool:
+	return data.has(field_name) or data.has(StringName(field_name))
+
+
+static func _get_field_value(data: Dictionary, field_name: String) -> Variant:
+	if data.has(field_name):
+		return data[field_name]
+	var string_name_field: StringName = StringName(field_name)
+	if data.has(string_name_field):
+		return data[string_name_field]
+	return null
+
+
+static func _get_strict_int_field(
+	data: Dictionary,
+	field_name: String,
+	default_value: int
+) -> int:
+	var value: Variant = _get_field_value(data, field_name)
+	return _to_strict_int(value) if typeof(value) == TYPE_INT else default_value
+
+
+static func _is_string_name_value(value: Variant) -> bool:
+	return value is String or value is StringName
+
+
+static func _is_string_value(value: Variant) -> bool:
+	return value is String
+
+
+static func _to_strict_string_name(value: Variant) -> StringName:
+	if value is StringName:
+		var string_name_value: StringName = value
+		return string_name_value
+	if value is String:
+		var text_value: String = value
+		return StringName(text_value)
+	return &""
+
+
+static func _to_strict_string(value: Variant) -> String:
+	if value is String:
+		var text_value: String = value
+		return text_value
+	return ""
+
+
+static func _to_strict_int(value: Variant) -> int:
+	if typeof(value) == TYPE_INT:
+		var int_value: int = value
+		return int_value
+	return 0
+
+
+static func _uniform_sort_key(uniform: Dictionary) -> String:
+	return "%s\u001f%010d\u001f%s\u001f%010d\u001f%s\u001f%010d" % [
+		GFVariantData.get_option_string(uniform, "name"),
+		GFVariantData.get_option_int(uniform, "type", TYPE_NIL),
+		GFVariantData.get_option_string(uniform, "class_name"),
+		GFVariantData.get_option_int(uniform, "hint", PROPERTY_HINT_NONE),
+		GFVariantData.get_option_string(uniform, "hint_string"),
+		GFVariantData.get_option_int(uniform, "usage", PROPERTY_USAGE_DEFAULT),
+	]
+
+
+static func _duplicate_uniform_entries(
+	uniform_entries: Array[Dictionary]
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for uniform: Dictionary in uniform_entries:
+		result.append(uniform.duplicate(true))
+	return result
+
+
+static func _is_valid_shader_mode(shader_mode: int) -> bool:
+	match shader_mode:
+		Shader.MODE_SPATIAL:
+			return true
+		Shader.MODE_CANVAS_ITEM:
+			return true
+		Shader.MODE_PARTICLES:
+			return true
+		Shader.MODE_SKY:
+			return true
+		Shader.MODE_FOG:
+			return true
+		Shader.MODE_TEXTURE_BLIT:
+			return true
+		_:
+			return false
+
+
+static func _make_report(
+	options: Dictionary,
+	default_subject: String
+) -> GFValidationReport:
+	return GFValidationReport.new(
+		GFVariantData.get_option_string(options, "subject", default_subject),
+		GFVariantData.get_option_dictionary(options, "metadata")
+	)
+
+
+static func _variant_to_parameter_name(value: Variant) -> StringName:
+	if value is StringName:
+		var string_name_value: StringName = value
+		return string_name_value
+	if value is String:
+		var text_value: String = value
+		return StringName(text_value)
+	return &""
+
+
+static func _get_value_mismatch_kind(
+	uniform: Dictionary,
+	value: Variant,
+	allow_null_object: bool
+) -> StringName:
+	var expected_type: int = GFVariantData.get_option_int(uniform, "type", TYPE_NIL)
+	var actual_type: int = typeof(value)
+	if expected_type != TYPE_OBJECT:
+		return &"" if actual_type == expected_type else _KIND_PARAMETER_TYPE_MISMATCH
+	if value == null:
+		return &"" if allow_null_object else _KIND_PARAMETER_TYPE_MISMATCH
+	if actual_type != TYPE_OBJECT or not (value is Object):
+		return _KIND_PARAMETER_TYPE_MISMATCH
+
+	var object_value: Object = value
+	if not is_instance_valid(object_value):
+		return _KIND_PARAMETER_CLASS_MISMATCH
+	var expected_class_name: String = _get_expected_object_class(uniform)
+	if expected_class_name.is_empty() or object_value.is_class(expected_class_name):
+		return &""
+	return _KIND_PARAMETER_CLASS_MISMATCH
+
+
+static func _get_expected_object_class(uniform: Dictionary) -> String:
+	var class_name_hint: String = GFVariantData.get_option_string(
+		uniform,
+		"class_name"
+	).strip_edges()
+	if not class_name_hint.is_empty():
+		return class_name_hint
+	var hint_string: String = GFVariantData.get_option_string(
+		uniform,
+		"hint_string"
+	).strip_edges()
+	if hint_string.is_empty():
+		return ""
+	return hint_string.split(",", false, 1)[0].strip_edges()
+
+
+static func _make_type_mismatch_metadata(
+	uniform: Dictionary,
+	value: Variant
+) -> Dictionary:
+	var expected_type: int = GFVariantData.get_option_int(uniform, "type", TYPE_NIL)
+	var actual_type: int = typeof(value)
+	return {
+		"expected_type": expected_type,
+		"expected_type_name": type_string(expected_type),
+		"actual_type": actual_type,
+		"actual_type_name": type_string(actual_type),
+		"expected_class_name": _get_expected_object_class(uniform),
+	}
+
+
+static func _get_severity_option(
+	options: Dictionary,
+	option_name: String,
+	default_value: String
+) -> String:
+	var severity: String = GFVariantData.get_option_string(
+		options,
+		option_name,
+		default_value
+	).strip_edges().to_lower()
+	if [
+		_SEVERITY_IGNORE,
+		_SEVERITY_INFO,
+		_SEVERITY_WARNING,
+		_SEVERITY_ERROR,
+	].has(severity):
+		return severity
+	return default_value
+
+
+static func _add_issue_by_severity(
+	report: GFValidationReport,
+	severity: String,
+	kind: StringName,
+	message: String,
+	key: Variant = null,
+	path: String = "",
+	metadata: Dictionary = {}
+) -> void:
+	match severity:
+		_SEVERITY_IGNORE:
+			return
+		_SEVERITY_INFO:
+			var _info_issue: RefCounted = report.add_info(
+				kind,
+				message,
+				key,
+				path,
+				metadata
+			)
+		_SEVERITY_WARNING:
+			var _warning_issue: RefCounted = report.add_warning(
+				kind,
+				message,
+				key,
+				path,
+				metadata
+			)
+		_:
+			var _error_issue: RefCounted = report.add_error(
+				kind,
+				message,
+				key,
+				path,
+				metadata
+			)
+
+
+static func _uniform_map(uniform_entries: Array[Dictionary]) -> Dictionary:
+	var result: Dictionary = {}
+	for uniform: Dictionary in uniform_entries:
+		var parameter_name: StringName = GFVariantData.get_option_string_name(
+			uniform,
+			"name",
+			&""
+		)
+		if parameter_name != &"":
+			result[String(parameter_name)] = uniform.duplicate(true)
+	return result
+
+
+static func _sorted_dictionary_keys(data: Dictionary) -> PackedStringArray:
+	var result: PackedStringArray = PackedStringArray()
+	for raw_key: Variant in data.keys():
+		var _key_appended: bool = result.append(GFVariantData.to_text(raw_key))
+	result.sort()
+	return result
+
+
+static func _changed_uniform_fields(
+	expected: Dictionary,
+	actual: Dictionary,
+	field_names: PackedStringArray
+) -> Array[String]:
+	var result: Array[String] = []
+	for field_name: String in field_names:
+		if expected[field_name] != actual[field_name]:
+			result.append(field_name)
+	return result
+
+
+static func _make_signature_mismatch_metadata(
+	expected: Dictionary,
+	actual: Dictionary,
+	changed_fields: Array[String]
+) -> Dictionary:
+	return {
+		"changed_fields": changed_fields.duplicate(),
+		"expected": expected.duplicate(true),
+		"actual": actual.duplicate(true),
+	}

--- a/addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd.uid
+++ b/addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd.uid
@@ -1,0 +1,1 @@
+uid://djdaopjwr23i2

--- a/addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd
+++ b/addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd
@@ -115,6 +115,8 @@ func clear_parameters() -> void:
 ## [br]
 ## @api public
 ## [br]
+## @since 4.3.0
+## [br]
 ## @return: 参数名数组。
 ## [br]
 ## @schema return: Array[StringName]，当前 profile 中可识别的 shader 参数名。
@@ -124,7 +126,43 @@ func get_parameter_names() -> Array[StringName]:
 		var parameter_name: StringName = _variant_to_parameter_name(raw_key)
 		if parameter_name != &"":
 			names.append(parameter_name)
+	names.sort()
 	return names
+
+
+## 根据 Shader 接口快照校验当前参数。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param interface_snapshot: 期望接口快照。
+## [br]
+## @param options: 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。
+## [br]
+## @schema options: Dictionary shader parameter validation options.
+## [br]
+## @return 标准校验报告。
+func validate_against(
+	interface_snapshot: GFShaderInterfaceSnapshot,
+	options: Dictionary = {}
+) -> GFValidationReport:
+	if interface_snapshot != null:
+		return interface_snapshot.validate_parameters(parameters, options)
+
+	var report: GFValidationReport = GFValidationReport.new(
+		GFVariantData.get_option_string(
+			options,
+			"subject",
+			"Shader parameter profile"
+		),
+		GFVariantData.get_option_dictionary(options, "metadata")
+	)
+	var _missing_snapshot_issue: RefCounted = report.add_error(
+		&"shader_interface_snapshot_missing",
+		"Shader interface snapshot is required to validate a parameter profile."
+	)
+	return report
 
 
 ## 合并另一个 profile。

--- a/addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd
+++ b/addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd
@@ -35,15 +35,17 @@ static var _registered_global_parameter_names: Dictionary = {}
 ## [br]
 ## @api public
 ## [br]
+## @since 4.3.0
+## [br]
 ## @param target: ShaderMaterial，或持有材质属性的对象。
 ## [br]
 ## @param profile: 要应用的 shader 参数 profile。
 ## [br]
-## @param options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、warn_on_invalid_target、warn_on_missing_parameters 和 copy_values。
+## @param options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、validate_parameter_types、warn_on_invalid_target、warn_on_missing_parameters、warn_on_type_mismatch 和 copy_values。
 ## [br]
 ## @return: 实际写入的参数数量。
 ## [br]
-## @schema options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；warn_on_invalid_target 和 warn_on_missing_parameters 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
+## @schema options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；validate_parameter_types 默认为 true，会跳过与 uniform 声明不兼容的值；warn_on_invalid_target、warn_on_missing_parameters 和 warn_on_type_mismatch 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
 func apply_profile(
 	target: Object,
 	profile: GFShaderParameterProfile,
@@ -84,17 +86,19 @@ func apply_global_profile(profile: GFShaderParameterProfile, options: Dictionary
 ## [br]
 ## @api public
 ## [br]
+## @since 4.3.0
+## [br]
 ## @param target: ShaderMaterial，或持有材质属性的对象。
 ## [br]
 ## @param parameters: 要应用的 shader 参数字典。
 ## [br]
-## @param options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、warn_on_invalid_target、warn_on_missing_parameters 和 copy_values。
+## @param options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、validate_parameter_types、warn_on_invalid_target、warn_on_missing_parameters、warn_on_type_mismatch 和 copy_values。
 ## [br]
 ## @return: 实际写入的参数数量。
 ## [br]
 ## @schema parameters: Dictionary[StringName, Variant]，shader uniform 名到参数值的映射。
 ## [br]
-## @schema options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；warn_on_invalid_target 和 warn_on_missing_parameters 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
+## @schema options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；validate_parameter_types 默认为 true，会跳过与 uniform 声明不兼容的值；warn_on_invalid_target、warn_on_missing_parameters 和 warn_on_type_mismatch 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
 func apply_parameters(target: Object, parameters: Dictionary, options: Dictionary = {}) -> int:
 	if parameters.is_empty():
 		return 0
@@ -128,18 +132,44 @@ func apply_parameters(target: Object, parameters: Dictionary, options: Dictionar
 		"warn_on_missing_parameters",
 		true
 	)
+	var validate_parameter_types: bool = GFVariantData.get_option_bool(
+		options,
+		"validate_parameter_types",
+		true
+	)
+	var warn_on_type_mismatch: bool = GFVariantData.get_option_bool(
+		options,
+		"warn_on_type_mismatch",
+		true
+	)
+	var interface_snapshot: GFShaderInterfaceSnapshot = capture_shader_interface(material)
 	var copy_values: bool = GFVariantData.get_option_bool(options, "copy_values", true)
 	var applied_count: int = 0
 	for raw_key: Variant in parameters.keys():
 		var parameter_name: StringName = _variant_to_parameter_name(raw_key)
 		if parameter_name == &"":
 			continue
-		if require_declared_parameters and not has_shader_parameter(material, parameter_name):
+		var parameter_declared: bool = (
+			interface_snapshot != null
+			and interface_snapshot.has_uniform(parameter_name)
+		)
+		if require_declared_parameters and not parameter_declared:
 			if warn_on_missing_parameters:
 				push_warning("[GFShaderParameterUtility] Shader 参数不存在：%s。" % String(parameter_name))
 			continue
 
 		var value: Variant = parameters[raw_key]
+		if (
+			validate_parameter_types
+			and parameter_declared
+			and not interface_snapshot.accepts_parameter_value(parameter_name, value)
+		):
+			if warn_on_type_mismatch:
+				push_warning(
+					"[GFShaderParameterUtility] Shader 参数值类型不符合声明：%s。"
+					% String(parameter_name)
+				)
+			continue
 		material.set_shader_parameter(
 			parameter_name,
 			GFVariantData.duplicate_variant(value) if copy_values else value
@@ -244,6 +274,8 @@ func apply_global_parameters(parameters: Dictionary, options: Dictionary = {}) -
 ## [br]
 ## @api public
 ## [br]
+## @since 4.3.0
+## [br]
 ## @param target: ShaderMaterial，或持有材质属性的对象。
 ## [br]
 ## @param material_property: 当 target 不是 ShaderMaterial 时读取的材质属性路径。
@@ -256,9 +288,108 @@ func resolve_shader_material(
 	return _resolve_shader_material(target, material_property, false, false)
 
 
+## 捕获 ShaderMaterial 当前 uniform 接口。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param material: 目标 ShaderMaterial。
+## [br]
+## @return 接口快照；材质或 Shader 为空时返回 null。
+func capture_shader_interface(
+	material: ShaderMaterial
+) -> GFShaderInterfaceSnapshot:
+	if material == null or material.shader == null:
+		return null
+	return GFShaderInterfaceSnapshot.capture(material.shader)
+
+
+## 校验 profile 是否符合 ShaderMaterial 当前 uniform 接口。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param material: 目标 ShaderMaterial。
+## [br]
+## @param profile: 要校验的 profile。
+## [br]
+## @param options: 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。
+## [br]
+## @schema options: Dictionary shader parameter validation options.
+## [br]
+## @return 标准校验报告。
+func validate_profile(
+	material: ShaderMaterial,
+	profile: GFShaderParameterProfile,
+	options: Dictionary = {}
+) -> GFValidationReport:
+	if profile == null:
+		var null_profile_report: GFValidationReport = GFValidationReport.new(
+			GFVariantData.get_option_string(
+				options,
+				"subject",
+				"Shader parameter profile"
+			),
+			GFVariantData.get_option_dictionary(options, "metadata")
+		)
+		var _null_profile_issue: RefCounted = null_profile_report.add_error(
+			&"shader_parameter_profile_missing",
+			"Shader parameter profile is missing."
+		)
+		return null_profile_report
+	return validate_parameters(material, profile.parameters, options)
+
+
+## 校验参数字典是否符合 ShaderMaterial 当前 uniform 接口。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param material: 目标 ShaderMaterial。
+## [br]
+## @param parameters: uniform 参数字典。
+## [br]
+## @param options: 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。
+## [br]
+## @schema parameters: Dictionary[StringName|String, Variant] shader parameter values.
+## [br]
+## @schema options: Dictionary shader parameter validation options.
+## [br]
+## @return 标准校验报告。
+func validate_parameters(
+	material: ShaderMaterial,
+	parameters: Dictionary,
+	options: Dictionary = {}
+) -> GFValidationReport:
+	var interface_snapshot: GFShaderInterfaceSnapshot = capture_shader_interface(
+		material
+	)
+	if interface_snapshot != null:
+		return interface_snapshot.validate_parameters(parameters, options)
+
+	var report: GFValidationReport = GFValidationReport.new(
+		GFVariantData.get_option_string(
+			options,
+			"subject",
+			"Shader parameter contract"
+		),
+		GFVariantData.get_option_dictionary(options, "metadata")
+	)
+	var _missing_snapshot_issue: RefCounted = report.add_error(
+		&"shader_interface_snapshot_missing",
+		"ShaderMaterial must provide a Shader before its parameter contract can be validated."
+	)
+	return report
+
+
 ## 获取 ShaderMaterial 当前 shader 声明的 uniform 参数名。
 ## [br]
 ## @api public
+## [br]
+## @since 4.3.0
 ## [br]
 ## @param material: 目标 ShaderMaterial。
 ## [br]
@@ -266,23 +397,20 @@ func resolve_shader_material(
 ## [br]
 ## @schema return: Array[StringName]，material.shader 声明的 shader uniform 名称。
 func get_shader_parameter_names(material: ShaderMaterial) -> Array[StringName]:
-	var names: Array[StringName] = []
-	if material == null or material.shader == null:
-		return names
-
-	for uniform_value: Variant in material.shader.get_shader_uniform_list():
-		if not (uniform_value is Dictionary):
-			continue
-		var uniform: Dictionary = uniform_value
-		var parameter_name: StringName = GFVariantData.get_option_string_name(uniform, "name", &"")
-		if parameter_name != &"":
-			names.append(parameter_name)
-	return names
+	var interface_snapshot: GFShaderInterfaceSnapshot = capture_shader_interface(
+		material
+	)
+	if interface_snapshot == null:
+		var empty_names: Array[StringName] = []
+		return empty_names
+	return interface_snapshot.get_uniform_names()
 
 
 ## 检查 ShaderMaterial 的 shader 是否声明了指定 uniform。
 ## [br]
 ## @api public
+## [br]
+## @since 4.3.0
 ## [br]
 ## @param material: 目标 ShaderMaterial。
 ## [br]
@@ -292,7 +420,13 @@ func get_shader_parameter_names(material: ShaderMaterial) -> Array[StringName]:
 func has_shader_parameter(material: ShaderMaterial, parameter_name: StringName) -> bool:
 	if parameter_name == &"":
 		return false
-	return get_shader_parameter_names(material).has(parameter_name)
+	var interface_snapshot: GFShaderInterfaceSnapshot = capture_shader_interface(
+		material
+	)
+	return (
+		interface_snapshot != null
+		and interface_snapshot.has_uniform(parameter_name)
+	)
 
 
 ## 确保 RenderingServer 全局 shader 参数存在，并可选写入 ProjectSettings。

--- a/addons/gf/standard/utilities/settings/gf_settings_load_result.gd
+++ b/addons/gf/standard/utilities/settings/gf_settings_load_result.gd
@@ -1,0 +1,427 @@
+## GFSettingsLoadResult: 设置加载操作的不可变终态快照。
+##
+## 结果将“合法空设置”与缺失、损坏、未来版本和底层存储失败明确区分，
+## 并保留实际应用状态、恢复动作和底层读取证据。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFSettingsLoadResult
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 持久化设置已成功读取并应用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_LOADED: StringName = &"loaded"
+
+## 调用方选择的显式恢复动作已完成。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_RECOVERED: StringName = &"recovered"
+
+## 文件名、路径或读取请求无效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_REQUEST: StringName = &"invalid_request"
+
+## 设置文件不存在。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_MISSING: StringName = &"missing"
+
+## 设置文件格式、载荷或完整性损坏。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_CORRUPT: StringName = &"corrupt"
+
+## 设置文件来自当前运行时无法读取的未来 schema。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_FUTURE_SCHEMA: StringName = &"future_schema"
+
+## 设置文件的迁移链缺失或迁移失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_MIGRATION_FAILED: StringName = &"migration_failed"
+
+## 底层存储读取失败或不可用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_STORAGE_FAILED: StringName = &"storage_failed"
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _ok: bool = false
+var _status: StringName = &""
+var _file_name: String = ""
+var _applied: bool = false
+var _recovered: bool = false
+var _recovery_action: StringName = &""
+var _error_code: Error = FAILED
+var _error: String = ""
+var _storage_result: GFStorageReadResult = null
+
+
+# --- 公共方法 ---
+
+## 检查加载是否进入成功终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 设置已加载或已按显式策略恢复时返回 true。
+func is_successful() -> bool:
+	return _ok
+
+
+## 获取稳定加载状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATUS_*` 常量之一。
+func get_status() -> StringName:
+	return _status
+
+
+## 获取本次加载使用的文件名。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 解析默认值后的设置文件名。
+func get_file_name() -> String:
+	return _file_name
+
+
+## 检查本次操作是否替换了有效设置状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已应用持久化载荷或默认值恢复时返回 true。
+func was_applied() -> bool:
+	return _applied
+
+
+## 检查本次操作是否执行了显式恢复动作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 使用恢复策略完成时返回 true。
+func was_recovered() -> bool:
+	return _recovered
+
+
+## 获取实际恢复动作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 未恢复时为空，否则为 `GFSettingsRecoveryPolicy.ACTION_*` 常量之一。
+func get_recovery_action() -> StringName:
+	return _recovery_action
+
+
+## 获取 Godot Error 码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时为 OK。
+func get_error_code() -> Error:
+	return _error_code
+
+
+## 获取稳定错误描述。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时为空。
+func get_error() -> String:
+	return _error
+
+
+## 获取底层存储读取结果副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 原始读取证据的隔离副本；读取未启动时为 null。
+func get_storage_result() -> GFStorageReadResult:
+	return _storage_result.duplicate_result() if _storage_result != null else null
+
+
+## 创建结果的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新结果对象。
+func duplicate_result() -> GFSettingsLoadResult:
+	var copy: GFSettingsLoadResult = GFSettingsLoadResult.new()
+	var _copy_configured: bool = copy.configure_for_framework(
+		_ok,
+		_status,
+		_file_name,
+		_applied,
+		_recovered,
+		_recovery_action,
+		_error_code,
+		_error,
+		_storage_result
+	)
+	return copy
+
+
+## 转换为不包含设置载荷的报告字典。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 加载终态摘要。
+## [br]
+## @schema return: Dictionary with ok, status, file_name, applied, recovered, recovery_action, error_code, error, and payload-free storage_result fields.
+func to_dict() -> Dictionary:
+	return {
+		"ok": _ok,
+		"status": _status,
+		"file_name": _file_name,
+		"applied": _applied,
+		"recovered": _recovered,
+		"recovery_action": _recovery_action,
+		"error_code": int(_error_code),
+		"error": _error,
+		"storage_result": _get_storage_result_summary(),
+	}
+
+
+# --- 框架内部方法 ---
+
+## 由 Settings Utility 一次性配置终态。
+##
+## 同一实例只能成功配置一次；不一致的状态组合会被拒绝。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param p_ok: 是否成功。
+## [br]
+## @param p_status: 稳定终态状态。
+## [br]
+## @param p_file_name: 实际设置文件名。
+## [br]
+## @param p_applied: 是否替换了有效设置状态。
+## [br]
+## @param p_recovered: 是否执行了恢复动作。
+## [br]
+## @param p_recovery_action: 实际恢复动作。
+## [br]
+## @param p_error_code: Godot Error 码。
+## [br]
+## @param p_error: 稳定错误描述。
+## [br]
+## @param p_storage_result: 底层读取证据。
+## [br]
+## @return 配置成功时返回 true。
+func configure_for_framework(
+	p_ok: bool,
+	p_status: StringName,
+	p_file_name: String,
+	p_applied: bool,
+	p_recovered: bool,
+	p_recovery_action: StringName = &"",
+	p_error_code: Error = OK,
+	p_error: String = "",
+	p_storage_result: GFStorageReadResult = null
+) -> bool:
+	if _configured:
+		push_error("[GFSettingsLoadResult] 结果已经配置，不能重复修改。")
+		return false
+	if not _is_valid_configuration(
+		p_ok,
+		p_status,
+		p_applied,
+		p_recovered,
+		p_recovery_action,
+		p_storage_result
+	):
+		push_error("[GFSettingsLoadResult] 已拒绝不一致的加载终态配置。")
+		return false
+
+	_configured = true
+	_ok = p_ok
+	_status = p_status
+	_file_name = p_file_name
+	_applied = p_applied
+	_recovered = p_recovered
+	_recovery_action = p_recovery_action
+	_error_code = OK if p_ok else (p_error_code if p_error_code != OK else FAILED)
+	_error = "" if p_ok else p_error.strip_edges()
+	_storage_result = p_storage_result.duplicate_result() if p_storage_result != null else null
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+func _is_valid_configuration(
+	p_ok: bool,
+	p_status: StringName,
+	p_applied: bool,
+	p_recovered: bool,
+	p_recovery_action: StringName,
+	p_storage_result: GFStorageReadResult
+) -> bool:
+	if not _is_known_status(p_status) or p_storage_result == null:
+		return false
+
+	if p_status == STATUS_LOADED:
+		return (
+			p_ok
+			and p_applied
+			and not p_recovered
+			and p_recovery_action == &""
+			and p_storage_result.ok
+			and p_storage_result.is_integrity_accepted()
+		)
+
+	if p_status == STATUS_RECOVERED:
+		return (
+			p_ok
+			and p_recovered
+			and _is_recoverable_storage_result(p_storage_result)
+			and (
+				(
+					p_recovery_action == GFSettingsRecoveryPolicy.ACTION_USE_CURRENT_STATE
+					and not p_applied
+				)
+				or (
+					p_recovery_action == GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS
+					and p_applied
+				)
+			)
+		)
+
+	return (
+		not p_ok
+		and not p_applied
+		and not p_recovered
+		and p_recovery_action == &""
+		and _storage_result_matches_failure_status(p_status, p_storage_result)
+	)
+
+
+func _is_known_status(status: StringName) -> bool:
+	return status in [
+		STATUS_LOADED,
+		STATUS_RECOVERED,
+		STATUS_INVALID_REQUEST,
+		STATUS_MISSING,
+		STATUS_CORRUPT,
+		STATUS_FUTURE_SCHEMA,
+		STATUS_MIGRATION_FAILED,
+		STATUS_STORAGE_FAILED,
+	]
+
+
+func _is_recoverable_storage_result(storage_result: GFStorageReadResult) -> bool:
+	if storage_result.ok:
+		return not storage_result.is_integrity_accepted()
+	return storage_result.failure_kind in [
+		GFStorageReadResult.FailureKind.NOT_FOUND,
+		GFStorageReadResult.FailureKind.CORRUPT,
+	]
+
+
+func _storage_result_matches_failure_status(
+	status: StringName,
+	storage_result: GFStorageReadResult
+) -> bool:
+	var failure_kind: int = storage_result.failure_kind
+	match status:
+		STATUS_INVALID_REQUEST:
+			return (
+				not storage_result.ok
+				and failure_kind == GFStorageReadResult.FailureKind.INVALID_REQUEST
+			)
+		STATUS_MISSING:
+			return (
+				not storage_result.ok
+				and failure_kind == GFStorageReadResult.FailureKind.NOT_FOUND
+			)
+		STATUS_CORRUPT:
+			return (
+				(
+					storage_result.ok
+					and not storage_result.is_integrity_accepted()
+				)
+				or (
+					not storage_result.ok
+					and failure_kind == GFStorageReadResult.FailureKind.CORRUPT
+				)
+			)
+		STATUS_FUTURE_SCHEMA:
+			return (
+				not storage_result.ok
+				and failure_kind == GFStorageReadResult.FailureKind.FUTURE_VERSION
+			)
+		STATUS_MIGRATION_FAILED:
+			return (
+				not storage_result.ok
+				and failure_kind == GFStorageReadResult.FailureKind.MIGRATION_FAILED
+			)
+		STATUS_STORAGE_FAILED:
+			return (
+				not storage_result.ok
+				and failure_kind in [
+					GFStorageReadResult.FailureKind.IO_FAILED,
+					GFStorageReadResult.FailureKind.UNAVAILABLE,
+				]
+			)
+		_:
+			return false
+
+
+func _get_storage_result_summary() -> Dictionary:
+	if _storage_result == null:
+		return {}
+	var summary: Dictionary = _storage_result.to_dict()
+	var _payload_erased: bool = summary.erase("payload")
+	return summary

--- a/addons/gf/standard/utilities/settings/gf_settings_load_result.gd.uid
+++ b/addons/gf/standard/utilities/settings/gf_settings_load_result.gd.uid
@@ -1,0 +1,1 @@
+uid://dmxhb4yf2ybqs

--- a/addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd
+++ b/addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd
@@ -1,0 +1,94 @@
+## GFSettingsRecoveryPolicy: 设置加载的显式恢复策略。
+##
+## 缺失与损坏设置默认严格失败。项目可以显式选择保留当前内存状态，
+## 或把有效设置重置为已注册默认值；恢复不会创建或覆盖持久化文件。
+## [br]
+## @api public
+## [br]
+## @category resource_definition
+## [br]
+## @since unreleased
+class_name GFSettingsRecoveryPolicy
+extends Resource
+
+
+# --- 常量 ---
+
+## 不执行自动恢复。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ACTION_FAIL: StringName = &"fail"
+
+## 保留当前有效值和暂存值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ACTION_USE_CURRENT_STATE: StringName = &"use_current_state"
+
+## 使用空 replace 语义恢复已注册默认值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ACTION_RESET_TO_DEFAULTS: StringName = &"reset_to_defaults"
+
+
+# --- 导出变量 ---
+
+## 文件缺失时的恢复动作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var missing_file_action: StringName = ACTION_FAIL
+
+## 文件损坏或完整性校验失败时的恢复动作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var corrupt_file_action: StringName = ACTION_FAIL
+
+
+# --- 公共方法 ---
+
+## 检查策略自身是否合法。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 结构化校验报告。
+## [br]
+## @schema return: GFValidationReportDictionary-compatible report with issues, counts, summary, and next_actions.
+func validate_policy() -> Dictionary:
+	var report: Dictionary = {"issues": []}
+	_append_action_issue(report, "missing_file_action", missing_file_action)
+	_append_action_issue(report, "corrupt_file_action", corrupt_file_action)
+	return GFValidationReportDictionary.finalize_report(report, "Settings recovery policy", {
+		"include_issue_count": true,
+		"next_actions": {
+			"invalid_recovery_action": (
+				"Use fail, use_current_state, or reset_to_defaults."
+			),
+		},
+		"fallback_action": "Review the first recovery policy issue.",
+		"no_action": "Settings recovery policy is valid.",
+	})
+
+
+# --- 私有/辅助方法 ---
+
+func _append_action_issue(report: Dictionary, path: String, action: StringName) -> void:
+	if action in [ACTION_FAIL, ACTION_USE_CURRENT_STATE, ACTION_RESET_TO_DEFAULTS]:
+		return
+	var _action_issue: Variant = GFValidationReportDictionary.append_issue(
+		report,
+		"error",
+		&"invalid_recovery_action",
+		"Recovery action is not supported.",
+		{"path": path, "value": action}
+	)

--- a/addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd.uid
+++ b/addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd.uid
@@ -1,0 +1,1 @@
+uid://roorsk4vdd08

--- a/addons/gf/standard/utilities/settings/gf_settings_utility.gd
+++ b/addons/gf/standard/utilities/settings/gf_settings_utility.gd
@@ -29,14 +29,14 @@ extends GFUtility
 ## @schema new_value: Variant next setting value or null when the setting was removed.
 signal setting_changed(key: StringName, old_value: Variant, new_value: Variant)
 
-## 设置加载完成时发出。
+## 设置加载进入终态时发出。
 ## [br]
 ## @api public
 ## [br]
-## @param data: 已加载的持久化设置数据。
+## @since unreleased
 ## [br]
-## @schema data: Dictionary[String, Variant] loaded persisted settings data.
-signal settings_loaded(data: Dictionary)
+## @param result: 隔离的结构化加载结果。
+signal settings_load_completed(result: GFSettingsLoadResult)
 
 ## 设置保存完成时发出。
 ## [br]
@@ -117,6 +117,7 @@ var _save_elapsed_seconds: float = 0.0
 var _save_queued_file_name: String = ""
 var _batch_depth: int = 0
 var _batch_save_requested: bool = false
+var _last_load_result: GFSettingsLoadResult = null
 
 
 # --- GF 生命周期方法 ---
@@ -126,7 +127,7 @@ var _batch_save_requested: bool = false
 ## @api public
 func init() -> void:
 	if auto_load_on_init:
-		var _loaded_data: Dictionary = load_settings()
+		var _load_result: GFSettingsLoadResult = load_settings()
 	else:
 		_apply_defaults_to_missing()
 
@@ -144,6 +145,7 @@ func dispose() -> void:
 	_save_queued_file_name = ""
 	_batch_depth = 0
 	_batch_save_requested = false
+	_last_load_result = null
 
 
 # --- 公共方法 ---
@@ -720,22 +722,133 @@ func merge_from_dict(data: Dictionary, emit_changes: bool = true) -> void:
 		_reconcile_staged_value(GFVariantData.to_string_name(staged_key_variant))
 
 
-## 读取持久化设置。
+## 读取持久化设置并返回结构化终态。
+##
+## 默认策略严格失败；缺失、损坏、未来 schema、迁移失败或 IO 失败不会被
+## 降级为空字典。只有显式恢复策略可以处理缺失或损坏，且加载本身从不保存。
+## 非空策略会在 IO 前验证；合法加载请求会取消全部旧延迟/批处理保存请求，
+## 防止新加载状态被旧保存目标重新序列化。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param file_name: 可选文件名；为空时使用 storage_file_name。
 ## [br]
-## @return 已读取的数据。
+## @param recovery_policy: 可选显式恢复策略；null 表示严格失败。
 ## [br]
-## @schema return: Dictionary[String, Variant] loaded persisted settings data.
-func load_settings(file_name: String = "") -> Dictionary:
+## @return 隔离的结构化加载结果。
+## [br]
+## @schema return: GFSettingsLoadResult preserving status, application state, recovery action, and storage evidence.
+func load_settings(
+	file_name: String = "",
+	recovery_policy: GFSettingsRecoveryPolicy = null
+) -> GFSettingsLoadResult:
 	var target_file_name: String = storage_file_name if file_name.is_empty() else file_name
-	_clear_pending_save(target_file_name)
-	var data: Dictionary = _read_persisted_data(target_file_name)
-	replace_from_dict(data, false)
-	settings_loaded.emit(data)
-	return data
+	if recovery_policy != null:
+		var policy_report: Dictionary = recovery_policy.validate_policy()
+		if not GFVariantData.get_option_bool(policy_report, "ok", false):
+			var policy_read_result: GFStorageReadResult = _make_persisted_read_failure(
+				"Settings recovery policy is invalid.",
+				ERR_INVALID_PARAMETER,
+				GFStorageReadResult.FailureKind.INVALID_REQUEST
+			)
+			return _complete_settings_load(
+				_make_settings_load_result(
+					false,
+					GFSettingsLoadResult.STATUS_INVALID_REQUEST,
+					target_file_name,
+					false,
+					false,
+					&"",
+					ERR_INVALID_PARAMETER,
+					"Settings recovery policy is invalid.",
+					policy_read_result
+				)
+			)
+
+	_clear_pending_saves_for_load()
+	var read_result: GFStorageReadResult = _read_persisted_data(target_file_name)
+	if read_result == null:
+		read_result = _make_persisted_read_failure(
+			"Settings storage returned no read result.",
+			ERR_INVALID_DATA,
+			GFStorageReadResult.FailureKind.IO_FAILED
+		)
+
+	var load_result: GFSettingsLoadResult
+	if read_result.ok and read_result.is_integrity_accepted():
+		replace_from_dict(read_result.payload, false)
+		load_result = _make_settings_load_result(
+			true,
+			GFSettingsLoadResult.STATUS_LOADED,
+			target_file_name,
+			true,
+			false,
+			&"",
+			OK,
+			"",
+			read_result
+		)
+	else:
+		var failure_status: StringName = _get_settings_load_failure_status(read_result)
+		var recovery_action: StringName = _resolve_settings_recovery_action(
+			read_result,
+			recovery_policy
+		)
+		match recovery_action:
+			GFSettingsRecoveryPolicy.ACTION_USE_CURRENT_STATE:
+				load_result = _make_settings_load_result(
+					true,
+					GFSettingsLoadResult.STATUS_RECOVERED,
+					target_file_name,
+					false,
+					true,
+					recovery_action,
+					OK,
+					"",
+					read_result
+				)
+			GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS:
+				replace_from_dict({}, false)
+				load_result = _make_settings_load_result(
+					true,
+					GFSettingsLoadResult.STATUS_RECOVERED,
+					target_file_name,
+					true,
+					true,
+					recovery_action,
+					OK,
+					"",
+					read_result
+				)
+			_:
+				var failure_error_code: Error = _get_settings_load_error_code(read_result)
+				var failure_error: String = _get_settings_load_error(read_result, failure_status)
+				load_result = _make_settings_load_result(
+					false,
+					failure_status,
+					target_file_name,
+					false,
+					false,
+					&"",
+					failure_error_code,
+					failure_error,
+					read_result
+				)
+
+	return _complete_settings_load(load_result)
+
+
+## 获取最近一次加载终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 最近结果的隔离副本；尚未加载或已释放时为 null。
+func get_last_load_result() -> GFSettingsLoadResult:
+	return _last_load_result.duplicate_result() if _last_load_result != null else null
 
 
 ## 保存持久化设置。
@@ -779,29 +892,86 @@ func tick(delta: float = 0.0) -> void:
 ## [br]
 ## @api protected
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param file_name: 要读取的设置文件名。
 ## [br]
-## @return 已读取的数据；不存在或无法解析时返回空字典。
+## @return 保留成功空载荷与稳定失败分类的存储读取结果。
 ## [br]
-## @schema return: Dictionary[String, Variant] persisted settings data.
-func _read_persisted_data(file_name: String) -> Dictionary:
+## @schema return: GFStorageReadResult with isolated Settings payload and failure_kind evidence.
+func _read_persisted_data(file_name: String) -> GFStorageReadResult:
 	var storage: GFStorageUtility = _get_storage_utility()
 	if storage != null:
 		var read_result: GFStorageReadResult = storage.load_data(file_name)
-		return read_result.payload.duplicate(true) if read_result.ok else {}
+		if read_result == null:
+			return _make_persisted_read_failure(
+				"Settings storage returned no read result.",
+				ERR_INVALID_DATA,
+				GFStorageReadResult.FailureKind.IO_FAILED
+			)
+		return read_result.duplicate_result()
 
 	var path: String = _get_fallback_path(file_name)
 	if path.is_empty():
-		return {}
+		return _make_persisted_read_failure(
+			"Settings file name is invalid.",
+			ERR_INVALID_PARAMETER,
+			GFStorageReadResult.FailureKind.INVALID_REQUEST
+		)
 	if not FileAccess.file_exists(path):
-		return {}
+		return _make_persisted_read_failure(
+			"Settings file does not exist.",
+			ERR_FILE_NOT_FOUND,
+			GFStorageReadResult.FailureKind.NOT_FOUND
+		)
 
-	var content: String = FileAccess.get_file_as_string(path)
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		var open_error: Error = FileAccess.get_open_error()
+		return _make_persisted_read_failure(
+			"Settings file could not be opened: %s" % error_string(open_error),
+			open_error if open_error != OK else ERR_FILE_CANT_OPEN,
+			GFStorageReadResult.FailureKind.IO_FAILED
+		)
+
+	var content: String = file.get_as_text()
+	var read_error: Error = file.get_error()
+	file.close()
+	if read_error != OK:
+		return _make_persisted_read_failure(
+			"Settings file could not be read: %s" % error_string(read_error),
+			read_error,
+			GFStorageReadResult.FailureKind.IO_FAILED
+		)
 	if content.is_empty():
-		return {}
+		return _make_persisted_read_failure(
+			"Settings file is empty.",
+			ERR_FILE_CORRUPT,
+			GFStorageReadResult.FailureKind.CORRUPT
+		)
 
-	var parsed: Variant = JSON.parse_string(content)
-	return GFVariantData.as_dictionary(parsed)
+	var parser: JSON = JSON.new()
+	var parse_error: Error = parser.parse(content)
+	if parse_error != OK:
+		return _make_persisted_read_failure(
+			"Settings JSON parse failed at line %d: %s" % [
+				parser.get_error_line(),
+				parser.get_error_message(),
+			],
+			ERR_PARSE_ERROR,
+			GFStorageReadResult.FailureKind.CORRUPT
+		)
+
+	var parsed: Variant = parser.data
+	if not parsed is Dictionary:
+		return _make_persisted_read_failure(
+			"Settings JSON root must be a Dictionary.",
+			ERR_INVALID_DATA,
+			GFStorageReadResult.FailureKind.CORRUPT
+		)
+
+	var data: Dictionary = parsed
+	return GFStorageReadResult.new().configure_success(data)
 
 
 ## 写入持久化设置数据。子类可覆盖该钩子以接入自定义存储后端。
@@ -839,6 +1009,109 @@ func _write_persisted_data(file_name: String, data: Dictionary) -> Error:
 
 
 # --- 私有/辅助方法 ---
+
+func _make_settings_load_result(
+	ok: bool,
+	status: StringName,
+	file_name: String,
+	applied: bool,
+	recovered: bool,
+	recovery_action: StringName,
+	error_code: Error,
+	error_message: String,
+	storage_result: GFStorageReadResult
+) -> GFSettingsLoadResult:
+	var result: GFSettingsLoadResult = GFSettingsLoadResult.new()
+	var configured: bool = result.configure_for_framework(
+		ok,
+		status,
+		file_name,
+		applied,
+		recovered,
+		recovery_action,
+		error_code,
+		error_message,
+		storage_result
+	)
+	assert(configured, "GFSettingsUtility produced an invalid load result.")
+	return result
+
+
+func _get_settings_load_failure_status(read_result: GFStorageReadResult) -> StringName:
+	if read_result.ok and not read_result.is_integrity_accepted():
+		return GFSettingsLoadResult.STATUS_CORRUPT
+
+	match read_result.failure_kind:
+		GFStorageReadResult.FailureKind.INVALID_REQUEST:
+			return GFSettingsLoadResult.STATUS_INVALID_REQUEST
+		GFStorageReadResult.FailureKind.NOT_FOUND:
+			return GFSettingsLoadResult.STATUS_MISSING
+		GFStorageReadResult.FailureKind.CORRUPT:
+			return GFSettingsLoadResult.STATUS_CORRUPT
+		GFStorageReadResult.FailureKind.FUTURE_VERSION:
+			return GFSettingsLoadResult.STATUS_FUTURE_SCHEMA
+		GFStorageReadResult.FailureKind.MIGRATION_FAILED:
+			return GFSettingsLoadResult.STATUS_MIGRATION_FAILED
+		_:
+			return GFSettingsLoadResult.STATUS_STORAGE_FAILED
+
+
+func _resolve_settings_recovery_action(
+	read_result: GFStorageReadResult,
+	recovery_policy: GFSettingsRecoveryPolicy
+) -> StringName:
+	if recovery_policy == null:
+		return GFSettingsRecoveryPolicy.ACTION_FAIL
+
+	var failure_status: StringName = _get_settings_load_failure_status(read_result)
+	match failure_status:
+		GFSettingsLoadResult.STATUS_MISSING:
+			return recovery_policy.missing_file_action
+		GFSettingsLoadResult.STATUS_CORRUPT:
+			return recovery_policy.corrupt_file_action
+		_:
+			return GFSettingsRecoveryPolicy.ACTION_FAIL
+
+
+func _get_settings_load_error_code(read_result: GFStorageReadResult) -> Error:
+	if read_result.ok and not read_result.is_integrity_accepted():
+		return ERR_FILE_CORRUPT
+	return read_result.error_code if read_result.error_code != OK else FAILED
+
+
+func _get_settings_load_error(
+	read_result: GFStorageReadResult,
+	failure_status: StringName
+) -> String:
+	if read_result.ok and not read_result.is_integrity_accepted():
+		return "Settings integrity status is not accepted."
+	if not read_result.error.is_empty():
+		return read_result.error
+	return "Settings load failed with status: %s." % String(failure_status)
+
+
+func _make_persisted_read_failure(
+	error_message: String,
+	error_code: Error,
+	failure_kind: GFStorageReadResult.FailureKind
+) -> GFStorageReadResult:
+	return GFStorageReadResult.new().configure_failure(
+		error_message,
+		error_code,
+		{},
+		GFStorageReadResult.IntegrityStatus.NOT_CHECKED,
+		0,
+		failure_kind
+	)
+
+
+func _complete_settings_load(
+	load_result: GFSettingsLoadResult
+) -> GFSettingsLoadResult:
+	_last_load_result = load_result.duplicate_result()
+	settings_load_completed.emit(load_result.duplicate_result())
+	return load_result
+
 
 func _reset_value_internal(key: StringName, emit_change: bool, save_after_change: bool) -> void:
 	var definition: GFSettingDefinition = _get_definition(key)
@@ -997,10 +1270,19 @@ func _queue_auto_save() -> void:
 
 func _clear_pending_save(file_name: String) -> void:
 	var target_file_name: String = storage_file_name if file_name.is_empty() else file_name
+	if target_file_name == storage_file_name:
+		_batch_save_requested = false
 	if _save_queued and _save_queued_file_name == target_file_name:
 		_save_queued = false
 		_save_elapsed_seconds = 0.0
 		_save_queued_file_name = ""
+
+
+func _clear_pending_saves_for_load() -> void:
+	_save_queued = false
+	_save_elapsed_seconds = 0.0
+	_save_queued_file_name = ""
+	_batch_save_requested = false
 
 
 func _should_persist(key: StringName) -> bool:

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "7bf8a342da3ab6d3a34ee2b181a97509116a7ed85266ef369a608a1e92a55968",
-  "class_count": 756,
+  "source_digest": "4060bc33e2c708bffdc75ad59374c80fca8719b9b88f30cf6ffb4c0f5f6b717b",
+  "class_count": 760,
   "package_count": 52,
   "packages": [
     {
@@ -13,6 +13,7 @@
         "gf.kernel",
         "gf.standard.base",
         "gf.standard.audio",
+        "gf.standard.display",
         "gf.standard.diagnostics"
       ],
       "description": "Package manifest for the bundled Action Queue extension.",
@@ -26824,6 +26825,13 @@
           "signature": "func _can_change_configuration(field_name: String) -> bool",
           "summary": "返回指定配置字段当前是否可修改。",
           "visibility": "protected"
+        },
+        {
+          "kind": "func",
+          "name": "_seal_configuration_for_execution",
+          "signature": "func _seal_configuration_for_execution() -> void",
+          "summary": "冻结命令配置。",
+          "visibility": "protected"
         }
       ]
     },
@@ -27326,6 +27334,137 @@
           "name": "_on_cancel",
           "signature": "func _on_cancel(_tool_context: GFEditorToolContextBase) -> void",
           "summary": "取消拾取流程时调用，供子类重写。",
+          "visibility": "protected"
+        }
+      ]
+    },
+    "GFEditorPropertyBatchCommand": {
+      "extends": "GFEditorCommand",
+      "module": "kernel",
+      "package_id": "gf.kernel",
+      "path": "addons/gf/kernel/editor/gf_editor_property_batch_command.gd",
+      "summary": "GFEditorPropertyBatchCommand: 通用多目标属性事务命令。 对调用方显式提供的 Object 属性先做全量零写入预检，再按稳定顺序提交。 任一写入或最终状态验证失败时，会按相反顺序恢复本次尝试前的全部目标属性。",
+      "visibility": "public",
+      "category": "editor_api",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_PENDING",
+          "signature": "const STATUS_PENDING: StringName = &\"pending\"",
+          "summary": "尚未验证或执行。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_READY",
+          "signature": "const STATUS_READY: StringName = &\"ready\"",
+          "summary": "全量预检通过。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_COMMITTED",
+          "signature": "const STATUS_COMMITTED: StringName = &\"committed\"",
+          "summary": "属性事务已提交。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_REVERTED",
+          "signature": "const STATUS_REVERTED: StringName = &\"reverted\"",
+          "summary": "属性事务已撤销。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_RECOVERED",
+          "signature": "const STATUS_RECOVERED: StringName = &\"recovered\"",
+          "summary": "未完整补偿的事务已恢复到该次操作开始前状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_PREFLIGHT_FAILED",
+          "signature": "const STATUS_PREFLIGHT_FAILED: StringName = &\"preflight_failed\"",
+          "summary": "全量预检失败，未开始写入。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_APPLY_FAILED",
+          "signature": "const STATUS_APPLY_FAILED: StringName = &\"apply_failed\"",
+          "summary": "提交失败，且已恢复本次尝试前状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_REVERT_FAILED",
+          "signature": "const STATUS_REVERT_FAILED: StringName = &\"revert_failed\"",
+          "summary": "撤销失败，且已恢复撤销前状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_ROLLBACK_FAILED",
+          "signature": "const STATUS_ROLLBACK_FAILED: StringName = &\"rollback_failed\"",
+          "summary": "补偿写入未完整恢复属性状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "configure",
+          "signature": "func configure( changes: Array[Dictionary], options: Dictionary = {} ) -> GFEditorPropertyBatchCommand",
+          "summary": "配置属性事务。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate",
+          "signature": "func validate() -> Dictionary",
+          "summary": "零写入验证全部属性变更。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_transaction_report",
+          "signature": "func get_transaction_report() -> Dictionary",
+          "summary": "获取最近一次预检、提交、撤销或恢复报告。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "recover",
+          "signature": "func recover() -> Error",
+          "summary": "恢复最近一次未完整补偿的操作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "can_execute",
+          "signature": "func can_execute() -> bool",
+          "summary": "当前命令是否允许执行。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "can_revert_before_execute",
+          "signature": "func can_revert_before_execute() -> bool",
+          "summary": "首次执行未成功但留下残余状态时，允许显式调用 revert() 重试恢复。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "_do_it",
+          "signature": "func _do_it() -> Error",
+          "summary": "执行属性事务。",
+          "visibility": "protected"
+        },
+        {
+          "kind": "func",
+          "name": "_undo_it",
+          "signature": "func _undo_it() -> Error",
+          "summary": "撤销属性事务，或恢复首次执行失败留下的残余状态。",
           "visibility": "protected"
         }
       ]
@@ -70599,6 +70738,205 @@
         }
       ]
     },
+    "GFSettingsLoadResult": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.settings",
+      "path": "addons/gf/standard/utilities/settings/gf_settings_load_result.gd",
+      "summary": "GFSettingsLoadResult: 设置加载操作的不可变终态快照。 结果将“合法空设置”与缺失、损坏、未来版本和底层存储失败明确区分， 并保留实际应用状态、恢复动作和底层读取证据。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_LOADED",
+          "signature": "const STATUS_LOADED: StringName = &\"loaded\"",
+          "summary": "持久化设置已成功读取并应用。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_RECOVERED",
+          "signature": "const STATUS_RECOVERED: StringName = &\"recovered\"",
+          "summary": "调用方选择的显式恢复动作已完成。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_REQUEST",
+          "signature": "const STATUS_INVALID_REQUEST: StringName = &\"invalid_request\"",
+          "summary": "文件名、路径或读取请求无效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_MISSING",
+          "signature": "const STATUS_MISSING: StringName = &\"missing\"",
+          "summary": "设置文件不存在。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_CORRUPT",
+          "signature": "const STATUS_CORRUPT: StringName = &\"corrupt\"",
+          "summary": "设置文件格式、载荷或完整性损坏。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_FUTURE_SCHEMA",
+          "signature": "const STATUS_FUTURE_SCHEMA: StringName = &\"future_schema\"",
+          "summary": "设置文件来自当前运行时无法读取的未来 schema。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_MIGRATION_FAILED",
+          "signature": "const STATUS_MIGRATION_FAILED: StringName = &\"migration_failed\"",
+          "summary": "设置文件的迁移链缺失或迁移失败。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_STORAGE_FAILED",
+          "signature": "const STATUS_STORAGE_FAILED: StringName = &\"storage_failed\"",
+          "summary": "底层存储读取失败或不可用。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "检查加载是否进入成功终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> StringName",
+          "summary": "获取稳定加载状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_file_name",
+          "signature": "func get_file_name() -> String",
+          "summary": "获取本次加载使用的文件名。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "was_applied",
+          "signature": "func was_applied() -> bool",
+          "summary": "检查本次操作是否替换了有效设置状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "was_recovered",
+          "signature": "func was_recovered() -> bool",
+          "summary": "检查本次操作是否执行了显式恢复动作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_recovery_action",
+          "signature": "func get_recovery_action() -> StringName",
+          "summary": "获取实际恢复动作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_code",
+          "signature": "func get_error_code() -> Error",
+          "summary": "获取 Godot Error 码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error",
+          "signature": "func get_error() -> String",
+          "summary": "获取稳定错误描述。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_storage_result",
+          "signature": "func get_storage_result() -> GFStorageReadResult",
+          "summary": "获取底层存储读取结果副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_result",
+          "signature": "func duplicate_result() -> GFSettingsLoadResult",
+          "summary": "创建结果的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为不包含设置载荷的报告字典。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSettingsRecoveryPolicy": {
+      "extends": "Resource",
+      "module": "standard",
+      "package_id": "gf.standard.settings",
+      "path": "addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd",
+      "summary": "GFSettingsRecoveryPolicy: 设置加载的显式恢复策略。 缺失与损坏设置默认严格失败。项目可以显式选择保留当前内存状态， 或把有效设置重置为已注册默认值；恢复不会创建或覆盖持久化文件。",
+      "visibility": "public",
+      "category": "resource_definition",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "ACTION_FAIL",
+          "signature": "const ACTION_FAIL: StringName = &\"fail\"",
+          "summary": "不执行自动恢复。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ACTION_USE_CURRENT_STATE",
+          "signature": "const ACTION_USE_CURRENT_STATE: StringName = &\"use_current_state\"",
+          "summary": "保留当前有效值和暂存值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ACTION_RESET_TO_DEFAULTS",
+          "signature": "const ACTION_RESET_TO_DEFAULTS: StringName = &\"reset_to_defaults\"",
+          "summary": "使用空 replace 语义恢复已注册默认值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "missing_file_action",
+          "signature": "var missing_file_action: StringName = ACTION_FAIL",
+          "summary": "文件缺失时的恢复动作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "corrupt_file_action",
+          "signature": "var corrupt_file_action: StringName = ACTION_FAIL",
+          "summary": "文件损坏或完整性校验失败时的恢复动作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_policy",
+          "signature": "func validate_policy() -> Dictionary",
+          "summary": "检查策略自身是否合法。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFSettingsUtility": {
       "extends": "GFUtility",
       "module": "standard",
@@ -70618,9 +70956,9 @@
         },
         {
           "kind": "signal",
-          "name": "settings_loaded",
-          "signature": "signal settings_loaded(data: Dictionary)",
-          "summary": "设置加载完成时发出。",
+          "name": "settings_load_completed",
+          "signature": "signal settings_load_completed(result: GFSettingsLoadResult)",
+          "summary": "设置加载进入终态时发出。",
           "visibility": "public"
         },
         {
@@ -70892,8 +71230,15 @@
         {
           "kind": "func",
           "name": "load_settings",
-          "signature": "func load_settings(file_name: String = \"\") -> Dictionary",
-          "summary": "读取持久化设置。",
+          "signature": "func load_settings( file_name: String = \"\", recovery_policy: GFSettingsRecoveryPolicy = null ) -> GFSettingsLoadResult",
+          "summary": "读取持久化设置并返回结构化终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_last_load_result",
+          "signature": "func get_last_load_result() -> GFSettingsLoadResult",
+          "summary": "获取最近一次加载终态。",
           "visibility": "public"
         },
         {
@@ -70913,7 +71258,7 @@
         {
           "kind": "func",
           "name": "_read_persisted_data",
-          "signature": "func _read_persisted_data(file_name: String) -> Dictionary",
+          "signature": "func _read_persisted_data(file_name: String) -> GFStorageReadResult",
           "summary": "读取持久化设置数据。子类可覆盖该钩子以接入自定义存储后端。",
           "visibility": "protected"
         },
@@ -70923,6 +71268,130 @@
           "signature": "func _write_persisted_data(file_name: String, data: Dictionary) -> Error",
           "summary": "写入持久化设置数据。子类可覆盖该钩子以接入自定义存储后端。",
           "visibility": "protected"
+        }
+      ]
+    },
+    "GFShaderInterfaceSnapshot": {
+      "extends": "Resource",
+      "module": "standard",
+      "package_id": "gf.standard.display",
+      "path": "addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd",
+      "summary": "GFShaderInterfaceSnapshot: 可持久化的 Shader uniform 接口快照。 从 Shader 反射结果捕获稳定排序的 uniform 声明，并用同一份数据校验参数集合 或比较接口漂移。快照只保存公开接口字段，不保存 shader 源码、材质当前值、",
+      "visibility": "public",
+      "category": "resource_definition",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "CURRENT_SCHEMA_VERSION",
+          "signature": "const CURRENT_SCHEMA_VERSION: int = 1",
+          "summary": "当前快照字典 schema 版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "capture",
+          "signature": "static func capture(shader: Shader) -> GFShaderInterfaceSnapshot",
+          "summary": "从 Shader 当前反射接口创建快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "from_dict",
+          "signature": "static func from_dict(data: Dictionary) -> GFShaderInterfaceSnapshot",
+          "summary": "从字典创建快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_schema_version",
+          "signature": "func get_schema_version() -> int",
+          "summary": "获取快照 schema 版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_shader_mode",
+          "signature": "func get_shader_mode() -> int",
+          "summary": "获取捕获时的 Shader 模式。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_uniforms",
+          "signature": "func get_uniforms() -> Array[Dictionary]",
+          "summary": "获取稳定排序的 uniform 条目深拷贝。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_uniform_names",
+          "signature": "func get_uniform_names() -> Array[StringName]",
+          "summary": "获取稳定排序的 uniform 名。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "has_uniform",
+          "signature": "func has_uniform(parameter_name: StringName) -> bool",
+          "summary": "检查接口是否声明 uniform。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_uniform",
+          "signature": "func get_uniform(parameter_name: StringName) -> Dictionary",
+          "summary": "获取 uniform 条目深拷贝。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "accepts_parameter_value",
+          "signature": "func accepts_parameter_value( parameter_name: StringName, value: Variant, options: Dictionary = {} ) -> bool",
+          "summary": "检查一个值是否符合已声明 uniform 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_definition",
+          "signature": "func validate_definition(options: Dictionary = {}) -> GFValidationReport",
+          "summary": "校验快照 schema、Shader 模式、uniform 字段和重复名称。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_parameters",
+          "signature": "func validate_parameters( parameters: Dictionary, options: Dictionary = {} ) -> GFValidationReport",
+          "summary": "根据快照校验参数字典。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "compare_with",
+          "signature": "func compare_with( actual: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -> GFValidationReport",
+          "summary": "比较期望快照与实际快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_shader",
+          "signature": "func validate_shader( shader: Shader, options: Dictionary = {} ) -> GFValidationReport",
+          "summary": "将 Shader 当前接口与本快照比较。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_snapshot",
+          "signature": "func duplicate_snapshot() -> GFShaderInterfaceSnapshot",
+          "summary": "创建快照深拷贝。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为稳定排序的快照字典。",
+          "visibility": "public"
         }
       ]
     },
@@ -71235,6 +71704,13 @@
         },
         {
           "kind": "func",
+          "name": "validate_against",
+          "signature": "func validate_against( interface_snapshot: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -> GFValidationReport",
+          "summary": "根据 Shader 接口快照校验当前参数。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "merge_from",
           "signature": "func merge_from(source: GFShaderParameterProfile, overwrite: bool = true) -> GFShaderParameterProfile",
           "summary": "合并另一个 profile。",
@@ -71327,6 +71803,27 @@
           "name": "resolve_shader_material",
           "signature": "func resolve_shader_material( target: Object, material_property: NodePath = DEFAULT_MATERIAL_PROPERTY ) -> ShaderMaterial",
           "summary": "从目标对象解析 ShaderMaterial。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "capture_shader_interface",
+          "signature": "func capture_shader_interface( material: ShaderMaterial ) -> GFShaderInterfaceSnapshot",
+          "summary": "捕获 ShaderMaterial 当前 uniform 接口。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_profile",
+          "signature": "func validate_profile( material: ShaderMaterial, profile: GFShaderParameterProfile, options: Dictionary = {} ) -> GFValidationReport",
+          "summary": "校验 profile 是否符合 ShaderMaterial 当前 uniform 接口。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_parameters",
+          "signature": "func validate_parameters( material: ShaderMaterial, parameters: Dictionary, options: Dictionary = {} ) -> GFValidationReport",
+          "summary": "校验参数字典是否符合 ShaderMaterial 当前 uniform 接口。",
           "visibility": "public"
         },
         {

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "4060bc33e2c708bffdc75ad59374c80fca8719b9b88f30cf6ffb4c0f5f6b717b",
+  "source_digest": "d8a88824fe386f1a8d5e1654ab67b6c2719ac720e0decb71f479796c64b75c66",
   "class_count": 760,
   "package_count": 52,
   "packages": [
@@ -63091,7 +63091,7 @@
           "kind": "signal",
           "name": "cell_value_committed",
           "signature": "signal cell_value_committed(resource: Resource, property: StringName, old_value: Variant, new_value: Variant)",
-          "summary": "单元格值提交后发出。",
+          "summary": "单元格值实际变化且整批事务成功后发出；空批次和规范化后同值的提交不发出。",
           "visibility": "public"
         },
         {
@@ -63147,7 +63147,7 @@
           "kind": "var",
           "name": "auto_save_committed_resources",
           "signature": "var auto_save_committed_resources: bool = false",
-          "summary": "提交单元格后是否自动保存已绑定路径的 Resource。",
+          "summary": "是否自动保存成功事务中实际发生属性变化且已绑定路径的 Resource。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFEditorCommand.xml
+++ b/docs/api_catalog/classes/GFEditorCommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFEditorCommand" path="addons/gf/kernel/editor/gf_editor_command.gd" module="kernel" extends="RefCounted" classDigest="a886ab5ba03f85dee45fccf3989da803defd36f5f59dde39753c34b66ec7ccc4">
+<class name="GFEditorCommand" path="addons/gf/kernel/editor/gf_editor_command.gd" module="kernel" extends="RefCounted" classDigest="6f1264fa1cbeb3d7d7c165b7286aaaea3167f7f1ad455190e78c840c2abb451c">
 	<description>GFEditorCommand: 可撤销编辑器操作的通用基类。
 用于把编辑器 UI、快捷键或交互工具产生的修改收敛成可执行、可撤销的命令。
 命令只描述操作协议，不绑定具体资源、节点类型或业务含义。</description>
@@ -38,6 +38,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">Godot 错误码。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="revert">
@@ -147,6 +148,16 @@
 				<tag name="param">field_name: 配置字段名。</tag>
 				<tag name="return">配置未冻结时返回 true；已冻结时报告错误并返回 false。</tag>
 				<tag name="since">8.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="_seal_configuration_for_execution">
+			<signature>func _seal_configuration_for_execution() -&gt; void:</signature>
+			<description>冻结命令配置。
+会在命令成功执行或注册到 UndoRedo 后由基类调用。可能发生部分写入的事务子类
+应在第一笔实际写入前主动调用，确保失败恢复仍使用不可变配置与首次快照。</description>
+			<tags>
+				<tag name="api">protected</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/classes/GFEditorPropertyBatchCommand.xml
+++ b/docs/api_catalog/classes/GFEditorPropertyBatchCommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFEditorPropertyBatchCommand" path="addons/gf/kernel/editor/gf_editor_property_batch_command.gd" module="kernel" extends="GFEditorCommand" classDigest="868e3934d1bbfdc97bff03721905057a287e8f0822951b1158ca14de5530e5c8">
+<class name="GFEditorPropertyBatchCommand" path="addons/gf/kernel/editor/gf_editor_property_batch_command.gd" module="kernel" extends="GFEditorCommand" classDigest="b7d4e7a9dba69993f3e7a468e2403c5a954853bf9ee25c3b2261003407dfdbc5">
 	<description>GFEditorPropertyBatchCommand: 通用多目标属性事务命令。
 对调用方显式提供的 Object 属性先做全量零写入预检，再按稳定顺序提交。
 任一写入或最终状态验证失败时，会按相反顺序恢复本次尝试前的全部目标属性。
@@ -91,15 +91,15 @@
 		<member kind="method" name="configure">
 			<signature>func configure( changes: Array[Dictionary], options: Dictionary = {} ) -&gt; GFEditorPropertyBatchCommand:</signature>
 			<description>配置属性事务。
-每个 change 必须包含 target、new_value，以及且仅包含 property_name 或
+changes 必须至少包含一项。每个 change 必须包含 target、new_value，以及且仅包含 property_name 或
 property_path。property_name 表示精确直接属性名；property_path 使用 Godot
 indexed path 语义。可选 metadata 会复制到条目和错误报告。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">changes: 属性变更数组。</tag>
+				<tag name="param">changes: 非空属性变更数组。</tag>
 				<tag name="param">options: 配置选项。</tag>
 				<tag name="return">当前命令。</tag>
-				<tag name="schema">changes: Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。</tag>
+				<tag name="schema">changes: 非空 Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。</tag>
 				<tag name="schema">options: Dictionary，可包含 command_name、metadata 和 duplicate_resources。</tag>
 				<tag name="since">unreleased</tag>
 			</tags>

--- a/docs/api_catalog/classes/GFEditorPropertyBatchCommand.xml
+++ b/docs/api_catalog/classes/GFEditorPropertyBatchCommand.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFEditorPropertyBatchCommand" path="addons/gf/kernel/editor/gf_editor_property_batch_command.gd" module="kernel" extends="GFEditorCommand" classDigest="868e3934d1bbfdc97bff03721905057a287e8f0822951b1158ca14de5530e5c8">
+	<description>GFEditorPropertyBatchCommand: 通用多目标属性事务命令。
+对调用方显式提供的 Object 属性先做全量零写入预检，再按稳定顺序提交。
+任一写入或最终状态验证失败时，会按相反顺序恢复本次尝试前的全部目标属性。
+命令只保证显式属性值边界，不代理 setter 的外部副作用、文件保存或业务事务。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">editor_api</tag>
+		<tag name="layer">kernel/editor</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_PENDING">
+			<signature>const STATUS_PENDING: StringName = &amp;"pending"</signature>
+			<description>尚未验证或执行。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_READY">
+			<signature>const STATUS_READY: StringName = &amp;"ready"</signature>
+			<description>全量预检通过。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_COMMITTED">
+			<signature>const STATUS_COMMITTED: StringName = &amp;"committed"</signature>
+			<description>属性事务已提交。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_REVERTED">
+			<signature>const STATUS_REVERTED: StringName = &amp;"reverted"</signature>
+			<description>属性事务已撤销。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_RECOVERED">
+			<signature>const STATUS_RECOVERED: StringName = &amp;"recovered"</signature>
+			<description>未完整补偿的事务已恢复到该次操作开始前状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_PREFLIGHT_FAILED">
+			<signature>const STATUS_PREFLIGHT_FAILED: StringName = &amp;"preflight_failed"</signature>
+			<description>全量预检失败，未开始写入。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_APPLY_FAILED">
+			<signature>const STATUS_APPLY_FAILED: StringName = &amp;"apply_failed"</signature>
+			<description>提交失败，且已恢复本次尝试前状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_REVERT_FAILED">
+			<signature>const STATUS_REVERT_FAILED: StringName = &amp;"revert_failed"</signature>
+			<description>撤销失败，且已恢复撤销前状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_ROLLBACK_FAILED">
+			<signature>const STATUS_ROLLBACK_FAILED: StringName = &amp;"rollback_failed"</signature>
+			<description>补偿写入未完整恢复属性状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="configure">
+			<signature>func configure( changes: Array[Dictionary], options: Dictionary = {} ) -&gt; GFEditorPropertyBatchCommand:</signature>
+			<description>配置属性事务。
+每个 change 必须包含 target、new_value，以及且仅包含 property_name 或
+property_path。property_name 表示精确直接属性名；property_path 使用 Godot
+indexed path 语义。可选 metadata 会复制到条目和错误报告。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">changes: 属性变更数组。</tag>
+				<tag name="param">options: 配置选项。</tag>
+				<tag name="return">当前命令。</tag>
+				<tag name="schema">changes: Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。</tag>
+				<tag name="schema">options: Dictionary，可包含 command_name、metadata 和 duplicate_resources。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate">
+			<signature>func validate() -&gt; Dictionary:</signature>
+			<description>零写入验证全部属性变更。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">结构化事务报告。</tag>
+				<tag name="schema">return: Dictionary，包含 ok、status、phase、error、requested_count、applied_count、unchanged_count、attempted_count、rollback_count、failed_count、failed_index、rolled_back、recovery_required、entries、issues 和 metadata。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_transaction_report">
+			<signature>func get_transaction_report() -&gt; Dictionary:</signature>
+			<description>获取最近一次预检、提交、撤销或恢复报告。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">结构化事务报告副本。</tag>
+				<tag name="schema">return: Dictionary，形状与 validate() 返回值相同。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="recover">
+			<signature>func recover() -&gt; Error:</signature>
+			<description>恢复最近一次未完整补偿的操作。
+恢复目标是该次失败 apply、redo 或 undo 开始前的 attempt guard，而不是固定的
+首次 undo 基线。undo 补偿失败时，恢复成功后命令仍保持 executed，调用方可再
+次调用 revert() 完成真正撤销。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Godot 错误码。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="can_execute">
+			<signature>func can_execute() -&gt; bool:</signature>
+			<description>当前命令是否允许执行。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">配置完整、目标可写且没有待恢复残余状态时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="can_revert_before_execute">
+			<signature>func can_revert_before_execute() -&gt; bool:</signature>
+			<description>首次执行未成功但留下残余状态时，允许显式调用 revert() 重试恢复。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">存在首次快照且需要恢复时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="_do_it">
+			<signature>func _do_it() -&gt; Error:</signature>
+			<description>执行属性事务。</description>
+			<tags>
+				<tag name="api">protected</tag>
+				<tag name="return">Godot 错误码。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="_undo_it">
+			<signature>func _undo_it() -&gt; Error:</signature>
+			<description>撤销属性事务，或恢复首次执行失败留下的残余状态。</description>
+			<tags>
+				<tag name="api">protected</tag>
+				<tag name="return">Godot 错误码。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFObjectPropertyTools.xml
+++ b/docs/api_catalog/classes/GFObjectPropertyTools.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFObjectPropertyTools" path="addons/gf/kernel/core/gf_object_property_tools.gd" module="kernel" extends="RefCounted" classDigest="923a624a0bc553f9ecfeafae2a9c922355f22e1d3d808a4131db953c3fe8daff">
+<class name="GFObjectPropertyTools" path="addons/gf/kernel/core/gf_object_property_tools.gd" module="kernel" extends="RefCounted" classDigest="bedfcf63698d59afd42fb8df996782311ae67a7f5e6d6391437fd6d7230f4a51">
 	<description>GFObjectPropertyTools: Godot Object 属性访问辅助。
 集中处理属性列表查询、属性路径读写、可写性判断和基础类型校验。
 它不负责属性绑定、自动派发、表达式执行或业务字段解释。</description>
@@ -123,6 +123,7 @@
 				<tag name="schema">value: Variant value requested for assignment.</tag>
 				<tag name="schema">options: Dictionary with optional bool keys check_writable, check_type, and coerce_value.</tag>
 				<tag name="schema">return: Dictionary { ok: bool, error: String, property_name: StringName, old_value: Variant, new_value: Variant }.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="write_direct_property">

--- a/docs/api_catalog/classes/GFResourceTableEditor.xml
+++ b/docs/api_catalog/classes/GFResourceTableEditor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFResourceTableEditor" path="addons/gf/kernel/editor/gf_resource_table_editor.gd" module="kernel" extends="VBoxContainer" classDigest="da5d0a5bee320fe9f632c44f9d8d37281e898df399729c594605859aaa88e1a8">
+<class name="GFResourceTableEditor" path="addons/gf/kernel/editor/gf_resource_table_editor.gd" module="kernel" extends="VBoxContainer" classDigest="523698d30afa12033d65ddde07627ab31ef982837b5908b43e0f5e474e09b190">
 	<description>GFResourceTableEditor: 通用 Resource 表格编辑控件。
 提供资源扫描、属性列提取、表格刷新与单元格提交，不绑定具体资源类型或业务数据。</description>
 	<tags>
@@ -277,6 +277,7 @@
 				<tag name="param">new_value: 新值。</tag>
 				<tag name="return">提交成功返回 true。</tag>
 				<tag name="schema">new_value: Variant value assigned to the resource property.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="commit_visible_cell_value">
@@ -294,14 +295,15 @@
 		<member kind="method" name="commit_cell_values">
 			<signature>func commit_cell_values(changes: Array[Dictionary]) -&gt; Dictionary:</signature>
 			<description>批量提交资源行单元格值。
-该方法会先处理所有变更，再统一刷新表格；启用自动保存时同一 Resource 只保存一次。
-它不是事务，部分失败不会回滚已成功的变更。</description>
+该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。
+任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。
+成功后统一刷新表格；启用自动保存时同一 Resource 只保存一次。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">changes: 单元格变更数组；每项包含 row_index、property 与 new_value。</tag>
 				<tag name="return">批量提交报告。</tag>
 				<tag name="schema">changes: Array[Dictionary]，每项包含 row_index: int、property: StringName/String、new_value: Variant。</tag>
-				<tag name="schema">return: Dictionary，包含 ok、requested_count、applied_count、unchanged_count、failed_count、committed 和 errors。</tag>
+				<tag name="schema">return: Dictionary，包含 ok、status、error、requested_count、applied_count、unchanged_count、failed_count、issue_count、rolled_back、recovery_required、committed、errors，以及需要显式恢复时的 transaction_command。</tag>
 				<tag name="since">6.0.0</tag>
 			</tags>
 		</member>
@@ -309,13 +311,14 @@
 			<signature>func commit_visible_cell_values(changes: Array[Dictionary]) -&gt; Dictionary:</signature>
 			<description>批量提交可见资源行单元格值。
 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。
-启用自动保存时同一 Resource 只保存一次；该方法不是事务，部分失败不会回滚已成功的变更。</description>
+全部变更通过 GFEditorPropertyBatchCommand 原子提交；启用自动保存时同一 Resource
+只保存一次。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">changes: 单元格变更数组；每项包含 visible_row_index、property 与 new_value。</tag>
 				<tag name="return">批量提交报告。</tag>
 				<tag name="schema">changes: Array[Dictionary]，每项包含 visible_row_index: int、property: StringName/String、new_value: Variant。</tag>
-				<tag name="schema">return: Dictionary，包含 ok、requested_count、applied_count、unchanged_count、failed_count、committed 和 errors。</tag>
+				<tag name="schema">return: Dictionary，包含 ok、status、error、requested_count、applied_count、unchanged_count、failed_count、issue_count、rolled_back、recovery_required、committed、errors，以及需要显式恢复时的 transaction_command。</tag>
 				<tag name="since">6.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFResourceTableEditor.xml
+++ b/docs/api_catalog/classes/GFResourceTableEditor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFResourceTableEditor" path="addons/gf/kernel/editor/gf_resource_table_editor.gd" module="kernel" extends="VBoxContainer" classDigest="523698d30afa12033d65ddde07627ab31ef982837b5908b43e0f5e474e09b190">
+<class name="GFResourceTableEditor" path="addons/gf/kernel/editor/gf_resource_table_editor.gd" module="kernel" extends="VBoxContainer" classDigest="d3694a4803a0da9b63a3c0a98f6d70fbcd705222070c4a3acf2d717fe15339f7">
 	<description>GFResourceTableEditor: 通用 Resource 表格编辑控件。
 提供资源扫描、属性列提取、表格刷新与单元格提交，不绑定具体资源类型或业务数据。</description>
 	<tags>
@@ -19,7 +19,7 @@
 		</member>
 		<member kind="signal" name="cell_value_committed">
 			<signature>signal cell_value_committed(resource: Resource, property: StringName, old_value: Variant, new_value: Variant)</signature>
-			<description>单元格值提交后发出。</description>
+			<description>单元格值实际变化且整批事务成功后发出；空批次和规范化后同值的提交不发出。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">resource: 被修改的资源。</tag>
@@ -28,6 +28,7 @@
 				<tag name="param">new_value: 提交后的新值。</tag>
 				<tag name="schema">old_value: Variant value before commit.</tag>
 				<tag name="schema">new_value: Variant value after commit.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="resource_save_failed">
@@ -97,9 +98,11 @@
 	<properties>
 		<member kind="property" name="auto_save_committed_resources">
 			<signature>var auto_save_committed_resources: bool = false</signature>
-			<description>提交单元格后是否自动保存已绑定路径的 Resource。</description>
+			<description>是否自动保存成功事务中实际发生属性变化且已绑定路径的 Resource。
+空批次和规范化后同值的提交不会触发保存。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="search_text">
@@ -269,7 +272,9 @@
 		</member>
 		<member kind="method" name="commit_cell_value">
 			<signature>func commit_cell_value(row_index: int, property: StringName, new_value: Variant) -&gt; bool:</signature>
-			<description>提交单元格值。</description>
+			<description>提交单元格值。
+当规范化请求值与稳定当前值相同时返回成功，但不调用 setter、不发出
+cell_value_committed、不自动保存，也不刷新表格。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">row_index: 资源行索引。</tag>
@@ -282,7 +287,9 @@
 		</member>
 		<member kind="method" name="commit_visible_cell_value">
 			<signature>func commit_visible_cell_value(visible_row_index: int, property: StringName, new_value: Variant) -&gt; bool:</signature>
-			<description>提交当前可见行的单元格值。</description>
+			<description>提交当前可见行的单元格值。
+当规范化请求值与稳定当前值相同时返回成功，但不调用 setter、不发出
+cell_value_committed、不自动保存，也不刷新表格。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">visible_row_index: 过滤后的可见行索引。</tag>
@@ -290,6 +297,7 @@
 				<tag name="param">new_value: 新值。</tag>
 				<tag name="return">提交成功返回 true。</tag>
 				<tag name="schema">new_value: Variant value assigned to the resource property.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="commit_cell_values">
@@ -297,7 +305,10 @@
 			<description>批量提交资源行单元格值。
 该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。
 任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。
-成功后统一刷新表格；启用自动保存时同一 Resource 只保存一次。</description>
+规范化后同值的条目计入 unchanged_count，不调用其 setter，也不发提交信号。
+仅当至少一项实际变化时统一刷新；启用自动保存时同一已变化 Resource 只保存一次。
+空变更数组返回 status = committed、error = OK 且全部计数为 0 的成功报告，
+不构造属性事务命令，也不触发信号、保存或刷新。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">changes: 单元格变更数组；每项包含 row_index、property 与 new_value。</tag>
@@ -311,8 +322,11 @@
 			<signature>func commit_visible_cell_values(changes: Array[Dictionary]) -&gt; Dictionary:</signature>
 			<description>批量提交可见资源行单元格值。
 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。
-全部变更通过 GFEditorPropertyBatchCommand 原子提交；启用自动保存时同一 Resource
-只保存一次。</description>
+全部变更通过 GFEditorPropertyBatchCommand 原子提交。规范化后同值的条目计入
+unchanged_count，不调用其 setter，也不发提交信号。仅当至少一项实际变化时
+统一刷新；启用自动保存时同一已变化 Resource 只保存一次。
+空变更数组返回 status = committed、error = OK 且全部计数为 0 的成功报告，
+不构造属性事务命令，也不触发信号、保存或刷新。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">changes: 单元格变更数组；每项包含 visible_row_index、property 与 new_value。</tag>

--- a/docs/api_catalog/classes/GFSettingsLoadResult.xml
+++ b/docs/api_catalog/classes/GFSettingsLoadResult.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSettingsLoadResult" path="addons/gf/standard/utilities/settings/gf_settings_load_result.gd" module="standard" extends="RefCounted" classDigest="8605b593685a155c484764282736cb94a80c0c067fe5ce895fc3a0c416decc33">
+	<description>GFSettingsLoadResult: 设置加载操作的不可变终态快照。
+结果将“合法空设置”与缺失、损坏、未来版本和底层存储失败明确区分，
+并保留实际应用状态、恢复动作和底层读取证据。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_LOADED">
+			<signature>const STATUS_LOADED: StringName = &amp;"loaded"</signature>
+			<description>持久化设置已成功读取并应用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_RECOVERED">
+			<signature>const STATUS_RECOVERED: StringName = &amp;"recovered"</signature>
+			<description>调用方选择的显式恢复动作已完成。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_REQUEST">
+			<signature>const STATUS_INVALID_REQUEST: StringName = &amp;"invalid_request"</signature>
+			<description>文件名、路径或读取请求无效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_MISSING">
+			<signature>const STATUS_MISSING: StringName = &amp;"missing"</signature>
+			<description>设置文件不存在。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_CORRUPT">
+			<signature>const STATUS_CORRUPT: StringName = &amp;"corrupt"</signature>
+			<description>设置文件格式、载荷或完整性损坏。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_FUTURE_SCHEMA">
+			<signature>const STATUS_FUTURE_SCHEMA: StringName = &amp;"future_schema"</signature>
+			<description>设置文件来自当前运行时无法读取的未来 schema。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_MIGRATION_FAILED">
+			<signature>const STATUS_MIGRATION_FAILED: StringName = &amp;"migration_failed"</signature>
+			<description>设置文件的迁移链缺失或迁移失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_STORAGE_FAILED">
+			<signature>const STATUS_STORAGE_FAILED: StringName = &amp;"storage_failed"</signature>
+			<description>底层存储读取失败或不可用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>检查加载是否进入成功终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">设置已加载或已按显式策略恢复时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; StringName:</signature>
+			<description>获取稳定加载状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATUS_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_file_name">
+			<signature>func get_file_name() -&gt; String:</signature>
+			<description>获取本次加载使用的文件名。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">解析默认值后的设置文件名。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="was_applied">
+			<signature>func was_applied() -&gt; bool:</signature>
+			<description>检查本次操作是否替换了有效设置状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已应用持久化载荷或默认值恢复时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="was_recovered">
+			<signature>func was_recovered() -&gt; bool:</signature>
+			<description>检查本次操作是否执行了显式恢复动作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">使用恢复策略完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_recovery_action">
+			<signature>func get_recovery_action() -&gt; StringName:</signature>
+			<description>获取实际恢复动作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">未恢复时为空，否则为 `GFSettingsRecoveryPolicy.ACTION_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_code">
+			<signature>func get_error_code() -&gt; Error:</signature>
+			<description>获取 Godot Error 码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时为 OK。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error">
+			<signature>func get_error() -&gt; String:</signature>
+			<description>获取稳定错误描述。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_storage_result">
+			<signature>func get_storage_result() -&gt; GFStorageReadResult:</signature>
+			<description>获取底层存储读取结果副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">原始读取证据的隔离副本；读取未启动时为 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_result">
+			<signature>func duplicate_result() -&gt; GFSettingsLoadResult:</signature>
+			<description>创建结果的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新结果对象。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为不包含设置载荷的报告字典。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">加载终态摘要。</tag>
+				<tag name="schema">return: Dictionary with ok, status, file_name, applied, recovered, recovery_action, error_code, error, and payload-free storage_result fields.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSettingsRecoveryPolicy.xml
+++ b/docs/api_catalog/classes/GFSettingsRecoveryPolicy.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSettingsRecoveryPolicy" path="addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd" module="standard" extends="Resource" classDigest="c66f5838692b440bb9bbe879b842b8bd4a350e613981675ade5bdd31d15134ff">
+	<description>GFSettingsRecoveryPolicy: 设置加载的显式恢复策略。
+缺失与损坏设置默认严格失败。项目可以显式选择保留当前内存状态，
+或把有效设置重置为已注册默认值；恢复不会创建或覆盖持久化文件。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">resource_definition</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="ACTION_FAIL">
+			<signature>const ACTION_FAIL: StringName = &amp;"fail"</signature>
+			<description>不执行自动恢复。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ACTION_USE_CURRENT_STATE">
+			<signature>const ACTION_USE_CURRENT_STATE: StringName = &amp;"use_current_state"</signature>
+			<description>保留当前有效值和暂存值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ACTION_RESET_TO_DEFAULTS">
+			<signature>const ACTION_RESET_TO_DEFAULTS: StringName = &amp;"reset_to_defaults"</signature>
+			<description>使用空 replace 语义恢复已注册默认值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties>
+		<member kind="property" name="missing_file_action" decorators="@export">
+			<signature>var missing_file_action: StringName = ACTION_FAIL</signature>
+			<description>文件缺失时的恢复动作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="corrupt_file_action" decorators="@export">
+			<signature>var corrupt_file_action: StringName = ACTION_FAIL</signature>
+			<description>文件损坏或完整性校验失败时的恢复动作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</properties>
+	<methods>
+		<member kind="method" name="validate_policy">
+			<signature>func validate_policy() -&gt; Dictionary:</signature>
+			<description>检查策略自身是否合法。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">结构化校验报告。</tag>
+				<tag name="schema">return: GFValidationReportDictionary-compatible report with issues, counts, summary, and next_actions.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSettingsUtility.xml
+++ b/docs/api_catalog/classes/GFSettingsUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSettingsUtility" path="addons/gf/standard/utilities/settings/gf_settings_utility.gd" module="standard" extends="GFUtility" classDigest="f9b2225f1d5ab3dc01fd8ff9143b0530eabb5939d619008f1efcb69dc9e84403">
+<class name="GFSettingsUtility" path="addons/gf/standard/utilities/settings/gf_settings_utility.gd" module="standard" extends="GFUtility" classDigest="6c77ea8f90c965193f38354031d1e8774234749595b4cacc42c4ef98b8b54c5d">
 	<description>GFSettingsUtility: 通用设置注册、读写与持久化工具。
 设置项以 StringName 键访问，可选使用 GFSettingDefinition 声明默认值和类型。
 该工具只管理抽象设置值，不直接绑定窗口、音频、输入或任何项目业务。</description>
@@ -21,13 +21,13 @@
 				<tag name="schema">new_value: Variant next setting value or null when the setting was removed.</tag>
 			</tags>
 		</member>
-		<member kind="signal" name="settings_loaded">
-			<signature>signal settings_loaded(data: Dictionary)</signature>
-			<description>设置加载完成时发出。</description>
+		<member kind="signal" name="settings_load_completed">
+			<signature>signal settings_load_completed(result: GFSettingsLoadResult)</signature>
+			<description>设置加载进入终态时发出。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">data: 已加载的持久化设置数据。</tag>
-				<tag name="schema">data: Dictionary[String, Variant] loaded persisted settings data.</tag>
+				<tag name="param">result: 隔离的结构化加载结果。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="settings_saved">
@@ -400,13 +400,28 @@
 			</tags>
 		</member>
 		<member kind="method" name="load_settings">
-			<signature>func load_settings(file_name: String = "") -&gt; Dictionary:</signature>
-			<description>读取持久化设置。</description>
+			<signature>func load_settings( file_name: String = "", recovery_policy: GFSettingsRecoveryPolicy = null ) -&gt; GFSettingsLoadResult:</signature>
+			<description>读取持久化设置并返回结构化终态。
+默认策略严格失败；缺失、损坏、未来 schema、迁移失败或 IO 失败不会被
+降级为空字典。只有显式恢复策略可以处理缺失或损坏，且加载本身从不保存。
+非空策略会在 IO 前验证；合法加载请求会取消全部旧延迟/批处理保存请求，
+防止新加载状态被旧保存目标重新序列化。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">file_name: 可选文件名；为空时使用 storage_file_name。</tag>
-				<tag name="return">已读取的数据。</tag>
-				<tag name="schema">return: Dictionary[String, Variant] loaded persisted settings data.</tag>
+				<tag name="param">recovery_policy: 可选显式恢复策略；null 表示严格失败。</tag>
+				<tag name="return">隔离的结构化加载结果。</tag>
+				<tag name="schema">return: GFSettingsLoadResult preserving status, application state, recovery action, and storage evidence.</tag>
+				<tag name="since">3.17.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_last_load_result">
+			<signature>func get_last_load_result() -&gt; GFSettingsLoadResult:</signature>
+			<description>获取最近一次加载终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">最近结果的隔离副本；尚未加载或已释放时为 null。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="save_settings">
@@ -427,13 +442,14 @@
 			</tags>
 		</member>
 		<member kind="method" name="_read_persisted_data">
-			<signature>func _read_persisted_data(file_name: String) -&gt; Dictionary:</signature>
+			<signature>func _read_persisted_data(file_name: String) -&gt; GFStorageReadResult:</signature>
 			<description>读取持久化设置数据。子类可覆盖该钩子以接入自定义存储后端。</description>
 			<tags>
 				<tag name="api">protected</tag>
 				<tag name="param">file_name: 要读取的设置文件名。</tag>
-				<tag name="return">已读取的数据；不存在或无法解析时返回空字典。</tag>
-				<tag name="schema">return: Dictionary[String, Variant] persisted settings data.</tag>
+				<tag name="return">保留成功空载荷与稳定失败分类的存储读取结果。</tag>
+				<tag name="schema">return: GFStorageReadResult with isolated Settings payload and failure_kind evidence.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="_write_persisted_data">

--- a/docs/api_catalog/classes/GFShaderInterfaceSnapshot.xml
+++ b/docs/api_catalog/classes/GFShaderInterfaceSnapshot.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFShaderInterfaceSnapshot" path="addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd" module="standard" extends="Resource" classDigest="30287a8add7b8f6f9b728af56b4fea4956994efa4b18dc385cbc38003a442eb9">
+	<description>GFShaderInterfaceSnapshot: 可持久化的 Shader uniform 接口快照。
+从 Shader 反射结果捕获稳定排序的 uniform 声明，并用同一份数据校验参数集合
+或比较接口漂移。快照只保存公开接口字段，不保存 shader 源码、材质当前值、
+渲染后端产物或项目视觉语义。直接 new() 的实例保持未配置，必须经 capture()
+或 from_dict() 建立后再使用。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">resource_definition</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="CURRENT_SCHEMA_VERSION">
+			<signature>const CURRENT_SCHEMA_VERSION: int = 1</signature>
+			<description>当前快照字典 schema 版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="capture">
+			<signature>static func capture(shader: Shader) -&gt; GFShaderInterfaceSnapshot:</signature>
+			<description>从 Shader 当前反射接口创建快照。
+参数分组提示不会进入快照；uniform 会按名称和签名稳定排序。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">shader: 要捕获的 Shader；为空时返回 null。</tag>
+				<tag name="return">新快照，或 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="from_dict">
+			<signature>static func from_dict(data: Dictionary) -&gt; GFShaderInterfaceSnapshot:</signature>
+			<description>从字典创建快照。
+输入会被深复制并规范化，但不会强转字段类型；不支持的 schema、缺失数组和
+无效条目由 validate_definition() 报告。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">data: 快照字典。</tag>
+				<tag name="return">新快照。</tag>
+				<tag name="schema">data: Dictionary，包含 schema_version、shader_mode 和 uniforms；uniform 字段为 name、type、class_name、hint、hint_string、usage。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_schema_version">
+			<signature>func get_schema_version() -&gt; int:</signature>
+			<description>获取快照 schema 版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">schema 版本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_shader_mode">
+			<signature>func get_shader_mode() -&gt; int:</signature>
+			<description>获取捕获时的 Shader 模式。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Shader.Mode 对应整数。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_uniforms">
+			<signature>func get_uniforms() -&gt; Array[Dictionary]:</signature>
+			<description>获取稳定排序的 uniform 条目深拷贝。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">uniform 条目数组。</tag>
+				<tag name="schema">return: Array[Dictionary]，每项包含 name、type、class_name、hint、hint_string 和 usage。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_uniform_names">
+			<signature>func get_uniform_names() -&gt; Array[StringName]:</signature>
+			<description>获取稳定排序的 uniform 名。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">uniform 名数组。</tag>
+				<tag name="schema">return: Array[StringName]，按名称稳定排序。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="has_uniform">
+			<signature>func has_uniform(parameter_name: StringName) -&gt; bool:</signature>
+			<description>检查接口是否声明 uniform。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">parameter_name: uniform 名。</tag>
+				<tag name="return">已声明时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_uniform">
+			<signature>func get_uniform(parameter_name: StringName) -&gt; Dictionary:</signature>
+			<description>获取 uniform 条目深拷贝。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">parameter_name: uniform 名。</tag>
+				<tag name="return">uniform 条目；不存在时返回空字典。</tag>
+				<tag name="schema">return: Dictionary，包含 name、type、class_name、hint、hint_string 和 usage。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="accepts_parameter_value">
+			<signature>func accepts_parameter_value( parameter_name: StringName, value: Variant, options: Dictionary = {} ) -&gt; bool:</signature>
+			<description>检查一个值是否符合已声明 uniform 类型。
+数字类型严格匹配，不做 int/float 隐式转换；Object 参数会继续检查资源类。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">parameter_name: uniform 名。</tag>
+				<tag name="param">value: 候选值。</tag>
+				<tag name="param">options: 支持 allow_null_object，默认 true。</tag>
+				<tag name="return">已声明且值兼容时返回 true。</tag>
+				<tag name="schema">value: Variant shader parameter value.</tag>
+				<tag name="schema">options: Dictionary，allow_null_object 控制 TYPE_OBJECT uniform 是否接受 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_definition">
+			<signature>func validate_definition(options: Dictionary = {}) -&gt; GFValidationReport:</signature>
+			<description>校验快照 schema、Shader 模式、uniform 字段和重复名称。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">options: 支持 subject 和 metadata。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">options: Dictionary，subject 覆盖报告主题，metadata 为调用方报告元数据。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_parameters">
+			<signature>func validate_parameters( parameters: Dictionary, options: Dictionary = {} ) -&gt; GFValidationReport:</signature>
+			<description>根据快照校验参数字典。
+Profile 默认按部分覆盖处理，因此缺失 uniform 默认忽略；未知参数和错型值默认报错。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">parameters: uniform 名到参数值的映射。</tag>
+				<tag name="param">options: 支持 subject、metadata、missing_severity、extra_severity、type_mismatch_severity 和 allow_null_object。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">parameters: Dictionary[StringName|String, Variant] shader parameter values.</tag>
+				<tag name="schema">options: Dictionary，severity 可为 ignore、info、warning 或 error；missing 默认 ignore，extra/type mismatch 默认 error；allow_null_object 默认 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="compare_with">
+			<signature>func compare_with( actual: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -&gt; GFValidationReport:</signature>
+			<description>比较期望快照与实际快照。
+当前快照作为 expected；actual 缺失和签名变化默认报错，新增 uniform 默认 warning。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">actual: 实际接口快照。</tag>
+				<tag name="param">options: 支持 subject、metadata、mode_mismatch_severity、missing_severity、extra_severity、signature_severity 和 usage_severity。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">options: Dictionary，severity 可为 ignore、info、warning 或 error；mode/missing/signature 默认 error，extra/usage 默认 warning。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_shader">
+			<signature>func validate_shader( shader: Shader, options: Dictionary = {} ) -&gt; GFValidationReport:</signature>
+			<description>将 Shader 当前接口与本快照比较。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">shader: 实际 Shader。</tag>
+				<tag name="param">options: 传给 compare_with() 的报告和 severity 选项。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">options: Dictionary compare_with() options.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_snapshot">
+			<signature>func duplicate_snapshot() -&gt; GFShaderInterfaceSnapshot:</signature>
+			<description>创建快照深拷贝。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新快照。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为稳定排序的快照字典。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">快照字典。</tag>
+				<tag name="schema">return: Dictionary，包含 schema_version、shader_mode 和 uniforms。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFShaderParameterProfile.xml
+++ b/docs/api_catalog/classes/GFShaderParameterProfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFShaderParameterProfile" path="addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd" module="standard" extends="Resource" classDigest="43f5a408d2a3c248b39bf89e2a12b4dc6e0546cf98a685f4ce81adda9f945669">
+<class name="GFShaderParameterProfile" path="addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd" module="standard" extends="Resource" classDigest="6c84bb059e32bb181c68cc19c9de19a77fd8cd039afb66e77035ae155d04d1a5">
 	<description>GFShaderParameterProfile: 通用 ShaderMaterial 参数集合资源。
 用 Resource 保存一组 shader uniform 参数值，便于项目把视觉 profile、天气表现、
 选中态或后处理参数声明为可合并、可复制、可插值的数据。它不提供具体 shader、
@@ -86,6 +86,19 @@
 				<tag name="api">public</tag>
 				<tag name="return">参数名数组。</tag>
 				<tag name="schema">return: Array[StringName]，当前 profile 中可识别的 shader 参数名。</tag>
+				<tag name="since">4.3.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_against">
+			<signature>func validate_against( interface_snapshot: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -&gt; GFValidationReport:</signature>
+			<description>根据 Shader 接口快照校验当前参数。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">interface_snapshot: 期望接口快照。</tag>
+				<tag name="param">options: 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">options: Dictionary shader parameter validation options.</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="merge_from">

--- a/docs/api_catalog/classes/GFShaderParameterUtility.xml
+++ b/docs/api_catalog/classes/GFShaderParameterUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFShaderParameterUtility" path="addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd" module="standard" extends="GFUtility" classDigest="e3472d0ef2e3145b0dfbcced63fa51d21e5981c642d023861840a3dec51071ca">
+<class name="GFShaderParameterUtility" path="addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd" module="standard" extends="GFUtility" classDigest="bdc411b576636bc0c82540c62bb458f25d559aada0bc8f3cf7601d9c373d2124">
 	<description>GFShaderParameterUtility: 通用 ShaderMaterial 参数应用工具。
 将 `GFShaderParameterProfile` 或参数字典写入 ShaderMaterial，也可以从持有
 `material` 属性的节点解析材质。它只处理参数存在性校验、共享材质复制和批量写入，
@@ -29,9 +29,10 @@
 				<tag name="api">public</tag>
 				<tag name="param">target: ShaderMaterial，或持有材质属性的对象。</tag>
 				<tag name="param">profile: 要应用的 shader 参数 profile。</tag>
-				<tag name="param">options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、warn_on_invalid_target、warn_on_missing_parameters 和 copy_values。</tag>
+				<tag name="param">options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、validate_parameter_types、warn_on_invalid_target、warn_on_missing_parameters、warn_on_type_mismatch 和 copy_values。</tag>
 				<tag name="return">实际写入的参数数量。</tag>
-				<tag name="schema">options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；warn_on_invalid_target 和 warn_on_missing_parameters 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。</tag>
+				<tag name="schema">options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；validate_parameter_types 默认为 true，会跳过与 uniform 声明不兼容的值；warn_on_invalid_target、warn_on_missing_parameters 和 warn_on_type_mismatch 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。</tag>
+				<tag name="since">4.3.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="apply_global_profile">
@@ -54,10 +55,11 @@
 				<tag name="api">public</tag>
 				<tag name="param">target: ShaderMaterial，或持有材质属性的对象。</tag>
 				<tag name="param">parameters: 要应用的 shader 参数字典。</tag>
-				<tag name="param">options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、warn_on_invalid_target、warn_on_missing_parameters 和 copy_values。</tag>
+				<tag name="param">options: 可选项，支持 material_property、duplicate_material、require_declared_parameters、validate_parameter_types、warn_on_invalid_target、warn_on_missing_parameters、warn_on_type_mismatch 和 copy_values。</tag>
 				<tag name="return">实际写入的参数数量。</tag>
 				<tag name="schema">parameters: Dictionary[StringName, Variant]，shader uniform 名到参数值的映射。</tag>
-				<tag name="schema">options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；warn_on_invalid_target 和 warn_on_missing_parameters 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。</tag>
+				<tag name="schema">options: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；validate_parameter_types 默认为 true，会跳过与 uniform 声明不兼容的值；warn_on_invalid_target、warn_on_missing_parameters 和 warn_on_type_mismatch 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。</tag>
+				<tag name="since">4.3.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="apply_global_parameters">
@@ -82,6 +84,44 @@
 				<tag name="param">target: ShaderMaterial，或持有材质属性的对象。</tag>
 				<tag name="param">material_property: 当 target 不是 ShaderMaterial 时读取的材质属性路径。</tag>
 				<tag name="return">解析出的 ShaderMaterial；失败时返回 null。</tag>
+				<tag name="since">4.3.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="capture_shader_interface">
+			<signature>func capture_shader_interface( material: ShaderMaterial ) -&gt; GFShaderInterfaceSnapshot:</signature>
+			<description>捕获 ShaderMaterial 当前 uniform 接口。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">material: 目标 ShaderMaterial。</tag>
+				<tag name="return">接口快照；材质或 Shader 为空时返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_profile">
+			<signature>func validate_profile( material: ShaderMaterial, profile: GFShaderParameterProfile, options: Dictionary = {} ) -&gt; GFValidationReport:</signature>
+			<description>校验 profile 是否符合 ShaderMaterial 当前 uniform 接口。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">material: 目标 ShaderMaterial。</tag>
+				<tag name="param">profile: 要校验的 profile。</tag>
+				<tag name="param">options: 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">options: Dictionary shader parameter validation options.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_parameters">
+			<signature>func validate_parameters( material: ShaderMaterial, parameters: Dictionary, options: Dictionary = {} ) -&gt; GFValidationReport:</signature>
+			<description>校验参数字典是否符合 ShaderMaterial 当前 uniform 接口。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">material: 目标 ShaderMaterial。</tag>
+				<tag name="param">parameters: uniform 参数字典。</tag>
+				<tag name="param">options: 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。</tag>
+				<tag name="return">标准校验报告。</tag>
+				<tag name="schema">parameters: Dictionary[StringName|String, Variant] shader parameter values.</tag>
+				<tag name="schema">options: Dictionary shader parameter validation options.</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_shader_parameter_names">
@@ -92,6 +132,7 @@
 				<tag name="param">material: 目标 ShaderMaterial。</tag>
 				<tag name="return">参数名数组。</tag>
 				<tag name="schema">return: Array[StringName]，material.shader 声明的 shader uniform 名称。</tag>
+				<tag name="since">4.3.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="has_shader_parameter">
@@ -102,6 +143,7 @@
 				<tag name="param">material: 目标 ShaderMaterial。</tag>
 				<tag name="param">parameter_name: Shader uniform 参数名。</tag>
 				<tag name="return">参数存在时返回 true。</tag>
+				<tag name="since">4.3.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="ensure_global_parameter">

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="35672b7563d83b4007db021fdd7acfb1a75b44076f9c3be2b8749191d8b0d54b" classCount="784" methodCount="7050">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="ca428dbfe15e28fe5bef1d94c4b69528a96750e67a4df158b5c31150055ce33b" classCount="784" methodCount="7050">
 	<module id="kernel" label="Kernel" classCount="72" methodCount="736">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="bd0e613b70e4ff289dee37f0ea9d8821aa3a11a905a82f5ac467187b014925aa" classCount="780" methodCount="7009">
-	<module id="kernel" label="Kernel" classCount="71" methodCount="727">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="35672b7563d83b4007db021fdd7acfb1a75b44076f9c3be2b8749191d8b0d54b" classCount="784" methodCount="7050">
+	<module id="kernel" label="Kernel" classCount="72" methodCount="736">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
 		<class name="GFAsyncCompletion" path="classes/GFAsyncCompletion.xml" sourcePath="addons/gf/kernel/core/gf_async_completion.gd" extends="RefCounted" />
@@ -24,6 +24,7 @@
 		<class name="GFEditorCommandSession" path="classes/GFEditorCommandSession.xml" sourcePath="addons/gf/kernel/editor/gf_editor_command_session.gd" extends="RefCounted" />
 		<class name="GFEditorOperationPlan" path="classes/GFEditorOperationPlan.xml" sourcePath="addons/gf/kernel/editor/gf_editor_operation_plan.gd" extends="RefCounted" />
 		<class name="GFEditorPickOperation" path="classes/GFEditorPickOperation.xml" sourcePath="addons/gf/kernel/editor/gf_editor_pick_operation.gd" extends="RefCounted" />
+		<class name="GFEditorPropertyBatchCommand" path="classes/GFEditorPropertyBatchCommand.xml" sourcePath="addons/gf/kernel/editor/gf_editor_property_batch_command.gd" extends="GFEditorCommand" />
 		<class name="GFEditorSceneMetadataPatch" path="classes/GFEditorSceneMetadataPatch.xml" sourcePath="addons/gf/kernel/editor/gf_editor_scene_metadata_patch.gd" extends="GFEditorCommand" />
 		<class name="GFEditorTool" path="classes/GFEditorTool.xml" sourcePath="addons/gf/kernel/editor/gf_editor_tool.gd" extends="RefCounted" />
 		<class name="GFEditorToolContext" path="classes/GFEditorToolContext.xml" sourcePath="addons/gf/kernel/editor/gf_editor_tool_context.gd" extends="RefCounted" />
@@ -73,7 +74,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="435" methodCount="4369">
+	<module id="standard" label="Standard" classCount="438" methodCount="4401">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />
@@ -404,7 +405,10 @@
 		<class name="GFSessionTraceRecipe" path="classes/GFSessionTraceRecipe.xml" sourcePath="addons/gf/standard/utilities/debug/gf_session_trace_recipe.gd" extends="Resource" />
 		<class name="GFSessionTraceUtility" path="classes/GFSessionTraceUtility.xml" sourcePath="addons/gf/standard/utilities/debug/gf_session_trace_utility.gd" extends="GFUtility" />
 		<class name="GFSettingDefinition" path="classes/GFSettingDefinition.xml" sourcePath="addons/gf/standard/utilities/settings/gf_setting_definition.gd" extends="Resource" />
+		<class name="GFSettingsLoadResult" path="classes/GFSettingsLoadResult.xml" sourcePath="addons/gf/standard/utilities/settings/gf_settings_load_result.gd" extends="RefCounted" />
+		<class name="GFSettingsRecoveryPolicy" path="classes/GFSettingsRecoveryPolicy.xml" sourcePath="addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd" extends="Resource" />
 		<class name="GFSettingsUtility" path="classes/GFSettingsUtility.xml" sourcePath="addons/gf/standard/utilities/settings/gf_settings_utility.gd" extends="GFUtility" />
+		<class name="GFShaderInterfaceSnapshot" path="classes/GFShaderInterfaceSnapshot.xml" sourcePath="addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd" extends="Resource" />
 		<class name="GFShaderParameterBinder" path="classes/GFShaderParameterBinder.xml" sourcePath="addons/gf/standard/utilities/display/gf_shader_parameter_binder.gd" extends="Node" />
 		<class name="GFShaderParameterProfile" path="classes/GFShaderParameterProfile.xml" sourcePath="addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd" extends="Resource" />
 		<class name="GFShaderParameterUtility" path="classes/GFShaderParameterUtility.xml" sourcePath="addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd" extends="GFUtility" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -22,10 +22,14 @@
 
 ## [未发布]
 
-**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、运行时 2D Spatial Canvas、有序资产集合、显式 Live Asset Slot、内容包查询与运行时目录挂载、扩展级 Debugger 工具贡献、存储后端故障转移、版本化 Analytics Schema 与专用 Outbox Adapter、惰性诊断采集、配方化运行时会话轨迹、UI 路由预加载规划、轨迹预测数学、有界权威快照同步协调和默认关闭的 Runtime Agent Environment，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
+**版本概述**：开发线升级为 `10.0.0-dev.0`，补齐通用 2D 编辑器缩略图、运行时 2D Spatial Canvas、有序资产集合、显式 Live Asset Slot、内容包查询与运行时目录挂载、扩展级 Debugger 工具贡献、存储后端故障转移、版本化 Analytics Schema 与专用 Outbox Adapter、结构化 Settings 恢复、多目标属性事务、Shader 接口契约、惰性诊断采集、配方化运行时会话轨迹、UI 路由预加载规划、轨迹预测数学、有界权威快照同步协调和默认关闭的 Runtime Agent Environment，修正 AI Developer Kit 的项目级资源所有权表达，并更新 CI/Release 基础 Actions；业务策略仍保持在各自调用方边界内。
 
 ### 🚀 新增特性 (Added)
 
+- 新增 `GFSettingsLoadResult` 与 `GFSettingsRecoveryPolicy`：Settings 加载现在明确区分成功空载荷、缺失、损坏、未来 schema、迁移失败和存储失败；默认严格失败，只有 missing/corrupt 可由调用方显式选择保留当前状态或重置已注册默认值，恢复阶段不会自动保存或覆盖证据文件。
+- 新增 `GFEditorPropertyBatchCommand`：对多个 Object 的精确直接属性或 indexed path 做全量零写入预检、稳定顺序提交、反序撤销、最终状态复核和 attempt-guard 补偿；失败恢复不完整时通过结构化报告与 `recover()` 暴露明确恢复入口，磁盘保存和 setter 外部副作用不属于该内存事务。
+- 新增 `GFShaderInterfaceSnapshot`：把 Shader mode 与 uniform 的名称、Variant 类型、资源类、hint 和 usage 捕获为可持久化、稳定排序的接口快照，并提供严格参数校验和 expected/actual 漂移比较；不保存 shader 源码、材质当前值或渲染后端产物。
+- 新增共享键盘本地多人和非破坏式实时调参预览配方：前者组合玩家级 `GFVirtualInputSource` 与互斥物理键区，后者组合资源补丁、显式 `GFAssetSlot`、可取消缩略图任务和编辑器属性事务；加入/控制权、业务参数、面板布局和持久化时机仍由项目负责。
 - 新增 `GFWeakMethodInvocation` 框架级弱方法调用原语，以及 `GFMainThreadDispatchQueue.post_method()` 和 `GFDeferredMutationQueue.record_method()`：长期记录只保存 owner 的弱引用、初始实例 ID 和方法名，调用参数只在执行时传入；队列安全入口不持久化任意参数或 metadata，并把 owner 释放、方法缺失、预检失败与真实业务返回值明确分离。
 - `GFTypeEventSystem` 新增 exact、assignable 与 simple 三类 token 订阅：每次订阅拥有独立稳定身份，可通过 `GFSubscriptionToken` 幂等取消；一次性订阅会在用户回调前退休，owner 清理、显式注销和事件系统清空也会同步使 token 失效。`GFArchitecture` 与 `Gf` 提供对应入口，而 `GFController` 的长期 desired binding 继续采用生命周期重建语义，不会让一次性订阅在架构切换后复活。
 - 新增平台 Contract Descriptor、Activation Intent 有界去重队列与 `GFPlatformAdapterConformance`，让外部 SDK Adapter 可以声明请求/结果 Schema、字节预算、能力、并发、取消和敏感字段，并在不调用 SDK 时完成静态覆盖审查。
@@ -55,6 +59,9 @@
 
 ### 🔄 机制更改 (Changed)
 
+- `GFSettingsUtility.load_settings()` 改为返回结构化终态，并为每个终态发出隔离的 `settings_load_completed`；合法 `{}` 继续使用 replace 语义，失败不再降级为空字典，合法加载请求开始时会取消此前全部陈旧延迟与批处理保存，显式恢复也不会产生隐式写盘。
+- `GFResourceTableEditor.commit_cell_values()` 与 `commit_visible_cell_values()` 从“允许部分成功”收敛为事务式整批提交：所有行、属性和值先解析和预检，只有完整成功后才发信号、刷新和执行去重自动保存。
+- `GFShaderParameterUtility` 默认按捕获的单份接口快照跳过错型参数；`GFShaderParameterProfile` 新增快照校验入口，`GFShaderParameterAction` 在材质复制、初值捕获和 Tween 创建前验证 uniform 存在性与目标值类型。Action Queue 因此显式依赖 `gf.standard.display`。
 - AI Developer Capability / Recipe 知识目录同步升级到 `1.6.0`，补齐可伸缩 UI 集合、渲染反馈编排、命令历史、有界运行时工作、网格路径发现与通用外部产物导出边界；新导出配方只组合缩略图、截图、矩形打包、产物报告和内容包计划，最终格式、认证、幂等、重试与写出仍归项目 Adapter。能力搜索统一标点、连字符和下划线，目录完整性检查新增包、类、Recipe 与类所属包依赖闭包的交叉复核。
 - TurnBased 使用指南明确 `GFTurnAction` 只调度一次性行动请求、项目自有 `GFUndoableCommand` 唯一修改或恢复权威状态、`GFActionQueueSystem` 只编排提交后的视觉与音频表现；三者由项目 Coordinator/Installer 按需组合，不新增跨扩展耦合类型，也不把反向 Tween 当作撤销事实源。
 - Architecture assignment、Installer、动态模块注册/替换和 `GFNodeContext` 安装统一采用 generation/scope 驱动的 prepare / commit / rollback 事务；候选未提交前不会通过全局 facade 暴露，旧异步 continuation 和生命周期回调重入不能覆盖最新状态。
@@ -141,6 +148,10 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
+- 新增公开类型 `GFSettingsLoadResult`、`GFSettingsRecoveryPolicy`、`GFEditorPropertyBatchCommand` 和 `GFShaderInterfaceSnapshot`；新增 API 均标记为 `@since unreleased`。
+- `GFSettingsUtility.load_settings(file_name)` 从返回 `Dictionary` 改为 `load_settings(file_name, recovery_policy) -> GFSettingsLoadResult`；`settings_loaded(data)` 被 `settings_load_completed(result)` 取代，新增 `get_last_load_result()`，受保护 `_read_persisted_data()` 的返回类型从 `Dictionary` 改为 `GFStorageReadResult`。本开发线不保留双轨兼容。
+- `GFObjectPropertyTools` 新增 framework-internal 的零写入 prepare 入口，`GFEditorCommand` 新增受保护配置封存入口；`GFResourceTableEditor` 批量提交报告新增事务状态、回滚状态和可选恢复命令。
+- `GFShaderParameterUtility` 新增接口捕获、Profile 校验和参数校验入口；既有 `apply_profile()` / `apply_parameters()` 的默认选项新增严格类型校验和错型 warning。
 - `GFTypeEventSystem` 新增 `subscribe()`、`subscribe_assignable()` 与 `subscribe_simple()`；`GFArchitecture` 新增 `subscribe_event()`、`subscribe_assignable_event()` 与 `subscribe_simple_event()`；`Gf` 新增同名三类快捷订阅入口。上述入口均返回 `GFSubscriptionToken`，接受 `once`，带 owner 的 `GFEventListener` 实际返回 `GFLifetimeSubscription`。`GFSubscriptionToken` 与 `GFLifetimeSubscription` 新增仅供订阅源使用的自动失效内部入口。
 - `GFUndoableCommand` 新增 `is_undo_successful(_undo_result)` 与 `is_redo_successful(_execute_result)`，均标记为 `@since unreleased` 且默认返回 `true`。同步历史入口传入命令的直接返回值；异步历史入口把完成 Signal 的零、单、二至 16 参数 payload 分别规范化为 `null`、单值和 `Array` 后传入，超过 16 个参数时告警并只保留前 16 个。
 - `Gf.set_architecture()` 改为原子提交候选架构：Installer 和三阶段初始化成功前，`Gf` facade 只暴露既有已提交架构或空状态；pending assignment 被更新赋值、尚无已提交架构时由 `Gf.create_architecture()` 创建的默认架构，或 Gf 退出场景树替代时，会取消其异步作用域并 dispose 未提交候选。函数签名不变，但依赖 Installer 期间 facade 指向候选、或依赖被替代候选仍可复用的代码需要迁移。
@@ -182,6 +193,9 @@
 
 ### 📘 升级指南 (Migration Guide)
 
+- Settings 调用方应把 `Dictionary` 接收值改为 `GFSettingsLoadResult`，先检查 `is_successful()` / `get_status()`，再通过 Utility 读取当前值；监听器迁移到 `settings_load_completed`，自定义读取子类返回 `GFStorageReadResult`。依赖“文件缺失或损坏自动当作空设置”的项目必须显式配置 `GFSettingsRecoveryPolicy`，并在接受恢复结果后另行决定是否保存。
+- 依赖 `GFResourceTableEditor` 批量接口“有效项先提交、无效项单独报错”的工具应改为一次只提交可共同成功或共同失败的变更；收到 `recovery_required` 时先修复 setter 可写条件并调用返回命令的 `recover()`，不要在属性事务完成前保存资源。
+- Shader Profile 中 int/float 混用、错误资源类或未知 uniform 现在默认被跳过并报告 warning；项目应把参数改为 Shader 反射声明的精确 Variant 类型。需要 CI 漂移门禁时保存 `GFShaderInterfaceSnapshot` 基线并检查 `validate_shader()` / `validate_against()` 报告，不要从 shader 源码文本自行推断接口。
 - `GFGridOccupancy` 的查询不再隐式回收已释放 `Object` 或发出释放信号；依赖该副作用的调用方应在明确的维护边界调用 `prune_invalid_receivers()`，或让下一次占用/预约写事务负责清理。运行期修改 `grid_size` 或 `max_occupants_per_cell` 现在会像重新配置一样清空既有记录；需要保留棋盘状态时，应先导出项目自己的稳定状态，再按新配置显式重建。
 - 既有 `GFUndoableCommand` 若不重入历史写操作则无需迁移：两个历史结果 hook 默认成功，`null` 返回值和无参数完成 Signal 保持原行为。只有撤销或重做可能进入“已完成但业务失败”终态的命令才需要覆盖对应 hook；异步 hook 应按 `null`、单值或最多 16 项的多值 `Array` 读取规范化完成 payload，并返回明确的 `bool`，更多字段应封装成单个 Result 或 `Dictionary`。`execute()`、`undo()`、`should_record()` 和结果 hook 现在统一处于非重入历史操作内；原先从这些回调嵌套执行、记录、清空、修改容量或恢复历史的项目代码，应改为在外层历史 API 完成后由项目队列提交后续操作。
 - 项目 Installer 必须改为通过 `install(architecture, scope)` 的显式 `architecture` 参数或 `install_bindings(binder, scope)` 的 `binder` 注册候选模块，不要在 `Gf.set_architecture()` 提交前使用 `Gf.register_*()`、`Gf.create_binder()` 或 `Gf.get_*()` 指向候选。异步 Installer 在每个 `await` 后检查 `scope.is_cancel_requested()` 并用 `scope.register_cleanup()` 释放临时资源；assignment 被替代并返回 `false` 后应创建新的 `GFArchitecture` 重试，不复用已经 dispose 的候选。释放回调和项目自定义等待器应通过 `is_disposing()` / `is_disposed()` 拒绝向终结中的架构提交新工作。
@@ -225,6 +239,14 @@
 
 ### 📁 核心受影响文件 (Affected Files)
 
+- `addons/gf/standard/utilities/settings/`
+- `addons/gf/kernel/editor/gf_editor_property_batch_command.gd`
+- `addons/gf/kernel/editor/gf_resource_table_editor.gd`
+- `addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd`
+- `addons/gf/standard/utilities/display/gf_shader_parameter_*.gd`
+- `addons/gf/extensions/action_queue/actions/gf_shader_parameter_action.gd`
+- `docs/zh/editor/non-destructive-live-preview.md`
+- `docs/zh/standard/input-flow/input-assist/virtual-recording-remap/shared-keyboard-local-multiplayer.md`
 - `addons/gf/kernel/core/gf_weak_method_invocation.gd`
 - `addons/gf/standard/common/gf_main_thread_dispatch_queue.gd`
 - `addons/gf/standard/common/gf_deferred_mutation_queue.gd`

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -60,7 +60,7 @@
 ### 🔄 机制更改 (Changed)
 
 - `GFSettingsUtility.load_settings()` 改为返回结构化终态，并为每个终态发出隔离的 `settings_load_completed`；合法 `{}` 继续使用 replace 语义，失败不再降级为空字典，合法加载请求开始时会取消此前全部陈旧延迟与批处理保存，显式恢复也不会产生隐式写盘。
-- `GFResourceTableEditor.commit_cell_values()` 与 `commit_visible_cell_values()` 从“允许部分成功”收敛为事务式整批提交：所有行、属性和值先解析和预检，只有完整成功后才发信号、刷新和执行去重自动保存。
+- `GFResourceTableEditor.commit_cell_values()` 与 `commit_visible_cell_values()` 从“允许部分成功”收敛为事务式整批提交：所有行、属性和值先解析和预检；规范化后同值的条目成功但不调用 setter、不发变更信号，只有至少一项实际变化后才统一刷新和执行去重自动保存。空变更数组是 `committed` / `OK` 的全零计数成功恒等操作。
 - `GFShaderParameterUtility` 默认按捕获的单份接口快照跳过错型参数；`GFShaderParameterProfile` 新增快照校验入口，`GFShaderParameterAction` 在材质复制、初值捕获和 Tween 创建前验证 uniform 存在性与目标值类型。Action Queue 因此显式依赖 `gf.standard.display`。
 - AI Developer Capability / Recipe 知识目录同步升级到 `1.6.0`，补齐可伸缩 UI 集合、渲染反馈编排、命令历史、有界运行时工作、网格路径发现与通用外部产物导出边界；新导出配方只组合缩略图、截图、矩形打包、产物报告和内容包计划，最终格式、认证、幂等、重试与写出仍归项目 Adapter。能力搜索统一标点、连字符和下划线，目录完整性检查新增包、类、Recipe 与类所属包依赖闭包的交叉复核。
 - TurnBased 使用指南明确 `GFTurnAction` 只调度一次性行动请求、项目自有 `GFUndoableCommand` 唯一修改或恢复权威状态、`GFActionQueueSystem` 只编排提交后的视觉与音频表现；三者由项目 Coordinator/Installer 按需组合，不新增跨扩展耦合类型，也不把反向 Tween 当作撤销事实源。
@@ -104,6 +104,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFResourceTableEditor` 把空单元格批次传给通用属性事务命令后错误报告 `missing_changes`、形成 `requested_count = 0` 但失败计数非零的问题；资源表适配层现在直接返回零计数成功报告，而 `GFEditorPropertyBatchCommand` 继续拒绝没有变更的事务配置。
 - 修复 `GFGridOccupancy` 在移动占用、移动预约、确认预约或批量释放的同步信号回调中发生重入写入时，外层后续提交可能突破格子容量、丢失预约或留下不一致反向索引的问题；所有内部映射现在先按单次事务完整提交，再发出通知，通知期的方法与配置属性写入均明确失败关闭。`grid_size` / `max_occupants_per_cell` 的实际变更会清空既有记录并保持容量至少为 1；查询改为只读过滤失效对象，清理索引和释放通知由显式 `prune_invalid_receivers()` 或下一次写事务负责。
 - 修复 `GFCommandHistoryUtility` 在命令已进入终态但业务撤销/重做失败时仍推进历史游标的问题；`GFUndoableCommand` 新增默认成功的 `is_undo_successful()` / `is_redo_successful()` hook，同步与异步入口只在 hook 成功后复核来源栈顶身份并原子移动栈。异步 Signal 的零、单、二至 16 参数终态分别规范化为 `null`、单值和 `Array`，处理锁贯穿命令回调、等待、hook 与提交；等待和 hook 内的只读查询仍观察最近一次完整提交，失败不触碰任一栈的身份、顺序或容量，生命周期切代后的旧 continuation 也不会回填新历史。
 - 修复 Interaction Sensor 对类型化 Receiver 派发时绕过项目 `receive_interaction()` 覆写，以及自定义 sender 的 2D/3D 碰撞广播在规范化报告前发出公开信号的问题；公开覆写继续参与派发，返回值和信号报告统一保持 JSON-safe。
@@ -150,7 +151,7 @@
 
 - 新增公开类型 `GFSettingsLoadResult`、`GFSettingsRecoveryPolicy`、`GFEditorPropertyBatchCommand` 和 `GFShaderInterfaceSnapshot`；新增 API 均标记为 `@since unreleased`。
 - `GFSettingsUtility.load_settings(file_name)` 从返回 `Dictionary` 改为 `load_settings(file_name, recovery_policy) -> GFSettingsLoadResult`；`settings_loaded(data)` 被 `settings_load_completed(result)` 取代，新增 `get_last_load_result()`，受保护 `_read_persisted_data()` 的返回类型从 `Dictionary` 改为 `GFStorageReadResult`。本开发线不保留双轨兼容。
-- `GFObjectPropertyTools` 新增 framework-internal 的零写入 prepare 入口，`GFEditorCommand` 新增受保护配置封存入口；`GFResourceTableEditor` 批量提交报告新增事务状态、回滚状态和可选恢复命令。
+- `GFObjectPropertyTools` 新增 framework-internal 的零写入 prepare 入口，`GFEditorCommand` 新增受保护配置封存入口；`GFResourceTableEditor` 批量提交报告新增事务状态、回滚状态和可选恢复命令。空批次返回 `committed` / `OK` 的全零计数成功报告；规范化后同值的单格或批量条目不再作为 setter、`cell_value_committed`、自动保存或刷新触发器。
 - `GFShaderParameterUtility` 新增接口捕获、Profile 校验和参数校验入口；既有 `apply_profile()` / `apply_parameters()` 的默认选项新增严格类型校验和错型 warning。
 - `GFTypeEventSystem` 新增 `subscribe()`、`subscribe_assignable()` 与 `subscribe_simple()`；`GFArchitecture` 新增 `subscribe_event()`、`subscribe_assignable_event()` 与 `subscribe_simple_event()`；`Gf` 新增同名三类快捷订阅入口。上述入口均返回 `GFSubscriptionToken`，接受 `once`，带 owner 的 `GFEventListener` 实际返回 `GFLifetimeSubscription`。`GFSubscriptionToken` 与 `GFLifetimeSubscription` 新增仅供订阅源使用的自动失效内部入口。
 - `GFUndoableCommand` 新增 `is_undo_successful(_undo_result)` 与 `is_redo_successful(_execute_result)`，均标记为 `@since unreleased` 且默认返回 `true`。同步历史入口传入命令的直接返回值；异步历史入口把完成 Signal 的零、单、二至 16 参数 payload 分别规范化为 `null`、单值和 `Array` 后传入，超过 16 个参数时告警并只保留前 16 个。
@@ -194,7 +195,7 @@
 ### 📘 升级指南 (Migration Guide)
 
 - Settings 调用方应把 `Dictionary` 接收值改为 `GFSettingsLoadResult`，先检查 `is_successful()` / `get_status()`，再通过 Utility 读取当前值；监听器迁移到 `settings_load_completed`，自定义读取子类返回 `GFStorageReadResult`。依赖“文件缺失或损坏自动当作空设置”的项目必须显式配置 `GFSettingsRecoveryPolicy`，并在接受恢复结果后另行决定是否保存。
-- 依赖 `GFResourceTableEditor` 批量接口“有效项先提交、无效项单独报错”的工具应改为一次只提交可共同成功或共同失败的变更；收到 `recovery_required` 时先修复 setter 可写条件并调用返回命令的 `recover()`，不要在属性事务完成前保存资源。
+- 依赖 `GFResourceTableEditor` 批量接口“有效项先提交、无效项单独报错”的工具应改为一次只提交可共同成功或共同失败的变更；收到 `recovery_required` 时先修复 setter 可写条件并调用返回命令的 `recover()`，不要在属性事务完成前保存资源。依赖等值提交触发 setter、通知、持久化或刷新副作用的工具应改用自己的显式项目流程；`10.0.0` 开发线不保留强制等值提交兼容入口。
 - Shader Profile 中 int/float 混用、错误资源类或未知 uniform 现在默认被跳过并报告 warning；项目应把参数改为 Shader 反射声明的精确 Variant 类型。需要 CI 漂移门禁时保存 `GFShaderInterfaceSnapshot` 基线并检查 `validate_shader()` / `validate_against()` 报告，不要从 shader 源码文本自行推断接口。
 - `GFGridOccupancy` 的查询不再隐式回收已释放 `Object` 或发出释放信号；依赖该副作用的调用方应在明确的维护边界调用 `prune_invalid_receivers()`，或让下一次占用/预约写事务负责清理。运行期修改 `grid_size` 或 `max_occupants_per_cell` 现在会像重新配置一样清空既有记录；需要保留棋盘状态时，应先导出项目自己的稳定状态，再按新配置显式重建。
 - 既有 `GFUndoableCommand` 若不重入历史写操作则无需迁移：两个历史结果 hook 默认成功，`null` 返回值和无参数完成 Signal 保持原行为。只有撤销或重做可能进入“已完成但业务失败”终态的命令才需要覆盖对应 hook；异步 hook 应按 `null`、单值或最多 16 项的多值 `Array` 读取规范化完成 payload，并返回明确的 `bool`，更多字段应封装成单个 Result 或 `Dictionary`。`execute()`、`undo()`、`should_record()` 和结果 hook 现在统一处于非重入历史操作内；原先从这些回调嵌套执行、记录、清空、修改容量或恢复历史的项目代码，应改为在外层历史 API 完成后由项目队列提交后续操作。

--- a/docs/zh/editor/index.md
+++ b/docs/zh/editor/index.md
@@ -19,6 +19,7 @@ GF 的编辑器层只负责装配和生成，不承载可选扩展的运行时�
 - [GF Workspace](workspace.md)：独立工作区窗口、内置页面和 Extensions 页面。
 - [菜单与脚本模板](menus-templates.md)：`工具 > GF` 菜单、脚本模板和生成入口。
 - [编辑器命令、动作与工具协议](tool-protocols.md)：`GFEditorCommand`、Action、Tool、Context、Option 和 Pick Operation。
+- [非破坏式实时调参预览](non-destructive-live-preview.md)：用临时资源副本、显式资产槽位、可取消渲染和命令会话分离预览与确认。
 - [访问器生成](access-generator.md)：`GFAccessGenerator` 和扩展生成钩子。
 - [Inspector、工作区页面与导出插件](editor-extensions.md)：标准库和扩展贡献编辑器入口的方式。
 - [通用 Resource 表格控件](resource-table-editor.md)：`GFResourceTableEditor` 的扫描、显示和编辑能力。

--- a/docs/zh/editor/non-destructive-live-preview.md
+++ b/docs/zh/editor/non-destructive-live-preview.md
@@ -1,0 +1,79 @@
+# 非破坏式实时调参预览
+
+材质、主题、粒子参数或项目自定义 Resource 的编辑器工具经常需要在拖动控件时立即更新预览。如果预览直接修改已加载资源或立即保存文件，取消操作、共享资源引用和失败恢复都会变得不可靠。
+
+GF 已有的属性补丁、显式资产槽位、缩略图渲染和编辑器命令协议可以组合出非破坏式流程，不需要再建立绑定某种素材类型的预览系统。
+
+## 所有权模型
+
+一次预览会话应明确持有以下对象：
+
+- 不可修改的基准 Resource 引用。
+- 一份 `GFResourcePropertyPatch`，只声明本工具允许调整的属性。
+- 一个短生命周期 `GFAssetSlot`，只发布当前预览副本及其 generation。
+- 当前 `GFThumbnailRenderTask` 或项目自己的可取消渲染请求。
+- 一个 `GFEditorCommandSession`，用于把预览命令与最终提交分开。
+
+`GFAssetSlot` 不监听文件，也不替换 `GFAssetUtility` 缓存。它只让预览面板、Viewport 和检查器围绕稳定身份观察“当前是哪一份临时资源”。
+
+## 每次调整都重建副本
+
+不要连续改写上一帧的临时资源。每次参数变化都从稳定基准重新构建副本，这样撤回某个字段、重排补丁或丢弃过期请求不会累积隐式状态。
+
+```gdscript
+var build_report: Dictionary = patch.build(base_resource, {
+	"duplicate_base": true,
+	"require_existing_property": true,
+	"copy_values": true,
+})
+if not GFVariantData.get_option_bool(build_report, "ok"):
+	return
+
+var candidate_value: Variant = GFVariantData.get_option_value(
+	build_report,
+	"resource"
+)
+if not candidate_value is Resource:
+	return
+var candidate: Resource = candidate_value
+
+if not preview_slot.is_configured():
+	var identity: GFResourceIdentity = GFResourceIdentity.new().configure(
+		&"project_tool/live_preview",
+		"",
+		base_resource.get_class(),
+		{"check_exists": false}
+	)
+	var _configured: bool = preview_slot.configure(identity, candidate, self)
+else:
+	var _replaced: bool = preview_slot.replace(candidate)
+```
+
+调用方应先检查补丁报告，再发布副本。补丁定义、属性类型和是否允许 `null` 都由工具显式声明；GF 不推断哪些属性适合实时调整。
+
+## 合并渲染请求
+
+发布新 generation 后，应取消上一项尚未完成的 `GFThumbnailRenderTask`，再用 `GFThumbnailRenderer` 渲染由当前副本构建的 `CanvasItem`、`Node3D` 或 `Mesh`。异步结果返回时再次比较槽位 generation；过期结果即使成功也不能覆盖新预览。
+
+高频滑杆可以在项目工具中增加一帧或固定毫秒的合并窗口，但窗口结束时仍只提交一份完整补丁。自定义 `_draw()`、粒子或依赖运行时脚本的内容应使用预览专用节点，并显式提供渲染边界；预览节点和任务都由当前工具会话释放。
+
+## 确认与取消
+
+预览命令只面向临时副本。用户确认后，再创建新的 `GFEditorPropertyBatchCommand`，把已批准的字段事务式写入权威 Resource，并通过 `GFEditorCommandSession.commit_command()` 或 `GFEditorToolContext.commit_command()` 接入 UndoRedo。自动保存、资源导入和外部产物写出仍应位于确认后的独立步骤。
+
+取消时执行以下清理：
+
+1. 取消并释放当前渲染任务和预览节点。
+2. 释放 `GFAssetSlot`，使旧观察者进入明确终态。
+3. 丢弃 `GFResourcePropertyPatch` 和未提交的命令。
+4. 不调用 `ResourceSaver.save()`，也不改写基准 Resource。
+
+如果确认后的批量属性命令失败，它会按属性事务边界尝试恢复内存值；setter 的外部副作用和磁盘保存不属于该事务。项目工具应先处理命令报告，再开始保存或生成产物，避免把未确认或回滚失败的状态写出。
+
+## 何时不使用
+
+- 只需显示静态资源且没有交互调整时，直接渲染基准资源即可。
+- 预览必须运行完整游戏逻辑、网络会话或第三方编辑器时，应由专用 Adapter 管理其生命周期，不要把这些副作用塞进 Resource 补丁。
+- 参数量巨大或重建成本高时，项目可以实现增量预览 Adapter，但仍要保留“临时状态、确认命令、持久化”三段边界，并提供取消与过期结果防护。
+
+这套组合只定义所有权和提交顺序，不规定面板布局、素材类型、shader 算法、粒子格式或项目业务字段。

--- a/docs/zh/editor/resource-table-editor.md
+++ b/docs/zh/editor/resource-table-editor.md
@@ -15,7 +15,7 @@ editor.move_resource(0, 2)
 
 `scan_resource_paths()` 默认限制递归深度和收集数量，项目工具可通过 `max_scan_depth` / `max_resource_paths` 调整。`commit_cell_value()` 始终接收原始资源行索引；启用过滤后可用 `get_visible_row_indices()` 做映射，或直接调用 `commit_visible_cell_value()`。
 
-需要一次性应用多格修改时，可使用 `commit_cell_values()` 或 `commit_visible_cell_values()`。前者接收原始资源行索引，后者接收当前可见行索引；可见行索引会在写入前统一解析，避免第一项修改刷新过滤结果后影响后续项。
+需要一次性应用多格修改时，可使用 `commit_cell_values()` 或 `commit_visible_cell_values()`。前者接收原始资源行索引，后者接收当前可见行索引；可见行索引会在写入前统一解析，避免第一项修改刷新过滤结果后影响后续项。两者都会先验证全部行和属性，再通过 `GFEditorPropertyBatchCommand` 原子提交：任一输入无效时零写入，运行期 setter 拒绝或最终状态不一致时恢复本次尝试前的全部显式属性。
 
 ```gdscript
 var report := editor.commit_visible_cell_values([
@@ -24,9 +24,9 @@ var report := editor.commit_visible_cell_values([
 ])
 ```
 
-批量提交不是事务；部分失败不会回滚已成功的资源修改。返回报告包含 `ok`、`requested_count`、`applied_count`、`unchanged_count`、`failed_count`、`committed` 和 `errors`。启用自动保存时，同一批中同一个 `Resource` 只会保存一次。
+返回报告包含 `ok`、`status`、`error`、`requested_count`、`applied_count`、`unchanged_count`、`failed_count`、`issue_count`、`rolled_back`、`recovery_required`、`committed` 和 `errors`。`failed_count` 按唯一变更索引计数，`issue_count` 保留写入、补偿与终态验证产生的全部问题数。仅当 `recovery_required = true` 时，报告才包含 `transaction_command`；调用方可在修复目标 setter 的可写条件后调用 `recover()`（未 executed 的失败也可调用 `revert()`），再刷新表格。正常成功和完整回滚不会暴露可绕过表格信号、自动保存与刷新链路的命令句柄。
 
-自动保存只会在 `auto_save_committed_resources = true` 且资源已有 `resource_path` 时触发；保存失败通过 `resource_save_failed` 交给调用方处理。
+`cell_value_committed`、刷新和自动保存只在整批属性事务成功后发生；同一批中同一个 `Resource` 只保存一次。自动保存只会在 `auto_save_committed_resources = true` 且资源已有 `resource_path` 时触发，保存失败通过 `resource_save_failed` 交给调用方处理。`ResourceSaver` 是属性事务完成后的副作用，不属于内存属性回滚边界，也不提供多文件磁盘事务保证。
 
 ## 值字段控件
 

--- a/docs/zh/editor/resource-table-editor.md
+++ b/docs/zh/editor/resource-table-editor.md
@@ -15,7 +15,7 @@ editor.move_resource(0, 2)
 
 `scan_resource_paths()` 默认限制递归深度和收集数量，项目工具可通过 `max_scan_depth` / `max_resource_paths` 调整。`commit_cell_value()` 始终接收原始资源行索引；启用过滤后可用 `get_visible_row_indices()` 做映射，或直接调用 `commit_visible_cell_value()`。
 
-需要一次性应用多格修改时，可使用 `commit_cell_values()` 或 `commit_visible_cell_values()`。前者接收原始资源行索引，后者接收当前可见行索引；可见行索引会在写入前统一解析，避免第一项修改刷新过滤结果后影响后续项。两者都会先验证全部行和属性，再通过 `GFEditorPropertyBatchCommand` 原子提交：任一输入无效时零写入，运行期 setter 拒绝或最终状态不一致时恢复本次尝试前的全部显式属性。
+需要一次性应用多格修改时，可使用 `commit_cell_values()` 或 `commit_visible_cell_values()`。前者接收原始资源行索引，后者接收当前可见行索引；可见行索引会在写入前统一解析，避免第一项修改刷新过滤结果后影响后续项。两者都会先验证全部行和属性，再通过 `GFEditorPropertyBatchCommand` 原子提交：任一输入无效时零写入，运行期 setter 拒绝或最终状态不一致时恢复本次尝试前的全部显式属性。空变更数组是成功恒等操作，返回 `status = committed`、`error = OK` 和全零计数，不构造属性事务命令。
 
 ```gdscript
 var report := editor.commit_visible_cell_values([
@@ -26,7 +26,7 @@ var report := editor.commit_visible_cell_values([
 
 返回报告包含 `ok`、`status`、`error`、`requested_count`、`applied_count`、`unchanged_count`、`failed_count`、`issue_count`、`rolled_back`、`recovery_required`、`committed` 和 `errors`。`failed_count` 按唯一变更索引计数，`issue_count` 保留写入、补偿与终态验证产生的全部问题数。仅当 `recovery_required = true` 时，报告才包含 `transaction_command`；调用方可在修复目标 setter 的可写条件后调用 `recover()`（未 executed 的失败也可调用 `revert()`），再刷新表格。正常成功和完整回滚不会暴露可绕过表格信号、自动保存与刷新链路的命令句柄。
 
-`cell_value_committed`、刷新和自动保存只在整批属性事务成功后发生；同一批中同一个 `Resource` 只保存一次。自动保存只会在 `auto_save_committed_resources = true` 且资源已有 `resource_path` 时触发，保存失败通过 `resource_save_failed` 交给调用方处理。`ResourceSaver` 是属性事务完成后的副作用，不属于内存属性回滚边界，也不提供多文件磁盘事务保证。
+规范化请求值与稳定当前值相同时，该条目仍提交成功并计入 `unchanged_count`，但不会调用 setter 或发出 `cell_value_committed`。只有至少一项属性实际变化时，表格才统一刷新并处理自动保存；因此只有同值条目的单格或整批提交也不会保存或刷新。自动保存只会在 `auto_save_committed_resources = true` 且已变化资源存在 `resource_path` 时触发，同一批中同一个 `Resource` 只保存一次，保存失败通过 `resource_save_failed` 交给调用方处理。需要把通知或持久化作为独立动作的项目工具应使用自己的显式流程，不应把等值提交当作触发器。`ResourceSaver` 是属性事务完成后的副作用，不属于内存属性回滚边界，也不提供多文件磁盘事务保证。
 
 ## 值字段控件
 

--- a/docs/zh/editor/tool-protocols.md
+++ b/docs/zh/editor/tool-protocols.md
@@ -5,6 +5,7 @@
 ## 协议类型
 
 - `GFEditorCommand`：封装一次可执行、可撤销的编辑器修改，可直接 `execute()` / `revert()`，也可写入 `EditorUndoRedoManager`。
+- `GFEditorPropertyBatchCommand`：对多个 Object 属性做全量预检、原子提交、失败补偿和可撤销恢复。
 - `GFEditorSceneMetadataPatch`：把节点 metadata 的写入或移除封装成可撤销命令，适合场景级编辑器工具保存自己的纯数据标记。
 - `GFEditorCommandSession`：围绕一组命令提供 preview、commit、revert history 和 debug snapshot，适合需要连续交互的编辑器工具。
 - `GFEditorActionDefinition`：描述菜单、按钮或快捷键入口，通过 `command_factory` 按上下文创建命令。
@@ -72,6 +73,42 @@ context.commit_command(command, true)
 ```
 
 metadata key 和 payload 仍由工具或项目定义。GF 只负责捕获旧值、执行写入或移除、撤销恢复，以及保持命令协议一致；不要把节点分组、资源分类或项目业务状态写进通用命令本身。
+
+## 多目标属性事务
+
+编辑器批处理需要同时修改多个节点或资源属性时，可使用 `GFEditorPropertyBatchCommand`。命令会先对全部目标、selector、可写性、类型和规范化值做零写入预检；只有全批通过才捕获首次快照并开始写入：
+
+```gdscript
+var command := GFEditorPropertyBatchCommand.new()
+command.configure([
+	{
+		"target": resource_a,
+		"property_name": &"priority",
+		"new_value": 20,
+		"metadata": { "row": 0 },
+	},
+	{
+		"target": node_b,
+		"property_path": ^"position:x",
+		"new_value": 96.0,
+		"metadata": { "row": 1 },
+	},
+], {
+	"command_name": "Edit Selected Properties",
+})
+
+var preview := command.validate()
+if preview.ok:
+	context.commit_command(command, true)
+```
+
+`property_name` 表示精确直接属性名，包含 `/` 或 `:` 时不会被当作路径；`property_path` 使用 Godot indexed path 语义。每个 change 必须且只能使用其中一个 selector。同一目标上的重复 selector、直接根属性与其子路径、或彼此包含的路径会在预检阶段失败；同根下互不包含的兄弟子路径可以组合。
+
+首次进入写阶段时，命令会冻结配置并保留不可变 undo 基线。apply 按调用方顺序执行，undo 按相反顺序执行；失败补偿使用相反于当前阶段的顺序。每个阶段结束后还会再次读取全部显式属性，防止后续 setter 间接改坏前面已写入的目标。完整补偿后的失败报告使用 `apply_failed` 或 `revert_failed`，并令 `rolled_back = true`；补偿仍有残余时使用 `rollback_failed` 和 `recovery_required = true`。
+
+待恢复快照始终来自“本次失败操作开始前”的 attempt guard，而不是固定的首次 undo 基线，因此 redo 前的外部状态不会被错误覆盖。调用方修复目标可写条件后可调用 `recover()` 恢复该 guard；未处于 executed 状态的 apply / redo 失败也允许用 `revert()` 触发同一恢复。undo 补偿失败时应先调用 `recover()` 回到完整 executed guard，再重试 `revert()`。
+
+事务边界只包含 changes 中显式声明的属性值。setter 发出的信号、网络请求、文件写入、资源保存或其他不可逆副作用不会自动回滚；带这类副作用的 setter 不应直接参加属性事务。Array、Dictionary 和 PackedArray 配置值会复制，Resource/Object 默认保留身份；确实需要独立 Resource 值时可显式传 `duplicate_resources = true`。
 
 ## 动作注册表
 

--- a/docs/zh/extensions/action-queue/interceptors-actions/action-factory.md
+++ b/docs/zh/extensions/action-queue/interceptors-actions/action-factory.md
@@ -40,7 +40,7 @@ q_sys.enqueue(GFAction.sequence([
 
 ## Shader 参数
 
-`GFShaderParameterAction` 只负责驱动 `ShaderMaterial` 的 uniform 参数，不提供任何具体 shader 或特效语义。目标可以直接是 `ShaderMaterial`，也可以是带 `material` 属性的节点；直接操作资源且需要 Tween 时，应通过 `host_node` 提供宿主节点。
+`GFShaderParameterAction` 只负责驱动 `ShaderMaterial` 的 uniform 参数，不提供任何具体 shader 或特效语义。目标可以直接是 `ShaderMaterial`，也可以是带 `material` 属性的节点；直接操作资源且需要 Tween 时，应通过 `host_node` 提供宿主节点。动作会在复制共享材质、捕获初值或创建 Tween 前，通过 `GFShaderInterfaceSnapshot` 检查参数是否存在并严格验证目标值类型；校验失败不会留下材质副本或部分写入。
 
 ```gdscript
 q_sys.enqueue(GFAction.shader_parameter(sprite, &"dissolve_progress", 1.0, 0.25, {

--- a/docs/zh/reference/api/classes/GFEditorCommand.md
+++ b/docs/zh/reference/api/classes/GFEditorCommand.md
@@ -30,6 +30,7 @@
 | 方法 | [`_do_it`](#member-gfeditorcommand-methods-_do_it) | `func _do_it() -> Error:` |
 | 方法 | [`_undo_it`](#member-gfeditorcommand-methods-_undo_it) | `func _undo_it() -> Error:` |
 | 方法 | [`_can_change_configuration`](#member-gfeditorcommand-methods-_can_change_configuration) | `func _can_change_configuration(field_name: String) -> bool:` |
+| 方法 | [`_seal_configuration_for_execution`](#member-gfeditorcommand-methods-_seal_configuration_for_execution) | `func _seal_configuration_for_execution() -> void:` |
 
 ## 属性
 
@@ -70,6 +71,7 @@ var metadata: Dictionary:
 ### `execute`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func execute() -> Error:
@@ -268,3 +270,16 @@ func _can_change_configuration(field_name: String) -> bool:
 | `field_name` | 配置字段名。 |
 
 返回：配置未冻结时返回 true；已冻结时报告错误并返回 false。
+
+<a id="member-gfeditorcommand-methods-_seal_configuration_for_execution"></a>
+
+### `_seal_configuration_for_execution`
+
+- API：`protected`
+- 首次版本：`unreleased`
+
+```gdscript
+func _seal_configuration_for_execution() -> void:
+```
+
+冻结命令配置。 会在命令成功执行或注册到 UndoRedo 后由基类调用。可能发生部分写入的事务子类 应在第一笔实际写入前主动调用，确保失败恢复仍使用不可变配置与首次快照。

--- a/docs/zh/reference/api/classes/GFEditorPropertyBatchCommand.md
+++ b/docs/zh/reference/api/classes/GFEditorPropertyBatchCommand.md
@@ -165,20 +165,20 @@ const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"
 func configure( changes: Array[Dictionary], options: Dictionary = {} ) -> GFEditorPropertyBatchCommand:
 ```
 
-配置属性事务。 每个 change 必须包含 target、new_value，以及且仅包含 property_name 或 property_path。property_name 表示精确直接属性名；property_path 使用 Godot indexed path 语义。可选 metadata 会复制到条目和错误报告。
+配置属性事务。 changes 必须至少包含一项。每个 change 必须包含 target、new_value，以及且仅包含 property_name 或 property_path。property_name 表示精确直接属性名；property_path 使用 Godot indexed path 语义。可选 metadata 会复制到条目和错误报告。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
-| `changes` | 属性变更数组。 |
+| `changes` | 非空属性变更数组。 |
 | `options` | 配置选项。 |
 
 返回：当前命令。
 
 结构：
 
-- `changes`: Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。
+- `changes`: 非空 Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。
 - `options`: Dictionary，可包含 command_name、metadata 和 duplicate_resources。
 
 <a id="member-gfeditorpropertybatchcommand-methods-validate"></a>

--- a/docs/zh/reference/api/classes/GFEditorPropertyBatchCommand.md
+++ b/docs/zh/reference/api/classes/GFEditorPropertyBatchCommand.md
@@ -1,0 +1,295 @@
+# GFEditorPropertyBatchCommand
+
+[API Reference](../index.md) / [Kernel](../kernel.md) / [类索引](index.md)
+
+- 路径：`addons/gf/kernel/editor/gf_editor_property_batch_command.gd`
+- 模块：`Kernel`
+- 继承：`GFEditorCommand`
+- API：`public`
+- 类别：编辑器 API (`editor_api`)
+- 首次版本：`unreleased`
+
+通用多目标属性事务命令。 对调用方显式提供的 Object 属性先做全量零写入预检，再按稳定顺序提交。 任一写入或最终状态验证失败时，会按相反顺序恢复本次尝试前的全部目标属性。 命令只保证显式属性值边界，不代理 setter 的外部副作用、文件保存或业务事务。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_PENDING`](#member-gfeditorpropertybatchcommand-constants-status_pending) | `const STATUS_PENDING: StringName = &"pending"` |
+| 常量 | [`STATUS_READY`](#member-gfeditorpropertybatchcommand-constants-status_ready) | `const STATUS_READY: StringName = &"ready"` |
+| 常量 | [`STATUS_COMMITTED`](#member-gfeditorpropertybatchcommand-constants-status_committed) | `const STATUS_COMMITTED: StringName = &"committed"` |
+| 常量 | [`STATUS_REVERTED`](#member-gfeditorpropertybatchcommand-constants-status_reverted) | `const STATUS_REVERTED: StringName = &"reverted"` |
+| 常量 | [`STATUS_RECOVERED`](#member-gfeditorpropertybatchcommand-constants-status_recovered) | `const STATUS_RECOVERED: StringName = &"recovered"` |
+| 常量 | [`STATUS_PREFLIGHT_FAILED`](#member-gfeditorpropertybatchcommand-constants-status_preflight_failed) | `const STATUS_PREFLIGHT_FAILED: StringName = &"preflight_failed"` |
+| 常量 | [`STATUS_APPLY_FAILED`](#member-gfeditorpropertybatchcommand-constants-status_apply_failed) | `const STATUS_APPLY_FAILED: StringName = &"apply_failed"` |
+| 常量 | [`STATUS_REVERT_FAILED`](#member-gfeditorpropertybatchcommand-constants-status_revert_failed) | `const STATUS_REVERT_FAILED: StringName = &"revert_failed"` |
+| 常量 | [`STATUS_ROLLBACK_FAILED`](#member-gfeditorpropertybatchcommand-constants-status_rollback_failed) | `const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"` |
+| 方法 | [`configure`](#member-gfeditorpropertybatchcommand-methods-configure) | `func configure( changes: Array[Dictionary], options: Dictionary = {} ) -> GFEditorPropertyBatchCommand:` |
+| 方法 | [`validate`](#member-gfeditorpropertybatchcommand-methods-validate) | `func validate() -> Dictionary:` |
+| 方法 | [`get_transaction_report`](#member-gfeditorpropertybatchcommand-methods-get_transaction_report) | `func get_transaction_report() -> Dictionary:` |
+| 方法 | [`recover`](#member-gfeditorpropertybatchcommand-methods-recover) | `func recover() -> Error:` |
+| 方法 | [`can_execute`](#member-gfeditorpropertybatchcommand-methods-can_execute) | `func can_execute() -> bool:` |
+| 方法 | [`can_revert_before_execute`](#member-gfeditorpropertybatchcommand-methods-can_revert_before_execute) | `func can_revert_before_execute() -> bool:` |
+| 方法 | [`_do_it`](#member-gfeditorpropertybatchcommand-methods-_do_it) | `func _do_it() -> Error:` |
+| 方法 | [`_undo_it`](#member-gfeditorpropertybatchcommand-methods-_undo_it) | `func _undo_it() -> Error:` |
+
+## 常量
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_pending"></a>
+
+### `STATUS_PENDING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_PENDING: StringName = &"pending"
+```
+
+尚未验证或执行。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_ready"></a>
+
+### `STATUS_READY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_READY: StringName = &"ready"
+```
+
+全量预检通过。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_committed"></a>
+
+### `STATUS_COMMITTED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_COMMITTED: StringName = &"committed"
+```
+
+属性事务已提交。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_reverted"></a>
+
+### `STATUS_REVERTED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_REVERTED: StringName = &"reverted"
+```
+
+属性事务已撤销。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_recovered"></a>
+
+### `STATUS_RECOVERED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_RECOVERED: StringName = &"recovered"
+```
+
+未完整补偿的事务已恢复到该次操作开始前状态。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_preflight_failed"></a>
+
+### `STATUS_PREFLIGHT_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_PREFLIGHT_FAILED: StringName = &"preflight_failed"
+```
+
+全量预检失败，未开始写入。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_apply_failed"></a>
+
+### `STATUS_APPLY_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_APPLY_FAILED: StringName = &"apply_failed"
+```
+
+提交失败，且已恢复本次尝试前状态。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_revert_failed"></a>
+
+### `STATUS_REVERT_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_REVERT_FAILED: StringName = &"revert_failed"
+```
+
+撤销失败，且已恢复撤销前状态。
+
+<a id="member-gfeditorpropertybatchcommand-constants-status_rollback_failed"></a>
+
+### `STATUS_ROLLBACK_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"
+```
+
+补偿写入未完整恢复属性状态。
+
+## 方法
+
+<a id="member-gfeditorpropertybatchcommand-methods-configure"></a>
+
+### `configure`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func configure( changes: Array[Dictionary], options: Dictionary = {} ) -> GFEditorPropertyBatchCommand:
+```
+
+配置属性事务。 每个 change 必须包含 target、new_value，以及且仅包含 property_name 或 property_path。property_name 表示精确直接属性名；property_path 使用 Godot indexed path 语义。可选 metadata 会复制到条目和错误报告。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `changes` | 属性变更数组。 |
+| `options` | 配置选项。 |
+
+返回：当前命令。
+
+结构：
+
+- `changes`: Array[Dictionary]，每项包含 target: Object、new_value: Variant、property_name: StringName/String 或 property_path: NodePath/String，以及可选 metadata: Dictionary。
+- `options`: Dictionary，可包含 command_name、metadata 和 duplicate_resources。
+
+<a id="member-gfeditorpropertybatchcommand-methods-validate"></a>
+
+### `validate`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate() -> Dictionary:
+```
+
+零写入验证全部属性变更。
+
+返回：结构化事务报告。
+
+结构：
+
+- `return`: Dictionary，包含 ok、status、phase、error、requested_count、applied_count、unchanged_count、attempted_count、rollback_count、failed_count、failed_index、rolled_back、recovery_required、entries、issues 和 metadata。
+
+<a id="member-gfeditorpropertybatchcommand-methods-get_transaction_report"></a>
+
+### `get_transaction_report`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_transaction_report() -> Dictionary:
+```
+
+获取最近一次预检、提交、撤销或恢复报告。
+
+返回：结构化事务报告副本。
+
+结构：
+
+- `return`: Dictionary，形状与 validate() 返回值相同。
+
+<a id="member-gfeditorpropertybatchcommand-methods-recover"></a>
+
+### `recover`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func recover() -> Error:
+```
+
+恢复最近一次未完整补偿的操作。 恢复目标是该次失败 apply、redo 或 undo 开始前的 attempt guard，而不是固定的 首次 undo 基线。undo 补偿失败时，恢复成功后命令仍保持 executed，调用方可再 次调用 revert() 完成真正撤销。
+
+返回：Godot 错误码。
+
+<a id="member-gfeditorpropertybatchcommand-methods-can_execute"></a>
+
+### `can_execute`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func can_execute() -> bool:
+```
+
+当前命令是否允许执行。
+
+返回：配置完整、目标可写且没有待恢复残余状态时返回 true。
+
+<a id="member-gfeditorpropertybatchcommand-methods-can_revert_before_execute"></a>
+
+### `can_revert_before_execute`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func can_revert_before_execute() -> bool:
+```
+
+首次执行未成功但留下残余状态时，允许显式调用 revert() 重试恢复。
+
+返回：存在首次快照且需要恢复时返回 true。
+
+<a id="member-gfeditorpropertybatchcommand-methods-_do_it"></a>
+
+### `_do_it`
+
+- API：`protected`
+- 首次版本：`unreleased`
+
+```gdscript
+func _do_it() -> Error:
+```
+
+执行属性事务。
+
+返回：Godot 错误码。
+
+<a id="member-gfeditorpropertybatchcommand-methods-_undo_it"></a>
+
+### `_undo_it`
+
+- API：`protected`
+- 首次版本：`unreleased`
+
+```gdscript
+func _undo_it() -> Error:
+```
+
+撤销属性事务，或恢复首次执行失败留下的残余状态。
+
+返回：Godot 错误码。

--- a/docs/zh/reference/api/classes/GFObjectPropertyTools.md
+++ b/docs/zh/reference/api/classes/GFObjectPropertyTools.md
@@ -249,6 +249,7 @@ static func read_property( object: Object, property_path: NodePath, default_valu
 ### `write_property`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 static func write_property( object: Object, property_path: NodePath, value: Variant, options: Dictionary = {} ) -> Dictionary:

--- a/docs/zh/reference/api/classes/GFResourceTableEditor.md
+++ b/docs/zh/reference/api/classes/GFResourceTableEditor.md
@@ -74,12 +74,13 @@ signal resource_selected(resource: Resource)
 ### `cell_value_committed`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 signal cell_value_committed(resource: Resource, property: StringName, old_value: Variant, new_value: Variant)
 ```
 
-单元格值提交后发出。
+单元格值实际变化且整批事务成功后发出；空批次和规范化后同值的提交不发出。
 
 参数：
 
@@ -227,12 +228,13 @@ const DEFAULT_MAX_RESOURCE_PATHS: int = 10000
 ### `auto_save_committed_resources`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var auto_save_committed_resources: bool = false
 ```
 
-提交单元格后是否自动保存已绑定路径的 Resource。
+是否自动保存成功事务中实际发生属性变化且已绑定路径的 Resource。 空批次和规范化后同值的提交不会触发保存。
 
 <a id="member-gfresourcetableeditor-properties-search_text"></a>
 
@@ -579,7 +581,7 @@ func duplicate_resource(row_index: int, deep: bool = false, insert_after: bool =
 func commit_cell_value(row_index: int, property: StringName, new_value: Variant) -> bool:
 ```
 
-提交单元格值。
+提交单元格值。 当规范化请求值与稳定当前值相同时返回成功，但不调用 setter、不发出 cell_value_committed、不自动保存，也不刷新表格。
 
 参数：
 
@@ -600,12 +602,13 @@ func commit_cell_value(row_index: int, property: StringName, new_value: Variant)
 ### `commit_visible_cell_value`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func commit_visible_cell_value(visible_row_index: int, property: StringName, new_value: Variant) -> bool:
 ```
 
-提交当前可见行的单元格值。
+提交当前可见行的单元格值。 当规范化请求值与稳定当前值相同时返回成功，但不调用 setter、不发出 cell_value_committed、不自动保存，也不刷新表格。
 
 参数：
 
@@ -632,7 +635,7 @@ func commit_visible_cell_value(visible_row_index: int, property: StringName, new
 func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ```
 
-批量提交资源行单元格值。 该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。 任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。 成功后统一刷新表格；启用自动保存时同一 Resource 只保存一次。
+批量提交资源行单元格值。 该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。 任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。 规范化后同值的条目计入 unchanged_count，不调用其 setter，也不发提交信号。 仅当至少一项实际变化时统一刷新；启用自动保存时同一已变化 Resource 只保存一次。 空变更数组返回 status = committed、error = OK 且全部计数为 0 的成功报告， 不构造属性事务命令，也不触发信号、保存或刷新。
 
 参数：
 
@@ -658,7 +661,7 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 func commit_visible_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ```
 
-批量提交可见资源行单元格值。 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。 全部变更通过 GFEditorPropertyBatchCommand 原子提交；启用自动保存时同一 Resource 只保存一次。
+批量提交可见资源行单元格值。 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。 全部变更通过 GFEditorPropertyBatchCommand 原子提交。规范化后同值的条目计入 unchanged_count，不调用其 setter，也不发提交信号。仅当至少一项实际变化时 统一刷新；启用自动保存时同一已变化 Resource 只保存一次。 空变更数组返回 status = committed、error = OK 且全部计数为 0 的成功报告， 不构造属性事务命令，也不触发信号、保存或刷新。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFResourceTableEditor.md
+++ b/docs/zh/reference/api/classes/GFResourceTableEditor.md
@@ -573,6 +573,7 @@ func duplicate_resource(row_index: int, deep: bool = false, insert_after: bool =
 ### `commit_cell_value`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func commit_cell_value(row_index: int, property: StringName, new_value: Variant) -> bool:
@@ -631,7 +632,7 @@ func commit_visible_cell_value(visible_row_index: int, property: StringName, new
 func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ```
 
-批量提交资源行单元格值。 该方法会先处理所有变更，再统一刷新表格；启用自动保存时同一 Resource 只保存一次。 它不是事务，部分失败不会回滚已成功的变更。
+批量提交资源行单元格值。 该方法先完成全部行、属性和值预检，再通过 GFEditorPropertyBatchCommand 原子提交。 任一 setter 拒绝或最终状态验证失败时会恢复本次尝试前的资源属性。 成功后统一刷新表格；启用自动保存时同一 Resource 只保存一次。
 
 参数：
 
@@ -644,7 +645,7 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 结构：
 
 - `changes`: Array[Dictionary]，每项包含 row_index: int、property: StringName/String、new_value: Variant。
-- `return`: Dictionary，包含 ok、requested_count、applied_count、unchanged_count、failed_count、committed 和 errors。
+- `return`: Dictionary，包含 ok、status、error、requested_count、applied_count、unchanged_count、failed_count、issue_count、rolled_back、recovery_required、committed、errors，以及需要显式恢复时的 transaction_command。
 
 <a id="member-gfresourcetableeditor-methods-commit_visible_cell_values"></a>
 
@@ -657,7 +658,7 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 func commit_visible_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ```
 
-批量提交可见资源行单元格值。 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。 启用自动保存时同一 Resource 只保存一次；该方法不是事务，部分失败不会回滚已成功的变更。
+批量提交可见资源行单元格值。 可见行索引会在任何写入发生前解析为资源行索引，避免搜索过滤刷新导致同一批变更漂移。 全部变更通过 GFEditorPropertyBatchCommand 原子提交；启用自动保存时同一 Resource 只保存一次。
 
 参数：
 
@@ -670,7 +671,7 @@ func commit_visible_cell_values(changes: Array[Dictionary]) -> Dictionary:
 结构：
 
 - `changes`: Array[Dictionary]，每项包含 visible_row_index: int、property: StringName/String、new_value: Variant。
-- `return`: Dictionary，包含 ok、requested_count、applied_count、unchanged_count、failed_count、committed 和 errors。
+- `return`: Dictionary，包含 ok、status、error、requested_count、applied_count、unchanged_count、failed_count、issue_count、rolled_back、recovery_required、committed、errors，以及需要显式恢复时的 transaction_command。
 
 <a id="member-gfresourcetableeditor-methods-refresh"></a>
 

--- a/docs/zh/reference/api/classes/GFSettingsLoadResult.md
+++ b/docs/zh/reference/api/classes/GFSettingsLoadResult.md
@@ -1,0 +1,313 @@
+# GFSettingsLoadResult
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/settings/gf_settings_load_result.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+设置加载操作的不可变终态快照。 结果将“合法空设置”与缺失、损坏、未来版本和底层存储失败明确区分， 并保留实际应用状态、恢复动作和底层读取证据。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_LOADED`](#member-gfsettingsloadresult-constants-status_loaded) | `const STATUS_LOADED: StringName = &"loaded"` |
+| 常量 | [`STATUS_RECOVERED`](#member-gfsettingsloadresult-constants-status_recovered) | `const STATUS_RECOVERED: StringName = &"recovered"` |
+| 常量 | [`STATUS_INVALID_REQUEST`](#member-gfsettingsloadresult-constants-status_invalid_request) | `const STATUS_INVALID_REQUEST: StringName = &"invalid_request"` |
+| 常量 | [`STATUS_MISSING`](#member-gfsettingsloadresult-constants-status_missing) | `const STATUS_MISSING: StringName = &"missing"` |
+| 常量 | [`STATUS_CORRUPT`](#member-gfsettingsloadresult-constants-status_corrupt) | `const STATUS_CORRUPT: StringName = &"corrupt"` |
+| 常量 | [`STATUS_FUTURE_SCHEMA`](#member-gfsettingsloadresult-constants-status_future_schema) | `const STATUS_FUTURE_SCHEMA: StringName = &"future_schema"` |
+| 常量 | [`STATUS_MIGRATION_FAILED`](#member-gfsettingsloadresult-constants-status_migration_failed) | `const STATUS_MIGRATION_FAILED: StringName = &"migration_failed"` |
+| 常量 | [`STATUS_STORAGE_FAILED`](#member-gfsettingsloadresult-constants-status_storage_failed) | `const STATUS_STORAGE_FAILED: StringName = &"storage_failed"` |
+| 方法 | [`is_successful`](#member-gfsettingsloadresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`get_status`](#member-gfsettingsloadresult-methods-get_status) | `func get_status() -> StringName:` |
+| 方法 | [`get_file_name`](#member-gfsettingsloadresult-methods-get_file_name) | `func get_file_name() -> String:` |
+| 方法 | [`was_applied`](#member-gfsettingsloadresult-methods-was_applied) | `func was_applied() -> bool:` |
+| 方法 | [`was_recovered`](#member-gfsettingsloadresult-methods-was_recovered) | `func was_recovered() -> bool:` |
+| 方法 | [`get_recovery_action`](#member-gfsettingsloadresult-methods-get_recovery_action) | `func get_recovery_action() -> StringName:` |
+| 方法 | [`get_error_code`](#member-gfsettingsloadresult-methods-get_error_code) | `func get_error_code() -> Error:` |
+| 方法 | [`get_error`](#member-gfsettingsloadresult-methods-get_error) | `func get_error() -> String:` |
+| 方法 | [`get_storage_result`](#member-gfsettingsloadresult-methods-get_storage_result) | `func get_storage_result() -> GFStorageReadResult:` |
+| 方法 | [`duplicate_result`](#member-gfsettingsloadresult-methods-duplicate_result) | `func duplicate_result() -> GFSettingsLoadResult:` |
+| 方法 | [`to_dict`](#member-gfsettingsloadresult-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfsettingsloadresult-constants-status_loaded"></a>
+
+### `STATUS_LOADED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_LOADED: StringName = &"loaded"
+```
+
+持久化设置已成功读取并应用。
+
+<a id="member-gfsettingsloadresult-constants-status_recovered"></a>
+
+### `STATUS_RECOVERED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_RECOVERED: StringName = &"recovered"
+```
+
+调用方选择的显式恢复动作已完成。
+
+<a id="member-gfsettingsloadresult-constants-status_invalid_request"></a>
+
+### `STATUS_INVALID_REQUEST`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_REQUEST: StringName = &"invalid_request"
+```
+
+文件名、路径或读取请求无效。
+
+<a id="member-gfsettingsloadresult-constants-status_missing"></a>
+
+### `STATUS_MISSING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_MISSING: StringName = &"missing"
+```
+
+设置文件不存在。
+
+<a id="member-gfsettingsloadresult-constants-status_corrupt"></a>
+
+### `STATUS_CORRUPT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_CORRUPT: StringName = &"corrupt"
+```
+
+设置文件格式、载荷或完整性损坏。
+
+<a id="member-gfsettingsloadresult-constants-status_future_schema"></a>
+
+### `STATUS_FUTURE_SCHEMA`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_FUTURE_SCHEMA: StringName = &"future_schema"
+```
+
+设置文件来自当前运行时无法读取的未来 schema。
+
+<a id="member-gfsettingsloadresult-constants-status_migration_failed"></a>
+
+### `STATUS_MIGRATION_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_MIGRATION_FAILED: StringName = &"migration_failed"
+```
+
+设置文件的迁移链缺失或迁移失败。
+
+<a id="member-gfsettingsloadresult-constants-status_storage_failed"></a>
+
+### `STATUS_STORAGE_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_STORAGE_FAILED: StringName = &"storage_failed"
+```
+
+底层存储读取失败或不可用。
+
+## 方法
+
+<a id="member-gfsettingsloadresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+检查加载是否进入成功终态。
+
+返回：设置已加载或已按显式策略恢复时返回 true。
+
+<a id="member-gfsettingsloadresult-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> StringName:
+```
+
+获取稳定加载状态。
+
+返回：`STATUS_*` 常量之一。
+
+<a id="member-gfsettingsloadresult-methods-get_file_name"></a>
+
+### `get_file_name`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_file_name() -> String:
+```
+
+获取本次加载使用的文件名。
+
+返回：解析默认值后的设置文件名。
+
+<a id="member-gfsettingsloadresult-methods-was_applied"></a>
+
+### `was_applied`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func was_applied() -> bool:
+```
+
+检查本次操作是否替换了有效设置状态。
+
+返回：已应用持久化载荷或默认值恢复时返回 true。
+
+<a id="member-gfsettingsloadresult-methods-was_recovered"></a>
+
+### `was_recovered`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func was_recovered() -> bool:
+```
+
+检查本次操作是否执行了显式恢复动作。
+
+返回：使用恢复策略完成时返回 true。
+
+<a id="member-gfsettingsloadresult-methods-get_recovery_action"></a>
+
+### `get_recovery_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_recovery_action() -> StringName:
+```
+
+获取实际恢复动作。
+
+返回：未恢复时为空，否则为 `GFSettingsRecoveryPolicy.ACTION_*` 常量之一。
+
+<a id="member-gfsettingsloadresult-methods-get_error_code"></a>
+
+### `get_error_code`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_code() -> Error:
+```
+
+获取 Godot Error 码。
+
+返回：成功时为 OK。
+
+<a id="member-gfsettingsloadresult-methods-get_error"></a>
+
+### `get_error`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error() -> String:
+```
+
+获取稳定错误描述。
+
+返回：成功时为空。
+
+<a id="member-gfsettingsloadresult-methods-get_storage_result"></a>
+
+### `get_storage_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_storage_result() -> GFStorageReadResult:
+```
+
+获取底层存储读取结果副本。
+
+返回：原始读取证据的隔离副本；读取未启动时为 null。
+
+<a id="member-gfsettingsloadresult-methods-duplicate_result"></a>
+
+### `duplicate_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_result() -> GFSettingsLoadResult:
+```
+
+创建结果的隔离副本。
+
+返回：新结果对象。
+
+<a id="member-gfsettingsloadresult-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为不包含设置载荷的报告字典。
+
+返回：加载终态摘要。
+
+结构：
+
+- `return`: Dictionary with ok, status, file_name, applied, recovered, recovery_action, error_code, error, and payload-free storage_result fields.

--- a/docs/zh/reference/api/classes/GFSettingsRecoveryPolicy.md
+++ b/docs/zh/reference/api/classes/GFSettingsRecoveryPolicy.md
@@ -1,0 +1,113 @@
+# GFSettingsRecoveryPolicy
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd`
+- 模块：`Standard`
+- 继承：`Resource`
+- API：`public`
+- 类别：资源定义 (`resource_definition`)
+- 首次版本：`unreleased`
+
+设置加载的显式恢复策略。 缺失与损坏设置默认严格失败。项目可以显式选择保留当前内存状态， 或把有效设置重置为已注册默认值；恢复不会创建或覆盖持久化文件。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`ACTION_FAIL`](#member-gfsettingsrecoverypolicy-constants-action_fail) | `const ACTION_FAIL: StringName = &"fail"` |
+| 常量 | [`ACTION_USE_CURRENT_STATE`](#member-gfsettingsrecoverypolicy-constants-action_use_current_state) | `const ACTION_USE_CURRENT_STATE: StringName = &"use_current_state"` |
+| 常量 | [`ACTION_RESET_TO_DEFAULTS`](#member-gfsettingsrecoverypolicy-constants-action_reset_to_defaults) | `const ACTION_RESET_TO_DEFAULTS: StringName = &"reset_to_defaults"` |
+| 属性 | [`missing_file_action`](#member-gfsettingsrecoverypolicy-properties-missing_file_action) | `var missing_file_action: StringName = ACTION_FAIL` |
+| 属性 | [`corrupt_file_action`](#member-gfsettingsrecoverypolicy-properties-corrupt_file_action) | `var corrupt_file_action: StringName = ACTION_FAIL` |
+| 方法 | [`validate_policy`](#member-gfsettingsrecoverypolicy-methods-validate_policy) | `func validate_policy() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfsettingsrecoverypolicy-constants-action_fail"></a>
+
+### `ACTION_FAIL`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ACTION_FAIL: StringName = &"fail"
+```
+
+不执行自动恢复。
+
+<a id="member-gfsettingsrecoverypolicy-constants-action_use_current_state"></a>
+
+### `ACTION_USE_CURRENT_STATE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ACTION_USE_CURRENT_STATE: StringName = &"use_current_state"
+```
+
+保留当前有效值和暂存值。
+
+<a id="member-gfsettingsrecoverypolicy-constants-action_reset_to_defaults"></a>
+
+### `ACTION_RESET_TO_DEFAULTS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ACTION_RESET_TO_DEFAULTS: StringName = &"reset_to_defaults"
+```
+
+使用空 replace 语义恢复已注册默认值。
+
+## 属性
+
+<a id="member-gfsettingsrecoverypolicy-properties-missing_file_action"></a>
+
+### `missing_file_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var missing_file_action: StringName = ACTION_FAIL
+```
+
+文件缺失时的恢复动作。
+
+<a id="member-gfsettingsrecoverypolicy-properties-corrupt_file_action"></a>
+
+### `corrupt_file_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var corrupt_file_action: StringName = ACTION_FAIL
+```
+
+文件损坏或完整性校验失败时的恢复动作。
+
+## 方法
+
+<a id="member-gfsettingsrecoverypolicy-methods-validate_policy"></a>
+
+### `validate_policy`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_policy() -> Dictionary:
+```
+
+检查策略自身是否合法。
+
+返回：结构化校验报告。
+
+结构：
+
+- `return`: GFValidationReportDictionary-compatible report with issues, counts, summary, and next_actions.

--- a/docs/zh/reference/api/classes/GFSettingsUtility.md
+++ b/docs/zh/reference/api/classes/GFSettingsUtility.md
@@ -16,7 +16,7 @@
 | 类型 | 名称 | 签名 |
 |---|---|---|
 | 信号 | [`setting_changed`](#member-gfsettingsutility-signals-setting_changed) | `signal setting_changed(key: StringName, old_value: Variant, new_value: Variant)` |
-| 信号 | [`settings_loaded`](#member-gfsettingsutility-signals-settings_loaded) | `signal settings_loaded(data: Dictionary)` |
+| 信号 | [`settings_load_completed`](#member-gfsettingsutility-signals-settings_load_completed) | `signal settings_load_completed(result: GFSettingsLoadResult)` |
 | 信号 | [`settings_saved`](#member-gfsettingsutility-signals-settings_saved) | `signal settings_saved(data: Dictionary)` |
 | 信号 | [`staged_setting_changed`](#member-gfsettingsutility-signals-staged_setting_changed) | `signal staged_setting_changed(key: StringName)` |
 | 信号 | [`staged_settings_applied`](#member-gfsettingsutility-signals-staged_settings_applied) | `signal staged_settings_applied(report: Dictionary)` |
@@ -55,10 +55,11 @@
 | 方法 | [`to_dict`](#member-gfsettingsutility-methods-to_dict) | `func to_dict(persistent_only: bool = true) -> Dictionary:` |
 | 方法 | [`replace_from_dict`](#member-gfsettingsutility-methods-replace_from_dict) | `func replace_from_dict(data: Dictionary, emit_changes: bool = true) -> void:` |
 | 方法 | [`merge_from_dict`](#member-gfsettingsutility-methods-merge_from_dict) | `func merge_from_dict(data: Dictionary, emit_changes: bool = true) -> void:` |
-| 方法 | [`load_settings`](#member-gfsettingsutility-methods-load_settings) | `func load_settings(file_name: String = "") -> Dictionary:` |
+| 方法 | [`load_settings`](#member-gfsettingsutility-methods-load_settings) | `func load_settings( file_name: String = "", recovery_policy: GFSettingsRecoveryPolicy = null ) -> GFSettingsLoadResult:` |
+| 方法 | [`get_last_load_result`](#member-gfsettingsutility-methods-get_last_load_result) | `func get_last_load_result() -> GFSettingsLoadResult:` |
 | 方法 | [`save_settings`](#member-gfsettingsutility-methods-save_settings) | `func save_settings(file_name: String = "") -> Error:` |
 | 方法 | [`tick`](#member-gfsettingsutility-methods-tick) | `func tick(delta: float = 0.0) -> void:` |
-| 方法 | [`_read_persisted_data`](#member-gfsettingsutility-methods-_read_persisted_data) | `func _read_persisted_data(file_name: String) -> Dictionary:` |
+| 方法 | [`_read_persisted_data`](#member-gfsettingsutility-methods-_read_persisted_data) | `func _read_persisted_data(file_name: String) -> GFStorageReadResult:` |
 | 方法 | [`_write_persisted_data`](#member-gfsettingsutility-methods-_write_persisted_data) | `func _write_persisted_data(file_name: String, data: Dictionary) -> Error:` |
 
 ## 信号
@@ -88,27 +89,24 @@ signal setting_changed(key: StringName, old_value: Variant, new_value: Variant)
 - `old_value`: Variant previous setting value or null when the setting did not exist.
 - `new_value`: Variant next setting value or null when the setting was removed.
 
-<a id="member-gfsettingsutility-signals-settings_loaded"></a>
+<a id="member-gfsettingsutility-signals-settings_load_completed"></a>
 
-### `settings_loaded`
+### `settings_load_completed`
 
 - API：`public`
+- 首次版本：`unreleased`
 
 ```gdscript
-signal settings_loaded(data: Dictionary)
+signal settings_load_completed(result: GFSettingsLoadResult)
 ```
 
-设置加载完成时发出。
+设置加载进入终态时发出。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
-| `data` | 已加载的持久化设置数据。 |
-
-结构：
-
-- `data`: Dictionary[String, Variant] loaded persisted settings data.
+| `result` | 隔离的结构化加载结果。 |
 
 <a id="member-gfsettingsutility-signals-settings_saved"></a>
 
@@ -846,24 +844,41 @@ func merge_from_dict(data: Dictionary, emit_changes: bool = true) -> void:
 ### `load_settings`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
-func load_settings(file_name: String = "") -> Dictionary:
+func load_settings( file_name: String = "", recovery_policy: GFSettingsRecoveryPolicy = null ) -> GFSettingsLoadResult:
 ```
 
-读取持久化设置。
+读取持久化设置并返回结构化终态。 默认策略严格失败；缺失、损坏、未来 schema、迁移失败或 IO 失败不会被 降级为空字典。只有显式恢复策略可以处理缺失或损坏，且加载本身从不保存。 非空策略会在 IO 前验证；合法加载请求会取消全部旧延迟/批处理保存请求， 防止新加载状态被旧保存目标重新序列化。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
 | `file_name` | 可选文件名；为空时使用 storage_file_name。 |
+| `recovery_policy` | 可选显式恢复策略；null 表示严格失败。 |
 
-返回：已读取的数据。
+返回：隔离的结构化加载结果。
 
 结构：
 
-- `return`: Dictionary[String, Variant] loaded persisted settings data.
+- `return`: GFSettingsLoadResult preserving status, application state, recovery action, and storage evidence.
+
+<a id="member-gfsettingsutility-methods-get_last_load_result"></a>
+
+### `get_last_load_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_last_load_result() -> GFSettingsLoadResult:
+```
+
+获取最近一次加载终态。
+
+返回：最近结果的隔离副本；尚未加载或已释放时为 null。
 
 <a id="member-gfsettingsutility-methods-save_settings"></a>
 
@@ -908,9 +923,10 @@ func tick(delta: float = 0.0) -> void:
 ### `_read_persisted_data`
 
 - API：`protected`
+- 首次版本：`3.17.0`
 
 ```gdscript
-func _read_persisted_data(file_name: String) -> Dictionary:
+func _read_persisted_data(file_name: String) -> GFStorageReadResult:
 ```
 
 读取持久化设置数据。子类可覆盖该钩子以接入自定义存储后端。
@@ -921,11 +937,11 @@ func _read_persisted_data(file_name: String) -> Dictionary:
 |---|---|
 | `file_name` | 要读取的设置文件名。 |
 
-返回：已读取的数据；不存在或无法解析时返回空字典。
+返回：保留成功空载荷与稳定失败分类的存储读取结果。
 
 结构：
 
-- `return`: Dictionary[String, Variant] persisted settings data.
+- `return`: GFStorageReadResult with isolated Settings payload and failure_kind evidence.
 
 <a id="member-gfsettingsutility-methods-_write_persisted_data"></a>
 

--- a/docs/zh/reference/api/classes/GFShaderInterfaceSnapshot.md
+++ b/docs/zh/reference/api/classes/GFShaderInterfaceSnapshot.md
@@ -1,0 +1,376 @@
+# GFShaderInterfaceSnapshot
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd`
+- 模块：`Standard`
+- 继承：`Resource`
+- API：`public`
+- 类别：资源定义 (`resource_definition`)
+- 首次版本：`unreleased`
+
+可持久化的 Shader uniform 接口快照。 从 Shader 反射结果捕获稳定排序的 uniform 声明，并用同一份数据校验参数集合 或比较接口漂移。快照只保存公开接口字段，不保存 shader 源码、材质当前值、 渲染后端产物或项目视觉语义。直接 new() 的实例保持未配置，必须经 capture() 或 from_dict() 建立后再使用。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`CURRENT_SCHEMA_VERSION`](#member-gfshaderinterfacesnapshot-constants-current_schema_version) | `const CURRENT_SCHEMA_VERSION: int = 1` |
+| 方法 | [`capture`](#member-gfshaderinterfacesnapshot-methods-capture) | `static func capture(shader: Shader) -> GFShaderInterfaceSnapshot:` |
+| 方法 | [`from_dict`](#member-gfshaderinterfacesnapshot-methods-from_dict) | `static func from_dict(data: Dictionary) -> GFShaderInterfaceSnapshot:` |
+| 方法 | [`get_schema_version`](#member-gfshaderinterfacesnapshot-methods-get_schema_version) | `func get_schema_version() -> int:` |
+| 方法 | [`get_shader_mode`](#member-gfshaderinterfacesnapshot-methods-get_shader_mode) | `func get_shader_mode() -> int:` |
+| 方法 | [`get_uniforms`](#member-gfshaderinterfacesnapshot-methods-get_uniforms) | `func get_uniforms() -> Array[Dictionary]:` |
+| 方法 | [`get_uniform_names`](#member-gfshaderinterfacesnapshot-methods-get_uniform_names) | `func get_uniform_names() -> Array[StringName]:` |
+| 方法 | [`has_uniform`](#member-gfshaderinterfacesnapshot-methods-has_uniform) | `func has_uniform(parameter_name: StringName) -> bool:` |
+| 方法 | [`get_uniform`](#member-gfshaderinterfacesnapshot-methods-get_uniform) | `func get_uniform(parameter_name: StringName) -> Dictionary:` |
+| 方法 | [`accepts_parameter_value`](#member-gfshaderinterfacesnapshot-methods-accepts_parameter_value) | `func accepts_parameter_value( parameter_name: StringName, value: Variant, options: Dictionary = {} ) -> bool:` |
+| 方法 | [`validate_definition`](#member-gfshaderinterfacesnapshot-methods-validate_definition) | `func validate_definition(options: Dictionary = {}) -> GFValidationReport:` |
+| 方法 | [`validate_parameters`](#member-gfshaderinterfacesnapshot-methods-validate_parameters) | `func validate_parameters( parameters: Dictionary, options: Dictionary = {} ) -> GFValidationReport:` |
+| 方法 | [`compare_with`](#member-gfshaderinterfacesnapshot-methods-compare_with) | `func compare_with( actual: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -> GFValidationReport:` |
+| 方法 | [`validate_shader`](#member-gfshaderinterfacesnapshot-methods-validate_shader) | `func validate_shader( shader: Shader, options: Dictionary = {} ) -> GFValidationReport:` |
+| 方法 | [`duplicate_snapshot`](#member-gfshaderinterfacesnapshot-methods-duplicate_snapshot) | `func duplicate_snapshot() -> GFShaderInterfaceSnapshot:` |
+| 方法 | [`to_dict`](#member-gfshaderinterfacesnapshot-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfshaderinterfacesnapshot-constants-current_schema_version"></a>
+
+### `CURRENT_SCHEMA_VERSION`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const CURRENT_SCHEMA_VERSION: int = 1
+```
+
+当前快照字典 schema 版本。
+
+## 方法
+
+<a id="member-gfshaderinterfacesnapshot-methods-capture"></a>
+
+### `capture`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func capture(shader: Shader) -> GFShaderInterfaceSnapshot:
+```
+
+从 Shader 当前反射接口创建快照。 参数分组提示不会进入快照；uniform 会按名称和签名稳定排序。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `shader` | 要捕获的 Shader；为空时返回 null。 |
+
+返回：新快照，或 null。
+
+<a id="member-gfshaderinterfacesnapshot-methods-from_dict"></a>
+
+### `from_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func from_dict(data: Dictionary) -> GFShaderInterfaceSnapshot:
+```
+
+从字典创建快照。 输入会被深复制并规范化，但不会强转字段类型；不支持的 schema、缺失数组和 无效条目由 validate_definition() 报告。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `data` | 快照字典。 |
+
+返回：新快照。
+
+结构：
+
+- `data`: Dictionary，包含 schema_version、shader_mode 和 uniforms；uniform 字段为 name、type、class_name、hint、hint_string、usage。
+
+<a id="member-gfshaderinterfacesnapshot-methods-get_schema_version"></a>
+
+### `get_schema_version`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_schema_version() -> int:
+```
+
+获取快照 schema 版本。
+
+返回：schema 版本。
+
+<a id="member-gfshaderinterfacesnapshot-methods-get_shader_mode"></a>
+
+### `get_shader_mode`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_shader_mode() -> int:
+```
+
+获取捕获时的 Shader 模式。
+
+返回：Shader.Mode 对应整数。
+
+<a id="member-gfshaderinterfacesnapshot-methods-get_uniforms"></a>
+
+### `get_uniforms`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_uniforms() -> Array[Dictionary]:
+```
+
+获取稳定排序的 uniform 条目深拷贝。
+
+返回：uniform 条目数组。
+
+结构：
+
+- `return`: Array[Dictionary]，每项包含 name、type、class_name、hint、hint_string 和 usage。
+
+<a id="member-gfshaderinterfacesnapshot-methods-get_uniform_names"></a>
+
+### `get_uniform_names`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_uniform_names() -> Array[StringName]:
+```
+
+获取稳定排序的 uniform 名。
+
+返回：uniform 名数组。
+
+结构：
+
+- `return`: Array[StringName]，按名称稳定排序。
+
+<a id="member-gfshaderinterfacesnapshot-methods-has_uniform"></a>
+
+### `has_uniform`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func has_uniform(parameter_name: StringName) -> bool:
+```
+
+检查接口是否声明 uniform。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `parameter_name` | uniform 名。 |
+
+返回：已声明时返回 true。
+
+<a id="member-gfshaderinterfacesnapshot-methods-get_uniform"></a>
+
+### `get_uniform`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_uniform(parameter_name: StringName) -> Dictionary:
+```
+
+获取 uniform 条目深拷贝。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `parameter_name` | uniform 名。 |
+
+返回：uniform 条目；不存在时返回空字典。
+
+结构：
+
+- `return`: Dictionary，包含 name、type、class_name、hint、hint_string 和 usage。
+
+<a id="member-gfshaderinterfacesnapshot-methods-accepts_parameter_value"></a>
+
+### `accepts_parameter_value`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func accepts_parameter_value( parameter_name: StringName, value: Variant, options: Dictionary = {} ) -> bool:
+```
+
+检查一个值是否符合已声明 uniform 类型。 数字类型严格匹配，不做 int/float 隐式转换；Object 参数会继续检查资源类。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `parameter_name` | uniform 名。 |
+| `value` | 候选值。 |
+| `options` | 支持 allow_null_object，默认 true。 |
+
+返回：已声明且值兼容时返回 true。
+
+结构：
+
+- `value`: Variant shader parameter value.
+- `options`: Dictionary，allow_null_object 控制 TYPE_OBJECT uniform 是否接受 null。
+
+<a id="member-gfshaderinterfacesnapshot-methods-validate_definition"></a>
+
+### `validate_definition`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_definition(options: Dictionary = {}) -> GFValidationReport:
+```
+
+校验快照 schema、Shader 模式、uniform 字段和重复名称。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `options` | 支持 subject 和 metadata。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `options`: Dictionary，subject 覆盖报告主题，metadata 为调用方报告元数据。
+
+<a id="member-gfshaderinterfacesnapshot-methods-validate_parameters"></a>
+
+### `validate_parameters`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_parameters( parameters: Dictionary, options: Dictionary = {} ) -> GFValidationReport:
+```
+
+根据快照校验参数字典。 Profile 默认按部分覆盖处理，因此缺失 uniform 默认忽略；未知参数和错型值默认报错。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `parameters` | uniform 名到参数值的映射。 |
+| `options` | 支持 subject、metadata、missing_severity、extra_severity、type_mismatch_severity 和 allow_null_object。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `parameters`: Dictionary[StringName|String, Variant] shader parameter values.
+- `options`: Dictionary，severity 可为 ignore、info、warning 或 error；missing 默认 ignore，extra/type mismatch 默认 error；allow_null_object 默认 true。
+
+<a id="member-gfshaderinterfacesnapshot-methods-compare_with"></a>
+
+### `compare_with`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func compare_with( actual: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -> GFValidationReport:
+```
+
+比较期望快照与实际快照。 当前快照作为 expected；actual 缺失和签名变化默认报错，新增 uniform 默认 warning。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `actual` | 实际接口快照。 |
+| `options` | 支持 subject、metadata、mode_mismatch_severity、missing_severity、extra_severity、signature_severity 和 usage_severity。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `options`: Dictionary，severity 可为 ignore、info、warning 或 error；mode/missing/signature 默认 error，extra/usage 默认 warning。
+
+<a id="member-gfshaderinterfacesnapshot-methods-validate_shader"></a>
+
+### `validate_shader`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_shader( shader: Shader, options: Dictionary = {} ) -> GFValidationReport:
+```
+
+将 Shader 当前接口与本快照比较。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `shader` | 实际 Shader。 |
+| `options` | 传给 compare_with() 的报告和 severity 选项。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `options`: Dictionary compare_with() options.
+
+<a id="member-gfshaderinterfacesnapshot-methods-duplicate_snapshot"></a>
+
+### `duplicate_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_snapshot() -> GFShaderInterfaceSnapshot:
+```
+
+创建快照深拷贝。
+
+返回：新快照。
+
+<a id="member-gfshaderinterfacesnapshot-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为稳定排序的快照字典。
+
+返回：快照字典。
+
+结构：
+
+- `return`: Dictionary，包含 schema_version、shader_mode 和 uniforms。

--- a/docs/zh/reference/api/classes/GFShaderParameterProfile.md
+++ b/docs/zh/reference/api/classes/GFShaderParameterProfile.md
@@ -23,6 +23,7 @@
 | 方法 | [`erase_parameter`](#member-gfshaderparameterprofile-methods-erase_parameter) | `func erase_parameter(parameter_name: StringName) -> bool:` |
 | 方法 | [`clear_parameters`](#member-gfshaderparameterprofile-methods-clear_parameters) | `func clear_parameters() -> void:` |
 | 方法 | [`get_parameter_names`](#member-gfshaderparameterprofile-methods-get_parameter_names) | `func get_parameter_names() -> Array[StringName]:` |
+| 方法 | [`validate_against`](#member-gfshaderparameterprofile-methods-validate_against) | `func validate_against( interface_snapshot: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -> GFValidationReport:` |
 | 方法 | [`merge_from`](#member-gfshaderparameterprofile-methods-merge_from) | `func merge_from(source: GFShaderParameterProfile, overwrite: bool = true) -> GFShaderParameterProfile:` |
 | 方法 | [`blend_with`](#member-gfshaderparameterprofile-methods-blend_with) | `func blend_with( target_profile: GFShaderParameterProfile, weight: float, options: Dictionary = {} ) -> GFShaderParameterProfile:` |
 | 方法 | [`duplicate_profile`](#member-gfshaderparameterprofile-methods-duplicate_profile) | `func duplicate_profile() -> GFShaderParameterProfile:` |
@@ -174,6 +175,7 @@ func clear_parameters() -> void:
 ### `get_parameter_names`
 
 - API：`public`
+- 首次版本：`4.3.0`
 
 ```gdscript
 func get_parameter_names() -> Array[StringName]:
@@ -186,6 +188,32 @@ func get_parameter_names() -> Array[StringName]:
 结构：
 
 - `return`: Array[StringName]，当前 profile 中可识别的 shader 参数名。
+
+<a id="member-gfshaderparameterprofile-methods-validate_against"></a>
+
+### `validate_against`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_against( interface_snapshot: GFShaderInterfaceSnapshot, options: Dictionary = {} ) -> GFValidationReport:
+```
+
+根据 Shader 接口快照校验当前参数。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `interface_snapshot` | 期望接口快照。 |
+| `options` | 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `options`: Dictionary shader parameter validation options.
 
 <a id="member-gfshaderparameterprofile-methods-merge_from"></a>
 

--- a/docs/zh/reference/api/classes/GFShaderParameterUtility.md
+++ b/docs/zh/reference/api/classes/GFShaderParameterUtility.md
@@ -21,6 +21,9 @@
 | 方法 | [`apply_parameters`](#member-gfshaderparameterutility-methods-apply_parameters) | `func apply_parameters(target: Object, parameters: Dictionary, options: Dictionary = {}) -> int:` |
 | 方法 | [`apply_global_parameters`](#member-gfshaderparameterutility-methods-apply_global_parameters) | `func apply_global_parameters(parameters: Dictionary, options: Dictionary = {}) -> Dictionary:` |
 | 方法 | [`resolve_shader_material`](#member-gfshaderparameterutility-methods-resolve_shader_material) | `func resolve_shader_material( target: Object, material_property: NodePath = DEFAULT_MATERIAL_PROPERTY ) -> ShaderMaterial:` |
+| 方法 | [`capture_shader_interface`](#member-gfshaderparameterutility-methods-capture_shader_interface) | `func capture_shader_interface( material: ShaderMaterial ) -> GFShaderInterfaceSnapshot:` |
+| 方法 | [`validate_profile`](#member-gfshaderparameterutility-methods-validate_profile) | `func validate_profile( material: ShaderMaterial, profile: GFShaderParameterProfile, options: Dictionary = {} ) -> GFValidationReport:` |
+| 方法 | [`validate_parameters`](#member-gfshaderparameterutility-methods-validate_parameters) | `func validate_parameters( material: ShaderMaterial, parameters: Dictionary, options: Dictionary = {} ) -> GFValidationReport:` |
 | 方法 | [`get_shader_parameter_names`](#member-gfshaderparameterutility-methods-get_shader_parameter_names) | `func get_shader_parameter_names(material: ShaderMaterial) -> Array[StringName]:` |
 | 方法 | [`has_shader_parameter`](#member-gfshaderparameterutility-methods-has_shader_parameter) | `func has_shader_parameter(material: ShaderMaterial, parameter_name: StringName) -> bool:` |
 | 方法 | [`ensure_global_parameter`](#member-gfshaderparameterutility-methods-ensure_global_parameter) | `func ensure_global_parameter( parameter_name: StringName, parameter_type: int, default_value: Variant = null, options: Dictionary = {} ) -> Dictionary:` |
@@ -52,6 +55,7 @@ const DEFAULT_MATERIAL_PROPERTY: NodePath = ^"material"
 ### `apply_profile`
 
 - API：`public`
+- 首次版本：`4.3.0`
 
 ```gdscript
 func apply_profile( target: Object, profile: GFShaderParameterProfile, options: Dictionary = {} ) -> int:
@@ -65,13 +69,13 @@ func apply_profile( target: Object, profile: GFShaderParameterProfile, options: 
 |---|---|
 | `target` | ShaderMaterial，或持有材质属性的对象。 |
 | `profile` | 要应用的 shader 参数 profile。 |
-| `options` | 可选项，支持 material_property、duplicate_material、require_declared_parameters、warn_on_invalid_target、warn_on_missing_parameters 和 copy_values。 |
+| `options` | 可选项，支持 material_property、duplicate_material、require_declared_parameters、validate_parameter_types、warn_on_invalid_target、warn_on_missing_parameters、warn_on_type_mismatch 和 copy_values。 |
 
 返回：实际写入的参数数量。
 
 结构：
 
-- `options`: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；warn_on_invalid_target 和 warn_on_missing_parameters 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
+- `options`: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；validate_parameter_types 默认为 true，会跳过与 uniform 声明不兼容的值；warn_on_invalid_target、warn_on_missing_parameters 和 warn_on_type_mismatch 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
 
 <a id="member-gfshaderparameterutility-methods-apply_global_profile"></a>
 
@@ -105,6 +109,7 @@ func apply_global_profile(profile: GFShaderParameterProfile, options: Dictionary
 ### `apply_parameters`
 
 - API：`public`
+- 首次版本：`4.3.0`
 
 ```gdscript
 func apply_parameters(target: Object, parameters: Dictionary, options: Dictionary = {}) -> int:
@@ -118,14 +123,14 @@ func apply_parameters(target: Object, parameters: Dictionary, options: Dictionar
 |---|---|
 | `target` | ShaderMaterial，或持有材质属性的对象。 |
 | `parameters` | 要应用的 shader 参数字典。 |
-| `options` | 可选项，支持 material_property、duplicate_material、require_declared_parameters、warn_on_invalid_target、warn_on_missing_parameters 和 copy_values。 |
+| `options` | 可选项，支持 material_property、duplicate_material、require_declared_parameters、validate_parameter_types、warn_on_invalid_target、warn_on_missing_parameters、warn_on_type_mismatch 和 copy_values。 |
 
 返回：实际写入的参数数量。
 
 结构：
 
 - `parameters`: Dictionary[StringName, Variant]，shader uniform 名到参数值的映射。
-- `options`: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；warn_on_invalid_target 和 warn_on_missing_parameters 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
+- `options`: Dictionary，material_property 为 NodePath/String，默认 material；duplicate_material 为 true 时会复制目标材质并写回属性；require_declared_parameters 默认为 true，会跳过 shader 未声明的 uniform；validate_parameter_types 默认为 true，会跳过与 uniform 声明不兼容的值；warn_on_invalid_target、warn_on_missing_parameters 和 warn_on_type_mismatch 控制警告；copy_values 默认为 true，会复制集合参数值后再写入。
 
 <a id="member-gfshaderparameterutility-methods-apply_global_parameters"></a>
 
@@ -160,6 +165,7 @@ func apply_global_parameters(parameters: Dictionary, options: Dictionary = {}) -
 ### `resolve_shader_material`
 
 - API：`public`
+- 首次版本：`4.3.0`
 
 ```gdscript
 func resolve_shader_material( target: Object, material_property: NodePath = DEFAULT_MATERIAL_PROPERTY ) -> ShaderMaterial:
@@ -176,11 +182,88 @@ func resolve_shader_material( target: Object, material_property: NodePath = DEFA
 
 返回：解析出的 ShaderMaterial；失败时返回 null。
 
+<a id="member-gfshaderparameterutility-methods-capture_shader_interface"></a>
+
+### `capture_shader_interface`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func capture_shader_interface( material: ShaderMaterial ) -> GFShaderInterfaceSnapshot:
+```
+
+捕获 ShaderMaterial 当前 uniform 接口。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `material` | 目标 ShaderMaterial。 |
+
+返回：接口快照；材质或 Shader 为空时返回 null。
+
+<a id="member-gfshaderparameterutility-methods-validate_profile"></a>
+
+### `validate_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_profile( material: ShaderMaterial, profile: GFShaderParameterProfile, options: Dictionary = {} ) -> GFValidationReport:
+```
+
+校验 profile 是否符合 ShaderMaterial 当前 uniform 接口。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `material` | 目标 ShaderMaterial。 |
+| `profile` | 要校验的 profile。 |
+| `options` | 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `options`: Dictionary shader parameter validation options.
+
+<a id="member-gfshaderparameterutility-methods-validate_parameters"></a>
+
+### `validate_parameters`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_parameters( material: ShaderMaterial, parameters: Dictionary, options: Dictionary = {} ) -> GFValidationReport:
+```
+
+校验参数字典是否符合 ShaderMaterial 当前 uniform 接口。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `material` | 目标 ShaderMaterial。 |
+| `parameters` | uniform 参数字典。 |
+| `options` | 传给 GFShaderInterfaceSnapshot.validate_parameters() 的选项。 |
+
+返回：标准校验报告。
+
+结构：
+
+- `parameters`: Dictionary[StringName|String, Variant] shader parameter values.
+- `options`: Dictionary shader parameter validation options.
+
 <a id="member-gfshaderparameterutility-methods-get_shader_parameter_names"></a>
 
 ### `get_shader_parameter_names`
 
 - API：`public`
+- 首次版本：`4.3.0`
 
 ```gdscript
 func get_shader_parameter_names(material: ShaderMaterial) -> Array[StringName]:
@@ -205,6 +288,7 @@ func get_shader_parameter_names(material: ShaderMaterial) -> Array[StringName]:
 ### `has_shader_parameter`
 
 - API：`public`
+- 首次版本：`4.3.0`
 
 ```gdscript
 func has_shader_parameter(material: ShaderMaterial, parameter_name: StringName) -> bool:

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -6,8 +6,8 @@
 
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
-| Kernel | 71 | 1003 | [Kernel](#module-kernel) |
-| Standard | 435 | 6874 | [Standard](#module-standard) |
+| Kernel | 72 | 1021 | [Kernel](#module-kernel) |
+| Standard | 438 | 6920 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -84,11 +84,12 @@
 | [`GFAccessGenerator`](GFAccessGenerator.md#gfaccessgenerator) | 编辑器 API (`editor_api`) | `RefCounted` | 13 | `addons/gf/kernel/editor/gf_access_generator.gd` |
 | [`GFBakeDependencyReport`](GFBakeDependencyReport.md#gfbakedependencyreport) | 编辑器 API (`editor_api`) | `RefCounted` | 21 | `addons/gf/kernel/editor/gf_bake_dependency_report.gd` |
 | [`GFEditorActionDefinition`](GFEditorActionDefinition.md#gfeditoractiondefinition) | 编辑器 API (`editor_api`) | `RefCounted` | 23 | `addons/gf/kernel/editor/gf_editor_action_definition.gd` |
-| [`GFEditorCommand`](GFEditorCommand.md#gfeditorcommand) | 编辑器 API (`editor_api`) | `RefCounted` | 15 | `addons/gf/kernel/editor/gf_editor_command.gd` |
+| [`GFEditorCommand`](GFEditorCommand.md#gfeditorcommand) | 编辑器 API (`editor_api`) | `RefCounted` | 16 | `addons/gf/kernel/editor/gf_editor_command.gd` |
 | [`GFEditorCommandRegistry`](GFEditorCommandRegistry.md#gfeditorcommandregistry) | 编辑器 API (`editor_api`) | `RefCounted` | 20 | `addons/gf/kernel/editor/gf_editor_command_registry.gd` |
 | [`GFEditorCommandSession`](GFEditorCommandSession.md#gfeditorcommandsession) | 编辑器 API (`editor_api`) | `RefCounted` | 10 | `addons/gf/kernel/editor/gf_editor_command_session.gd` |
 | [`GFEditorOperationPlan`](GFEditorOperationPlan.md#gfeditoroperationplan) | 编辑器 API (`editor_api`) | `RefCounted` | 17 | `addons/gf/kernel/editor/gf_editor_operation_plan.gd` |
 | [`GFEditorPickOperation`](GFEditorPickOperation.md#gfeditorpickoperation) | 编辑器 API (`editor_api`) | `RefCounted` | 18 | `addons/gf/kernel/editor/gf_editor_pick_operation.gd` |
+| [`GFEditorPropertyBatchCommand`](GFEditorPropertyBatchCommand.md#gfeditorpropertybatchcommand) | 编辑器 API (`editor_api`) | `GFEditorCommand` | 17 | `addons/gf/kernel/editor/gf_editor_property_batch_command.gd` |
 | [`GFEditorSceneMetadataPatch`](GFEditorSceneMetadataPatch.md#gfeditorscenemetadatapatch) | 编辑器 API (`editor_api`) | `GFEditorCommand` | 9 | `addons/gf/kernel/editor/gf_editor_scene_metadata_patch.gd` |
 | [`GFEditorTool`](GFEditorTool.md#gfeditortool) | 编辑器 API (`editor_api`) | `RefCounted` | 28 | `addons/gf/kernel/editor/gf_editor_tool.gd` |
 | [`GFEditorToolContext`](GFEditorToolContext.md#gfeditortoolcontext) | 编辑器 API (`editor_api`) | `RefCounted` | 9 | `addons/gf/kernel/editor/gf_editor_tool_context.gd` |
@@ -247,8 +248,8 @@
 | [`GFScriptStructureTools`](GFScriptStructureTools.md#gfscriptstructuretools) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/utilities/assets/gf_script_structure_tools.gd` |
 | [`GFSeedUtility`](GFSeedUtility.md#gfseedutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 18 | `addons/gf/standard/utilities/random/gf_seed_utility.gd` |
 | [`GFSessionTraceUtility`](GFSessionTraceUtility.md#gfsessiontraceutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 47 | `addons/gf/standard/utilities/debug/gf_session_trace_utility.gd` |
-| [`GFSettingsUtility`](GFSettingsUtility.md#gfsettingsutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 45 | `addons/gf/standard/utilities/settings/gf_settings_utility.gd` |
-| [`GFShaderParameterUtility`](GFShaderParameterUtility.md#gfshaderparameterutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 15 | `addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd` |
+| [`GFSettingsUtility`](GFSettingsUtility.md#gfsettingsutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 46 | `addons/gf/standard/utilities/settings/gf_settings_utility.gd` |
+| [`GFShaderParameterUtility`](GFShaderParameterUtility.md#gfshaderparameterutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 18 | `addons/gf/standard/utilities/display/gf_shader_parameter_utility.gd` |
 | [`GFSignalRuntimeProbe`](GFSignalRuntimeProbe.md#gfsignalruntimeprobe) | 运行时服务 (`runtime_service`) | `RefCounted` | 27 | `addons/gf/standard/utilities/debug/gf_signal_runtime_probe.gd` |
 | [`GFSignalUtility`](GFSignalUtility.md#gfsignalutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 10 | `addons/gf/standard/utilities/signals/gf_signal_utility.gd` |
 | [`GFSnapshotHistoryUtility`](GFSnapshotHistoryUtility.md#gfsnapshothistoryutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 21 | `addons/gf/standard/utilities/history/gf_snapshot_history_utility.gd` |
@@ -418,7 +419,9 @@
 | [`GFSessionTraceCheckpoint`](GFSessionTraceCheckpoint.md#gfsessiontracecheckpoint) | 资源定义 (`resource_definition`) | `Resource` | 6 | `addons/gf/standard/utilities/debug/gf_session_trace_checkpoint.gd` |
 | [`GFSessionTraceRecipe`](GFSessionTraceRecipe.md#gfsessiontracerecipe) | 资源定义 (`resource_definition`) | `Resource` | 16 | `addons/gf/standard/utilities/debug/gf_session_trace_recipe.gd` |
 | [`GFSettingDefinition`](GFSettingDefinition.md#gfsettingdefinition) | 资源定义 (`resource_definition`) | `Resource` | 10 | `addons/gf/standard/utilities/settings/gf_setting_definition.gd` |
-| [`GFShaderParameterProfile`](GFShaderParameterProfile.md#gfshaderparameterprofile) | 资源定义 (`resource_definition`) | `Resource` | 14 | `addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd` |
+| [`GFSettingsRecoveryPolicy`](GFSettingsRecoveryPolicy.md#gfsettingsrecoverypolicy) | 资源定义 (`resource_definition`) | `Resource` | 6 | `addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd` |
+| [`GFShaderInterfaceSnapshot`](GFShaderInterfaceSnapshot.md#gfshaderinterfacesnapshot) | 资源定义 (`resource_definition`) | `Resource` | 16 | `addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd` |
+| [`GFShaderParameterProfile`](GFShaderParameterProfile.md#gfshaderparameterprofile) | 资源定义 (`resource_definition`) | `Resource` | 15 | `addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd` |
 | [`GFSignalBridge`](GFSignalBridge.md#gfsignalbridge) | 资源定义 (`resource_definition`) | `Resource` | 15 | `addons/gf/standard/utilities/signals/bridge/gf_signal_bridge.gd` |
 | [`GFSignalSourceRef`](GFSignalSourceRef.md#gfsignalsourceref) | 资源定义 (`resource_definition`) | `Resource` | 8 | `addons/gf/standard/utilities/signals/bridge/gf_signal_source_ref.gd` |
 | [`GFSteeringBehaviorResource`](GFSteeringBehaviorResource.md#gfsteeringbehaviorresource) | 资源定义 (`resource_definition`) | `Resource` | 20 | `addons/gf/standard/foundation/math/gf_steering_behavior_resource.gd` |
@@ -512,6 +515,7 @@
 | [`GFResourceLoadState`](GFResourceLoadState.md#gfresourceloadstate) | 值对象 (`value_object`) | `RefCounted` | 34 | `addons/gf/standard/utilities/assets/gf_resource_load_state.gd` |
 | [`GFResultDictionary`](GFResultDictionary.md#gfresultdictionary) | 值对象 (`value_object`) | `RefCounted` | 21 | `addons/gf/standard/foundation/validation/gf_result_dictionary.gd` |
 | [`GFSequenceContext`](GFSequenceContext.md#gfsequencecontext) | 值对象 (`value_object`) | `RefCounted` | 6 | `addons/gf/standard/sequence/gf_sequence_context.gd` |
+| [`GFSettingsLoadResult`](GFSettingsLoadResult.md#gfsettingsloadresult) | 值对象 (`value_object`) | `RefCounted` | 19 | `addons/gf/standard/utilities/settings/gf_settings_load_result.gd` |
 | [`GFSourceSpan`](GFSourceSpan.md#gfsourcespan) | 值对象 (`value_object`) | `RefCounted` | 23 | `addons/gf/standard/foundation/validation/gf_source_span.gd` |
 | [`GFSpatialQueryIdentity`](GFSpatialQueryIdentity.md#gfspatialqueryidentity) | 值对象 (`value_object`) | `RefCounted` | 19 | `addons/gf/standard/foundation/math/gf_spatial_query_identity.gd` |
 | [`GFSteeringAcceleration`](GFSteeringAcceleration.md#gfsteeringacceleration) | 值对象 (`value_object`) | `RefCounted` | 8 | `addons/gf/standard/foundation/math/gf_steering_acceleration.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,16 +5,16 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`780`
-- 公开成员：`11322`
-- 公开方法：`7009`
+- 公开类：`784`
+- 公开成员：`11386`
+- 公开方法：`7050`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
-| Kernel | 71 | 1003 | 727 | [kernel.md](kernel.md) |
-| Standard | 435 | 6874 | 4369 | [standard.md](standard.md) |
+| Kernel | 72 | 1021 | 736 | [kernel.md](kernel.md) |
+| Standard | 438 | 6920 | 4401 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/kernel.md
+++ b/docs/zh/reference/api/kernel.md
@@ -12,7 +12,7 @@
 | [运行时句柄](#category-runtime_handle) | 9 | 86 | 70 |
 | [值对象](#category-value_object) | 1 | 1 | 0 |
 | [事件契约](#category-event_contract) | 1 | 10 | 10 |
-| [编辑器 API](#category-editor_api) | 25 | 371 | 233 |
+| [编辑器 API](#category-editor_api) | 26 | 389 | 242 |
 
 ## 类
 
@@ -118,6 +118,7 @@
 | [`GFEditorCommandSession`](classes/GFEditorCommandSession.md#gfeditorcommandsession) | `RefCounted` | `addons/gf/kernel/editor/gf_editor_command_session.gd` |
 | [`GFEditorOperationPlan`](classes/GFEditorOperationPlan.md#gfeditoroperationplan) | `RefCounted` | `addons/gf/kernel/editor/gf_editor_operation_plan.gd` |
 | [`GFEditorPickOperation`](classes/GFEditorPickOperation.md#gfeditorpickoperation) | `RefCounted` | `addons/gf/kernel/editor/gf_editor_pick_operation.gd` |
+| [`GFEditorPropertyBatchCommand`](classes/GFEditorPropertyBatchCommand.md#gfeditorpropertybatchcommand) | `GFEditorCommand` | `addons/gf/kernel/editor/gf_editor_property_batch_command.gd` |
 | [`GFEditorSceneMetadataPatch`](classes/GFEditorSceneMetadataPatch.md#gfeditorscenemetadatapatch) | `GFEditorCommand` | `addons/gf/kernel/editor/gf_editor_scene_metadata_patch.gd` |
 | [`GFEditorTool`](classes/GFEditorTool.md#gfeditortool) | `RefCounted` | `addons/gf/kernel/editor/gf_editor_tool.gd` |
 | [`GFEditorToolContext`](classes/GFEditorToolContext.md#gfeditortoolcontext) | `RefCounted` | `addons/gf/kernel/editor/gf_editor_tool_context.gd` |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,11 +6,11 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 187 | 3342 | 2259 |
+| [运行时服务](#category-runtime_service) | 187 | 3346 | 2263 |
 | [协议与扩展点](#category-protocol) | 24 | 337 | 266 |
-| [资源定义](#category-resource_definition) | 117 | 1505 | 771 |
+| [资源定义](#category-resource_definition) | 119 | 1528 | 788 |
 | [运行时句柄](#category-runtime_handle) | 45 | 757 | 495 |
-| [值对象](#category-value_object) | 38 | 698 | 442 |
+| [值对象](#category-value_object) | 39 | 717 | 453 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |
 | [事件契约](#category-event_contract) | 6 | 61 | 23 |
 | [编辑器 API](#category-editor_api) | 11 | 68 | 46 |
@@ -343,6 +343,8 @@
 | [`GFSessionTraceCheckpoint`](classes/GFSessionTraceCheckpoint.md#gfsessiontracecheckpoint) | `Resource` | `addons/gf/standard/utilities/debug/gf_session_trace_checkpoint.gd` |
 | [`GFSessionTraceRecipe`](classes/GFSessionTraceRecipe.md#gfsessiontracerecipe) | `Resource` | `addons/gf/standard/utilities/debug/gf_session_trace_recipe.gd` |
 | [`GFSettingDefinition`](classes/GFSettingDefinition.md#gfsettingdefinition) | `Resource` | `addons/gf/standard/utilities/settings/gf_setting_definition.gd` |
+| [`GFSettingsRecoveryPolicy`](classes/GFSettingsRecoveryPolicy.md#gfsettingsrecoverypolicy) | `Resource` | `addons/gf/standard/utilities/settings/gf_settings_recovery_policy.gd` |
+| [`GFShaderInterfaceSnapshot`](classes/GFShaderInterfaceSnapshot.md#gfshaderinterfacesnapshot) | `Resource` | `addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd` |
 | [`GFShaderParameterProfile`](classes/GFShaderParameterProfile.md#gfshaderparameterprofile) | `Resource` | `addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd` |
 | [`GFSignalBridge`](classes/GFSignalBridge.md#gfsignalbridge) | `Resource` | `addons/gf/standard/utilities/signals/bridge/gf_signal_bridge.gd` |
 | [`GFSignalSourceRef`](classes/GFSignalSourceRef.md#gfsignalsourceref) | `Resource` | `addons/gf/standard/utilities/signals/bridge/gf_signal_source_ref.gd` |
@@ -451,6 +453,7 @@
 | [`GFResourceLoadState`](classes/GFResourceLoadState.md#gfresourceloadstate) | `RefCounted` | `addons/gf/standard/utilities/assets/gf_resource_load_state.gd` |
 | [`GFResultDictionary`](classes/GFResultDictionary.md#gfresultdictionary) | `RefCounted` | `addons/gf/standard/foundation/validation/gf_result_dictionary.gd` |
 | [`GFSequenceContext`](classes/GFSequenceContext.md#gfsequencecontext) | `RefCounted` | `addons/gf/standard/sequence/gf_sequence_context.gd` |
+| [`GFSettingsLoadResult`](classes/GFSettingsLoadResult.md#gfsettingsloadresult) | `RefCounted` | `addons/gf/standard/utilities/settings/gf_settings_load_result.gd` |
 | [`GFSourceSpan`](classes/GFSourceSpan.md#gfsourcespan) | `RefCounted` | `addons/gf/standard/foundation/validation/gf_source_span.gd` |
 | [`GFSpatialQueryIdentity`](classes/GFSpatialQueryIdentity.md#gfspatialqueryidentity) | `RefCounted` | `addons/gf/standard/foundation/math/gf_spatial_query_identity.gd` |
 | [`GFSteeringAcceleration`](classes/GFSteeringAcceleration.md#gfsteeringacceleration) | `RefCounted` | `addons/gf/standard/foundation/math/gf_steering_acceleration.gd` |

--- a/docs/zh/standard/input-flow/input-assist/virtual-recording-remap/index.md
+++ b/docs/zh/standard/input-flow/input-assist/virtual-recording-remap/index.md
@@ -5,6 +5,7 @@
 ## 阅读入口
 
 - [虚拟输入与录制回放](virtual-recording.md)：`GFVirtualInputSource`、`GFInputRecording` 和 `GFInputPlayback`。
+- [共享键盘本地多人](shared-keyboard-local-multiplayer.md)：把互斥键区显式路由到玩家级 `GFVirtualInputSource`，并处理释放与失焦清理。
 - [重映射配置与 Profile](remap-profiles.md)：`GFInputRemapConfig`、`GFInputProfileBank` 和持久化格式。
 - [输入检测、格式化与图标](detection-formatting-icons.md)：`GFInputDetector`、`GFInputFormatter`、图标 provider、冲突分析和上下文结构诊断。
 

--- a/docs/zh/standard/input-flow/input-assist/virtual-recording-remap/shared-keyboard-local-multiplayer.md
+++ b/docs/zh/standard/input-flow/input-assist/virtual-recording-remap/shared-keyboard-local-multiplayer.md
@@ -1,0 +1,102 @@
+# 共享键盘本地多人
+
+一块键盘在 Godot 中只有一个键鼠设备身份，不能通过 device id 拆成多个玩家。项目需要共享键盘本地多人时，应把互不重叠的物理键区显式路由到不同玩家的 `GFVirtualInputSource`；`GFInputDeviceUtility` 仍把整块键盘视为一个物理设备，不负责猜测席位。
+
+## 建立项目侧路由
+
+每个席位使用独立的 `source_id` 和 `player_index`。键位表只保存“物理键 -> 抽象动作”，加入流程、角色控制权和动作含义继续由项目决定。
+
+```gdscript
+extends Node
+
+const SEAT_BINDINGS: Array[Dictionary] = [
+	{
+		"player_index": 0,
+		"source_id": &"shared_keyboard/left",
+		"keys": {
+			KEY_A: &"move_left",
+			KEY_D: &"move_right",
+			KEY_W: &"move_up",
+			KEY_S: &"move_down",
+			KEY_F: &"confirm",
+		},
+	},
+	{
+		"player_index": 1,
+		"source_id": &"shared_keyboard/right",
+		"keys": {
+			KEY_LEFT: &"move_left",
+			KEY_RIGHT: &"move_right",
+			KEY_UP: &"move_up",
+			KEY_DOWN: &"move_down",
+			KEY_KP_ENTER: &"confirm",
+		},
+	},
+]
+
+var _sources: Array[GFVirtualInputSource] = []
+
+
+func _ready() -> void:
+	var input_mapping: GFInputMappingUtility = (
+		Gf.get_utility(GFInputMappingUtility) as GFInputMappingUtility
+	)
+	if input_mapping == null:
+		return
+	for seat: Dictionary in SEAT_BINDINGS:
+		_sources.append(input_mapping.create_virtual_source(
+			GFVariantData.get_option_string_name(seat, "source_id"),
+			GFVariantData.get_option_int(seat, "player_index")
+		))
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if not event is InputEventKey:
+		return
+	var key_event: InputEventKey = event
+	if key_event.echo:
+		return
+
+	for seat_index: int in range(SEAT_BINDINGS.size()):
+		var keys: Dictionary = GFVariantData.get_option_dictionary(
+			SEAT_BINDINGS[seat_index],
+			"keys"
+		)
+		if not keys.has(key_event.physical_keycode):
+			continue
+		var action_id: StringName = GFVariantData.to_string_name(
+			keys[key_event.physical_keycode]
+		)
+		if key_event.pressed:
+			var _pressed: bool = _sources[seat_index].press(action_id)
+		else:
+			var _released: bool = _sources[seat_index].release(action_id)
+		get_viewport().set_input_as_handled()
+		return
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_APPLICATION_FOCUS_OUT:
+		_clear_sources()
+
+
+func _exit_tree() -> void:
+	_clear_sources()
+
+
+func _clear_sources() -> void:
+	for source: GFVirtualInputSource in _sources:
+		source.clear_all()
+```
+
+示例使用 `physical_keycode`，让键区跟随键盘物理位置；需要按当前布局解释字符时，项目可以改用 `keycode`。路由放在 `_unhandled_key_input()`，可让文本框、重绑定界面或其他 UI 先消费按键。项目仍应为暂停、聊天和输入法状态定义自己的输入优先级。
+
+## 生命周期与边界
+
+- 不同席位必须使用不同 `source_id`。`clear_all()` 按 source 清理贡献，复用同一 ID 会让一个席位清掉另一个席位的状态。
+- 忽略键盘 repeat，并在应用失焦、场景退出、玩家离席或路由切换时清理虚拟源，避免释放事件丢失后动作一直保持按下。
+- 同一物理键只能归一个席位；启动时应由项目校验键位表重复项。多键映射到同一动作时，还要在项目路由中维护按键集合，只有最后一个键释放后才释放动作。
+- 普通键盘可能受 rollover 或 ghosting 限制。GF 不能保证任意组合键都被硬件同时报告，项目应在目标设备上验证实际键区。
+- `GFVirtualInputSource` 只写入玩家级抽象动作。玩家加入、准备状态、设备提示、暂停归属、角色选择和存档配置都不应写进通用输入路由。
+
+如果项目需要运行时改键，应先从 `GFInputRemapConfig` 或自己的席位配置生成上述互斥键位表，再交给同一个路由；不要同时让真实 InputMap 和虚拟源为同一玩家重复贡献同一按键。

--- a/docs/zh/standard/utilities/runtime/index.md
+++ b/docs/zh/standard/utilities/runtime/index.md
@@ -13,7 +13,7 @@
 - [视口、文本与节点树工具](settings-ui-scene/ui-stack-routing/viewport-text-node-tools/index.md)：分屏视口、文本适配、富文本格式化和节点树操作。
 - [场景与流程切换](settings-ui-scene/scene-flow/index.md)：场景切换、Loading 过渡、预加载缓存、场景参数和瞬态模块清理。
 - [3D 表面材质查询](settings-ui-scene/surface-query.md)：碰撞 face 到 Mesh surface 或材质的查询。
-- [Shader 参数 Profile](settings-ui-scene/shader-parameter-profile.md)：ShaderMaterial uniform 参数集合、合并、插值、批量写入和场景绑定。
+- [Shader 参数 Profile](settings-ui-scene/shader-parameter-profile.md)：ShaderMaterial uniform 接口快照、参数契约、合并、插值、批量写入和场景绑定。
 - [音频管理](audio/index.md)：背景音乐、音效、环境音、音频片段、音频 Bank 和可插拔后端。
 - [调试、日志、诊断与控制台](debug-observability/index.md)：开发期观测、运行时日志、诊断、支持报告、通知和控制台总览。
 - [调试可视化、运行时检查与信号诊断](debug-observability/debug-visual-inspection/index.md)：DebugDraw、Overlay、运行时调参和信号探针。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/index.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/index.md
@@ -8,7 +8,7 @@
 - [UI 栈、路由、视口与文本辅助](ui-stack-routing/index.md)：`GFUIUtility`、`GFUIRouterUtility`、`GFViewportUtility`、`GFTextFitter`、`GFTextAutoFit`、`GFRichTextFormatter` 与 `GFNodeTreeOps`。
 - [场景与流程切换](scene-flow/index.md)：`GFSceneUtility`、`GFSceneTransitionConfig`、`GFScenePreloadMap` 与瞬态模块清理。
 - [3D 表面材质查询](surface-query.md)：`GFSurfaceUtility` 的 face 到 surface/material 映射。
-- [Shader 参数 Profile](shader-parameter-profile.md)：`GFShaderParameterProfile`、`GFShaderParameterUtility` 与 `GFShaderParameterBinder` 的参数集合、合并、插值、批量写入和场景绑定。
+- [Shader 参数 Profile](shader-parameter-profile.md)：`GFShaderInterfaceSnapshot`、`GFShaderParameterProfile`、`GFShaderParameterUtility` 与 `GFShaderParameterBinder` 的接口快照、契约校验、参数合并、批量写入和场景绑定。
 
 ## 使用边界
 
@@ -16,4 +16,4 @@
 - UI 工具负责栈、层级、加载和通用交互策略，不规定视觉、动画、焦点规则或页面通信协议。
 - 场景工具管理资源加载、过渡、缓存和瞬态模块清理，不替代目标场景自己的初始化流程。
 - 表面查询只把碰撞 face 映射到 Mesh surface 或材质，不解释脚步声、弹孔、地形标签等业务语义。
-- Shader 参数工具只处理 uniform 参数集合、写入和场景绑定，不提供具体视觉风格、天气规则或 shader 算法。
+- Shader 参数工具只处理可反射 uniform 的接口快照、参数集合、校验、写入和场景绑定，不提供具体视觉风格、天气规则或 shader 算法。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/settings-display/settings-utility.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/settings-display/settings-utility.md
@@ -22,7 +22,37 @@ settings.save_settings()
 
 未接入存储后端时，fallback 文件名必须是简单 basename，不能包含路径分隔符、`..`、盘符或绝对路径。需要把设置写到项目自定义目录时，应实现明确的存储后端，而不是把外部路径塞进 fallback 文件名。
 
-从持久化数据恢复时使用 `replace_from_dict()`：输入中缺失的已定义键恢复默认值，缺失的未定义旧键被移除；`load_settings()` 固定采用这一语义。只有明确把输入当作覆盖层时才使用 `merge_from_dict()`，它会保留输入中未出现的当前值。两种入口分离后，切换 profile 或读取空文件不会静默继承上一份 profile 的残留字段。
+从合法持久化数据恢复时使用 `replace_from_dict()`：输入中缺失的已定义键恢复默认值，缺失的未定义旧键被移除；`load_settings()` 固定采用这一语义。只有明确把输入当作覆盖层时才使用 `merge_from_dict()`，它会保留输入中未出现的当前值。两种入口分离后，切换 profile 或读取合法空对象不会静默继承上一份 profile 的残留字段。
+
+## 结构化加载与恢复
+
+`load_settings()` 返回 `GFSettingsLoadResult`，调用方应先检查终态，再读取当前设置。合法空对象 `{}` 是一次成功加载；文件缺失、空文件、格式损坏、完整性失败、未来 schema、迁移失败和 IO 失败则保留各自的稳定分类，不再被折叠为空字典。
+
+```gdscript
+var result: GFSettingsLoadResult = settings.load_settings()
+if result.is_successful():
+	print("设置终态：", result.get_status())
+else:
+	push_warning("设置加载失败：%s" % result.get_error())
+```
+
+默认的 null 恢复策略是严格模式：失败不会修改当前有效值或暂存值，也不会创建、修复或覆盖源文件。项目确实接受缺失或损坏数据时，必须显式提供 `GFSettingsRecoveryPolicy`。恢复只支持保留当前内存状态或重置为已注册默认值；未来 schema、迁移失败和存储 IO 失败始终不可恢复。
+
+```gdscript
+var policy := GFSettingsRecoveryPolicy.new()
+policy.missing_file_action = GFSettingsRecoveryPolicy.ACTION_USE_CURRENT_STATE
+policy.corrupt_file_action = GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS
+
+var result: GFSettingsLoadResult = settings.load_settings("", policy)
+if result.was_recovered():
+	print("恢复动作：", result.get_recovery_action())
+```
+
+加载与恢复本身都不会保存。确认恢复结果符合项目决策后，如需持久化默认值，调用方应在独立步骤中显式调用 `save_settings()`。这样损坏证据不会在读取阶段被静默覆盖。
+
+非空策略会在存储读取前完整校验；未知动作返回 `STATUS_INVALID_REQUEST`，不会访问存储或取消既有保存队列。合法加载请求一旦开始，则会作为全局顺序屏障取消此前尚未执行的延迟保存和批处理保存请求，而不只取消同名文件，避免加载 B 后把新内存状态写回旧来源 A。
+
+`auto_load_on_init` 使用严格 null 策略。启动阶段需要自定义恢复时，应把它设为 `false`，先完成设置定义注册，再显式调用带策略的 `load_settings()`；不要依赖初始化时自动猜测恢复动作。每次终态都会通过 `settings_load_completed` 发出隔离结果，也可用 `get_last_load_result()` 获取最近结果的副本。
 
 自动保存默认会按 `save_debounce_seconds` 做防抖，避免设置页拖动滑块时每次变化都落盘。需要一次性应用多个字段时，可用 `begin_batch()` / `end_batch()` 包裹，或手动 `queue_save()` 后在合适时机 `flush_pending_save()`。
 

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/shader-parameter-profile.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/shader-parameter-profile.md
@@ -17,6 +17,54 @@ shader_params.apply_profile($WeatherOverlay, profile, {
 
 目标可以直接是 `ShaderMaterial`，也可以是带 `material` 属性的节点。默认会检查 shader 是否声明了对应 uniform，避免 profile 中的拼写错误被静默吞掉。多个节点共享同一个材质资源时，传入 `"duplicate_material": true` 会先复制材质并写回目标属性，再应用参数。
 
+`apply_profile()` / `apply_parameters()` 还会默认拒绝与 uniform 声明类型不一致的值。GF 不做 int 到 float 等隐式数值兼容；需要在工具、CI 或资源导入阶段获得完整问题列表时，应先使用下节的显式契约校验，而不是只依赖应用数量和 warning。
+
+## 接口快照与参数契约
+
+`GFShaderInterfaceSnapshot` 把 `Shader.get_shader_uniform_list(false)` 公开的 uniform 接口规范化为稳定数据。快照记录 `schema_version`、`shader_mode`，以及按名称排序的 `name`、`type`、`class_name`、`hint`、`hint_string`、`usage`；它不会保存 shader 源码、默认值、材质当前值或渲染后端生成代码。
+
+从外部字典恢复时，`from_dict()` 只接受显式 schema 字段类型，不会把字符串数字或缺失的 `uniforms` 静默强转为合法契约；调用方应先检查 `validate_definition()`，再把快照作为基线使用。
+
+```gdscript
+var snapshot := GFShaderInterfaceSnapshot.capture(weather_material.shader)
+var report := runtime_profile.validate_against(snapshot)
+if not report.is_ok():
+	push_error(report.make_summary())
+	return
+
+shader_params.apply_profile(weather_material, runtime_profile)
+```
+
+Profile 被视为“部分覆盖”：默认不要求它提供 shader 的全部 uniform，但 Profile 中不存在于接口的参数、值类型错误和资源类错误会进入 `GFValidationReport`。需要校验一份完整参数集时，显式启用缺失错误：
+
+```gdscript
+var complete_report := snapshot.validate_parameters(parameters, {
+	"missing_severity": "error",
+})
+```
+
+数值类型使用严格 Variant 类型匹配，因此 `float` uniform 应提供 `float`，不能依赖 Godot 对错误类型写入的静默行为。纹理等 Object uniform 允许用 `null` 清除；非空对象还会根据反射得到的资源类进行校验。
+
+### 持久化基线与接口漂移
+
+快照是使用私有 storage 字段封存的 Resource。公开 getter 返回深拷贝，调用方不能通过正常 API 原地修改已捕获接口；制作工具可以用 `ResourceSaver` 保存基线，再用当前 Shader 重新捕获和比较：
+
+```gdscript
+var loaded_value: Variant = load(
+	"res://contracts/weather_shader_interface.tres"
+)
+if not loaded_value is GFShaderInterfaceSnapshot:
+	return
+var expected: GFShaderInterfaceSnapshot = loaded_value
+var drift_report := expected.validate_shader(weather_material.shader)
+if not drift_report.is_healthy():
+	push_warning(drift_report.make_summary())
+```
+
+直接 `GFShaderInterfaceSnapshot.new()` 得到的是未配置 Resource，不代表合法的空 spatial 接口；必须通过 `capture()` 或严格 `from_dict()` 建立快照，并在保存或作为门禁前检查 `validate_definition()`。Storage 在加载时会重新规范化 uniform 顺序，缺少配置标记、未来 schema、畸形字段或非规范字段类型仍会失败关闭。
+
+比较默认把 shader mode、缺失 uniform 和类型/提示签名变化作为 error，把新增 uniform 与 `usage` 变化作为 warning。调用方可以通过 `mode_mismatch_severity`、`missing_severity`、`extra_severity`、`signature_severity` 和 `usage_severity` 显式调整门禁，但 GF 不做隐式 schema 降级。
+
 ## 合并与过渡
 
 `merge_from()` 可把默认 profile、场景 profile 和运行时覆盖值合并成一个最终 profile。`blend_with()` 会对 float、int、`Color`、`Vector2`、`Vector3`、`Vector4` 和 `Quaternion` 做插值；纹理、bool、字符串等不可插值值会保持源值，权重到 1 时切换到目标值。需要平滑过渡的参数应在两端 profile 中都提供默认值。
@@ -68,6 +116,7 @@ Godot 的部分 `RenderingServer` 全局参数枚举和读回接口在不同渲�
 ## 使用边界
 
 - GF 只负责参数 profile 和写入流程；shader 代码、uniform 命名和视觉含义由项目维护。
+- 接口快照只约束可反射的 uniform 形状，不解析 shader 源码，也不承诺 GPU 后端二进制兼容。
 - 不要把某个游戏的海面、天气、选中态或后处理规则写进 GF。
 - Binder 只绑定 profile 到目标材质，不负责读取风、时间、角色状态或其他业务状态。
 - 对复杂 GPU compute、CompositorEffect 或 shader 变体编译缓存，应在出现明确重复需求后再做独立工具，不要塞进参数 profile。

--- a/packages/extensions/gf.extension.action_queue.json
+++ b/packages/extensions/gf.extension.action_queue.json
@@ -9,6 +9,7 @@
     "gf.kernel",
     "gf.standard.base",
     "gf.standard.audio",
+    "gf.standard.display",
     "gf.standard.diagnostics"
   ],
   "paths": [

--- a/packages/standard/gf.standard.display.json
+++ b/packages/standard/gf.standard.display.json
@@ -14,6 +14,8 @@
     "addons/gf/standard/utilities/display/gf_render_warmup_manifest.gd.uid",
     "addons/gf/standard/utilities/display/gf_render_warmup_utility.gd",
     "addons/gf/standard/utilities/display/gf_render_warmup_utility.gd.uid",
+    "addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd",
+    "addons/gf/standard/utilities/display/gf_shader_interface_snapshot.gd.uid",
     "addons/gf/standard/utilities/display/gf_shader_parameter_binder.gd",
     "addons/gf/standard/utilities/display/gf_shader_parameter_binder.gd.uid",
     "addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd",

--- a/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
+++ b/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
@@ -101,6 +101,7 @@ func _make_shader_material(initial_strength: float = 0.0) -> ShaderMaterial:
 	shader.code = (
 		"shader_type canvas_item;\n"
 		+ "uniform float strength = 0.0;\n"
+		+ "uniform float alternate_strength = 0.0;\n"
 		+ "uniform vec4 tint : source_color = vec4(1.0, 1.0, 1.0, 1.0);\n"
 		+ "void fragment() {\n"
 		+ "\tCOLOR = tint;\n"
@@ -113,9 +114,18 @@ func _make_shader_material(initial_strength: float = 0.0) -> ShaderMaterial:
 
 
 func _get_shader_strength(material: Material) -> float:
+	return _get_shader_float_parameter(material, &"strength")
+
+
+func _get_shader_float_parameter(
+	material: Material,
+	parameter_name: StringName
+) -> float:
 	if material is ShaderMaterial:
 		var shader_material: ShaderMaterial = material
-		return GFVariantData.to_float(shader_material.get_shader_parameter(&"strength"))
+		return GFVariantData.to_float(
+			shader_material.get_shader_parameter(parameter_name)
+		)
 	return 0.0
 
 
@@ -952,6 +962,37 @@ func test_shader_parameter_action_finish_sets_final_value_and_releases_waiters()
 	assert_almost_eq(_get_shader_strength(item.material), 1.0, 0.001, "finish 应直接写入 Shader 参数最终值。")
 
 
+func test_shader_parameter_action_seals_parameter_and_value_for_active_tween() -> void:
+	var item: ColorRect = ColorRect.new()
+	item.material = _make_shader_material()
+	add_child_autofree(item)
+	var action: GFShaderParameterAction = GFShaderParameterAction.new(
+		item,
+		&"strength",
+		1.0,
+		1.0
+	)
+	var result: Variant = action.execute()
+
+	action.parameter_name = &"alternate_strength"
+	action.target_value = 0.25
+	action.finish()
+
+	assert_true(result is Signal, "封存测试应先创建有效 Tween。")
+	assert_almost_eq(
+		_get_shader_strength(item.material),
+		1.0,
+		0.001,
+		"执行后的公开字段变化不得改写已校验动作的目标值。"
+	)
+	assert_almost_eq(
+		_get_shader_float_parameter(item.material, &"alternate_strength"),
+		0.0,
+		0.001,
+		"执行后的参数名变化不得把 Tween 重定向到未校验 uniform。"
+	)
+
+
 func test_shader_parameter_action_rejects_detached_target_for_timed_tween() -> void:
 	var item: ColorRect = ColorRect.new()
 	item.material = _make_shader_material()
@@ -1009,6 +1050,32 @@ func test_shader_parameter_action_validates_before_duplicating_material() -> voi
 	assert_true(result == null, "无效参数动作应同步拒绝。")
 	assert_same(item.material, shared_material, "校验失败前不得复制并写回材质。")
 	assert_push_warning("[GFShaderParameterAction] Shader 参数不存在：missing。")
+
+
+func test_shader_parameter_action_rejects_declared_type_mismatch_before_duplication() -> void:
+	var shared_material: ShaderMaterial = _make_shader_material()
+	var item: ColorRect = ColorRect.new()
+	item.material = shared_material
+	add_child_autofree(item)
+	var action: GFShaderParameterAction = GFShaderParameterAction.new(
+		item,
+		&"strength",
+		Vector2.ONE,
+		0.0
+	)
+	action.duplicate_material_on_execute = true
+
+	var result: Variant = action.execute()
+
+	assert_true(result == null, "错型 Shader 参数动作应同步拒绝。")
+	assert_same(item.material, shared_material, "类型校验失败前不得复制并写回材质。")
+	assert_almost_eq(
+		_get_shader_strength(item.material),
+		0.0,
+		0.001,
+		"类型校验失败不得修改原材质参数。"
+	)
+	assert_push_warning("[GFShaderParameterAction] Shader 参数值类型不符合声明：strength。")
 
 
 func test_shader_parameter_action_cancel_releases_waiters_and_restores() -> void:

--- a/tests/gf_core/kernel/core/test_gf_object_property_tools.gd
+++ b/tests/gf_core/kernel/core/test_gf_object_property_tools.gd
@@ -215,6 +215,89 @@ func test_snapshot_roundtrip_preserves_direct_property_names_with_separators() -
 	assert_eq(object.colon_like_value, "colon")
 
 
+func test_prepare_property_write_validates_and_coerces_without_mutation() -> void:
+	var node: Node2D = Node2D.new()
+	node.position = Vector2(1.0, 2.0)
+
+	var result: Dictionary = GFObjectPropertyTools.prepare_property_write(
+		node,
+		^"position:x",
+		4
+	)
+
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(result, "ok"),
+		"零写入准备应接受可转换的 indexed property 值。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_float(result, "old_value"),
+		1.0,
+		"准备结果应包含当前属性值。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_float(result, "new_value"),
+		4.0,
+		"准备结果应包含与真实写入一致的规范化值。"
+	)
+	assert_eq(node.position, Vector2(1.0, 2.0), "prepare 不得修改目标对象。")
+
+	node.free()
+
+
+func test_prepare_direct_property_write_preserves_exact_name_without_mutation() -> void:
+	var object: DynamicPropertyObject = DynamicPropertyObject.new()
+
+	var result: Dictionary = GFObjectPropertyTools.prepare_direct_property_write(
+		object,
+		&"colon:like",
+		"next"
+	)
+
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(result, "ok"),
+		"直接属性准备应保留包含分隔符的精确 StringName。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(result, "property_name"),
+		&"colon:like"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string(result, "new_value"),
+		"next"
+	)
+	assert_eq(object.colon_like_value, "colon", "direct prepare 不得触发 `_set()`。")
+
+
+func test_prepare_property_write_rejects_invalid_input_without_setter_side_effects() -> void:
+	var object: DynamicPropertyObject = DynamicPropertyObject.new()
+	var before_value: int = object.dynamic_number_value
+
+	var read_only: Dictionary = GFObjectPropertyTools.prepare_direct_property_write(
+		object,
+		&"locked_number",
+		12
+	)
+	var type_mismatch: Dictionary = GFObjectPropertyTools.prepare_direct_property_write(
+		object,
+		&"dynamic_number",
+		"bad"
+	)
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(read_only, "ok"),
+		"只读属性必须在任何写入前失败。"
+	)
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(type_mismatch, "ok"),
+		"类型不匹配必须在任何写入前失败。"
+	)
+	assert_eq(
+		object.dynamic_number_value,
+		before_value,
+		"预检失败不得触发动态 setter。"
+	)
+
+
 # --- 内部类 ---
 
 class DynamicPropertyObject extends RefCounted:

--- a/tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd
+++ b/tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd
@@ -9,6 +9,37 @@ const GF_VARIANT_ACCESS = preload("res://addons/gf/kernel/core/gf_variant_access
 
 # --- 测试 ---
 
+func test_empty_configuration_remains_invalid_for_transaction_command() -> void:
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([])
+
+	var validation: Dictionary = command.validate()
+	var execute_error: Error = command.execute()
+	var report: Dictionary = command.get_transaction_report()
+	var issues: Array = GF_VARIANT_ACCESS.as_array(validation.get("issues", []))
+	var first_issue: Dictionary = (
+		GF_VARIANT_ACCESS.as_dictionary(issues[0])
+		if not issues.is_empty()
+		else {}
+	)
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(validation, "ok"),
+		"通用属性事务命令必须拒绝没有变更的配置。"
+	)
+	assert_eq(issues.size(), 1)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(first_issue, "kind"),
+		&"missing_changes"
+	)
+	assert_eq(execute_error, ERR_UNAVAILABLE)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"preflight_failed"
+	)
+	assert_false(command.is_executed())
+
+
 func test_preflight_failure_keeps_every_target_unchanged() -> void:
 	var first: ControlledTarget = ControlledTarget.new(1)
 	var second: ValueTarget = ValueTarget.new()

--- a/tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd
+++ b/tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd
@@ -1,0 +1,590 @@
+## 测试通用多目标属性事务命令。
+@tool
+
+extends GutTest
+
+
+const GF_VARIANT_ACCESS = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
+
+
+# --- 测试 ---
+
+func test_preflight_failure_keeps_every_target_unchanged() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ValueTarget = ValueTarget.new()
+	second.value = 2
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"missing",
+			"new_value": 20,
+		},
+	])
+
+	var validation: Dictionary = command.validate()
+	var execute_error: Error = command.execute()
+	var report: Dictionary = command.get_transaction_report()
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(validation, "ok"),
+		"任一条目无效时必须让整批预检失败。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(validation, "status"),
+		&"preflight_failed"
+	)
+	assert_eq(execute_error, ERR_UNAVAILABLE, "预检失败的命令不应进入写阶段。")
+	assert_eq(first.stored_value, 1, "前置有效条目也不得提前写入。")
+	assert_eq(first.set_attempts, 0, "零写入预检不得触发 setter。")
+	assert_eq(second.value, 2)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"preflight_failed",
+		"失败报告应保留预检阶段。"
+	)
+
+
+func test_multi_target_execute_undo_and_redo_keep_first_snapshot() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	], {
+		"command_name": "Edit Multiple Values",
+	})
+
+	assert_eq(command.execute(), OK, "多目标事务应能一次提交。")
+	assert_eq(first.stored_value, 10)
+	assert_eq(second.stored_value, 20)
+	assert_true(command.is_executed())
+	assert_true(command.is_sealed(), "进入首次写阶段后配置必须冻结。")
+
+	assert_eq(command.revert(), OK, "undo 应反序恢复首次执行前快照。")
+	assert_eq(first.stored_value, 1)
+	assert_eq(second.stored_value, 2)
+
+	first.stored_value = 77
+	assert_eq(command.execute(), OK, "redo 应复用原命令配置。")
+	assert_eq(first.stored_value, 10)
+	assert_eq(second.stored_value, 20)
+	assert_eq(command.revert(), OK)
+	assert_eq(first.stored_value, 1, "redo 后的 undo 不得把中间态刷新成新基线。")
+	assert_eq(second.stored_value, 2)
+
+
+func test_failed_redo_recovery_restores_redo_attempt_guard() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	])
+	assert_eq(command.execute(), OK)
+	assert_eq(command.revert(), OK)
+
+	first.stored_value = 77
+	second.rejected_values.append(20)
+	second.before_set = func(requested_value: int) -> void:
+		if requested_value == 20 and not first.rejected_values.has(77):
+			first.rejected_values.append(77)
+
+	assert_ne(command.execute(), OK, "redo 写入及补偿失败时应留下 recovery guard。")
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(
+			command.get_transaction_report(),
+			"recovery_required"
+		)
+	)
+	assert_eq(first.stored_value, 10)
+
+	first.rejected_values.clear()
+	second.rejected_values.clear()
+	second.before_set = Callable()
+	assert_eq(
+		command.revert(),
+		OK,
+		"未 executed 的 redo 残余应允许通过 revert 恢复本次 attempt guard。"
+	)
+	assert_eq(first.stored_value, 77, "恢复不得覆盖 redo 前的外部状态。")
+	assert_eq(second.stored_value, 2)
+
+
+func test_setter_rejection_rolls_back_prior_target() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	second.rejected_values.append(20)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	])
+
+	var execute_error: Error = command.execute()
+	var report: Dictionary = command.get_transaction_report()
+
+	assert_ne(execute_error, OK, "运行期 setter 拒绝必须让事务失败。")
+	assert_eq(first.stored_value, 1, "前面已成功写入的目标必须恢复。")
+	assert_eq(second.stored_value, 2)
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(report, "rolled_back"),
+		"完整恢复 attempt guard 后报告应明确 rolled_back。"
+	)
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(report, "recovery_required"),
+		"完整回滚不应要求人工恢复。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"apply_failed"
+	)
+
+
+func test_final_verification_rolls_back_cross_setter_pollution() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	second.before_set = func(requested_value: int) -> void:
+		if requested_value == 20:
+			first.stored_value = 999
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	])
+
+	var execute_error: Error = command.execute()
+	var report: Dictionary = command.get_transaction_report()
+
+	assert_ne(
+		execute_error,
+		OK,
+		"后续 setter 污染先前目标时，最终状态验证必须让事务失败。"
+	)
+	assert_eq(first.stored_value, 1, "跨 setter 污染必须恢复到 attempt guard。")
+	assert_eq(second.stored_value, 2)
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "rolled_back"))
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"apply_failed"
+	)
+
+
+func test_rollback_failure_seals_command_and_allows_explicit_recovery() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	second.rejected_values.append(20)
+	second.before_set = func(requested_value: int) -> void:
+		if requested_value == 20 and not first.rejected_values.has(1):
+			first.rejected_values.append(1)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	])
+
+	var execute_error: Error = command.execute()
+	var failure_report: Dictionary = command.get_transaction_report()
+
+	assert_ne(execute_error, OK)
+	assert_eq(first.stored_value, 10, "恢复 setter 被拒绝时应保留可诊断的残余状态。")
+	assert_eq(second.stored_value, 2)
+	assert_true(command.is_sealed(), "发生过写入尝试后不得再修改事务配置。")
+	assert_false(command.is_executed())
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(failure_report, "recovery_required"),
+		"不完整回滚必须显式要求恢复。"
+	)
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(failure_report, "rolled_back"))
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(failure_report, "status"),
+		&"rollback_failed"
+	)
+
+	first.rejected_values.clear()
+	assert_eq(
+		command.revert(),
+		OK,
+		"首次 execute 未成功但留有残余状态时，应允许显式 revert 重试恢复。"
+	)
+	assert_eq(first.stored_value, 1)
+	assert_eq(second.stored_value, 2)
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(
+			command.get_transaction_report(),
+			"recovery_required"
+		)
+	)
+
+
+func test_undo_failure_rolls_forward_to_complete_executed_state() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	])
+	assert_eq(command.execute(), OK)
+	first.rejected_values.append(1)
+
+	var revert_error: Error = command.revert()
+	var report: Dictionary = command.get_transaction_report()
+
+	assert_ne(revert_error, OK, "任一 undo setter 拒绝必须让 undo 失败。")
+	assert_eq(first.stored_value, 10, "失败 undo 应恢复到撤销前完整状态。")
+	assert_eq(second.stored_value, 20, "已撤销条目必须向前补偿。")
+	assert_true(command.is_executed(), "补偿成功后命令仍应处于 executed 状态。")
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "rolled_back"))
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "recovery_required"))
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"revert_failed"
+	)
+
+	first.rejected_values.clear()
+	assert_eq(command.revert(), OK, "目标恢复可写后应能再次 undo。")
+	assert_eq(first.stored_value, 1)
+	assert_eq(second.stored_value, 2)
+
+
+func test_incomplete_undo_compensation_recovers_executed_guard_before_retry() -> void:
+	var first: ControlledTarget = ControlledTarget.new(1)
+	var second: ControlledTarget = ControlledTarget.new(2)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": first,
+			"property_name": &"value",
+			"new_value": 10,
+		},
+		{
+			"target": second,
+			"property_name": &"value",
+			"new_value": 20,
+		},
+	])
+	assert_eq(command.execute(), OK)
+	first.rejected_values.append(1)
+	second.before_set = func(requested_value: int) -> void:
+		if requested_value == 20 and not second.rejected_values.has(20):
+			second.rejected_values.append(20)
+
+	assert_ne(command.revert(), OK, "undo 与前向补偿均不完整时必须要求恢复。")
+	assert_true(command.is_executed())
+	assert_eq(first.stored_value, 10)
+	assert_eq(second.stored_value, 2)
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(
+			command.get_transaction_report(),
+			"recovery_required"
+		)
+	)
+
+	second.rejected_values.clear()
+	second.before_set = Callable()
+	assert_eq(command.recover(), OK, "显式恢复应回到 undo 前的 executed guard。")
+	assert_eq(first.stored_value, 10)
+	assert_eq(second.stored_value, 20)
+	assert_true(command.is_executed(), "恢复 executed guard 不等于完成 undo。")
+
+	first.rejected_values.clear()
+	assert_eq(command.revert(), OK, "恢复完整 executed 状态后应能重试 undo。")
+	assert_eq(first.stored_value, 1)
+	assert_eq(second.stored_value, 2)
+
+
+func test_overlapping_selector_is_rejected_without_writes() -> void:
+	var target: ValueTarget = ValueTarget.new()
+	target.vector_value = Vector2(1.0, 2.0)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": target,
+			"property_name": &"vector_value",
+			"new_value": Vector2(3.0, 4.0),
+		},
+		{
+			"target": target,
+			"property_path": ^"vector_value:x",
+			"new_value": 8.0,
+		},
+	])
+
+	var report: Dictionary = command.validate()
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(report, "ok"),
+		"直接根属性与其 indexed 子路径不得出现在同一事务。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"preflight_failed"
+	)
+	assert_eq(target.vector_value, Vector2(1.0, 2.0))
+	assert_eq(command.execute(), ERR_UNAVAILABLE)
+
+
+func test_equivalent_indexed_path_aliases_are_rejected_without_writes() -> void:
+	var target: ValueTarget = ValueTarget.new()
+	target.vector_value = Vector2(1.0, 2.0)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": target,
+			"property_path": ^"vector_value:x",
+			"new_value": 3.0,
+		},
+		{
+			"target": target,
+			"property_path": ^":vector_value:x",
+			"new_value": 4.0,
+		},
+	])
+
+	var report: Dictionary = command.validate()
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(report, "ok"),
+		"等价 indexed path 写法必须在零写入预检阶段识别为重叠。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"preflight_failed"
+	)
+	assert_eq(target.vector_value, Vector2(1.0, 2.0))
+	assert_eq(command.execute(), ERR_UNAVAILABLE)
+
+
+func test_subname_root_alias_overlaps_descendant_without_writes() -> void:
+	var target: ValueTarget = ValueTarget.new()
+	target.vector_value = Vector2(1.0, 2.0)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": target,
+			"property_path": ^":vector_value",
+			"new_value": Vector2(3.0, 4.0),
+		},
+		{
+			"target": target,
+			"property_path": ^"vector_value:x",
+			"new_value": 8.0,
+		},
+	])
+
+	var report: Dictionary = command.validate()
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(report, "ok"),
+		"以 subname 起始的根 selector 必须与其后代路径判定为重叠。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+		&"preflight_failed"
+	)
+	assert_eq(target.vector_value, Vector2(1.0, 2.0))
+	assert_eq(command.execute(), ERR_UNAVAILABLE)
+
+
+func test_configuration_copies_values_and_is_sealed_after_first_write() -> void:
+	var target: ValueTarget = ValueTarget.new()
+	target.payload = {
+		"items": [],
+	}
+	var requested_payload: Dictionary = {
+		"items": [1],
+	}
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": target,
+			"property_name": &"payload",
+			"new_value": requested_payload,
+		},
+	])
+	var requested_items: Array = GF_VARIANT_ACCESS.get_option_array(
+		requested_payload,
+		"items"
+	)
+	requested_items.append(2)
+
+	assert_eq(command.execute(), OK)
+	var applied_items: Array = GF_VARIANT_ACCESS.get_option_array(
+		target.payload,
+		"items"
+	)
+	assert_eq(applied_items, [1], "调用方后续修改输入集合不得改变已配置命令。")
+
+	var _reconfigured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": target,
+			"property_name": &"payload",
+			"new_value": { "items": [99] },
+		},
+	])
+	assert_push_error("[GFEditorCommand] 命令配置已冻结，不能修改：configure。")
+
+	assert_eq(command.revert(), OK)
+	assert_eq(command.execute(), OK)
+	applied_items = GF_VARIANT_ACCESS.get_option_array(target.payload, "items")
+	assert_eq(applied_items, [1], "冻结后的 reconfigure 不得改变 redo 内容。")
+
+
+func test_exact_direct_property_and_indexed_path_share_one_transaction() -> void:
+	var target: SelectorTarget = SelectorTarget.new()
+	target.exact_value = "old"
+	target.vector_value = Vector2(1.0, 2.0)
+	var command: GFEditorPropertyBatchCommand = GFEditorPropertyBatchCommand.new()
+	var _configured: GFEditorPropertyBatchCommand = command.configure([
+		{
+			"target": target,
+			"property_name": &"colon:like",
+			"new_value": "new",
+		},
+		{
+			"target": target,
+			"property_path": ^"vector_value:x",
+			"new_value": 8.0,
+		},
+	])
+
+	assert_eq(command.execute(), OK)
+	assert_eq(target.exact_value, "new", "property_name 必须按精确直接属性写入。")
+	assert_eq(target.vector_value, Vector2(8.0, 2.0))
+	assert_eq(command.revert(), OK)
+	assert_eq(target.exact_value, "old")
+	assert_eq(target.vector_value, Vector2(1.0, 2.0))
+
+
+# --- 辅助类型 ---
+
+class ValueTarget:
+	extends RefCounted
+
+	var value: int = 0
+	var vector_value: Vector2 = Vector2.ZERO
+	var payload: Dictionary = {}
+
+
+class ControlledTarget:
+	extends RefCounted
+
+	var stored_value: int = 0
+	var rejected_values: Array[int] = []
+	var before_set: Callable = Callable()
+	var set_attempts: int = 0
+
+
+	func _init(initial_value: int = 0) -> void:
+		stored_value = initial_value
+
+
+	func _get_property_list() -> Array[Dictionary]:
+		return [{
+			"name": "value",
+			"type": TYPE_INT,
+			"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
+		}]
+
+
+	func _get(property: StringName) -> Variant:
+		if property == &"value":
+			return stored_value
+		return null
+
+
+	func _set(property: StringName, raw_value: Variant) -> bool:
+		if property != &"value":
+			return false
+		var requested_value: int = GF_VARIANT_ACCESS.to_int(raw_value)
+		set_attempts += 1
+		if before_set.is_valid():
+			var _callback_result: Variant = before_set.call(requested_value)
+		if rejected_values.has(requested_value):
+			return false
+		stored_value = requested_value
+		return true
+
+
+class SelectorTarget:
+	extends RefCounted
+
+	var exact_value: String = ""
+	var vector_value: Vector2 = Vector2.ZERO
+
+
+	func _get_property_list() -> Array[Dictionary]:
+		return [{
+			"name": "colon:like",
+			"type": TYPE_STRING,
+			"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
+		}]
+
+
+	func _get(property: StringName) -> Variant:
+		if property == &"colon:like":
+			return exact_value
+		return null
+
+
+	func _set(property: StringName, raw_value: Variant) -> bool:
+		if property != &"colon:like":
+			return false
+		exact_value = GF_VARIANT_ACCESS.to_text(raw_value)
+		return true

--- a/tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd.uid
+++ b/tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd.uid
@@ -1,0 +1,1 @@
+uid://ci6ro3yex8q4p

--- a/tests/gf_core/kernel/editor/test_gf_resource_table_editor.gd
+++ b/tests/gf_core/kernel/editor/test_gf_resource_table_editor.gd
@@ -104,7 +104,7 @@ func test_resource_table_search_filters_visible_rows_and_commits_visible_cell() 
 	assert_eq(second.amount, 5, "可见行提交应更新匹配资源。")
 
 
-func test_resource_table_commit_cell_values_reports_partial_failures() -> void:
+func test_resource_table_commit_cell_values_is_atomic_when_preflight_fails() -> void:
 	var first: TableResource = TableResource.new()
 	first.label = "Alpha"
 	first.amount = 1
@@ -129,14 +129,54 @@ func test_resource_table_commit_cell_values_reports_partial_failures() -> void:
 		{ "row_index": 0, "property": &"missing", "new_value": 1 },
 	])
 
-	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "部分失败时批量报告应标记为失败。")
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "任一预检失败时整批提交应失败。")
 	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "requested_count"), 4, "报告应记录请求数量。")
-	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "applied_count"), 1, "只应计入实际改值的单元格。")
-	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "unchanged_count"), 1, "相同值应计为未变化。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "applied_count"), 0, "事务失败后不得留下已应用单元格。")
 	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "failed_count"), 2, "无效行和未知属性应计为失败。")
-	assert_eq(first.label, "Gamma", "有效变更应写回资源。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "issue_count"), 2)
+	assert_eq(first.label, "Alpha", "后置无效条目不得让前置有效条目部分提交。")
 	assert_eq(second.amount, 2, "相同值应保持不变。")
-	assert_signal_emit_count(editor, "cell_value_committed", 1)
+	assert_signal_not_emitted(
+		editor,
+		"cell_value_committed",
+		"事务失败或回滚后不得发出提交信号。"
+	)
+
+
+func test_resource_table_commit_cell_values_rolls_back_runtime_setter_failure() -> void:
+	var first: TableResource = TableResource.new()
+	first.label = "Alpha"
+	var second: RejectingTableResource = RejectingTableResource.new()
+	second.amount_value = 2
+	second.rejected_values.append(9)
+	var editor: GFResourceTableEditor = GFResourceTableEditor.new()
+	add_child_autofree(editor)
+	watch_signals(editor)
+	editor.load_resources([first, second], [{
+		"name": &"label",
+		"type": TYPE_STRING,
+	}, {
+		"name": &"amount",
+		"type": TYPE_INT,
+	}])
+
+	var report: Dictionary = editor.commit_cell_values([
+		{ "row_index": 0, "property": &"label", "new_value": "Gamma" },
+		{ "row_index": 1, "property": &"amount", "new_value": 9 },
+	])
+
+	assert_false(
+		GF_VARIANT_ACCESS.get_option_bool(report, "ok"),
+		"运行期 setter 拒绝必须让资源批量事务失败。"
+	)
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(report, "rolled_back"),
+		"已完整恢复资源属性时报告应明确 rolled_back。"
+	)
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "applied_count"), 0)
+	assert_eq(first.label, "Alpha", "前置成功写入必须回滚。")
+	assert_eq(second.amount_value, 2)
+	assert_signal_not_emitted(editor, "cell_value_committed")
 
 
 func test_resource_table_commit_visible_cell_values_resolves_indices_before_refresh() -> void:
@@ -167,6 +207,50 @@ func test_resource_table_commit_visible_cell_values_resolves_indices_before_refr
 	assert_eq(first.label, "drop-a", "第一个可见行应仍指向提交前的 first。")
 	assert_eq(second.amount, 9, "第二个可见行应仍指向提交前的 second。")
 	assert_eq(editor.get_visible_row_indices(), PackedInt32Array([1]), "刷新后过滤结果应反映最终资源值。")
+	assert_false(
+		report.has("transaction_command"),
+		"成功报告不得暴露可绕过表格副作用链的已执行命令。"
+	)
+
+
+func test_resource_table_failure_counts_unique_changes_and_exposes_only_recovery_handle() -> void:
+	var first: RejectingTableResource = RejectingTableResource.new()
+	first.amount_value = 1
+	first.rejected_values.append(1)
+	var second: RejectingTableResource = RejectingTableResource.new()
+	second.amount_value = 2
+	second.rejected_values.append(9)
+	var editor: GFResourceTableEditor = GFResourceTableEditor.new()
+	add_child_autofree(editor)
+	editor.load_resources([first, second], [{
+		"name": &"amount",
+		"type": TYPE_INT,
+	}])
+
+	var report: Dictionary = editor.commit_cell_values([
+		{ "row_index": 0, "property": &"amount", "new_value": 5 },
+		{ "row_index": 1, "property": &"amount", "new_value": 9 },
+	])
+
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"))
+	assert_true(
+		GF_VARIANT_ACCESS.get_option_bool(report, "recovery_required"),
+		"回滚 setter 拒绝必须留下显式恢复句柄。"
+	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_int(report, "failed_count"),
+		2,
+		"同一变更的补偿与终态问题只能计为一个失败变更。"
+	)
+	assert_gt(
+		GF_VARIANT_ACCESS.get_option_int(report, "issue_count"),
+		GF_VARIANT_ACCESS.get_option_int(report, "failed_count"),
+		"issue_count 应保留同一变更上的多个诊断问题。"
+	)
+	assert_true(
+		report.has("transaction_command"),
+		"仅不完整回滚应暴露可显式恢复的事务句柄。"
+	)
 
 
 func test_resource_table_supports_sort_duplicate_move_and_remove() -> void:
@@ -392,6 +476,37 @@ class TableResource:
 
 	@export var label: String = ""
 	@export var amount: int = 0
+
+
+class RejectingTableResource:
+	extends Resource
+
+	var amount_value: int = 0
+	var rejected_values: Array[int] = []
+
+
+	func _get_property_list() -> Array[Dictionary]:
+		return [{
+			"name": "amount",
+			"type": TYPE_INT,
+			"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
+		}]
+
+
+	func _get(property: StringName) -> Variant:
+		if property == &"amount":
+			return amount_value
+		return null
+
+
+	func _set(property: StringName, raw_value: Variant) -> bool:
+		if property != &"amount":
+			return false
+		var requested_value: int = GF_VARIANT_ACCESS.to_int(raw_value)
+		if rejected_values.has(requested_value):
+			return false
+		amount_value = requested_value
+		return true
 
 
 class CustomValueControl:

--- a/tests/gf_core/kernel/editor/test_gf_resource_table_editor.gd
+++ b/tests/gf_core/kernel/editor/test_gf_resource_table_editor.gd
@@ -1,3 +1,5 @@
+@tool
+
 ## 测试通用资源表格编辑器的列提取与单元格提交。
 extends GutTest
 
@@ -211,6 +213,162 @@ func test_resource_table_commit_visible_cell_values_resolves_indices_before_refr
 		report.has("transaction_command"),
 		"成功报告不得暴露可绕过表格副作用链的已执行命令。"
 	)
+
+
+func test_resource_table_empty_batches_are_successful_no_ops() -> void:
+	var editor: TrackingResourceTableEditor = TrackingResourceTableEditor.new()
+	add_child_autofree(editor)
+	watch_signals(editor)
+	var refresh_count_before: int = editor.refresh_call_count
+
+	var reports: Array[Dictionary] = [
+		editor.commit_cell_values([]),
+		editor.commit_visible_cell_values([]),
+	]
+
+	for report: Dictionary in reports:
+		assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "空批次应是成功恒等操作。")
+		assert_eq(
+			GF_VARIANT_ACCESS.get_option_string_name(report, "status"),
+			&"committed",
+			"空批次应报告 committed。"
+		)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "error"), OK)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "requested_count"), 0)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "applied_count"), 0)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "unchanged_count"), 0)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "failed_count"), 0)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "issue_count"), 0)
+		assert_eq(GF_VARIANT_ACCESS.as_array(report.get("committed", [])), [])
+		assert_eq(GF_VARIANT_ACCESS.as_array(report.get("errors", [])), [])
+		assert_false(report.has("transaction_command"), "空批次不得暴露事务命令。")
+	assert_eq(editor.refresh_call_count, refresh_count_before, "空批次不得刷新表格。")
+	assert_signal_not_emitted(editor, "cell_value_committed", "空批次不得发出单元格提交信号。")
+
+
+func test_resource_table_unchanged_commits_are_side_effect_free() -> void:
+	var resource: RejectingTableResource = RejectingTableResource.new()
+	resource.ratio_value = 3.0
+	var editor: TrackingResourceTableEditor = TrackingResourceTableEditor.new()
+	add_child_autofree(editor)
+	editor.load_resources([resource], [{
+		"name": &"ratio",
+		"type": TYPE_FLOAT,
+	}])
+	watch_signals(editor)
+	var refresh_count_before: int = editor.refresh_call_count
+
+	var raw_committed: bool = editor.commit_cell_value(0, &"ratio", 3)
+	var visible_committed: bool = editor.commit_visible_cell_value(0, &"ratio", 3)
+	var raw_batch: Dictionary = editor.commit_cell_values([
+		{ "row_index": 0, "property": &"ratio", "new_value": 3 },
+	])
+	var visible_batch: Dictionary = editor.commit_visible_cell_values([
+		{ "visible_row_index": 0, "property": &"ratio", "new_value": 3 },
+	])
+
+	assert_true(raw_committed, "原始行规范化后同值的提交应成功。")
+	assert_true(visible_committed, "可见行规范化后同值的提交应成功。")
+	for report: Dictionary in [raw_batch, visible_batch]:
+		assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "规范化后同值的批次应成功。")
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "requested_count"), 1)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "applied_count"), 0)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "unchanged_count"), 1)
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "failed_count"), 0)
+	assert_eq(resource.ratio_value, 3.0)
+	assert_eq(resource.ratio_setter_call_count, 0, "所有规范化后同值入口都不得调用 setter。")
+	assert_eq(editor.refresh_call_count, refresh_count_before, "同值提交不得刷新表格。")
+	assert_signal_not_emitted(editor, "cell_value_committed", "同值提交不得发出变更信号。")
+
+
+func test_resource_table_uses_transaction_status_for_equivalent_variant_values() -> void:
+	var resource: RejectingTableResource = RejectingTableResource.new()
+	resource.variant_value = &"same"
+	var editor: TrackingResourceTableEditor = TrackingResourceTableEditor.new()
+	add_child_autofree(editor)
+	editor.load_resources([resource], [{
+		"name": &"variant_value",
+		"type": TYPE_NIL,
+	}])
+	watch_signals(editor)
+	var refresh_count_before: int = editor.refresh_call_count
+
+	var report: Dictionary = editor.commit_cell_values([
+		{ "row_index": 0, "property": &"variant_value", "new_value": "same" },
+	])
+
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"))
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "applied_count"), 0)
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "unchanged_count"), 1)
+	assert_eq(typeof(resource.variant_value), TYPE_STRING_NAME)
+	assert_eq(str(resource.variant_value), "same")
+	assert_eq(resource.variant_setter_call_count, 0, "事务判定等价的 Variant 不得调用 setter。")
+	assert_eq(editor.refresh_call_count, refresh_count_before, "事务判定等价的 Variant 不得刷新表格。")
+	assert_signal_not_emitted(
+		editor,
+		"cell_value_committed",
+		"事务判定等价的 Variant 不得被适配层重新解释为实际变化。"
+	)
+
+
+func test_resource_table_no_op_commits_do_not_auto_save_resources() -> void:
+	var path: String = "user://gf_resource_table_no_op_auto_save.tres"
+	var resource: GFConfigTableColumn = GFConfigTableColumn.new()
+	resource.field_name = &"same"
+	resource.metadata = { "state": "persisted" }
+	assert_eq(ResourceSaver.save(resource, path), OK, "测试资源应能先保存到 user://。")
+
+	var loaded: GFConfigTableColumn = _as_config_table_column(
+		ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+	)
+	loaded.metadata = { "state": "dirty" }
+	var editor: TrackingResourceTableEditor = TrackingResourceTableEditor.new()
+	add_child_autofree(editor)
+	editor.auto_save_committed_resources = true
+	editor.load_resources([loaded], [{
+		"name": &"field_name",
+		"type": TYPE_STRING_NAME,
+	}])
+	watch_signals(editor)
+	var refresh_count_before: int = editor.refresh_call_count
+
+	var empty_reports: Array[Dictionary] = [
+		editor.commit_cell_values([]),
+		editor.commit_visible_cell_values([]),
+	]
+	var raw_committed: bool = editor.commit_cell_value(0, &"field_name", "same")
+	var visible_committed: bool = editor.commit_visible_cell_value(0, &"field_name", "same")
+	var unchanged_reports: Array[Dictionary] = [
+		editor.commit_cell_values([
+			{ "row_index": 0, "property": &"field_name", "new_value": "same" },
+		]),
+		editor.commit_visible_cell_values([
+			{ "visible_row_index": 0, "property": &"field_name", "new_value": "same" },
+		]),
+	]
+	var reloaded: GFConfigTableColumn = _as_config_table_column(
+		ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+	)
+	assert_eq(
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(path)),
+		OK,
+		"测试应能删除同值自动保存临时资源。"
+	)
+
+	for report: Dictionary in empty_reports:
+		assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "空批次应保持成功。")
+	for report: Dictionary in unchanged_reports:
+		assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "同值批次应保持成功。")
+		assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "unchanged_count"), 1)
+	assert_true(raw_committed)
+	assert_true(visible_committed)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string(reloaded.metadata, "state"),
+		"persisted",
+		"空批次和规范化后同值提交不得把内存脏状态自动保存到资源文件。"
+	)
+	assert_eq(editor.refresh_call_count, refresh_count_before, "no-op 提交不得刷新表格。")
+	assert_signal_not_emitted(editor, "cell_value_committed", "no-op 提交不得发出变更信号。")
 
 
 func test_resource_table_failure_counts_unique_changes_and_exposes_only_recovery_handle() -> void:
@@ -482,31 +640,70 @@ class RejectingTableResource:
 	extends Resource
 
 	var amount_value: int = 0
+	var ratio_value: float = 0.0
+	var variant_value: Variant = null
 	var rejected_values: Array[int] = []
+	var ratio_setter_call_count: int = 0
+	var variant_setter_call_count: int = 0
 
 
 	func _get_property_list() -> Array[Dictionary]:
-		return [{
-			"name": "amount",
-			"type": TYPE_INT,
-			"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
-		}]
+		return [
+			{
+				"name": "amount",
+				"type": TYPE_INT,
+				"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
+			},
+			{
+				"name": "ratio",
+				"type": TYPE_FLOAT,
+				"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
+			},
+			{
+				"name": "variant_value",
+				"type": TYPE_NIL,
+				"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORAGE,
+			},
+		]
 
 
 	func _get(property: StringName) -> Variant:
 		if property == &"amount":
 			return amount_value
+		if property == &"ratio":
+			return ratio_value
+		if property == &"variant_value":
+			return variant_value
 		return null
 
 
 	func _set(property: StringName, raw_value: Variant) -> bool:
-		if property != &"amount":
-			return false
-		var requested_value: int = GF_VARIANT_ACCESS.to_int(raw_value)
-		if rejected_values.has(requested_value):
-			return false
-		amount_value = requested_value
-		return true
+		if property == &"amount":
+			var requested_value: int = GF_VARIANT_ACCESS.to_int(raw_value)
+			if rejected_values.has(requested_value):
+				return false
+			amount_value = requested_value
+			return true
+		if property == &"ratio":
+			ratio_setter_call_count += 1
+			ratio_value = GF_VARIANT_ACCESS.to_float(raw_value)
+			return true
+		if property == &"variant_value":
+			variant_setter_call_count += 1
+			variant_value = raw_value
+			return true
+		return false
+
+
+class TrackingResourceTableEditor:
+	extends "res://addons/gf/kernel/editor/gf_resource_table_editor.gd"
+
+	var refresh_call_count: int = 0
+
+
+	func refresh() -> void:
+		refresh_call_count += 1
+		super.refresh()
 
 
 class CustomValueControl:

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -76,6 +76,7 @@
       "res://tests/gf_core/kernel/core/test_gf_weak_method_invocation.gd",
       "res://tests/gf_core/kernel/editor/test_gf_bake_dependency_report.gd",
       "res://tests/gf_core/kernel/editor/test_gf_editor_command_tools.gd",
+      "res://tests/gf_core/kernel/editor/test_gf_editor_property_batch_command.gd",
       "res://tests/gf_core/kernel/editor/test_gf_editor_operation_plan.gd",
       "res://tests/gf_core/kernel/editor/test_gf_generated_artifact_report.gd",
       "res://tests/gf_core/kernel/editor/test_gf_template_generation_manifest.gd",
@@ -254,6 +255,7 @@
       "res://tests/gf_core/standard/utilities/storage/editor/test_gf_storage_editor_package.gd"
     ],
     "gf.standard.display": [
+      "res://tests/gf_core/standard/utilities/display/test_gf_shader_interface_snapshot.gd",
       "res://tests/gf_core/standard/utilities/display/test_gf_shader_parameter_profile.gd",
       "res://tests/gf_core/standard/utilities/display/test_gf_viewport_utility.gd"
     ],

--- a/tests/gf_core/standard/utilities/display/test_gf_shader_interface_snapshot.gd
+++ b/tests/gf_core/standard/utilities/display/test_gf_shader_interface_snapshot.gd
@@ -1,0 +1,395 @@
+## 测试 GFShaderInterfaceSnapshot 的稳定捕获、持久化与参数契约校验。
+extends GutTest
+
+
+var _temporary_resource_paths: PackedStringArray = PackedStringArray()
+
+
+func after_each() -> void:
+	for resource_path: String in _temporary_resource_paths:
+		var absolute_path: String = ProjectSettings.globalize_path(resource_path)
+		if FileAccess.file_exists(absolute_path):
+			var _remove_result: Error = DirAccess.remove_absolute(absolute_path)
+	_temporary_resource_paths.clear()
+
+
+func test_capture_normalizes_uniform_schema_and_stable_order() -> void:
+	var shader: Shader = _make_contract_shader()
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.capture(shader)
+
+	assert_not_null(snapshot)
+	assert_eq(snapshot.get_schema_version(), GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION)
+	assert_eq(snapshot.get_shader_mode(), Shader.MODE_CANVAS_ITEM)
+	assert_eq(
+		snapshot.get_uniform_names(),
+		[&"albedo_texture", &"amount", &"direction", &"z_tint"],
+		"接口快照必须脱离 shader 声明顺序，按参数名稳定排序。"
+	)
+
+	var amount_uniform: Dictionary = snapshot.get_uniform(&"amount")
+	for field_name: String in ["name", "type", "class_name", "hint", "hint_string", "usage"]:
+		assert_has(amount_uniform, field_name, "规范化 uniform 必须包含字段：%s。" % field_name)
+	assert_eq(GFVariantData.get_option_string_name(amount_uniform, "name"), &"amount")
+	assert_eq(GFVariantData.get_option_int(amount_uniform, "type"), TYPE_FLOAT)
+	assert_eq(GFVariantData.get_option_int(amount_uniform, "hint"), PROPERTY_HINT_RANGE)
+
+
+func test_snapshot_getters_return_deep_copies() -> void:
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.capture(
+		_make_contract_shader()
+	)
+	var uniforms: Array[Dictionary] = snapshot.get_uniforms()
+	var first_uniform: Dictionary = uniforms[0]
+	first_uniform["name"] = &"mutated"
+	first_uniform["hint_string"] = "mutated"
+	uniforms[0] = first_uniform
+
+	var amount_uniform: Dictionary = snapshot.get_uniform(&"amount")
+	amount_uniform["type"] = TYPE_STRING
+
+	assert_eq(
+		snapshot.get_uniform_names(),
+		[&"albedo_texture", &"amount", &"direction", &"z_tint"],
+		"调用方修改返回值不得污染已捕获的契约。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(snapshot.get_uniform(&"amount"), "type"),
+		TYPE_FLOAT
+	)
+
+
+func test_snapshot_resource_roundtrip_preserves_sealed_storage() -> void:
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.capture(
+		_make_contract_shader()
+	)
+	var reversed_uniforms: Array[Dictionary] = snapshot.get_uniforms()
+	reversed_uniforms.reverse()
+	snapshot.set(&"_uniforms", reversed_uniforms)
+	assert_eq(
+		snapshot.get_uniform_names(),
+		[&"albedo_texture", &"amount", &"direction", &"z_tint"],
+		"Storage setter 必须在保存前恢复规范顺序。"
+	)
+	var resource_path: String = "user://gf_shader_interface_snapshot_%d.tres" % Time.get_ticks_usec()
+	var _path_appended: bool = _temporary_resource_paths.append(resource_path)
+
+	assert_eq(ResourceSaver.save(snapshot, resource_path), OK)
+	var loaded_value: Variant = ResourceLoader.load(
+		resource_path,
+		"",
+		ResourceLoader.CACHE_MODE_IGNORE
+	)
+	var loaded_snapshot: GFShaderInterfaceSnapshot = _variant_to_snapshot(loaded_value)
+
+	assert_not_null(loaded_snapshot, "@export_storage 字段必须支持 Resource 持久化。")
+	assert_eq(loaded_snapshot.to_dict(), snapshot.to_dict())
+	assert_true(loaded_snapshot.validate_definition().is_ok())
+
+
+func test_blank_snapshot_resource_is_not_a_valid_empty_spatial_contract() -> void:
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.new()
+	var resource_path: String = (
+		"user://gf_shader_interface_blank_%d.tres" % Time.get_ticks_usec()
+	)
+	var _path_appended: bool = _temporary_resource_paths.append(resource_path)
+
+	var report: GFValidationReport = snapshot.validate_definition()
+	assert_false(report.is_ok(), "未捕获的空 Resource 不得伪装成合法接口。")
+	assert_eq(
+		GFVariantData.get_option_int(
+			report.get_issue_counts_by_kind(),
+			"shader_interface_snapshot_missing"
+		),
+		1
+	)
+
+	assert_eq(ResourceSaver.save(snapshot, resource_path), OK)
+	var loaded_value: Variant = ResourceLoader.load(
+		resource_path,
+		"",
+		ResourceLoader.CACHE_MODE_IGNORE
+	)
+	var loaded_snapshot: GFShaderInterfaceSnapshot = _variant_to_snapshot(
+		loaded_value
+	)
+
+	assert_not_null(loaded_snapshot)
+	assert_false(
+		loaded_snapshot.validate_definition().is_ok(),
+		"字段缺失的持久化 Resource 重载后仍必须失败关闭。"
+	)
+
+
+func test_definition_validation_rejects_future_schema_and_invalid_uniforms() -> void:
+	var future_snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.from_dict({
+		"schema_version": GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION + 1,
+		"shader_mode": Shader.MODE_CANVAS_ITEM,
+		"uniforms": [_make_uniform_entry(&"amount", TYPE_FLOAT)],
+	})
+	var future_report: GFValidationReport = future_snapshot.validate_definition()
+
+	assert_false(future_report.is_ok(), "未来 schema 不得被当前实现静默接受。")
+	assert_eq(
+		GFVariantData.get_option_int(
+			future_report.get_issue_counts_by_kind(),
+			"shader_interface_schema_version_unsupported"
+		),
+		1
+	)
+	assert_false(
+		future_snapshot.accepts_parameter_value(&"amount", 0.5),
+		"不支持的快照 schema 不得通过单参数快捷校验。"
+	)
+
+	var invalid_snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.from_dict({
+		"schema_version": GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION,
+		"shader_mode": Shader.MODE_CANVAS_ITEM,
+		"uniforms": [
+			_make_uniform_entry(&"amount", TYPE_FLOAT),
+			_make_uniform_entry(&"amount", TYPE_FLOAT),
+			_make_uniform_entry(&"", TYPE_NIL),
+		],
+	})
+	var invalid_report: GFValidationReport = invalid_snapshot.validate_definition()
+	var issue_counts: Dictionary = invalid_report.get_issue_counts_by_kind()
+
+	assert_false(invalid_report.is_ok())
+	assert_eq(
+		GFVariantData.get_option_int(issue_counts, "shader_uniform_duplicate"),
+		1,
+		"重复 uniform 必须使契约定义失败。"
+	)
+	assert_gt(
+		GFVariantData.get_option_int(issue_counts, "shader_uniform_invalid"),
+		0,
+		"空名称和 TYPE_NIL 必须作为无效 uniform 报告。"
+	)
+
+
+func test_from_dict_rejects_malformed_schema_without_coercion() -> void:
+	var malformed_entries: Array[Dictionary] = []
+	for field_name: String in [
+		"name",
+		"type",
+		"class_name",
+		"hint",
+		"hint_string",
+		"usage",
+	]:
+		var malformed_entry: Dictionary = _make_uniform_entry(&"amount", TYPE_FLOAT)
+		if field_name in ["name", "class_name", "hint_string"]:
+			malformed_entry[field_name] = 123
+		else:
+			malformed_entry[field_name] = "123"
+		malformed_entries.append(malformed_entry)
+
+	var malformed_snapshot: GFShaderInterfaceSnapshot = (
+		GFShaderInterfaceSnapshot.from_dict({
+			"schema_version": "1",
+			"shader_mode": "canvas_item",
+			"uniforms": malformed_entries,
+		})
+	)
+	var malformed_counts: Dictionary = (
+		malformed_snapshot.validate_definition().get_issue_counts_by_kind()
+	)
+
+	assert_eq(
+		GFVariantData.get_option_int(
+			malformed_counts,
+			"shader_interface_schema_version_unsupported"
+		),
+		1,
+		"schema_version 不得从字符串强转。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(
+			malformed_counts,
+			"shader_interface_mode_invalid"
+		),
+		1,
+		"shader_mode 不得从字符串强转。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(malformed_counts, "shader_uniform_invalid"),
+		malformed_entries.size(),
+		"uniform 字段必须保持显式类型，错误字段不得被默认值掩盖。"
+	)
+
+	var missing_uniforms_snapshot: GFShaderInterfaceSnapshot = (
+		GFShaderInterfaceSnapshot.from_dict({
+			"schema_version": GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION,
+			"shader_mode": Shader.MODE_CANVAS_ITEM,
+		})
+	)
+	var missing_uniforms_counts: Dictionary = (
+		missing_uniforms_snapshot.validate_definition().get_issue_counts_by_kind()
+	)
+	assert_eq(
+		GFVariantData.get_option_int(
+			missing_uniforms_counts,
+			"shader_uniform_invalid"
+		),
+		1,
+		"缺失 uniforms 数组必须失败关闭。"
+	)
+
+	var wrong_uniforms_snapshot: GFShaderInterfaceSnapshot = (
+		GFShaderInterfaceSnapshot.from_dict({
+			"schema_version": GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION,
+			"shader_mode": Shader.MODE_CANVAS_ITEM,
+			"uniforms": {},
+		})
+	)
+	assert_eq(
+		GFVariantData.get_option_int(
+			wrong_uniforms_snapshot.validate_definition().get_issue_counts_by_kind(),
+			"shader_uniform_invalid"
+		),
+		1,
+		"非数组 uniforms 也必须失败关闭。"
+	)
+
+
+func test_parameter_validation_is_partial_but_strict_by_default() -> void:
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.capture(
+		_make_contract_shader()
+	)
+	var partial_report: GFValidationReport = snapshot.validate_parameters({
+		&"amount": 0.5,
+	})
+
+	assert_true(partial_report.is_ok(), "Profile 默认是部分覆盖，不应要求声明全部 uniform。")
+
+	var invalid_report: GFValidationReport = snapshot.validate_parameters({
+		&"amount": 1,
+		&"unknown_parameter": 1.0,
+	})
+	var invalid_counts: Dictionary = invalid_report.get_issue_counts_by_kind()
+
+	assert_false(invalid_report.is_ok())
+	assert_eq(
+		GFVariantData.get_option_int(invalid_counts, "shader_parameter_type_mismatch"),
+		1,
+		"float uniform 不得隐式接受 int。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(invalid_counts, "shader_parameter_extra"),
+		1,
+		"未知参数必须默认作为契约错误。"
+	)
+
+	var complete_report: GFValidationReport = snapshot.validate_parameters({
+		&"amount": 0.5,
+	}, {
+		"missing_severity": "error",
+	})
+	assert_false(complete_report.is_ok(), "完整契约模式必须显式报告缺失参数。")
+	assert_gt(
+		GFVariantData.get_option_int(
+			complete_report.get_issue_counts_by_kind(),
+			"shader_parameter_missing"
+		),
+		0
+	)
+
+
+func test_sampler_contract_accepts_null_and_expected_resource_class_only() -> void:
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.capture(
+		_make_contract_shader()
+	)
+
+	var null_report: GFValidationReport = snapshot.validate_parameters({
+		&"albedo_texture": null,
+	})
+	var texture_report: GFValidationReport = snapshot.validate_parameters({
+		&"albedo_texture": ImageTexture.new(),
+	})
+	var wrong_class_report: GFValidationReport = snapshot.validate_parameters({
+		&"albedo_texture": Curve.new(),
+	})
+
+	assert_true(null_report.is_ok(), "sampler 参数必须允许用 null 清除纹理。")
+	assert_true(texture_report.is_ok(), "sampler 参数必须接受声明的 Texture2D 子类。")
+	assert_false(wrong_class_report.is_ok())
+	assert_eq(
+		GFVariantData.get_option_int(
+			wrong_class_report.get_issue_counts_by_kind(),
+			"shader_parameter_class_mismatch"
+		),
+		1,
+		"TYPE_OBJECT 外层类型相同仍必须校验 shader 声明的资源类型。"
+	)
+
+
+func test_compare_reports_mode_presence_signature_and_usage_drift() -> void:
+	var expected: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.from_dict({
+		"schema_version": GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION,
+		"shader_mode": Shader.MODE_CANVAS_ITEM,
+		"uniforms": [
+			_make_uniform_entry(&"amount", TYPE_FLOAT),
+			_make_uniform_entry(&"only_expected", TYPE_FLOAT),
+			_make_uniform_entry(&"usage_only", TYPE_FLOAT),
+		],
+	})
+	var changed_usage_entry: Dictionary = _make_uniform_entry(&"usage_only", TYPE_FLOAT)
+	changed_usage_entry["usage"] = PROPERTY_USAGE_DEFAULT + 1
+	var actual: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.from_dict({
+		"schema_version": GFShaderInterfaceSnapshot.CURRENT_SCHEMA_VERSION,
+		"shader_mode": Shader.MODE_SPATIAL,
+		"uniforms": [
+			_make_uniform_entry(&"amount", TYPE_VECTOR2),
+			_make_uniform_entry(&"only_actual", TYPE_FLOAT),
+			changed_usage_entry,
+		],
+	})
+
+	var report: GFValidationReport = expected.compare_with(actual)
+	var issue_counts: Dictionary = report.get_issue_counts_by_kind()
+
+	assert_false(report.is_ok(), "mode、缺失和类型漂移必须使契约失败。")
+	assert_false(report.is_healthy(), "新增参数和 usage 漂移默认也应保留 warning。")
+	assert_eq(
+		GFVariantData.get_option_int(issue_counts, "shader_interface_mode_mismatch"),
+		1
+	)
+	assert_eq(GFVariantData.get_option_int(issue_counts, "shader_uniform_missing"), 1)
+	assert_eq(GFVariantData.get_option_int(issue_counts, "shader_uniform_extra"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(issue_counts, "shader_uniform_signature_mismatch"),
+		2,
+		"类型签名与 usage 漂移必须分别形成稳定问题。"
+	)
+
+
+func _make_contract_shader() -> Shader:
+	var shader: Shader = Shader.new()
+	shader.code = "\n".join(PackedStringArray([
+		"shader_type canvas_item;",
+		"uniform vec4 z_tint : source_color = vec4(1.0);",
+		"uniform vec2 direction = vec2(1.0, 0.0);",
+		"uniform float amount : hint_range(0.0, 1.0) = 0.0;",
+		"uniform sampler2D albedo_texture;",
+		"void fragment() {",
+		"	COLOR = z_tint * amount;",
+		"}",
+	]))
+	return shader
+
+
+func _make_uniform_entry(parameter_name: StringName, value_type: int) -> Dictionary:
+	return {
+		"name": parameter_name,
+		"type": value_type,
+		"class_name": &"",
+		"hint": PROPERTY_HINT_NONE,
+		"hint_string": "",
+		"usage": PROPERTY_USAGE_DEFAULT,
+	}
+
+
+func _variant_to_snapshot(value: Variant) -> GFShaderInterfaceSnapshot:
+	if value is GFShaderInterfaceSnapshot:
+		var snapshot: GFShaderInterfaceSnapshot = value
+		return snapshot
+	return null

--- a/tests/gf_core/standard/utilities/display/test_gf_shader_interface_snapshot.gd.uid
+++ b/tests/gf_core/standard/utilities/display/test_gf_shader_interface_snapshot.gd.uid
@@ -1,0 +1,1 @@
+uid://rtgijx3hn4t0

--- a/tests/gf_core/standard/utilities/display/test_gf_shader_parameter_profile.gd
+++ b/tests/gf_core/standard/utilities/display/test_gf_shader_parameter_profile.gd
@@ -81,6 +81,33 @@ func test_profile_emits_changed_when_public_methods_mutate_parameters() -> void:
 	assert_eq(GFVariantData.get_option_int(counter, "count"), 2)
 
 
+func test_profile_validates_against_shader_interface_snapshot() -> void:
+	var material: ShaderMaterial = _make_test_shader_material()
+	var snapshot: GFShaderInterfaceSnapshot = GFShaderInterfaceSnapshot.capture(material.shader)
+	var profile: GFShaderParameterProfile = GFShaderParameterProfile.new()
+	var _set_valid_result: GFShaderParameterProfile = profile.set_parameter(
+		&"storm_pressure",
+		0.5
+	)
+
+	assert_true(profile.validate_against(snapshot).is_ok())
+
+	var _set_invalid_result: GFShaderParameterProfile = profile.set_parameter(
+		&"storm_pressure",
+		Vector2.ONE
+	)
+	var report: GFValidationReport = profile.validate_against(snapshot)
+
+	assert_false(report.is_ok(), "Profile 必须能在写入材质前验证 shader 参数类型。")
+	assert_eq(
+		GFVariantData.get_option_int(
+			report.get_issue_counts_by_kind(),
+			"shader_parameter_type_mismatch"
+		),
+		1
+	)
+
+
 func test_utility_applies_profile_to_shader_material() -> void:
 	var utility: GFShaderParameterUtility = GFShaderParameterUtility.new()
 	var material: ShaderMaterial = _make_test_shader_material()
@@ -108,6 +135,35 @@ func test_utility_skips_missing_declared_parameters_by_default() -> void:
 
 	assert_eq(applied_count, 1)
 	assert_almost_eq(GFVariantData.to_float(material.get_shader_parameter(&"storm_pressure")), 0.5, 0.001)
+
+
+func test_utility_skips_shader_parameter_type_mismatches_by_default() -> void:
+	var utility: GFShaderParameterUtility = GFShaderParameterUtility.new()
+	var material: ShaderMaterial = _make_test_shader_material()
+
+	var applied_count: int = utility.apply_parameters(material, {
+		&"storm_pressure": Vector2.ONE,
+	}, {
+		"warn_on_type_mismatch": false,
+	})
+	var report: GFValidationReport = utility.validate_parameters(material, {
+		&"storm_pressure": Vector2.ONE,
+	})
+
+	assert_eq(applied_count, 0, "默认应用流程不得把错型值交给 ShaderMaterial。")
+	assert_almost_eq(
+		GFVariantData.to_float(material.get_shader_parameter(&"storm_pressure")),
+		0.0,
+		0.001
+	)
+	assert_false(report.is_ok())
+	assert_eq(
+		GFVariantData.get_option_int(
+			report.get_issue_counts_by_kind(),
+			"shader_parameter_type_mismatch"
+		),
+		1
+	)
 
 
 func test_utility_duplicates_target_material_when_requested() -> void:

--- a/tests/gf_core/standard/utilities/settings/test_gf_settings_utility.gd
+++ b/tests/gf_core/standard/utilities/settings/test_gf_settings_utility.gd
@@ -5,6 +5,7 @@ extends GutTest
 # --- 私有变量 ---
 
 var _settings: GFSettingsUtility
+var _fallback_file_names: PackedStringArray = PackedStringArray()
 
 
 # --- Godot 生命周期方法 ---
@@ -20,6 +21,11 @@ func after_each() -> void:
 	if _settings != null:
 		_settings.dispose()
 		_settings = null
+	for file_name: String in _fallback_file_names:
+		var path: String = "user://" + file_name
+		if FileAccess.file_exists(path):
+			var _remove_error: Error = DirAccess.remove_absolute(path)
+	_fallback_file_names.clear()
 
 
 # --- 测试方法 ---
@@ -174,11 +180,538 @@ func test_load_settings_uses_replace_semantics() -> void:
 	settings.set_value(&"audio/music", 0.3, false)
 	settings.loaded_data = {"audio/master": 0.5}
 
-	var _loaded: Dictionary = settings.load_settings("profile.json")
+	var load_result: GFSettingsLoadResult = settings.load_settings("profile.json")
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
 
+	assert_true(load_result.is_successful(), "合法持久化数据应进入成功终态。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_LOADED, "成功读取应报告 loaded。")
+	assert_true(load_result.was_applied(), "成功读取应应用持久化设置。")
+	assert_false(load_result.was_recovered(), "普通成功读取不应标记为恢复。")
+	assert_not_null(storage_result, "Settings 结果应保留底层 Storage 结果。")
+	assert_true(storage_result.ok, "底层读取应保持成功证据。")
 	assert_eq(_setting_float(settings, &"audio/master"), 0.5, "load 应应用持久化值。")
 	assert_eq(_setting_float(settings, &"audio/music"), 0.8, "load 应重置持久化数据中缺失的已定义键。")
 	settings.dispose()
+
+
+func test_load_settings_treats_successful_empty_payload_as_loaded_replace() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		GFStorageReadResult.new().configure_success({})
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.25, false)
+	settings.set_value(&"legacy/flag", true, false)
+	settings.stage_value(&"audio/master", 0.75)
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("empty.json")
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
+
+	assert_true(load_result.is_successful(), "合法空载荷仍应是成功读取。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_LOADED, "合法空载荷不得被误判为 missing。")
+	assert_true(load_result.was_applied(), "合法空载荷应执行 replace 语义。")
+	assert_false(load_result.was_recovered(), "合法空载荷不应经过恢复策略。")
+	assert_not_null(storage_result, "结果应保留合法空载荷的底层读取证据。")
+	assert_true(storage_result.ok, "底层空载荷读取应保持 ok。")
+	assert_true(storage_result.payload.is_empty(), "底层载荷应保持合法空字典。")
+	assert_eq(_setting_float(settings, &"audio/master"), 1.0, "空载荷应把已定义键恢复默认值。")
+	assert_false(settings.has_setting(&"legacy/flag"), "空载荷应移除未定义的旧键。")
+	assert_false(settings.has_staged_values(), "成功 replace 后不应保留旧 staged 值。")
+	assert_eq(settings.write_count, 0, "读取合法空载荷不应产生保存副作用。")
+	settings.dispose()
+
+
+func test_load_settings_strict_missing_preserves_current_and_staged_state() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		_make_storage_failure(
+			GFStorageReadResult.FailureKind.NOT_FOUND,
+			ERR_FILE_NOT_FOUND,
+			"Settings file not found."
+		)
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.25, false)
+	settings.set_value(&"runtime/marker", "current", false)
+	settings.stage_value(&"audio/master", 0.75)
+	var values_before: Dictionary = settings.to_dict(false)
+	var staged_before: Dictionary = settings.get_staged_values()
+	watch_signals(settings)
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("missing.json")
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
+
+	assert_false(load_result.is_successful(), "默认策略下缺失文件应严格失败。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_MISSING, "缺失文件应保留稳定状态。")
+	assert_false(load_result.was_applied(), "严格失败不得应用空载荷。")
+	assert_false(load_result.was_recovered(), "未提供策略时不得自动恢复。")
+	assert_not_null(storage_result, "失败结果应保留底层 Storage 证据。")
+	assert_eq(storage_result.failure_kind, GFStorageReadResult.FailureKind.NOT_FOUND)
+	assert_eq(settings.to_dict(false), values_before, "缺失文件失败不得修改当前设置。")
+	assert_eq(settings.get_staged_values(), staged_before, "缺失文件失败不得清除 staged 设置。")
+	assert_eq(settings.write_count, 0, "缺失文件失败不得创建或覆盖文件。")
+	assert_signal_emitted(settings, "settings_load_completed", "失败读取也应发出类型化终态信号。")
+	assert_signal_not_emitted(settings, "setting_changed", "严格失败不得发出设置变化。")
+	settings.dispose()
+
+
+func test_load_settings_cancels_stale_batch_save_across_sources() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		_make_storage_failure(
+			GFStorageReadResult.FailureKind.NOT_FOUND,
+			ERR_FILE_NOT_FOUND,
+			"Settings file not found."
+		)
+	)
+	settings.storage_file_name = "missing.json"
+	settings.auto_save_on_change = true
+	settings.save_debounce_seconds = 0.0
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.begin_batch()
+	settings.set_value(&"audio/master", 0.25)
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("other_missing.json")
+	settings.end_batch()
+
+	assert_false(load_result.is_successful(), "严格缺失仍应失败。")
+	assert_eq(settings.write_count, 0, "加载屏障应取消其他源尚未形成的批处理自动保存。")
+	settings.dispose()
+
+
+func test_load_settings_cancels_queued_save_before_replacing_from_other_source() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		GFStorageReadResult.new().configure_success({"audio/master": 0.8})
+	)
+	settings.storage_file_name = "source_a.json"
+	settings.auto_save_on_change = true
+	settings.save_debounce_seconds = 10.0
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.25)
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("source_b.json")
+	settings.tick(20.0)
+
+	assert_true(load_result.is_successful(), "第二来源的合法设置应加载成功。")
+	assert_eq(_setting_float(settings, &"audio/master"), 0.8)
+	assert_eq(
+		settings.write_count,
+		0,
+		"加载后的值不得被陈旧队列重新序列化并写回先前来源。"
+	)
+	settings.dispose()
+
+
+func test_load_settings_strict_corrupt_preserves_current_and_staged_state() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		_make_storage_failure(
+			GFStorageReadResult.FailureKind.CORRUPT,
+			ERR_FILE_CORRUPT,
+			"Settings payload is corrupt."
+		)
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.4, false)
+	settings.set_value(&"runtime/marker", "current", false)
+	settings.stage_value(&"audio/master", 0.8)
+	var values_before: Dictionary = settings.to_dict(false)
+	var staged_before: Dictionary = settings.get_staged_values()
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("corrupt.json")
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
+
+	assert_false(load_result.is_successful(), "默认策略下损坏文件应严格失败。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_CORRUPT, "损坏文件应保留稳定状态。")
+	assert_false(load_result.was_applied(), "损坏文件不得被降级为空载荷应用。")
+	assert_false(load_result.was_recovered(), "未提供策略时不得自动恢复损坏文件。")
+	assert_not_null(storage_result, "损坏结果应保留底层 Storage 证据。")
+	assert_eq(storage_result.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_eq(settings.to_dict(false), values_before, "损坏文件失败不得修改当前设置。")
+	assert_eq(settings.get_staged_values(), staged_before, "损坏文件失败不得清除 staged 设置。")
+	assert_eq(settings.write_count, 0, "损坏文件失败不得覆盖原文件。")
+	settings.dispose()
+
+
+func test_load_settings_can_explicitly_recover_missing_with_current_state() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		_make_storage_failure(
+			GFStorageReadResult.FailureKind.NOT_FOUND,
+			ERR_FILE_NOT_FOUND,
+			"Settings file not found."
+		)
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.35, false)
+	settings.set_value(&"runtime/marker", "current", false)
+	settings.stage_value(&"audio/master", 0.7)
+	var values_before: Dictionary = settings.to_dict(false)
+	var staged_before: Dictionary = settings.get_staged_values()
+	var policy: GFSettingsRecoveryPolicy = GFSettingsRecoveryPolicy.new()
+	policy.missing_file_action = GFSettingsRecoveryPolicy.ACTION_USE_CURRENT_STATE
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("missing.json", policy)
+
+	assert_true(load_result.is_successful(), "显式接受当前状态应形成成功恢复终态。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_RECOVERED)
+	assert_false(load_result.was_applied(), "保留当前状态不应应用替代载荷。")
+	assert_true(load_result.was_recovered(), "结果应记录恢复动作。")
+	assert_eq(
+		load_result.get_recovery_action(),
+		GFSettingsRecoveryPolicy.ACTION_USE_CURRENT_STATE
+	)
+	assert_eq(settings.to_dict(false), values_before, "保留当前状态不得修改有效设置。")
+	assert_eq(settings.get_staged_values(), staged_before, "保留当前状态不得清除 staged 设置。")
+	assert_eq(settings.write_count, 0, "显式接受当前状态仍不得自动保存。")
+	settings.dispose()
+
+
+func test_load_settings_can_explicitly_recover_corrupt_with_defaults_without_saving() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		_make_storage_failure(
+			GFStorageReadResult.FailureKind.CORRUPT,
+			ERR_FILE_CORRUPT,
+			"Settings payload is corrupt."
+		)
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.2, false)
+	settings.set_value(&"legacy/flag", true, false)
+	settings.stage_value(&"audio/master", 0.8)
+	var policy: GFSettingsRecoveryPolicy = GFSettingsRecoveryPolicy.new()
+	policy.corrupt_file_action = GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("corrupt.json", policy)
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
+
+	assert_true(load_result.is_successful(), "显式默认值恢复应形成成功终态。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_RECOVERED)
+	assert_true(load_result.was_applied(), "默认值恢复应应用空 replace 语义。")
+	assert_true(load_result.was_recovered(), "结果应记录恢复动作。")
+	assert_eq(
+		load_result.get_recovery_action(),
+		GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS
+	)
+	assert_not_null(storage_result, "恢复结果仍应保留原始损坏证据。")
+	assert_eq(storage_result.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_eq(_setting_float(settings, &"audio/master"), 1.0, "恢复应重置已定义设置。")
+	assert_false(settings.has_setting(&"legacy/flag"), "恢复应移除未定义旧设置。")
+	assert_false(settings.has_staged_values(), "默认值恢复应清除旧 staged 设置。")
+	assert_eq(settings.write_count, 0, "默认值恢复不得隐式覆盖损坏文件。")
+	settings.dispose()
+
+
+func test_settings_recovery_policy_defaults_to_strict_and_rejects_unknown_actions() -> void:
+	var policy: GFSettingsRecoveryPolicy = GFSettingsRecoveryPolicy.new()
+
+	assert_eq(policy.missing_file_action, GFSettingsRecoveryPolicy.ACTION_FAIL)
+	assert_eq(policy.corrupt_file_action, GFSettingsRecoveryPolicy.ACTION_FAIL)
+	assert_true(
+		GFVariantData.get_option_bool(policy.validate_policy(), "ok", false),
+		"默认策略应是合法的严格策略。"
+	)
+
+	policy.corrupt_file_action = &"overwrite_source"
+	var invalid_report: Dictionary = policy.validate_policy()
+
+	assert_false(
+		GFVariantData.get_option_bool(invalid_report, "ok", true),
+		"未知动作不得被恢复策略接受。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(invalid_report, "error_count"),
+		1,
+		"无效动作应形成结构化校验问题。"
+	)
+
+
+func test_load_settings_rejects_invalid_recovery_policy_before_storage_read() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		GFStorageReadResult.new().configure_success({"audio/master": 0.1})
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.45, false)
+	settings.stage_value(&"audio/master", 0.9)
+	var values_before: Dictionary = settings.to_dict(false)
+	var staged_before: Dictionary = settings.get_staged_values()
+	var policy: GFSettingsRecoveryPolicy = GFSettingsRecoveryPolicy.new()
+	policy.corrupt_file_action = &"overwrite_source"
+	watch_signals(settings)
+
+	var load_result: GFSettingsLoadResult = settings.load_settings(
+		"profile.json",
+		policy
+	)
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
+
+	assert_false(load_result.is_successful(), "无效恢复策略必须形成失败终态。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_INVALID_REQUEST)
+	assert_eq(load_result.get_error_code(), ERR_INVALID_PARAMETER)
+	assert_not_null(storage_result)
+	assert_eq(
+		storage_result.failure_kind,
+		GFStorageReadResult.FailureKind.INVALID_REQUEST
+	)
+	assert_eq(settings.read_count, 0, "无效策略不得触发底层读取。")
+	assert_eq(settings.to_dict(false), values_before)
+	assert_eq(settings.get_staged_values(), staged_before)
+	assert_signal_emitted(settings, "settings_load_completed")
+	settings.dispose()
+
+
+func test_settings_load_result_rejects_status_storage_mismatch() -> void:
+	var missing_storage: GFStorageReadResult = _make_storage_failure(
+		GFStorageReadResult.FailureKind.NOT_FOUND,
+		ERR_FILE_NOT_FOUND,
+		"Settings file not found."
+	)
+	var load_result: GFSettingsLoadResult = GFSettingsLoadResult.new()
+
+	var configured: bool = load_result.configure_for_framework(
+		false,
+		GFSettingsLoadResult.STATUS_CORRUPT,
+		"profile.json",
+		false,
+		false,
+		&"",
+		ERR_FILE_CORRUPT,
+		"Settings payload is corrupt.",
+		missing_storage
+	)
+
+	assert_false(configured, "终态 status 必须与底层 Storage 失败分类一致。")
+	assert_push_error("[GFSettingsLoadResult] 已拒绝不一致的加载终态配置。")
+
+
+func test_load_settings_never_recovers_non_recoverable_failure_kinds() -> void:
+	var failure_kinds: Array[GFStorageReadResult.FailureKind] = [
+		GFStorageReadResult.FailureKind.INVALID_REQUEST,
+		GFStorageReadResult.FailureKind.IO_FAILED,
+		GFStorageReadResult.FailureKind.FUTURE_VERSION,
+		GFStorageReadResult.FailureKind.MIGRATION_FAILED,
+		GFStorageReadResult.FailureKind.UNAVAILABLE,
+	]
+	var error_codes: Array[Error] = [
+		ERR_INVALID_PARAMETER,
+		ERR_FILE_CANT_OPEN,
+		ERR_FILE_UNRECOGNIZED,
+		ERR_INVALID_DATA,
+		ERR_UNAVAILABLE,
+	]
+	var expected_statuses: Array[StringName] = [
+		GFSettingsLoadResult.STATUS_INVALID_REQUEST,
+		GFSettingsLoadResult.STATUS_STORAGE_FAILED,
+		GFSettingsLoadResult.STATUS_FUTURE_SCHEMA,
+		GFSettingsLoadResult.STATUS_MIGRATION_FAILED,
+		GFSettingsLoadResult.STATUS_STORAGE_FAILED,
+	]
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		_make_storage_failure(failure_kinds[0], error_codes[0], "Load failed.")
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.45, false)
+	settings.stage_value(&"audio/master", 0.9)
+	var values_before: Dictionary = settings.to_dict(false)
+	var staged_before: Dictionary = settings.get_staged_values()
+	var policy: GFSettingsRecoveryPolicy = GFSettingsRecoveryPolicy.new()
+	policy.missing_file_action = GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS
+	policy.corrupt_file_action = GFSettingsRecoveryPolicy.ACTION_RESET_TO_DEFAULTS
+
+	for index: int in range(failure_kinds.size()):
+		settings.read_result = _make_storage_failure(
+			failure_kinds[index],
+			error_codes[index],
+			"Load failed."
+		)
+		var load_result: GFSettingsLoadResult = settings.load_settings(
+			"unrecoverable_%d.json" % index,
+			policy
+		)
+
+		assert_false(load_result.is_successful(), "不可恢复失败不能被 missing/corrupt 策略接受。")
+		assert_eq(load_result.get_status(), expected_statuses[index])
+		assert_false(load_result.was_applied(), "不可恢复失败不得应用默认值。")
+		assert_false(load_result.was_recovered(), "不可恢复失败不得标记为 recovered。")
+		assert_eq(settings.to_dict(false), values_before, "不可恢复失败不得修改有效设置。")
+		assert_eq(settings.get_staged_values(), staged_before, "不可恢复失败不得清除 staged 设置。")
+
+	assert_eq(settings.write_count, 0, "不可恢复失败不得产生保存副作用。")
+	settings.dispose()
+
+
+func test_load_settings_rejects_unaccepted_integrity_even_when_storage_read_is_ok() -> void:
+	var read_result: GFStorageReadResult = GFStorageReadResult.new().configure_success(
+		{"audio/master": 0.1},
+		{},
+		GFStorageReadResult.IntegrityStatus.INVALID
+	)
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(read_result)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	settings.set_value(&"audio/master", 0.55, false)
+	settings.stage_value(&"audio/master", 0.9)
+	var values_before: Dictionary = settings.to_dict(false)
+	var staged_before: Dictionary = settings.get_staged_values()
+
+	var load_result: GFSettingsLoadResult = settings.load_settings("invalid_integrity.json")
+	var stored_read_result: GFStorageReadResult = load_result.get_storage_result()
+
+	assert_false(load_result.is_successful(), "未接受的完整性状态不得应用。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_CORRUPT)
+	assert_false(load_result.was_applied(), "完整性失败不得应用底层 payload。")
+	assert_not_null(stored_read_result, "结果应保留底层完整性证据。")
+	assert_true(stored_read_result.ok, "底层非严格 codec 的 ok 证据不应被改写。")
+	assert_eq(
+		stored_read_result.integrity_status,
+		GFStorageReadResult.IntegrityStatus.INVALID
+	)
+	assert_eq(settings.to_dict(false), values_before, "完整性失败不得修改有效设置。")
+	assert_eq(settings.get_staged_values(), staged_before, "完整性失败不得清除 staged 设置。")
+	assert_eq(settings.write_count, 0, "完整性失败不得自动覆盖文件。")
+	settings.dispose()
+
+
+func test_load_settings_signal_and_last_result_are_defensive_copies() -> void:
+	var settings: ScriptedSettingsUtility = _make_scripted_settings(
+		GFStorageReadResult.new().configure_success({"audio/master": 0.4})
+	)
+	var _register_master: Variant = settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	watch_signals(settings)
+
+	var returned_result: GFSettingsLoadResult = settings.load_settings("profile.json")
+	var signal_parameters: Array = get_signal_parameters(settings, "settings_load_completed")
+	var signal_value: Variant = signal_parameters[0] if not signal_parameters.is_empty() else null
+	var first_last_result: GFSettingsLoadResult = settings.get_last_load_result()
+	var second_last_result: GFSettingsLoadResult = settings.get_last_load_result()
+
+	assert_signal_emitted(settings, "settings_load_completed")
+	assert_true(signal_value is GFSettingsLoadResult, "完成信号应携带类型化结果。")
+	assert_not_null(first_last_result, "最近读取结果应可观察。")
+	assert_not_null(second_last_result, "重复读取最近结果应继续可用。")
+	assert_false(is_same(returned_result, first_last_result), "last result 不应暴露返回对象身份。")
+	assert_false(is_same(first_last_result, second_last_result), "每次查询应返回隔离结果。")
+	if signal_value is GFSettingsLoadResult:
+		var signal_result: GFSettingsLoadResult = signal_value
+		assert_false(is_same(returned_result, signal_result), "信号应发送隔离结果副本。")
+		assert_eq(signal_result.get_status(), GFSettingsLoadResult.STATUS_LOADED)
+
+	var mutable_storage_copy: GFStorageReadResult = returned_result.get_storage_result()
+	mutable_storage_copy.payload["audio/master"] = 0.95
+	var observed_storage_copy: GFStorageReadResult = first_last_result.get_storage_result()
+	var result_summary: Dictionary = returned_result.to_dict()
+	var storage_summary: Dictionary = GFVariantData.get_option_dictionary(
+		result_summary,
+		"storage_result"
+	)
+	assert_eq(
+		GFVariantData.get_option_float(observed_storage_copy.payload, "audio/master"),
+		0.4,
+		"修改调用方取得的 Storage 副本不得污染 last result。"
+	)
+	assert_false(storage_summary.has("payload"), "可报告结果摘要不得泄露设置载荷。")
+	settings.dispose()
+
+
+func test_fallback_load_classifies_missing_corrupt_and_successful_empty_payloads() -> void:
+	var _register_master: Variant = _settings.register_setting(
+		&"audio/master",
+		1.0,
+		GFSettingDefinition.ValueType.FLOAT
+	)
+	_settings.set_value(&"audio/master", 0.3, false)
+	_settings.stage_value(&"audio/master", 0.8)
+	var values_before: Dictionary = _settings.to_dict(false)
+	var staged_before: Dictionary = _settings.get_staged_values()
+	var missing_file: String = _new_fallback_file_name("missing")
+
+	var missing_result: GFSettingsLoadResult = _settings.load_settings(missing_file)
+	var missing_storage: GFStorageReadResult = missing_result.get_storage_result()
+
+	assert_eq(missing_result.get_status(), GFSettingsLoadResult.STATUS_MISSING)
+	assert_eq(missing_storage.failure_kind, GFStorageReadResult.FailureKind.NOT_FOUND)
+	assert_eq(_settings.to_dict(false), values_before, "fallback 缺失失败不得修改当前值。")
+	assert_eq(_settings.get_staged_values(), staged_before, "fallback 缺失失败不得清 staged。")
+
+	var empty_file: String = _new_fallback_file_name("empty")
+	_write_fallback_text(empty_file, "")
+	var empty_result: GFSettingsLoadResult = _settings.load_settings(empty_file)
+	var empty_storage: GFStorageReadResult = empty_result.get_storage_result()
+
+	assert_eq(empty_result.get_status(), GFSettingsLoadResult.STATUS_CORRUPT)
+	assert_eq(empty_storage.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_eq(_settings.to_dict(false), values_before, "空文件不得被降级为合法空载荷。")
+	assert_eq(_settings.get_staged_values(), staged_before, "空文件失败不得清 staged。")
+
+	var malformed_file: String = _new_fallback_file_name("malformed")
+	_write_fallback_text(malformed_file, "{invalid")
+	var malformed_result: GFSettingsLoadResult = _settings.load_settings(malformed_file)
+	var malformed_storage: GFStorageReadResult = malformed_result.get_storage_result()
+
+	assert_eq(malformed_result.get_status(), GFSettingsLoadResult.STATUS_CORRUPT)
+	assert_eq(malformed_storage.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_eq(_settings.to_dict(false), values_before, "解析失败不得修改当前值。")
+	assert_eq(_settings.get_staged_values(), staged_before, "解析失败不得清 staged。")
+
+	var non_dictionary_file: String = _new_fallback_file_name("array")
+	_write_fallback_text(non_dictionary_file, "[]")
+	var non_dictionary_result: GFSettingsLoadResult = _settings.load_settings(non_dictionary_file)
+	var non_dictionary_storage: GFStorageReadResult = non_dictionary_result.get_storage_result()
+
+	assert_eq(non_dictionary_result.get_status(), GFSettingsLoadResult.STATUS_CORRUPT)
+	assert_eq(non_dictionary_storage.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_eq(_settings.to_dict(false), values_before, "非 Dictionary JSON 不得当作合法空设置。")
+	assert_eq(_settings.get_staged_values(), staged_before, "非 Dictionary JSON 不得清 staged。")
+
+	var valid_empty_file: String = _new_fallback_file_name("valid_empty")
+	_write_fallback_text(valid_empty_file, "{}")
+	var valid_empty_result: GFSettingsLoadResult = _settings.load_settings(valid_empty_file)
+	var valid_empty_storage: GFStorageReadResult = valid_empty_result.get_storage_result()
+
+	assert_true(valid_empty_result.is_successful(), "合法空 JSON 对象应读取成功。")
+	assert_eq(valid_empty_result.get_status(), GFSettingsLoadResult.STATUS_LOADED)
+	assert_true(valid_empty_storage.ok, "合法空 JSON 对象应保留底层成功证据。")
+	assert_true(valid_empty_storage.payload.is_empty())
+	assert_eq(_setting_float(_settings, &"audio/master"), 1.0, "合法空对象应应用 replace 默认值。")
+	assert_false(_settings.has_staged_values(), "合法空对象成功应用后应清 staged。")
 
 
 func test_save_settings_rejects_cyclic_values_without_recursing() -> void:
@@ -400,10 +933,14 @@ func test_fallback_persistence_rejects_native_absolute_paths() -> void:
 	var _register_setting_result: Variant = _settings.register_setting(&"audio/master", 1.0, GFSettingDefinition.ValueType.FLOAT)
 
 	var save_error: Error = _settings.save_settings(native_absolute_path)
-	var loaded: Dictionary = _settings.load_settings(native_absolute_path)
+	var load_result: GFSettingsLoadResult = _settings.load_settings(native_absolute_path)
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
 
 	assert_eq(save_error, ERR_INVALID_PARAMETER, "无 GFStorageUtility 后端时 fallback 持久化不应写入原生绝对路径。")
-	assert_true(loaded.is_empty(), "被拒绝的原生绝对路径不应读取数据。")
+	assert_false(load_result.is_successful(), "被拒绝的原生绝对路径不应读取数据。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_INVALID_REQUEST)
+	assert_not_null(storage_result, "非法 fallback 路径应返回结构化读取失败。")
+	assert_eq(storage_result.failure_kind, GFStorageReadResult.FailureKind.INVALID_REQUEST)
 	assert_push_error("[GFSettingsUtility] 已拒绝原生绝对设置路径：C:/gf_settings_denied.json。")
 	assert_push_error("[GFSettingsUtility] 已拒绝原生绝对设置路径：C:/gf_settings_denied.json。")
 
@@ -447,11 +984,17 @@ func test_storage_backed_settings_roundtrip_keeps_framework_metadata_out_of_busi
 		{},
 		GFSettingDefinition.ValueType.DICTIONARY
 	)
-	var loaded: Dictionary = restored.load_settings()
+	var load_result: GFSettingsLoadResult = restored.load_settings()
+	var loaded_storage_result: GFStorageReadResult = load_result.get_storage_result()
 	var profile: Dictionary = GFVariantData.as_dictionary(restored.get_value(&"profile/metadata"))
 	var project_meta: Dictionary = GFVariantData.get_option_dictionary(profile, "_meta")
 
-	assert_false(loaded.has(GFStorageCodec.VERSION_KEY), "Settings 读取结果不得包含存储 metadata。")
+	assert_true(load_result.is_successful(), "Storage-backed Settings 应返回成功终态。")
+	assert_not_null(loaded_storage_result, "Settings 结果应保留底层读取结果。")
+	assert_false(
+		loaded_storage_result.payload.has(GFStorageCodec.VERSION_KEY),
+		"Settings 业务载荷不得包含存储 metadata。"
+	)
 	assert_eq(GFVariantData.get_option_string(project_meta, "owner"), "project", "业务 `_meta` 应完整往返。")
 	assert_eq(GFVariantData.get_option_int(profile, "value"), 7, "业务设置值应完整往返。")
 
@@ -468,15 +1011,65 @@ func test_fallback_persistence_rejects_parent_traversal_paths() -> void:
 	var _register_setting_result: Variant = _settings.register_setting(&"audio/master", 1.0, GFSettingDefinition.ValueType.FLOAT)
 
 	var save_error: Error = _settings.save_settings("../gf_settings_escape.json")
-	var loaded: Dictionary = _settings.load_settings("../gf_settings_escape.json")
+	var load_result: GFSettingsLoadResult = _settings.load_settings("../gf_settings_escape.json")
+	var storage_result: GFStorageReadResult = load_result.get_storage_result()
 
 	assert_eq(save_error, ERR_INVALID_PARAMETER, "fallback 持久化只应接受纯文件名。")
-	assert_true(loaded.is_empty(), "被拒绝的 traversal 路径不应读取数据。")
+	assert_false(load_result.is_successful(), "被拒绝的 traversal 路径不应读取数据。")
+	assert_eq(load_result.get_status(), GFSettingsLoadResult.STATUS_INVALID_REQUEST)
+	assert_not_null(storage_result, "非法 traversal 应返回结构化读取失败。")
+	assert_eq(storage_result.failure_kind, GFStorageReadResult.FailureKind.INVALID_REQUEST)
 	assert_push_error("[GFSettingsUtility] 已拒绝不安全设置文件名：../gf_settings_escape.json。")
 	assert_push_error("[GFSettingsUtility] 已拒绝不安全设置文件名：../gf_settings_escape.json。")
 
 
 # --- 私有/辅助方法 ---
+
+func _make_scripted_settings(read_result: GFStorageReadResult) -> ScriptedSettingsUtility:
+	var settings: ScriptedSettingsUtility = ScriptedSettingsUtility.new()
+	settings.read_result = read_result.duplicate_result()
+	settings.auto_load_on_init = false
+	settings.auto_save_on_change = false
+	settings.init()
+	return settings
+
+
+func _make_storage_failure(
+	failure_kind: GFStorageReadResult.FailureKind,
+	error_code: Error,
+	error_message: String
+) -> GFStorageReadResult:
+	return GFStorageReadResult.new().configure_failure(
+		error_message,
+		error_code,
+		{},
+		GFStorageReadResult.IntegrityStatus.NOT_CHECKED,
+		0,
+		failure_kind
+	)
+
+
+func _new_fallback_file_name(label: String) -> String:
+	var file_name: String = "gf_settings_contract_%d_%d_%s.json" % [
+		get_instance_id(),
+		_fallback_file_names.size(),
+		label,
+	]
+	var _appended: bool = _fallback_file_names.append(file_name)
+	var path: String = "user://" + file_name
+	if FileAccess.file_exists(path):
+		var _remove_error: Error = DirAccess.remove_absolute(path)
+	return file_name
+
+
+func _write_fallback_text(file_name: String, content: String) -> void:
+	var file: FileAccess = FileAccess.open("user://" + file_name, FileAccess.WRITE)
+	assert_not_null(file, "fallback 测试夹具应可写入 user://。")
+	if file == null:
+		return
+	var _store_result: Variant = file.store_string(content)
+	file.close()
+
 
 func _setting_bool(settings: GFSettingsUtility, key: StringName) -> bool:
 	return GFVariantData.to_bool(settings.get_value(key))
@@ -536,8 +1129,24 @@ class LoadedSettingsUtility:
 
 	var loaded_data: Dictionary = {}
 
-	func _read_persisted_data(_file_name: String) -> Dictionary:
-		return loaded_data.duplicate(true)
+	func _read_persisted_data(_file_name: String) -> GFStorageReadResult:
+		return GFStorageReadResult.new().configure_success(loaded_data)
+
+
+class ScriptedSettingsUtility:
+	extends GFSettingsUtility
+
+	var read_result: GFStorageReadResult = GFStorageReadResult.new().configure_success({})
+	var read_count: int = 0
+	var write_count: int = 0
+
+	func _read_persisted_data(_file_name: String) -> GFStorageReadResult:
+		read_count += 1
+		return read_result.duplicate_result()
+
+	func _write_persisted_data(_file_name: String, _data: Dictionary) -> Error:
+		write_count += 1
+		return OK
 
 
 class StorageBackedSettingsUtility:


### PR DESCRIPTION
## Summary

- Replace ambiguous Settings fallback behavior with structured `GFSettingsLoadResult` outcomes and explicit `GFSettingsRecoveryPolicy`; valid empty payloads remain successful, recovery never writes implicitly, and a valid load request cancels stale pending saves.
- Add `GFEditorPropertyBatchCommand` for zero-write preflight, overlap detection, ordered apply/reverse compensation, final-state verification, and explicit recovery; route resource-table batches through this atomic contract.
- Define resource-table no-op semantics: empty batches are committed zero-work operations, while normalized equivalent values do not call setters, emit commit signals, auto-save, or refresh. Transaction entry status is the sole applied/unchanged truth source.
- Add persistable shader interface snapshots and strict reflected Variant/resource validation across parameter utilities, profiles, and shader actions; declare the Action Queue display dependency.
- Document framework-native composition recipes and update focused tests, manifests, changelog, generated API references, and AI Developer Kit knowledge.

## Contract and Risk

- Change type: feat + fix
- Consumer-visible behavior: Settings loads expose explicit terminal results; resource-table edits are atomic, empty batches succeed with zero counts, and equivalent-value commits are successful side-effect-free no-ops; shader parameter application rejects reflected type/resource mismatches by default.
- API or extension contract: adds `GFSettingsLoadResult`, `GFSettingsRecoveryPolicy`, `GFEditorPropertyBatchCommand`, and `GFShaderInterfaceSnapshot`; replaces the old Settings dictionary/signal contract; extends resource-table transaction reports and shader validation APIs; declares the Action Queue display dependency.
- Persisted data, package, protocol, or ProjectSettings impact: recovery does not persist implicitly; resource-table auto-save only touches actually changed resources; no persisted format or ProjectSettings change; generated API/AI knowledge and package metadata are refreshed.
- Failure, cancellation, rollback, concurrency, and ownership impact: valid loads cancel stale delayed/batch saves; resource-table batches preflight before writes and compensate in reverse order, exposing a recovery handle only when compensation is incomplete; shader drift/type failures are explicit and fail closed.
- Compatibility and migration: targets the 10.0.0 development line with no compatibility shims. Callers must migrate from the old Settings return/signal contract and must use an explicit project action instead of relying on equivalent-value commits to trigger setter, notification, persistence, or refresh side effects.

## Verification

- [x] Focused tests cover the changed behavior and failure path: `GFEditorPropertyBatchCommand` 14/14 tests, 106 assertions; `GFResourceTableEditor` 20/20 tests, 143 assertions; lifecycle gates clean.
- [x] `python tools/gf_maintenance.py check --suite quick --allow-breaking-api --failed-only` — 22/22 checks passed.
- [x] GDScript warning and LSP gates are clean when `.gd` files changed — 1,232 files scanned, 0 diagnostics and 0 timeouts.
- [x] Generated API or knowledge output is fresh when its source changed — API Catalog/Reference and AI Developer Kit source checks passed.
- [x] Draft PR feedback completed through `GF draft gate` when applicable — not applicable to this already-Ready PR.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate` — latest SHA `8073148c` passed.
- [x] `python tools/gf_maintenance.py check --suite full --jobs 3 --allow-breaking-api --failed-only` — 35/35 checks passed in 1,552.162 seconds.
- [x] `python tools/gf_maintenance.py api-baseline-diff --base-tag 9.0.1 --version 10.0.0 --enforce-version --json` — passed; the 10.0 major line permits the existing approved breaking baseline.
- [x] Three independent GF change-audit tracks (architecture, specification/tests, standards/API compatibility) completed with no unresolved findings.

## Documentation and Release

- [x] Relevant guide and `[未发布]` changelog entries are updated.
- [x] Development version impact remains 10.0.0-dev.0; no separate version bump is required.
- [x] This PR does not create a tag or publish a release.