### PR TITLE
fix(grid): stabilize occupancy receiver identity

### DIFF
--- a/addons/gf/standard/foundation/math/gf_grid_occupancy.gd
+++ b/addons/gf/standard/foundation/math/gf_grid_occupancy.gd
@@ -4,6 +4,8 @@
 ## 它不负责路径查找、碰撞或胜负规则。
 ## 占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态，
 ## 但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。
+## receiver 只接受 Object、非空 StringName、非空 String 或 int 稳定身份；可变复合值
+## 和其他 Variant 类型失败关闭。公开信号只描述实际状态变化，成功恒等操作不发信号。
 ## [br]
 ## @api public
 ## [br]
@@ -16,46 +18,54 @@ extends RefCounted
 
 # --- 信号 ---
 
-## 接收者占用格子时发出。
+## 接收者实际新建占用或移动到其他格子时发出。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @param cell: 格子坐标。
 signal cell_occupied(receiver: Variant, cell: Vector2i)
 
-## 接收者释放格子时发出。
+## 接收者的既有占用实际释放时发出。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, int, or null for an expired weak Object.
 ## [br]
 ## @param cell: 格子坐标。
 signal cell_released(receiver: Variant, cell: Vector2i)
 
-## 接收者预约格子时发出。
+## 接收者实际新建预约或移动预约到其他格子时发出。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @param cell: 格子坐标。
 signal cell_reserved(receiver: Variant, cell: Vector2i)
 
-## 接收者释放预约时发出。
+## 接收者的既有预约实际释放时发出。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, int, or null for an expired weak Object.
 ## [br]
 ## @param cell: 格子坐标。
 signal reservation_released(receiver: Variant, cell: Vector2i)
@@ -150,15 +160,18 @@ func is_in_bounds(cell: Vector2i) -> bool:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @param cell: 格子坐标。
 ## [br]
 ## @return 可占用时返回 true。
 func can_occupy(receiver: Variant, cell: Vector2i) -> bool:
-	return _can_occupy_current(receiver, cell)
+	var receiver_key: String = _make_receiver_key(receiver)
+	return _can_occupy_key_current(receiver_key, cell, true)
 
 
 ## 获取当前被占用的格子快照。
@@ -191,29 +204,34 @@ func get_reserved_cells() -> Array[Vector2i]:
 ## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @return 当前可被该接收者占用的格子数组，按 y/x 稳定顺序返回。
 func get_occupiable_cells(receiver: Variant) -> Array[Vector2i]:
 	var result: Array[Vector2i] = []
 	if grid_size.x <= 0 or grid_size.y <= 0:
 		return result
+	var receiver_key: String = _make_receiver_key(receiver)
+	if receiver_key.is_empty():
+		return result
 
 	for y: int in range(grid_size.y):
 		for x: int in range(grid_size.x):
 			var cell: Vector2i = Vector2i(x, y)
-			if _can_occupy_current(receiver, cell):
+			if _can_occupy_key_current(receiver_key, cell, true):
 				result.append(cell)
 	return result
 
 
-## 占用格子。接收者若已占用其他格子，会先释放旧格子。
+## 占用格子；已有其他格占用时先移动，已占用目标格时成功且不发信号。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @param cell: 格子坐标。
 ## [br]
@@ -224,11 +242,11 @@ func occupy(receiver: Variant, cell: Vector2i) -> bool:
 
 	var notifications: Array[Dictionary] = []
 	_prune_invalid_records(notifications)
-	if not _can_occupy_current(receiver, cell):
+	var receiver_key: String = _make_receiver_key(receiver)
+	if not _can_occupy_key_current(receiver_key, cell, true):
 		_finish_mutation(notifications)
 		return false
 
-	var receiver_key: String = _make_receiver_key(receiver)
 	var current_record: Dictionary = _get_record(_receiver_records, receiver_key)
 	var current_cell: Vector2i = _get_record_cell(current_record)
 	if current_cell == cell:
@@ -251,9 +269,11 @@ func occupy(receiver: Variant, cell: Vector2i) -> bool:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 func release(receiver: Variant) -> void:
 	if not _begin_mutation(&"release"):
 		return
@@ -280,13 +300,15 @@ func release_cell(cell: Vector2i) -> void:
 	_finish_mutation(notifications)
 
 
-## 预约格子，防止其他接收者抢占。
+## 预约格子；已有其他预约时先移动，已有效预约目标格时成功且不发释放或预约信号。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @param cell: 格子坐标。
 ## [br]
@@ -297,11 +319,11 @@ func reserve_cell(receiver: Variant, cell: Vector2i) -> bool:
 
 	var notifications: Array[Dictionary] = []
 	_prune_invalid_records(notifications)
-	if not _can_occupy_current(receiver, cell):
+	var receiver_key: String = _make_receiver_key(receiver)
+	if not _can_occupy_key_current(receiver_key, cell):
 		_finish_mutation(notifications)
 		return false
 
-	var receiver_key: String = _make_receiver_key(receiver)
 	var current_cell: Vector2i = _get_dictionary_vector2i(
 		_receiver_reservations,
 		receiver_key,
@@ -325,9 +347,11 @@ func reserve_cell(receiver: Variant, cell: Vector2i) -> bool:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @return 成功时返回 true。
 func confirm_reservation(receiver: Variant) -> bool:
@@ -346,7 +370,7 @@ func confirm_reservation(receiver: Variant) -> bool:
 		receiver_key,
 		_INVALID_CELL
 	)
-	if not _can_occupy_current(receiver, cell):
+	if not _can_occupy_key_current(receiver_key, cell):
 		_finish_mutation(notifications)
 		return false
 
@@ -372,9 +396,11 @@ func confirm_reservation(receiver: Variant) -> bool:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 func release_reservation(receiver: Variant) -> void:
 	if not _begin_mutation(&"release_reservation"):
 		return
@@ -443,9 +469,11 @@ func get_cell_occupant(cell: Vector2i) -> Variant:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param receiver: 接收者。
 ## [br]
-## @schema receiver: Variant receiver identity stored by value or weak Object reference.
+## @schema receiver: Object, non-empty StringName, non-empty String, or int stable identity.
 ## [br]
 ## @return 格子坐标；未占用时返回 Vector2i(-1, -1)。
 func get_receiver_cell(receiver: Variant) -> Vector2i:
@@ -577,13 +605,28 @@ func _get_or_create_occupant_keys(cell: Vector2i) -> Array:
 	return new_occupants
 
 
-func _can_occupy_current(receiver: Variant, cell: Vector2i) -> bool:
+func _can_occupy_key_current(
+	receiver_key: String,
+	cell: Vector2i,
+	allow_idempotent_occupant: bool = false
+) -> bool:
 	if not is_in_bounds(cell):
 		return false
-
-	var receiver_key: String = _make_receiver_key(receiver)
 	if receiver_key.is_empty():
 		return false
+
+	var valid_occupant_count: int = 0
+	var receiver_already_occupies: bool = false
+	for occupant_key: String in _get_occupant_keys(cell):
+		var record: Dictionary = _get_record(_receiver_records, occupant_key)
+		if not _record_is_valid(record) or _get_record_cell(record) != cell:
+			continue
+		if occupant_key == receiver_key:
+			receiver_already_occupies = true
+		else:
+			valid_occupant_count += 1
+	if allow_idempotent_occupant and receiver_already_occupies:
+		return true
 
 	var reserved_by: String = GFVariantData.get_option_string(_cell_reservations, cell, "")
 	if (
@@ -592,15 +635,8 @@ func _can_occupy_current(receiver: Variant, cell: Vector2i) -> bool:
 		and reserved_by != receiver_key
 	):
 		return false
-
-	var valid_occupant_count: int = 0
-	for occupant_key: String in _get_occupant_keys(cell):
-		var record: Dictionary = _get_record(_receiver_records, occupant_key)
-		if not _record_is_valid(record) or _get_record_cell(record) != cell:
-			continue
-		if occupant_key == receiver_key:
-			return true
-		valid_occupant_count += 1
+	if receiver_already_occupies:
+		return true
 	return valid_occupant_count < max_occupants_per_cell
 
 
@@ -661,12 +697,7 @@ func _reservation_is_valid_for_cell(receiver_key: String, cell: Vector2i) -> boo
 
 
 func _make_receiver_key(receiver: Variant) -> String:
-	if receiver == null:
-		return ""
-	if receiver is Object:
-		var object: Object = receiver
-		return "object:%d" % object.get_instance_id()
-	return "%d:%s" % [typeof(receiver), str(receiver)]
+	return GFSpatialQueryIdentity.make_key(receiver)
 
 
 func _make_receiver_record(receiver: Variant, cell: Vector2i) -> Dictionary:

--- a/addons/gf/standard/foundation/math/gf_spatial_query_identity.gd
+++ b/addons/gf/standard/foundation/math/gf_spatial_query_identity.gd
@@ -1,6 +1,6 @@
 ## GFSpatialQueryIdentity: 空间查询实体身份值对象。
 ##
-## 将 Object、StringName、String 与 int 统一成稳定 key。Object 使用 weakref
+## 将 Object、非空 StringName、非空 String 与 int 统一成稳定 key。Object 使用 weakref
 ## 保存，避免空间索引因为查询身份持有场景对象生命周期；值类型会复制保存。
 ## Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份。
 ## [br]
@@ -96,11 +96,11 @@ var _object_ref: WeakRef = null
 ## [br]
 ## @since 8.0.0
 ## [br]
-## @param entity: Object、StringName、String 或 int 实体身份。
+## @param entity: Object、非空 StringName、非空 String 或 int 实体身份。
 ## [br]
 ## @return 空间查询身份；不支持的实体值会返回空 key 身份。
 ## [br]
-## @schema entity: Object, StringName, String, or int identity.
+## @schema entity: Object, non-empty StringName, non-empty String, or int identity.
 static func from_value(entity: Variant) -> GFSpatialQueryIdentity:
 	var identity: GFSpatialQueryIdentity = GFSpatialQueryIdentity.new()
 	identity._assign(entity)
@@ -113,11 +113,11 @@ static func from_value(entity: Variant) -> GFSpatialQueryIdentity:
 ## [br]
 ## @since 8.0.0
 ## [br]
-## @param entity: Object、StringName、String 或 int 实体身份。
+## @param entity: Object、非空 StringName、非空 String 或 int 实体身份。
 ## [br]
 ## @return 支持的实体值返回稳定 key；不支持时返回空字符串。
 ## [br]
-## @schema entity: Object, StringName, String, or int identity.
+## @schema entity: Object, non-empty StringName, non-empty String, or int identity.
 static func make_key(entity: Variant) -> String:
 	return from_value(entity).key
 
@@ -132,7 +132,7 @@ static func make_key(entity: Variant) -> String:
 ## [br]
 ## @return 支持时返回 true。
 ## [br]
-## @schema entity: Object, StringName, String, or int identity candidate.
+## @schema entity: Object, non-empty StringName, non-empty String, or int identity candidate.
 static func supports_value(entity: Variant) -> bool:
 	return not make_key(entity).is_empty()
 
@@ -211,7 +211,7 @@ func is_valid() -> bool:
 ## [br]
 ## @return Object 身份返回 live Object；值身份返回保存的值；无效身份返回 null。
 ## [br]
-## @schema return: Object, StringName, String, int, or null entity value.
+## @schema return: Object, non-empty StringName, non-empty String, int, or null entity value.
 func get_value() -> Variant:
 	if kind == KIND_OBJECT:
 		return get_object()

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "10.0.0-dev.0",
-  "source_digest": "d8a88824fe386f1a8d5e1654ab67b6c2719ac720e0decb71f479796c64b75c66",
+  "source_digest": "d39aae4d093b5f82d9df758dfd9a324b4cec8dd7e626c26ac8dc43888a76fced",
   "class_count": 760,
   "package_count": 52,
   "packages": [
@@ -33539,28 +33539,28 @@
           "kind": "signal",
           "name": "cell_occupied",
           "signature": "signal cell_occupied(receiver: Variant, cell: Vector2i)",
-          "summary": "接收者占用格子时发出。",
+          "summary": "接收者实际新建占用或移动到其他格子时发出。",
           "visibility": "public"
         },
         {
           "kind": "signal",
           "name": "cell_released",
           "signature": "signal cell_released(receiver: Variant, cell: Vector2i)",
-          "summary": "接收者释放格子时发出。",
+          "summary": "接收者的既有占用实际释放时发出。",
           "visibility": "public"
         },
         {
           "kind": "signal",
           "name": "cell_reserved",
           "signature": "signal cell_reserved(receiver: Variant, cell: Vector2i)",
-          "summary": "接收者预约格子时发出。",
+          "summary": "接收者实际新建预约或移动预约到其他格子时发出。",
           "visibility": "public"
         },
         {
           "kind": "signal",
           "name": "reservation_released",
           "signature": "signal reservation_released(receiver: Variant, cell: Vector2i)",
-          "summary": "接收者释放预约时发出。",
+          "summary": "接收者的既有预约实际释放时发出。",
           "visibility": "public"
         },
         {
@@ -33623,7 +33623,7 @@
           "kind": "func",
           "name": "occupy",
           "signature": "func occupy(receiver: Variant, cell: Vector2i) -> bool",
-          "summary": "占用格子。接收者若已占用其他格子，会先释放旧格子。",
+          "summary": "占用格子；已有其他格占用时先移动，已占用目标格时成功且不发信号。",
           "visibility": "public"
         },
         {
@@ -33644,7 +33644,7 @@
           "kind": "func",
           "name": "reserve_cell",
           "signature": "func reserve_cell(receiver: Variant, cell: Vector2i) -> bool",
-          "summary": "预约格子，防止其他接收者抢占。",
+          "summary": "预约格子；已有其他预约时先移动，已有效预约目标格时成功且不发释放或预约信号。",
           "visibility": "public"
         },
         {
@@ -75239,7 +75239,7 @@
       "module": "standard",
       "package_id": "gf.standard.spatial",
       "path": "addons/gf/standard/foundation/math/gf_spatial_query_identity.gd",
-      "summary": "GFSpatialQueryIdentity: 空间查询实体身份值对象。 将 Object、StringName、String 与 int 统一成稳定 key。Object 使用 weakref 保存，避免空间索引因为查询身份持有场景对象生命周期；值类型会复制保存。",
+      "summary": "GFSpatialQueryIdentity: 空间查询实体身份值对象。 将 Object、非空 StringName、非空 String 与 int 统一成稳定 key。Object 使用 weakref 保存，避免空间索引因为查询身份持有场景对象生命周期；值类型会复制保存。",
       "visibility": "public",
       "category": "value_object",
       "since": "8.0.0",

--- a/docs/api_catalog/classes/GFGridOccupancy.xml
+++ b/docs/api_catalog/classes/GFGridOccupancy.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFGridOccupancy" path="addons/gf/standard/foundation/math/gf_grid_occupancy.gd" module="standard" extends="RefCounted" classDigest="feba97fe54b6fe04063104c48b3f9aa19a9cc5cf344e3e25bf11cd1cd90f4910">
+<class name="GFGridOccupancy" path="addons/gf/standard/foundation/math/gf_grid_occupancy.gd" module="standard" extends="RefCounted" classDigest="889e3cd144159d0032978deea6f30021aad1847be4a7e3236b580eb6820c1d04">
 	<description>GFGridOccupancy: 网格占用与预约数据结构。
 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。
 它不负责路径查找、碰撞或胜负规则。
 占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态，
-但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。</description>
+但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。
+receiver 只接受 Object、非空 StringName、非空 String 或 int 稳定身份；可变复合值
+和其他 Variant 类型失败关闭。公开信号只描述实际状态变化，成功恒等操作不发信号。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -13,42 +15,46 @@
 	<signals>
 		<member kind="signal" name="cell_occupied">
 			<signature>signal cell_occupied(receiver: Variant, cell: Vector2i)</signature>
-			<description>接收者占用格子时发出。</description>
+			<description>接收者实际新建占用或移动到其他格子时发出。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="cell_released">
 			<signature>signal cell_released(receiver: Variant, cell: Vector2i)</signature>
-			<description>接收者释放格子时发出。</description>
+			<description>接收者的既有占用实际释放时发出。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, int, or null for an expired weak Object.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="cell_reserved">
 			<signature>signal cell_reserved(receiver: Variant, cell: Vector2i)</signature>
-			<description>接收者预约格子时发出。</description>
+			<description>接收者实际新建预约或移动预约到其他格子时发出。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="reservation_released">
 			<signature>signal reservation_released(receiver: Variant, cell: Vector2i)</signature>
-			<description>接收者释放预约时发出。</description>
+			<description>接收者的既有预约实际释放时发出。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, int, or null for an expired weak Object.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</signals>
@@ -101,7 +107,8 @@
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
 				<tag name="return">可占用时返回 true。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_occupied_cells">
@@ -129,19 +136,20 @@
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="return">当前可被该接收者占用的格子数组，按 y/x 稳定顺序返回。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="occupy">
 			<signature>func occupy(receiver: Variant, cell: Vector2i) -&gt; bool:</signature>
-			<description>占用格子。接收者若已占用其他格子，会先释放旧格子。</description>
+			<description>占用格子；已有其他格占用时先移动，已占用目标格时成功且不发信号。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
 				<tag name="return">成功时返回 true。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="release">
@@ -150,7 +158,8 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="release_cell">
@@ -163,13 +172,14 @@
 		</member>
 		<member kind="method" name="reserve_cell">
 			<signature>func reserve_cell(receiver: Variant, cell: Vector2i) -&gt; bool:</signature>
-			<description>预约格子，防止其他接收者抢占。</description>
+			<description>预约格子；已有其他预约时先移动，已有效预约目标格时成功且不发释放或预约信号。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="param">cell: 格子坐标。</tag>
 				<tag name="return">成功时返回 true。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="confirm_reservation">
@@ -179,7 +189,8 @@
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="return">成功时返回 true。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="release_reservation">
@@ -188,7 +199,8 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="is_cell_occupied">
@@ -236,7 +248,8 @@
 				<tag name="api">public</tag>
 				<tag name="param">receiver: 接收者。</tag>
 				<tag name="return">格子坐标；未占用时返回 Vector2i(-1, -1)。</tag>
-				<tag name="schema">receiver: Variant receiver identity stored by value or weak Object reference.</tag>
+				<tag name="schema">receiver: Object, non-empty StringName, non-empty String, or int stable identity.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="prune_invalid_receivers">

--- a/docs/api_catalog/classes/GFSpatialQueryIdentity.xml
+++ b/docs/api_catalog/classes/GFSpatialQueryIdentity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSpatialQueryIdentity" path="addons/gf/standard/foundation/math/gf_spatial_query_identity.gd" module="standard" extends="RefCounted" classDigest="13fd1b98a5c2cb3813d8dc692295c9c27715963c4a4a1154a7cfc3f0aa1c93f2">
+<class name="GFSpatialQueryIdentity" path="addons/gf/standard/foundation/math/gf_spatial_query_identity.gd" module="standard" extends="RefCounted" classDigest="6dae4f7193942280c7012bbf9c56618351e297b5509bffaa991443afc84f3a39">
 	<description>GFSpatialQueryIdentity: 空间查询实体身份值对象。
-将 Object、StringName、String 与 int 统一成稳定 key。Object 使用 weakref
+将 Object、非空 StringName、非空 String 与 int 统一成稳定 key。Object 使用 weakref
 保存，避免空间索引因为查询身份持有场景对象生命周期；值类型会复制保存。
 Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份。</description>
 	<tags>
@@ -93,9 +93,9 @@ Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份�
 			<description>从实体值创建空间查询身份。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">entity: Object、StringName、String 或 int 实体身份。</tag>
+				<tag name="param">entity: Object、非空 StringName、非空 String 或 int 实体身份。</tag>
 				<tag name="return">空间查询身份；不支持的实体值会返回空 key 身份。</tag>
-				<tag name="schema">entity: Object, StringName, String, or int identity.</tag>
+				<tag name="schema">entity: Object, non-empty StringName, non-empty String, or int identity.</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
@@ -104,9 +104,9 @@ Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份�
 			<description>直接获取实体值对应的稳定 key。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">entity: Object、StringName、String 或 int 实体身份。</tag>
+				<tag name="param">entity: Object、非空 StringName、非空 String 或 int 实体身份。</tag>
 				<tag name="return">支持的实体值返回稳定 key；不支持时返回空字符串。</tag>
-				<tag name="schema">entity: Object, StringName, String, or int identity.</tag>
+				<tag name="schema">entity: Object, non-empty StringName, non-empty String, or int identity.</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
@@ -117,7 +117,7 @@ Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份�
 				<tag name="api">public</tag>
 				<tag name="param">entity: 待检测实体身份。</tag>
 				<tag name="return">支持时返回 true。</tag>
-				<tag name="schema">entity: Object, StringName, String, or int identity candidate.</tag>
+				<tag name="schema">entity: Object, non-empty StringName, non-empty String, or int identity candidate.</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
@@ -167,7 +167,7 @@ Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份�
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">Object 身份返回 live Object；值身份返回保存的值；无效身份返回 null。</tag>
-				<tag name="schema">return: Object, StringName, String, int, or null entity value.</tag>
+				<tag name="schema">return: Object, non-empty StringName, non-empty String, int, or null entity value.</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="ca428dbfe15e28fe5bef1d94c4b69528a96750e67a4df158b5c31150055ce33b" classCount="784" methodCount="7050">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="8ef49a204dc98819f388d2800dc040cf1ed3cb44a41bf68c0976164d9cb96514" classCount="784" methodCount="7050">
 	<module id="kernel" label="Kernel" classCount="72" methodCount="736">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -61,6 +61,7 @@
 
 - `GFSettingsUtility.load_settings()` 改为返回结构化终态，并为每个终态发出隔离的 `settings_load_completed`；合法 `{}` 继续使用 replace 语义，失败不再降级为空字典，合法加载请求开始时会取消此前全部陈旧延迟与批处理保存，显式恢复也不会产生隐式写盘。
 - `GFResourceTableEditor.commit_cell_values()` 与 `commit_visible_cell_values()` 从“允许部分成功”收敛为事务式整批提交：所有行、属性和值先解析和预检；规范化后同值的条目成功但不调用 setter、不发变更信号，只有至少一项实际变化后才统一刷新和执行去重自动保存。空变更数组是 `committed` / `OK` 的全零计数成功恒等操作。
+- `GFGridOccupancy` 的 receiver 身份与 `GFSpatialQueryIdentity` 收敛到同一稳定契约，只接受 `Object`、非空 `StringName`、非空 `String` 或 `int`；重复占用或预约已持有的目标格继续返回成功，但公开信号只描述实际状态变化，不再作为逐请求回执。
 - `GFShaderParameterUtility` 默认按捕获的单份接口快照跳过错型参数；`GFShaderParameterProfile` 新增快照校验入口，`GFShaderParameterAction` 在材质复制、初值捕获和 Tween 创建前验证 uniform 存在性与目标值类型。Action Queue 因此显式依赖 `gf.standard.display`。
 - AI Developer Capability / Recipe 知识目录同步升级到 `1.6.0`，补齐可伸缩 UI 集合、渲染反馈编排、命令历史、有界运行时工作、网格路径发现与通用外部产物导出边界；新导出配方只组合缩略图、截图、矩形打包、产物报告和内容包计划，最终格式、认证、幂等、重试与写出仍归项目 Adapter。能力搜索统一标点、连字符和下划线，目录完整性检查新增包、类、Recipe 与类所属包依赖闭包的交叉复核。
 - TurnBased 使用指南明确 `GFTurnAction` 只调度一次性行动请求、项目自有 `GFUndoableCommand` 唯一修改或恢复权威状态、`GFActionQueueSystem` 只编排提交后的视觉与音频表现；三者由项目 Coordinator/Installer 按需组合，不新增跨扩展耦合类型，也不把反向 Tween 当作撤销事实源。
@@ -106,6 +107,7 @@
 
 - 修复 `GFResourceTableEditor` 把空单元格批次传给通用属性事务命令后错误报告 `missing_changes`、形成 `requested_count = 0` 但失败计数非零的问题；资源表适配层现在直接返回零计数成功报告，而 `GFEditorPropertyBatchCommand` 继续拒绝没有变更的事务配置。
 - 修复 `GFGridOccupancy` 在移动占用、移动预约、确认预约或批量释放的同步信号回调中发生重入写入时，外层后续提交可能突破格子容量、丢失预约或留下不一致反向索引的问题；所有内部映射现在先按单次事务完整提交，再发出通知，通知期的方法与配置属性写入均明确失败关闭。`grid_size` / `max_occupants_per_cell` 的实际变更会清空既有记录并保持容量至少为 1；查询改为只读过滤失效对象，清理索引和释放通知由显式 `prune_invalid_receivers()` 或下一次写事务负责。
+- 修复 `GFGridOccupancy` 曾按 `typeof + str(value)` 接受 `Array`、`Dictionary` 等可变 receiver，导致确认预约的同步回调修改内容后键漂移并留下不可达幽灵占用的问题；统一稳定身份键后，可变复合值与其他未声明 Variant 类型在写入前失败关闭，Object 内容变化仍由实例 ID 保持可达。
 - 修复 `GFCommandHistoryUtility` 在命令已进入终态但业务撤销/重做失败时仍推进历史游标的问题；`GFUndoableCommand` 新增默认成功的 `is_undo_successful()` / `is_redo_successful()` hook，同步与异步入口只在 hook 成功后复核来源栈顶身份并原子移动栈。异步 Signal 的零、单、二至 16 参数终态分别规范化为 `null`、单值和 `Array`，处理锁贯穿命令回调、等待、hook 与提交；等待和 hook 内的只读查询仍观察最近一次完整提交，失败不触碰任一栈的身份、顺序或容量，生命周期切代后的旧 continuation 也不会回填新历史。
 - 修复 Interaction Sensor 对类型化 Receiver 派发时绕过项目 `receive_interaction()` 覆写，以及自定义 sender 的 2D/3D 碰撞广播在规范化报告前发出公开信号的问题；公开覆写继续参与派发，返回值和信号报告统一保持 JSON-safe。
 - 修复 Audio backend 接管 `Master`、`BGM` 等本地同名总线时，duck、生命周期恢复和 mix snapshot 的逐总线 fallback 仍会静默写入 `AudioServer` 的问题；总线所有权和 backend identity 现在贯穿捕获、应用与恢复，只有 backend 明确拒绝的字段才进入本地回退。
@@ -152,6 +154,7 @@
 - 新增公开类型 `GFSettingsLoadResult`、`GFSettingsRecoveryPolicy`、`GFEditorPropertyBatchCommand` 和 `GFShaderInterfaceSnapshot`；新增 API 均标记为 `@since unreleased`。
 - `GFSettingsUtility.load_settings(file_name)` 从返回 `Dictionary` 改为 `load_settings(file_name, recovery_policy) -> GFSettingsLoadResult`；`settings_loaded(data)` 被 `settings_load_completed(result)` 取代，新增 `get_last_load_result()`，受保护 `_read_persisted_data()` 的返回类型从 `Dictionary` 改为 `GFStorageReadResult`。本开发线不保留双轨兼容。
 - `GFObjectPropertyTools` 新增 framework-internal 的零写入 prepare 入口，`GFEditorCommand` 新增受保护配置封存入口；`GFResourceTableEditor` 批量提交报告新增事务状态、回滚状态和可选恢复命令。空批次返回 `committed` / `OK` 的全零计数成功报告；规范化后同值的单格或批量条目不再作为 setter、`cell_value_committed`、自动保存或刷新触发器。
+- `GFGridOccupancy` 的所有 receiver 参数从任意 Variant 收窄为 `Object`、非空 `StringName`、非空 `String` 或 `int` 稳定身份；四个公开信号只在占用或预约状态实际变化时发出。同格成功恒等请求与不稳定身份不保留兼容入口，该破坏性契约由 10.0 开发线承载。
 - `GFShaderParameterUtility` 新增接口捕获、Profile 校验和参数校验入口；既有 `apply_profile()` / `apply_parameters()` 的默认选项新增严格类型校验和错型 warning。
 - `GFTypeEventSystem` 新增 `subscribe()`、`subscribe_assignable()` 与 `subscribe_simple()`；`GFArchitecture` 新增 `subscribe_event()`、`subscribe_assignable_event()` 与 `subscribe_simple_event()`；`Gf` 新增同名三类快捷订阅入口。上述入口均返回 `GFSubscriptionToken`，接受 `once`，带 owner 的 `GFEventListener` 实际返回 `GFLifetimeSubscription`。`GFSubscriptionToken` 与 `GFLifetimeSubscription` 新增仅供订阅源使用的自动失效内部入口。
 - `GFUndoableCommand` 新增 `is_undo_successful(_undo_result)` 与 `is_redo_successful(_execute_result)`，均标记为 `@since unreleased` 且默认返回 `true`。同步历史入口传入命令的直接返回值；异步历史入口把完成 Signal 的零、单、二至 16 参数 payload 分别规范化为 `null`、单值和 `Array` 后传入，超过 16 个参数时告警并只保留前 16 个。
@@ -197,7 +200,7 @@
 - Settings 调用方应把 `Dictionary` 接收值改为 `GFSettingsLoadResult`，先检查 `is_successful()` / `get_status()`，再通过 Utility 读取当前值；监听器迁移到 `settings_load_completed`，自定义读取子类返回 `GFStorageReadResult`。依赖“文件缺失或损坏自动当作空设置”的项目必须显式配置 `GFSettingsRecoveryPolicy`，并在接受恢复结果后另行决定是否保存。
 - 依赖 `GFResourceTableEditor` 批量接口“有效项先提交、无效项单独报错”的工具应改为一次只提交可共同成功或共同失败的变更；收到 `recovery_required` 时先修复 setter 可写条件并调用返回命令的 `recover()`，不要在属性事务完成前保存资源。依赖等值提交触发 setter、通知、持久化或刷新副作用的工具应改用自己的显式项目流程；`10.0.0` 开发线不保留强制等值提交兼容入口。
 - Shader Profile 中 int/float 混用、错误资源类或未知 uniform 现在默认被跳过并报告 warning；项目应把参数改为 Shader 反射声明的精确 Variant 类型。需要 CI 漂移门禁时保存 `GFShaderInterfaceSnapshot` 基线并检查 `validate_shader()` / `validate_against()` 报告，不要从 shader 源码文本自行推断接口。
-- `GFGridOccupancy` 的查询不再隐式回收已释放 `Object` 或发出释放信号；依赖该副作用的调用方应在明确的维护边界调用 `prune_invalid_receivers()`，或让下一次占用/预约写事务负责清理。运行期修改 `grid_size` 或 `max_occupants_per_cell` 现在会像重新配置一样清空既有记录；需要保留棋盘状态时，应先导出项目自己的稳定状态，再按新配置显式重建。
+- `GFGridOccupancy` 的查询不再隐式回收已释放 `Object` 或发出释放信号；依赖该副作用的调用方应在明确的维护边界调用 `prune_invalid_receivers()`，或让下一次占用/预约事务在提交前执行清理。运行期修改 `grid_size` 或 `max_occupants_per_cell` 现在会像重新配置一样清空既有记录；需要保留棋盘状态时，应先导出项目自己的稳定状态，再按新配置显式重建。把 `Array`、`Dictionary`、空 `StringName` / `String` 或其他 Variant 当 receiver 的调用方必须改为分配稳定的非空 `StringName` / `String` / `int` ID，或传入拥有该数据的 `Object`；依赖每次成功 `reserve_cell()` 都收到释放/预约信号的流程应根据返回值自行发送请求确认，状态变化信号不提供兼容性逐请求回执。
 - 既有 `GFUndoableCommand` 若不重入历史写操作则无需迁移：两个历史结果 hook 默认成功，`null` 返回值和无参数完成 Signal 保持原行为。只有撤销或重做可能进入“已完成但业务失败”终态的命令才需要覆盖对应 hook；异步 hook 应按 `null`、单值或最多 16 项的多值 `Array` 读取规范化完成 payload，并返回明确的 `bool`，更多字段应封装成单个 Result 或 `Dictionary`。`execute()`、`undo()`、`should_record()` 和结果 hook 现在统一处于非重入历史操作内；原先从这些回调嵌套执行、记录、清空、修改容量或恢复历史的项目代码，应改为在外层历史 API 完成后由项目队列提交后续操作。
 - 项目 Installer 必须改为通过 `install(architecture, scope)` 的显式 `architecture` 参数或 `install_bindings(binder, scope)` 的 `binder` 注册候选模块，不要在 `Gf.set_architecture()` 提交前使用 `Gf.register_*()`、`Gf.create_binder()` 或 `Gf.get_*()` 指向候选。异步 Installer 在每个 `await` 后检查 `scope.is_cancel_requested()` 并用 `scope.register_cleanup()` 释放临时资源；assignment 被替代并返回 `false` 后应创建新的 `GFArchitecture` 重试，不复用已经 dispose 的候选。释放回调和项目自定义等待器应通过 `is_disposing()` / `is_disposed()` 拒绝向终结中的架构提交新工作。
 - `GFNodeContext` 的父级 Architecture identity 与首次 READY generation 现在按每轮入树固定。不要在 child 场景分支仍活动时调用其 owned Architecture 的 `set_parent_architecture()`，也不要让父级失败后原地重试或热替换全局父级；需要绑定新父级或新 generation 时，应让对应 child 分支退出并重新进入，或重建该场景分支。

--- a/docs/zh/reference/api/classes/GFGridOccupancy.md
+++ b/docs/zh/reference/api/classes/GFGridOccupancy.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`3.17.0`
 
-网格占用与预约数据结构。 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。 它不负责路径查找、碰撞或胜负规则。 占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态， 但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。
+网格占用与预约数据结构。 适合格子移动、战棋、推箱子和解谜类玩法在 System 中跟踪运行时占用。 它不负责路径查找、碰撞或胜负规则。 占用变更会先完整提交内部映射，再同步发出通知；通知回调可以查询已提交状态， 但通知期间重入调用本类型的写入方法会失败关闭，避免嵌套修改破坏容量与双向索引。 receiver 只接受 Object、非空 StringName、非空 String 或 int 稳定身份；可变复合值 和其他 Variant 类型失败关闭。公开信号只描述实际状态变化，成功恒等操作不发信号。
 
 ## 成员概览
 
@@ -48,12 +48,13 @@
 ### `cell_occupied`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 signal cell_occupied(receiver: Variant, cell: Vector2i)
 ```
 
-接收者占用格子时发出。
+接收者实际新建占用或移动到其他格子时发出。
 
 参数：
 
@@ -64,19 +65,20 @@ signal cell_occupied(receiver: Variant, cell: Vector2i)
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-signals-cell_released"></a>
 
 ### `cell_released`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 signal cell_released(receiver: Variant, cell: Vector2i)
 ```
 
-接收者释放格子时发出。
+接收者的既有占用实际释放时发出。
 
 参数：
 
@@ -87,19 +89,20 @@ signal cell_released(receiver: Variant, cell: Vector2i)
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, int, or null for an expired weak Object.
 
 <a id="member-gfgridoccupancy-signals-cell_reserved"></a>
 
 ### `cell_reserved`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 signal cell_reserved(receiver: Variant, cell: Vector2i)
 ```
 
-接收者预约格子时发出。
+接收者实际新建预约或移动预约到其他格子时发出。
 
 参数：
 
@@ -110,19 +113,20 @@ signal cell_reserved(receiver: Variant, cell: Vector2i)
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-signals-reservation_released"></a>
 
 ### `reservation_released`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 signal reservation_released(receiver: Variant, cell: Vector2i)
 ```
 
-接收者释放预约时发出。
+接收者的既有预约实际释放时发出。
 
 参数：
 
@@ -133,7 +137,7 @@ signal reservation_released(receiver: Variant, cell: Vector2i)
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, int, or null for an expired weak Object.
 
 ## 属性
 
@@ -209,6 +213,7 @@ func is_in_bounds(cell: Vector2i) -> bool:
 ### `can_occupy`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func can_occupy(receiver: Variant, cell: Vector2i) -> bool:
@@ -227,7 +232,7 @@ func can_occupy(receiver: Variant, cell: Vector2i) -> bool:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-get_occupied_cells"></a>
 
@@ -282,19 +287,20 @@ func get_occupiable_cells(receiver: Variant) -> Array[Vector2i]:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-occupy"></a>
 
 ### `occupy`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func occupy(receiver: Variant, cell: Vector2i) -> bool:
 ```
 
-占用格子。接收者若已占用其他格子，会先释放旧格子。
+占用格子；已有其他格占用时先移动，已占用目标格时成功且不发信号。
 
 参数：
 
@@ -307,13 +313,14 @@ func occupy(receiver: Variant, cell: Vector2i) -> bool:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-release"></a>
 
 ### `release`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func release(receiver: Variant) -> void:
@@ -329,7 +336,7 @@ func release(receiver: Variant) -> void:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-release_cell"></a>
 
@@ -354,12 +361,13 @@ func release_cell(cell: Vector2i) -> void:
 ### `reserve_cell`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func reserve_cell(receiver: Variant, cell: Vector2i) -> bool:
 ```
 
-预约格子，防止其他接收者抢占。
+预约格子；已有其他预约时先移动，已有效预约目标格时成功且不发释放或预约信号。
 
 参数：
 
@@ -372,13 +380,14 @@ func reserve_cell(receiver: Variant, cell: Vector2i) -> bool:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-confirm_reservation"></a>
 
 ### `confirm_reservation`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func confirm_reservation(receiver: Variant) -> bool:
@@ -396,13 +405,14 @@ func confirm_reservation(receiver: Variant) -> bool:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-release_reservation"></a>
 
 ### `release_reservation`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func release_reservation(receiver: Variant) -> void:
@@ -418,7 +428,7 @@ func release_reservation(receiver: Variant) -> void:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-is_cell_occupied"></a>
 
@@ -513,6 +523,7 @@ func get_cell_occupant(cell: Vector2i) -> Variant:
 ### `get_receiver_cell`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func get_receiver_cell(receiver: Variant) -> Vector2i:
@@ -530,7 +541,7 @@ func get_receiver_cell(receiver: Variant) -> Vector2i:
 
 结构：
 
-- `receiver`: Variant receiver identity stored by value or weak Object reference.
+- `receiver`: Object, non-empty StringName, non-empty String, or int stable identity.
 
 <a id="member-gfgridoccupancy-methods-prune_invalid_receivers"></a>
 

--- a/docs/zh/reference/api/classes/GFSpatialQueryIdentity.md
+++ b/docs/zh/reference/api/classes/GFSpatialQueryIdentity.md
@@ -9,7 +9,7 @@
 - 类别：值对象 (`value_object`)
 - 首次版本：`8.0.0`
 
-空间查询实体身份值对象。 将 Object、StringName、String 与 int 统一成稳定 key。Object 使用 weakref 保存，避免空间索引因为查询身份持有场景对象生命周期；值类型会复制保存。 Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份。
+空间查询实体身份值对象。 将 Object、非空 StringName、非空 String 与 int 统一成稳定 key。Object 使用 weakref 保存，避免空间索引因为查询身份持有场景对象生命周期；值类型会复制保存。 Array、Dictionary 等可变复合值不会被接受为稳定空间查询身份。
 
 ## 成员概览
 
@@ -175,13 +175,13 @@ static func from_value(entity: Variant) -> GFSpatialQueryIdentity:
 
 | 名称 | 说明 |
 |---|---|
-| `entity` | Object、StringName、String 或 int 实体身份。 |
+| `entity` | Object、非空 StringName、非空 String 或 int 实体身份。 |
 
 返回：空间查询身份；不支持的实体值会返回空 key 身份。
 
 结构：
 
-- `entity`: Object, StringName, String, or int identity.
+- `entity`: Object, non-empty StringName, non-empty String, or int identity.
 
 <a id="member-gfspatialqueryidentity-methods-make_key"></a>
 
@@ -200,13 +200,13 @@ static func make_key(entity: Variant) -> String:
 
 | 名称 | 说明 |
 |---|---|
-| `entity` | Object、StringName、String 或 int 实体身份。 |
+| `entity` | Object、非空 StringName、非空 String 或 int 实体身份。 |
 
 返回：支持的实体值返回稳定 key；不支持时返回空字符串。
 
 结构：
 
-- `entity`: Object, StringName, String, or int identity.
+- `entity`: Object, non-empty StringName, non-empty String, or int identity.
 
 <a id="member-gfspatialqueryidentity-methods-supports_value"></a>
 
@@ -231,7 +231,7 @@ static func supports_value(entity: Variant) -> bool:
 
 结构：
 
-- `entity`: Object, StringName, String, or int identity candidate.
+- `entity`: Object, non-empty StringName, non-empty String, or int identity candidate.
 
 <a id="member-gfspatialqueryidentity-methods-sort_keys"></a>
 
@@ -329,7 +329,7 @@ func get_value() -> Variant:
 
 结构：
 
-- `return`: Object, StringName, String, int, or null entity value.
+- `return`: Object, non-empty StringName, non-empty String, int, or null entity value.
 
 <a id="member-gfspatialqueryidentity-methods-get_object"></a>
 

--- a/docs/zh/standard/foundation/grid-spatial/occupancy-tile-spatial/grid-occupancy.md
+++ b/docs/zh/standard/foundation/grid-spatial/occupancy-tile-spatial/grid-occupancy.md
@@ -30,12 +30,12 @@ if not candidates.is_empty():
 	occupancy.reserve_cell(spawn_token, cell)
 ```
 
-`occupy()`、`release_cell()`、`reserve_cell()` 与 `confirm_reservation()` 等写入入口以单次事务更新占用、预约和接收者反向索引，再同步发出对应信号。因此信号回调可以查询完整提交后的状态，但不能在同一通知调用栈中再次修改这个 `GFGridOccupancy`；重入写入会明确失败，`bool` 入口返回 `false`，`void` 入口保持无操作。需要连锁移动、批量放置或响应式规则时，应先在项目 `System` 中计算完整计划，再按确定顺序提交后续事务，而不是在占用信号里继续写入。
+`occupy()`、`release_cell()`、`reserve_cell()` 与 `confirm_reservation()` 等写入入口以单次事务更新占用、预约和接收者反向索引，再同步发出对应信号。因此信号回调可以查询完整提交后的状态，但不能在同一通知调用栈中再次修改这个 `GFGridOccupancy`；重入写入会明确失败，`bool` 入口返回 `false`，`void` 入口保持无操作。公开信号只描述实际状态变化：接收者已经占用或有效预约目标格时，重复调用对应入口仍返回 `true`，但不会重复发出释放、占用或预约信号。调用方若需要为每次请求发送确认，应在项目流程中根据返回值显式确认，不应把状态变化信号当作逐请求回执。需要连锁移动、批量放置或响应式规则时，应先在项目 `System` 中计算完整计划，再按确定顺序提交后续事务，而不是在占用信号里继续写入。
 
 `grid_size` 与 `max_occupants_per_cell` 的直接赋值同样属于写事务：值实际变化时会清空既有占用与预约，容量会钳制到至少 1；通知期间的直接赋值会失败关闭。需要同时修改两个配置时优先调用 `configure()`，避免分别赋值造成两次清理。
 
 ## 生命周期与标识
 
-对象接收者使用弱引用记录。需要回收已释放对象留下的索引并通知缓存消费者时，显式调用 `prune_invalid_receivers()`，或等待下一次占用/预约事务在提交前执行清理；失效对象释放占用时会发出 `cell_released(null, cell)`。不要依赖任意查询触发清理信号。
+receiver 只接受 `Object`、非空 `StringName`、非空 `String` 或 `int`。这些类型与 `GFSpatialQueryIdentity` 使用同一稳定 key 规则；`StringName` 与 `String` 即使文本相同也属于不同身份。`Array`、`Dictionary`、空 `StringName` / `String` 和其他 Variant 类型会失败关闭，不能作为长期身份。项目若持有复合业务数据，应另外分配稳定 ID 或使用拥有该数据的 `Object`，不要让可变内容本身参与索引。
 
-非 `Object` 接收者会以 `typeof + str(value)` 生成内部 key，推荐使用 `StringName`、`int`、稳定字符串或 `Object`，不要直接把 `Dictionary` / `Array` 当作长期唯一标识。
+对象接收者以实例 ID 建立身份并使用弱引用记录，因此对象字段在同步通知回调中变化也不会让占用失去可达性。需要回收已释放对象留下的索引并通知缓存消费者时，显式调用 `prune_invalid_receivers()`，或等待下一次占用/预约事务在提交前执行清理；失效对象释放占用时会发出 `cell_released(null, cell)`。不要依赖任意查询触发清理信号。

--- a/tests/gf_core/standard/foundation/math/test_gf_grid_occupancy.gd
+++ b/tests/gf_core/standard/foundation/math/test_gf_grid_occupancy.gd
@@ -73,6 +73,205 @@ func test_reservation_blocks_other_receivers_and_can_confirm() -> void:
 	assert_false(grid.is_cell_reserved(Vector2i(2, 1)), "确认后预约记录应释放。")
 
 
+func test_supported_receiver_identities_are_distinct_and_reachable() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(4, 1))
+	var actor: Object = _make_object()
+	var receivers: Array[Variant] = [
+		actor,
+		&"shared",
+		"shared",
+		17,
+	]
+
+	for index: int in range(receivers.size()):
+		var cell: Vector2i = Vector2i(index, 0)
+		var receiver: Variant = receivers[index]
+		assert_true(grid.occupy(receiver, cell), "受支持的稳定身份应能占用格子。")
+
+	for index: int in range(receivers.size()):
+		var cell: Vector2i = Vector2i(index, 0)
+		var receiver: Variant = receivers[index]
+		assert_eq(grid.get_receiver_cell(receiver), cell, "稳定身份应能查询自己的占用。")
+		assert_eq(grid.get_cell_occupants(cell), [receiver], "每种稳定身份都必须使用互异 key。")
+
+	for index: int in range(receivers.size()):
+		var cell: Vector2i = Vector2i(index, 0)
+		var receiver: Variant = receivers[index]
+		grid.release(receiver)
+		assert_false(grid.is_cell_occupied(cell), "受支持的稳定身份应能释放自己的占用。")
+		assert_eq(grid.get_receiver_cell(receiver), Vector2i(-1, -1))
+		for remaining_index: int in range(index + 1, receivers.size()):
+			assert_eq(
+				grid.get_receiver_cell(receivers[remaining_index]),
+				Vector2i(remaining_index, 0),
+				"释放一个身份不得让其他稳定身份失去可达性。"
+			)
+
+
+func test_unsupported_receiver_identities_fail_closed() -> void:
+	var unsupported_receivers: Array[Variant] = [
+		null,
+		true,
+		1.5,
+		"",
+		Vector2.ZERO,
+		Vector2i.ZERO,
+		Rect2(),
+		Rect2i(),
+		Vector3.ZERO,
+		Vector3i.ZERO,
+		Transform2D(),
+		Vector4.ZERO,
+		Vector4i.ZERO,
+		Plane(),
+		Quaternion(),
+		AABB(),
+		Basis(),
+		Transform3D(),
+		Projection(),
+		Color.WHITE,
+		&"",
+		NodePath(),
+		RID(),
+		Callable(),
+		Signal(),
+		{},
+		[],
+		PackedByteArray(),
+		PackedInt32Array(),
+		PackedInt64Array(),
+		PackedFloat32Array(),
+		PackedFloat64Array(),
+		PackedStringArray(),
+		PackedVector2Array(),
+		PackedVector3Array(),
+		PackedColorArray(),
+		PackedVector4Array(),
+	]
+
+	for receiver: Variant in unsupported_receivers:
+		var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(3, 1), 2)
+		var occupied_cell: Vector2i = Vector2i.ZERO
+		var reserved_cell: Vector2i = Vector2i(1, 0)
+		var candidate_cell: Vector2i = Vector2i(2, 0)
+		assert_true(grid.occupy(&"baseline_occupant", occupied_cell))
+		assert_true(grid.reserve_cell(&"baseline_reservation", reserved_cell))
+		watch_signals(grid)
+
+		assert_false(grid.can_occupy(receiver, candidate_cell))
+		assert_true(grid.get_occupiable_cells(receiver).is_empty())
+		assert_false(grid.occupy(receiver, candidate_cell))
+		assert_false(grid.reserve_cell(receiver, candidate_cell))
+		assert_false(grid.confirm_reservation(receiver))
+		assert_eq(grid.get_receiver_cell(receiver), Vector2i(-1, -1))
+		grid.release(receiver)
+		grid.release_reservation(receiver)
+
+		assert_eq(grid.get_receiver_cell(&"baseline_occupant"), occupied_cell)
+		assert_eq(grid.get_occupied_cells(), [occupied_cell])
+		assert_eq(grid.get_reserved_cells(), [reserved_cell])
+		assert_signal_not_emitted(grid, "cell_occupied")
+		assert_signal_not_emitted(grid, "cell_released")
+		assert_signal_not_emitted(grid, "cell_reserved")
+		assert_signal_not_emitted(grid, "reservation_released")
+
+
+func test_same_cell_reservation_is_successful_without_duplicate_notifications() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i.ONE)
+	var receiver: StringName = &"actor"
+	watch_signals(grid)
+
+	assert_true(grid.reserve_cell(receiver, Vector2i.ZERO))
+	assert_true(grid.reserve_cell(receiver, Vector2i.ZERO))
+
+	assert_signal_emit_count(
+		grid,
+		"cell_reserved",
+		1,
+		"重复预约同一格只是成功恒等操作，不得重复发出预约通知。"
+	)
+	assert_signal_not_emitted(
+		grid,
+		"reservation_released",
+		"重复预约同一格不得伪造释放与重新预约状态变化。"
+	)
+	assert_true(grid.is_cell_reserved(Vector2i.ZERO))
+
+
+func test_existing_occupant_remains_idempotent_under_another_reservation() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i.ONE, 2)
+	var occupant: StringName = &"occupant"
+	var reserver: StringName = &"reserver"
+	watch_signals(grid)
+
+	assert_true(grid.occupy(occupant, Vector2i.ZERO))
+	assert_true(grid.reserve_cell(reserver, Vector2i.ZERO))
+	assert_true(
+		grid.can_occupy(occupant, Vector2i.ZERO),
+		"第三方预约不得让既有 occupant 的同格恒等查询失败。"
+	)
+	assert_eq(
+		grid.get_occupiable_cells(occupant),
+		[Vector2i.ZERO],
+		"第三方预约不得从既有 occupant 的可占用格快照中移除当前格。"
+	)
+	assert_true(
+		grid.occupy(occupant, Vector2i.ZERO),
+		"第三方预约不得让既有 occupant 的同格恒等提交失败。"
+	)
+
+	assert_signal_emit_count(
+		grid,
+		"cell_occupied",
+		1,
+		"既有 occupant 的同格恒等提交不得重复发出占用信号。"
+	)
+	assert_signal_not_emitted(grid, "cell_released")
+	assert_eq(grid.get_cell_occupants(Vector2i.ZERO), [occupant])
+	assert_true(grid.is_cell_reserved(Vector2i.ZERO))
+	assert_false(
+		grid.reserve_cell(occupant, Vector2i.ZERO),
+		"既有 occupant 不得越权覆盖另一个 receiver 的预约。"
+	)
+	assert_true(grid.is_cell_reserved(Vector2i.ZERO), "被拒绝的预约不得破坏现有预约。")
+	assert_true(grid.confirm_reservation(reserver), "原预约者仍应能确认预约。")
+	assert_eq(grid.get_cell_occupants(Vector2i.ZERO), [occupant, reserver])
+	assert_false(grid.is_cell_reserved(Vector2i.ZERO))
+
+
+func test_object_identity_remains_reachable_when_confirmation_callback_mutates_object() -> void:
+	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1))
+	var actor: Node = Node.new()
+	_objects.append(actor)
+	var target_cell: Vector2i = Vector2i(1, 0)
+	var observed_cells: Array[Vector2i] = []
+	watch_signals(grid)
+	var release_callback: Callable = func(
+		_receiver: Variant,
+		_released_cell: Vector2i
+	) -> void:
+		actor.set_meta(&"label", "changed")
+		observed_cells.append(grid.get_receiver_cell(actor))
+	var connect_error: Error = grid.reservation_released.connect(
+		release_callback
+	) as Error
+	assert_eq(connect_error, OK)
+
+	assert_true(grid.reserve_cell(actor, target_cell))
+	assert_true(grid.confirm_reservation(actor))
+
+	assert_eq(str(actor.get_meta(&"label")), "changed")
+	assert_eq(observed_cells, [target_cell], "回调应观察到已提交且仍可寻址的 Object 占用。")
+	assert_eq(grid.get_receiver_cell(actor), target_cell)
+	grid.release(actor)
+	assert_false(grid.is_cell_occupied(target_cell), "Object 内容变化不得破坏实例身份键。")
+	assert_signal_emit_count(grid, "cell_reserved", 1)
+	assert_signal_emit_count(grid, "reservation_released", 1)
+	assert_signal_emit_count(grid, "cell_occupied", 1)
+	assert_signal_emit_count(grid, "cell_released", 1)
+	grid.reservation_released.disconnect(release_callback)
+
+
 func test_confirm_reservation_is_atomic_against_release_notification_reentry() -> void:
 	var grid: GFGridOccupancy = GFGridOccupancy.new(Vector2i(2, 1))
 	var actor_a: Object = _make_object()


### PR DESCRIPTION
## Summary

Addresses the two unresolved Grid review findings from #46.

- Replace `GFGridOccupancy`'s ad-hoc `typeof + str(value)` receiver keys with the canonical `GFSpatialQueryIdentity` contract.
- Reject mutable and unsupported Variant receiver values before they can enter occupancy or reservation indexes.
- Define same-cell `occupy()` and `reserve_cell()` calls as successful identity operations with no duplicate state-change signals.
- Preserve foreign reservation ownership while allowing an existing occupant to query and idempotently occupy its current shared-capacity cell.

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: receiver values are limited to `Object`, non-empty `StringName`, non-empty `String`, or `int`; public signals now represent actual occupancy/reservation transitions rather than request acknowledgements.
- API or extension contract: public signatures are unchanged, but the accepted Variant domain and signal behavior are intentionally narrowed.
- Persisted data, package, protocol, or ProjectSettings impact: none.
- Failure, cancellation, rollback, concurrency, and ownership impact: unsupported identities fail closed without mutating legal state or emitting signals; Object identity remains stable across synchronous callback mutation; reservation ownership cannot be overwritten by another receiver.
- Compatibility and migration: breaking behavior is carried by the 10.0 development line with no compatibility shim. Callers using mutable receiver values must allocate a stable ID or pass the owning Object; callers needing per-request acknowledgement must use return values and project-level acknowledgement flow.

## Verification

- [x] Focused tests cover the changed behavior and failure path.
  - `godot --headless --log-file ai_analysis/godot_logs/grid_identity_audit_green.log --path . -s res://tests/gf_core/support/gf_gut_cli.gd -gtest=res://tests/gf_core/standard/foundation/math/test_gf_grid_occupancy.gd -gpre_run_script=res://tests/gf_core/support/gf_gut_pre_run_hook.gd -gpost_run_script=res://tests/gf_core/support/gf_gut_post_run_hook.gd -gexit -gdisable_colors`: 20/20 tests, 694 assertions, lifecycle gate clean.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only`: 22/22 checks.
- [x] GDScript warning and LSP gates are clean when `.gd` files changed.
  - `python tools/gf_maintenance.py check --check gdscript_warnings --json`: 2/2 checks.
  - `python tools/gf_maintenance.py check --check gdscript_lsp_diagnostics --json`: 1232 files, 0 diagnostics, 0 timeouts.
- [x] Generated API or knowledge output is fresh when its source changed.
- [x] Draft PR feedback completed through `GF draft gate` when applicable.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`.
- [x] `python tools/gf_maintenance.py --json-output build/grid-full-final.json check --suite full --jobs 3 --allow-breaking-api --failed-only`: 35/35 checks, 0 failures.

## Documentation and Release

- [x] Relevant guide and `[未发布]` changelog entries are updated, or the change is not user-visible.
- [x] Development version impact is correct, or the change does not alter the intended SemVer line.
- [x] This PR does not create a tag or publish a release.
