### PR TITLE
Harden runtime reliability and fail-fast concurrency contracts

### DIFF
--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -1616,6 +1616,69 @@ func get_utility(script_cls: Script, require_ready: bool = false) -> Object:
 	return _get_registered_instance_with_parent_lookup("utility", script_cls, require_ready)
 
 
+## 可选查找 System 实例，未找到时不输出严格依赖缺失错误。
+## 非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param script_cls: 脚本类。
+## [br]
+## @param require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。
+## [br]
+## @return 系统实例；可选依赖不存在或尚未 ready 时返回 null。
+func find_system(script_cls: Script, require_ready: bool = false) -> Object:
+	return _get_registered_instance_with_parent_lookup(
+		"system",
+		script_cls,
+		require_ready,
+		false
+	)
+
+
+## 可选查找 Model 实例，未找到时不输出严格依赖缺失错误。
+## 非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param script_cls: 脚本类。
+## [br]
+## @param require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。
+## [br]
+## @return 模型实例；可选依赖不存在或尚未 ready 时返回 null。
+func find_model(script_cls: Script, require_ready: bool = false) -> Object:
+	return _get_registered_instance_with_parent_lookup(
+		"model",
+		script_cls,
+		require_ready,
+		false
+	)
+
+
+## 可选查找 Utility 实例，未找到时不输出严格依赖缺失错误。
+## 非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param script_cls: 脚本类。
+## [br]
+## @param require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。
+## [br]
+## @return 工具实例；可选依赖不存在或尚未 ready 时返回 null。
+func find_utility(script_cls: Script, require_ready: bool = false) -> Object:
+	return _get_registered_instance_with_parent_lookup(
+		"utility",
+		script_cls,
+		require_ready,
+		false
+	)
+
+
 ## 仅从当前架构获取 System，不回退父级架构。
 ## [br]
 ## @api public
@@ -2648,7 +2711,8 @@ func _call_module_release_dependencies(instance: Object) -> void:
 func _get_registered_instance_with_parent_lookup(
 	registry_kind: String,
 	script_cls: Script,
-	require_ready: bool
+	require_ready: bool,
+	report_strict_miss: bool = true
 ) -> Object:
 	var current: GFArchitecture = self
 	var visited: Dictionary = _create_parent_lookup_visited()
@@ -2660,7 +2724,11 @@ func _get_registered_instance_with_parent_lookup(
 		if instance != null:
 			return instance if not require_ready or current._is_module_ready_for_lookup(instance) else null
 		if current.strict_dependency_lookup:
-			current._report_strict_lookup_miss(script_cls, module_registry.label)
+			if report_strict_miss:
+				current._report_strict_lookup_miss(
+					script_cls,
+					module_registry.label
+				)
 			return null
 		if not current._should_fallback_after_local_module_miss(module_registry, script_cls):
 			return null

--- a/addons/gf/standard/common/gf_async_keyed_gate.gd
+++ b/addons/gf/standard/common/gf_async_keyed_gate.gd
@@ -146,6 +146,13 @@ const STATUS_INVALID: StringName = &"invalid"
 ## @since 10.0.0
 const STATUS_REJECTED: StringName = &"rejected"
 
+## fail-fast 请求未取得租约；请求未进入等待队列。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_BUSY: StringName = &"busy"
+
 ## 默认每个 key 的并发槽位数。
 ## [br]
 ## @api public
@@ -468,6 +475,7 @@ var _cancelled_count: int = 0
 var _timeout_count: int = 0
 var _acquired_count: int = 0
 var _released_count: int = 0
+var _busy_count: int = 0
 var _high_watermark: int = 0
 var _key_high_watermark: int = 0
 var _rejected_count: int = 0
@@ -638,6 +646,69 @@ func request_lease(key: Variant, options: Dictionary = {}) -> Dictionary:
 	if not terminal_result.is_empty():
 		return terminal_result.duplicate(true)
 	return queued_result
+
+
+## 尝试立即取得一个 key 的执行租约。
+## [br]
+## 合法且未取消的请求只有在不越过同 key waiter、未完成的公平推进周期或生命周期
+## 通知边界时能够立即提交，才返回 acquired；容量或仲裁暂时不可用时返回 busy。
+## busy 不分配请求 ID 或 completion，不进入等待队列、不发出请求生命周期信号，
+## 也不改变公平游标。非法调用返回 invalid；cancel_token 在租约提交前胜出时返回
+## cancelled，且按已接受请求记录取消终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param key: 并发仲裁 key。
+## [br]
+## @param options: 即时请求选项，支持 metadata、max_concurrency、lease_timeout_msec 和 cancel_token。
+## [br]
+## @return 即时请求结果字典。
+## [br]
+## @schema key: Variant，必须是 GFVariantKeyCodec 接受的稳定 key。
+## [br]
+## @schema options: Dictionary，可包含 metadata: Dictionary、max_concurrency: int、lease_timeout_msec: int、cancel_token: GFCancellationToken。
+## [br]
+## @schema return: Dictionary，包含 ok、status、queued、acquired、request_id、key、metadata 和 reason，所有分支 queued 均为 false；status 为 acquired 时包含 lease 和已成功完成的 completion，busy 时 request_id 为 0 且不包含 lease 或 completion，cancelled/invalid 不包含 lease 或 completion。
+func try_request_lease(key: Variant, options: Dictionary = {}) -> Dictionary:
+	if not Thread.is_main_thread():
+		return _make_wrong_thread_request_result()
+
+	var key_report: Dictionary = _GF_VARIANT_KEY_CODEC_SCRIPT.try_make_key_token(key)
+	if not GFVariantData.get_option_bool(key_report, "ok"):
+		return _make_invalid_key_result(key, key_report)
+	var key_token: String = GFVariantData.get_option_string(key_report, "key_token")
+	var request_probe: Dictionary = {
+		"max_concurrency": _get_request_max_concurrency(options),
+	}
+	var can_commit_immediately: bool = (
+		not _pump_in_progress
+		and _notification_depth <= 0
+		and _lifecycle_batch_depth <= 0
+		and not _draining_pending_releases
+		and _pending_release_order.is_empty()
+		and (
+			_queued_count <= 0
+			or (
+				not _deferred_pump_scheduled
+				and _pump_scan_remaining_keys <= 0
+				and not _pump_dirty
+				and not _pump_followup_requested
+				and _pending_pump_cutoff <= 0
+			)
+		)
+		and _get_queue_size(key_token) <= 0
+		and (
+			_is_key_tracked(key_token)
+			or _key_data.size() < _max_tracked_keys
+		)
+		and _can_activate_request(key_token, request_probe)
+	)
+	if not can_commit_immediately:
+		_busy_count += 1
+		return _make_busy_request_result(key, options)
+	return request_lease(key, options)
 
 
 ## 等待并返回租约。
@@ -1067,7 +1138,7 @@ func get_recent_events() -> Array[Dictionary]:
 ## [br]
 ## @return gate 状态快照。
 ## [br]
-## @schema return: Dictionary，包含 queued_count、active_count、key_count、max_active_leases、等待、key 与推进预算配置、high_watermark、key_high_watermark、rejected_count、dropped_count、acquired_count、released_count、cancelled_count、timeout_count、keys 和 recent_events。
+## @schema return: Dictionary，包含 queued_count、active_count、key_count、max_active_leases、等待、key 与推进预算配置、high_watermark、key_high_watermark、busy_count、rejected_count、dropped_count、acquired_count、released_count、cancelled_count、timeout_count、keys 和 recent_events。
 func get_debug_snapshot() -> Dictionary:
 	if not Thread.is_main_thread():
 		return _make_wrong_thread_debug_snapshot()
@@ -1086,6 +1157,7 @@ func get_debug_snapshot() -> Dictionary:
 		"key_count": key_snapshots.size(),
 		"high_watermark": _high_watermark,
 		"key_high_watermark": _key_high_watermark,
+		"busy_count": _busy_count,
 		"rejected_count": _rejected_count,
 		"dropped_count": _dropped_count,
 		"acquired_count": _acquired_count,
@@ -1910,6 +1982,7 @@ func _make_wrong_thread_debug_snapshot() -> Dictionary:
 		"key_count": -1,
 		"high_watermark": -1,
 		"key_high_watermark": -1,
+		"busy_count": -1,
 		"rejected_count": -1,
 		"dropped_count": -1,
 		"acquired_count": -1,
@@ -1939,6 +2012,19 @@ func _make_rejected_request_result(
 	result["capacity_scope"] = capacity_scope
 	_record_event(&"request_rejected", request, null, reason)
 	return result
+
+
+func _make_busy_request_result(key: Variant, options: Dictionary) -> Dictionary:
+	return {
+		"ok": false,
+		"status": STATUS_BUSY,
+		"queued": false,
+		"acquired": false,
+		"request_id": 0,
+		"key": GFVariantData.duplicate_variant(key),
+		"metadata": GFVariantData.get_option_dictionary(options, "metadata"),
+		"reason": STATUS_BUSY,
+	}
 
 
 func _bind_request_cancel_token(request: Dictionary) -> bool:

--- a/addons/gf/standard/utilities/audio/gf_audio_utility.gd
+++ b/addons/gf/standard/utilities/audio/gf_audio_utility.gd
@@ -306,8 +306,10 @@ func dispose() -> void:
 	_clear_mix_control_tweens()
 	if is_instance_valid(_bgm_player):
 		_bgm_player.queue_free()
+	_bgm_player = null
 	if is_instance_valid(_bgm_fade_player):
 		_bgm_fade_player.queue_free()
+	_bgm_fade_player = null
 	_root = null
 	_audio_banks.clear()
 	_audio_bank_base_values.clear()
@@ -6823,23 +6825,18 @@ func _stop_all_local_bgm_players() -> void:
 	_cancel_bgm_fade_tween()
 	_cancel_bgm_stop_tween()
 	_cancel_bgm_transport_tween()
-	for player: AudioStreamPlayer in [_bgm_player, _bgm_fade_player]:
-		if not is_instance_valid(player):
-			continue
-		player.stream_paused = false
-		player.stop()
-		player.stream = null
-		if player.has_meta(_BGM_SESSION_META):
-			player.remove_meta(_BGM_SESSION_META)
+	_sanitize_local_bgm_player_references()
+	_stop_local_bgm_player(_bgm_player)
+	_stop_local_bgm_player(_bgm_fade_player)
 	_bgm_sessions.clear()
 	_bgm_current_session_id = 0
 	_bgm_incoming_session_id = 0
 
 
 func _clear_bgm_session_state() -> void:
-	for player: AudioStreamPlayer in [_bgm_player, _bgm_fade_player]:
-		if is_instance_valid(player) and player.has_meta(_BGM_SESSION_META):
-			player.remove_meta(_BGM_SESSION_META)
+	_sanitize_local_bgm_player_references()
+	_clear_local_bgm_player_session_meta(_bgm_player)
+	_clear_local_bgm_player_session_meta(_bgm_fade_player)
 	_bgm_sessions.clear()
 	_bgm_current_session_id = 0
 	_bgm_incoming_session_id = 0
@@ -6848,6 +6845,27 @@ func _clear_bgm_session_state() -> void:
 	_bgm_paused = false
 	_current_bgm_key = ""
 	_current_bgm_region.clear()
+
+
+func _sanitize_local_bgm_player_references() -> void:
+	if not is_instance_valid(_bgm_player):
+		_bgm_player = null
+	if not is_instance_valid(_bgm_fade_player):
+		_bgm_fade_player = null
+
+
+func _stop_local_bgm_player(player: AudioStreamPlayer) -> void:
+	if player == null:
+		return
+	player.stream_paused = false
+	player.stop()
+	player.stream = null
+	_clear_local_bgm_player_session_meta(player)
+
+
+func _clear_local_bgm_player_session_meta(player: AudioStreamPlayer) -> void:
+	if player != null and player.has_meta(_BGM_SESSION_META):
+		player.remove_meta(_BGM_SESSION_META)
 
 
 func _start_bgm_session_stop(

--- a/addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd
+++ b/addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd
@@ -1987,7 +1987,7 @@ func _is_builtin_tool_snapshot_id(tool_id: StringName) -> bool:
 
 
 func _get_build_info_utility() -> GFBuildInfoUtility:
-	var utility: Variant = get_utility(GFBuildInfoUtility)
+	var utility: Variant = _find_optional_utility(GFBuildInfoUtility)
 	if utility is GFBuildInfoUtility:
 		var build_info_utility: GFBuildInfoUtility = utility
 		return build_info_utility
@@ -1995,7 +1995,7 @@ func _get_build_info_utility() -> GFBuildInfoUtility:
 
 
 func _get_log_utility() -> GFLogUtility:
-	var utility: Variant = get_utility(GFLogUtility)
+	var utility: Variant = _find_optional_utility(GFLogUtility)
 	if utility is GFLogUtility:
 		var log_utility: GFLogUtility = utility
 		return log_utility
@@ -2003,11 +2003,18 @@ func _get_log_utility() -> GFLogUtility:
 
 
 func _get_console_utility() -> GFConsoleUtility:
-	var utility: Variant = get_utility(GFConsoleUtility)
+	var utility: Variant = _find_optional_utility(GFConsoleUtility)
 	if utility is GFConsoleUtility:
 		var console_utility: GFConsoleUtility = utility
 		return console_utility
 	return null
+
+
+func _find_optional_utility(utility_type: Script) -> Object:
+	var architecture: GFArchitecture = _get_architecture_or_null()
+	if architecture == null:
+		return null
+	return architecture.find_utility(utility_type)
 
 
 func _get_main_scene_tree() -> SceneTree:
@@ -2744,16 +2751,38 @@ func _monitor_event_system_stats() -> Dictionary:
 
 
 func _monitor_tool_timer_snapshot() -> Dictionary:
-	return _get_instance_debug_snapshot(get_utility(GFTimerUtility))
+	return _get_instance_debug_snapshot(
+		_find_optional_utility(GFTimerUtility)
+	)
 
 
 func _collect_tool_debug_snapshots() -> Dictionary:
 	var result: Dictionary = {}
-	_add_tool_debug_snapshot(result, &"build_info", get_utility(GFBuildInfoUtility))
-	_add_tool_debug_snapshot(result, &"timer", get_utility(GFTimerUtility))
-	_add_tool_debug_snapshot(result, &"object_pool", get_utility(GFObjectPoolUtility))
-	_add_tool_debug_snapshot(result, &"operation_diagnostics", get_utility(GFOperationDiagnosticsUtility))
-	_add_tool_debug_snapshot(result, &"async_tracker", get_utility(GFAsyncTrackerUtility))
+	_add_tool_debug_snapshot(
+		result,
+		&"build_info",
+		_find_optional_utility(GFBuildInfoUtility)
+	)
+	_add_tool_debug_snapshot(
+		result,
+		&"timer",
+		_find_optional_utility(GFTimerUtility)
+	)
+	_add_tool_debug_snapshot(
+		result,
+		&"object_pool",
+		_find_optional_utility(GFObjectPoolUtility)
+	)
+	_add_tool_debug_snapshot(
+		result,
+		&"operation_diagnostics",
+		_find_optional_utility(GFOperationDiagnosticsUtility)
+	)
+	_add_tool_debug_snapshot(
+		result,
+		&"async_tracker",
+		_find_optional_utility(GFAsyncTrackerUtility)
+	)
 	_add_published_tool_snapshots(result)
 	return result
 

--- a/addons/gf/standard/utilities/display/gf_render_warmup_utility.gd
+++ b/addons/gf/standard/utilities/display/gf_render_warmup_utility.gd
@@ -65,9 +65,12 @@ enum TouchMode {
 
 # --- 公共变量 ---
 
-## 每次 tick 默认处理的最大条目数。
+## 每次 tick 默认处理的最大条目数。未显式覆盖清单预算时，小于等于 0 会暂停正常帧推进；
+## 恢复为正数后从原队列位置继续。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 var default_entries_per_tick: int = 4
 
 ## 默认预热时间预算，单位秒。小于等于 0 表示不限制。
@@ -132,7 +135,17 @@ var _temporary_render_nodes: Array[Node] = []
 ## @param _delta: 本帧时间增量。
 func tick(_delta: float) -> void:
 	release_temporary_render_nodes()
-	var _processed_count: int = process_queue(default_entries_per_tick)
+	if _queue.is_empty():
+		return
+
+	var head_item: Dictionary = GFVariantData.as_dictionary(_queue[0])
+	var head_options: Dictionary = GFVariantData.get_option_dictionary(head_item, "options")
+	var head_entries_per_tick: int = GFVariantData.get_option_int(
+		head_options,
+		"entries_per_tick",
+		default_entries_per_tick
+	)
+	var _processed_count: int = _process_queue_budget(head_entries_per_tick, true)
 
 
 ## 清空预热队列、缓存资源和临时渲染节点。
@@ -156,11 +169,11 @@ func dispose() -> void:
 ## [br]
 ## @param manifest: 预热清单。
 ## [br]
-## @param options: 可选参数，支持 entries_per_tick、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation。
+## @param options: 可选参数。显式 entries_per_tick 会在入队时钳制到最小 1 并固定；未提供时继续读取当前 default_entries_per_tick。其余支持 max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes 和 allow_scene_instantiation。
 ## [br]
 ## @return 队列标识；失败返回 -1。
 ## [br]
-## @schema options: Dictionary，包含 entries_per_tick、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation、temporary_parent 和 temporary_viewport_size。
+## @schema options: Dictionary，可包含 entries_per_tick: int（显式值最小为 1，并在入队时固定）、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation、temporary_parent 和 temporary_viewport_size；缺少 entries_per_tick 时使用实时全局默认值。
 func queue_manifest(manifest: GFRenderWarmupManifest, options: Dictionary = {}) -> int:
 	if manifest == null or manifest.is_empty():
 		return -1
@@ -168,6 +181,16 @@ func queue_manifest(manifest: GFRenderWarmupManifest, options: Dictionary = {}) 
 	var queue_id: int = _next_queue_id
 	_next_queue_id += 1
 	var entry_list: Array[Dictionary] = manifest.get_entries()
+	var normalized_options: Dictionary = options.duplicate(true)
+	if options.has("entries_per_tick"):
+		normalized_options["entries_per_tick"] = maxi(
+			GFVariantData.get_option_int(
+				options,
+				"entries_per_tick",
+				default_entries_per_tick
+			),
+			1
+		)
 	_queue.append({
 		"queue_id": queue_id,
 		"manifest_id": manifest.manifest_id,
@@ -175,7 +198,7 @@ func queue_manifest(manifest: GFRenderWarmupManifest, options: Dictionary = {}) 
 		"index": 0,
 		"processed": 0,
 		"failed": 0,
-		"options": options.duplicate(true),
+		"options": normalized_options,
 		"started_at_unix": Time.get_unix_time_from_system(),
 		"started_at_msec": Time.get_ticks_msec(),
 	})
@@ -243,39 +266,7 @@ func warmup_manifest_now(manifest: GFRenderWarmupManifest, options: Dictionary =
 ## [br]
 ## @return 实际处理条目数。
 func process_queue(max_entries: int = 1) -> int:
-	if max_entries <= 0:
-		return 0
-
-	var processed_now: int = 0
-	while processed_now < max_entries and not _queue.is_empty():
-		var item: Dictionary = GFVariantData.as_dictionary(_queue[0])
-		if _is_queue_item_budget_exhausted(item):
-			_finish_queue_item(item, true)
-			_queue.remove_at(0)
-			continue
-
-		var entries: Array = GFVariantData.get_option_array(item, "entries")
-		var index: int = GFVariantData.get_option_int(item, "index")
-		if index >= entries.size():
-			_finish_queue_item(item, false)
-			_queue.remove_at(0)
-			continue
-
-		var options: Dictionary = GFVariantData.get_option_dictionary(item, "options")
-		var result: Dictionary = _process_entry(GFVariantData.as_dictionary(entries[index]), options)
-		result["entry_index"] = index
-		item["index"] = index + 1
-		item["processed"] = GFVariantData.get_option_int(item, "processed") + 1
-		if not GFVariantData.get_option_bool(result, "ok"):
-			item["failed"] = GFVariantData.get_option_int(item, "failed") + 1
-		processed_now += 1
-		warmup_entry_processed.emit(GFVariantData.get_option_int(item, "queue_id", -1), index, result)
-
-		if GFVariantData.get_option_int(item, "index") >= entries.size():
-			_finish_queue_item(item, false)
-			_queue.remove_at(0)
-
-	return processed_now
+	return _process_queue_budget(max_entries, false)
 
 
 ## 从节点树收集可预热的渲染资源。
@@ -450,6 +441,49 @@ func get_debug_snapshot() -> Dictionary:
 
 
 # --- 私有/辅助方法 ---
+
+func _process_queue_budget(max_entries: int, head_only: bool) -> int:
+	if max_entries <= 0:
+		return 0
+
+	var selected_queue_id: int = -1
+	if head_only and not _queue.is_empty():
+		var selected_item: Dictionary = GFVariantData.as_dictionary(_queue[0])
+		selected_queue_id = GFVariantData.get_option_int(selected_item, "queue_id", -1)
+
+	var processed_now: int = 0
+	while processed_now < max_entries and not _queue.is_empty():
+		var item: Dictionary = GFVariantData.as_dictionary(_queue[0])
+		if head_only and GFVariantData.get_option_int(item, "queue_id", -1) != selected_queue_id:
+			break
+		if _is_queue_item_budget_exhausted(item):
+			_finish_queue_item(item, true)
+			_queue.remove_at(0)
+			continue
+
+		var entries: Array = GFVariantData.get_option_array(item, "entries")
+		var index: int = GFVariantData.get_option_int(item, "index")
+		if index >= entries.size():
+			_finish_queue_item(item, false)
+			_queue.remove_at(0)
+			continue
+
+		var options: Dictionary = GFVariantData.get_option_dictionary(item, "options")
+		var result: Dictionary = _process_entry(GFVariantData.as_dictionary(entries[index]), options)
+		result["entry_index"] = index
+		item["index"] = index + 1
+		item["processed"] = GFVariantData.get_option_int(item, "processed") + 1
+		if not GFVariantData.get_option_bool(result, "ok"):
+			item["failed"] = GFVariantData.get_option_int(item, "failed") + 1
+		processed_now += 1
+		warmup_entry_processed.emit(GFVariantData.get_option_int(item, "queue_id", -1), index, result)
+
+		if GFVariantData.get_option_int(item, "index") >= entries.size():
+			_finish_queue_item(item, false)
+			_queue.remove_at(0)
+
+	return processed_now
+
 
 func _process_entry(entry: Dictionary, options: Dictionary) -> Dictionary:
 	var normalized: Dictionary = GFRenderWarmupManifest.normalize_entry(entry)

--- a/addons/gf/standard/utilities/jobs/gf_background_work_task.gd
+++ b/addons/gf/standard/utilities/jobs/gf_background_work_task.gd
@@ -140,6 +140,8 @@ var finished_msec: int = 0
 
 var _worker_callback: Callable = Callable()
 var _apply_callback: Callable = Callable()
+var _worker_callback_target: RefCounted = null
+var _apply_callback_target: RefCounted = null
 
 
 # --- 公共方法 ---
@@ -234,8 +236,13 @@ static func status_name(value: Status) -> String:
 ## [br]
 ## @param apply_callback: 主线程应用阶段回调。
 func set_internal_callbacks(worker_callback: Callable, apply_callback: Callable) -> void:
+	# Callable 不会替 RefCounted target 持有引用；先捕获新 target，避免替换时出现零引用窗口。
+	var worker_target: RefCounted = _get_ref_counted_callback_target(worker_callback)
+	var apply_target: RefCounted = _get_ref_counted_callback_target(apply_callback)
 	_worker_callback = worker_callback
 	_apply_callback = apply_callback
+	_worker_callback_target = worker_target
+	_apply_callback_target = apply_target
 
 
 ## 获取后台工作回调。
@@ -254,3 +261,15 @@ func get_worker_callback() -> Callable:
 ## @return 主线程应用回调。
 func get_apply_callback() -> Callable:
 	return _apply_callback
+
+
+# --- 私有/辅助方法 ---
+
+func _get_ref_counted_callback_target(callback: Callable) -> RefCounted:
+	if not callback.is_valid():
+		return null
+	var callback_target: Object = callback.get_object()
+	if callback_target is RefCounted:
+		var retained_target: RefCounted = callback_target
+		return retained_target
+	return null

--- a/addons/gf/standard/utilities/jobs/gf_background_work_utility.gd
+++ b/addons/gf/standard/utilities/jobs/gf_background_work_utility.gd
@@ -587,6 +587,7 @@ func _poll_thread_tasks() -> void:
 		var result_variant: Variant = thread.wait_to_finish()
 		var _removed_active: bool = _active_thread_tasks.erase(work_id)
 		var task: GFBackgroundWorkTask = _get_thread_entry_task(entry)
+		_release_worker_callback_after_join(task)
 		_finish_thread_task(task, result_variant)
 
 
@@ -788,6 +789,7 @@ func _complete_task(task: GFBackgroundWorkTask) -> void:
 	task.status = GFBackgroundWorkTask.Status.COMPLETED
 	task.progress = 1.0
 	task.finished_msec = Time.get_ticks_msec()
+	_release_task_callbacks_at_terminal(task)
 	_finished_tasks.append(task)
 	_trim_finished_tasks()
 	work_completed.emit(task)
@@ -802,6 +804,7 @@ func _fail_task(task: GFBackgroundWorkTask, error_message: String = "", result: 
 	task.error_message = error_message
 	task.result = result
 	task.finished_msec = Time.get_ticks_msec()
+	_release_task_callbacks_at_terminal(task)
 	_finished_tasks.append(task)
 	_trim_finished_tasks()
 	work_failed.emit(task)
@@ -827,6 +830,7 @@ func _cancel_task(task: GFBackgroundWorkTask) -> void:
 	_apply_queue.erase(task)
 	task.status = GFBackgroundWorkTask.Status.CANCELLED
 	task.finished_msec = Time.get_ticks_msec()
+	_release_task_callbacks_at_terminal(task)
 	_finished_tasks.append(task)
 	_trim_finished_tasks()
 	work_cancelled.emit(task)
@@ -842,8 +846,21 @@ func _wait_for_active_thread_tasks() -> void:
 		if thread != null:
 			result_variant = thread.wait_to_finish()
 		var task: GFBackgroundWorkTask = _get_thread_entry_task(entry)
+		_release_worker_callback_after_join(task)
 		_finish_thread_task(task, result_variant)
 	_active_thread_tasks.clear()
+
+
+func _release_worker_callback_after_join(task: GFBackgroundWorkTask) -> void:
+	if task == null:
+		return
+	task.set_internal_callbacks(Callable(), task.get_apply_callback())
+
+
+func _release_task_callbacks_at_terminal(task: GFBackgroundWorkTask) -> void:
+	if task == null:
+		return
+	task.set_internal_callbacks(Callable(), Callable())
 
 
 func _trim_finished_tasks() -> void:

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "7a0dd36d16523f5764c8f7405c05c3966572ffba79719c6688d2fac48a7d1c6f",
+  "source_digest": "34c315b76753015025c03069fdcfd284028c732645fb2f76d36de5ff84bf4d20",
   "class_count": 763,
   "package_count": 52,
   "packages": [
@@ -2634,6 +2634,27 @@
           "name": "get_utility",
           "signature": "func get_utility(script_cls: Script, require_ready: bool = false) -> Object",
           "summary": "通过脚本类获取 Utility 实例。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "find_system",
+          "signature": "func find_system(script_cls: Script, require_ready: bool = false) -> Object",
+          "summary": "可选查找 System 实例，未找到时不输出严格依赖缺失错误。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "find_model",
+          "signature": "func find_model(script_cls: Script, require_ready: bool = false) -> Object",
+          "summary": "可选查找 Model 实例，未找到时不输出严格依赖缺失错误。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "find_utility",
+          "signature": "func find_utility(script_cls: Script, require_ready: bool = false) -> Object",
+          "summary": "可选查找 Utility 实例，未找到时不输出严格依赖缺失错误。",
           "visibility": "public"
         },
         {
@@ -5892,6 +5913,13 @@
         },
         {
           "kind": "const",
+          "name": "STATUS_BUSY",
+          "signature": "const STATUS_BUSY: StringName = &\"busy\"",
+          "summary": "fail-fast 请求未取得租约；请求未进入等待队列。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
           "name": "DEFAULT_MAX_CONCURRENCY",
           "signature": "const DEFAULT_MAX_CONCURRENCY: int = 1",
           "summary": "默认每个 key 的并发槽位数。",
@@ -6070,6 +6098,13 @@
           "name": "request_lease",
           "signature": "func request_lease(key: Variant, options: Dictionary = {}) -> Dictionary",
           "summary": "请求一个 key 的执行租约。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "try_request_lease",
+          "signature": "func try_request_lease(key: Variant, options: Dictionary = {}) -> Dictionary",
+          "summary": "尝试立即取得一个 key 的执行租约。",
           "visibility": "public"
         },
         {
@@ -60943,7 +60978,7 @@
           "kind": "var",
           "name": "default_entries_per_tick",
           "signature": "var default_entries_per_tick: int = 4",
-          "summary": "每次 tick 默认处理的最大条目数。",
+          "summary": "每次 tick 默认处理的最大条目数。未显式覆盖清单预算时，小于等于 0 会暂停正常帧推进；",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFArchitecture.xml
+++ b/docs/api_catalog/classes/GFArchitecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="4dc51b63c790b58220d7ee60b575d1b7b1ddc9c96373f061cff12a52e209dad6">
+<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="f8bf63c3d4680c2455f0346de461df6d8ba12ac3e92f5fb518310faceba6d472">
 	<description>GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。
 生命周期遵循三阶段初始化协议：
 阶段一 (init)       ：所有模块执行自身内部变量初始化。
@@ -953,6 +953,42 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 				<tag name="param">script_cls: 脚本类。</tag>
 				<tag name="param">require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。</tag>
 				<tag name="return">工具实例，如果未找到则返回 null。</tag>
+			</tags>
+		</member>
+		<member kind="method" name="find_system">
+			<signature>func find_system(script_cls: Script, require_ready: bool = false) -&gt; Object:</signature>
+			<description>可选查找 System 实例，未找到时不输出严格依赖缺失错误。
+非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">script_cls: 脚本类。</tag>
+				<tag name="param">require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。</tag>
+				<tag name="return">系统实例；可选依赖不存在或尚未 ready 时返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="find_model">
+			<signature>func find_model(script_cls: Script, require_ready: bool = false) -&gt; Object:</signature>
+			<description>可选查找 Model 实例，未找到时不输出严格依赖缺失错误。
+非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">script_cls: 脚本类。</tag>
+				<tag name="param">require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。</tag>
+				<tag name="return">模型实例；可选依赖不存在或尚未 ready 时返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="find_utility">
+			<signature>func find_utility(script_cls: Script, require_ready: bool = false) -&gt; Object:</signature>
+			<description>可选查找 Utility 实例，未找到时不输出严格依赖缺失错误。
+非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">script_cls: 脚本类。</tag>
+				<tag name="param">require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。</tag>
+				<tag name="return">工具实例；可选依赖不存在或尚未 ready 时返回 null。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_local_system">

--- a/docs/api_catalog/classes/GFAsyncKeyedGate.xml
+++ b/docs/api_catalog/classes/GFAsyncKeyedGate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFAsyncKeyedGate" path="addons/gf/standard/common/gf_async_keyed_gate.gd" module="standard" extends="RefCounted" classDigest="9fe64e0211f7cdb2b1ae4b4052cca7f14bc217ae10f914804deab95a1f0e2e66">
+<class name="GFAsyncKeyedGate" path="addons/gf/standard/common/gf_async_keyed_gate.gd" module="standard" extends="RefCounted" classDigest="c0a91377c7d0c7e731c985845d3444be8d9e0e5e5b043afe8da25e53f7a2368f">
 	<description>GFAsyncKeyedGate: 按 key 仲裁异步并发槽位。
 用于把“同一个资源、槽位、存档、玩家或编辑器目标”的异步操作限制在可控并发内。
 gate 只负责排队、发放租约、释放后推进队列，以及记录取消/超时诊断；
@@ -128,6 +128,14 @@ gate 只负责排队、发放租约、释放后推进队列，以及记录取消
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">10.0.0</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_BUSY">
+			<signature>const STATUS_BUSY: StringName = &amp;"busy"</signature>
+			<description>fail-fast 请求未取得租约；请求未进入等待队列。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="const" name="DEFAULT_MAX_CONCURRENCY">
@@ -351,6 +359,25 @@ GFAsyncCompletion。队列推进后 completion 会成功并携带 lease。</desc
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>
+		<member kind="method" name="try_request_lease">
+			<signature>func try_request_lease(key: Variant, options: Dictionary = {}) -&gt; Dictionary:</signature>
+			<description>尝试立即取得一个 key 的执行租约。
+合法且未取消的请求只有在不越过同 key waiter、未完成的公平推进周期或生命周期
+通知边界时能够立即提交，才返回 acquired；容量或仲裁暂时不可用时返回 busy。
+busy 不分配请求 ID 或 completion，不进入等待队列、不发出请求生命周期信号，
+也不改变公平游标。非法调用返回 invalid；cancel_token 在租约提交前胜出时返回
+cancelled，且按已接受请求记录取消终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">key: 并发仲裁 key。</tag>
+				<tag name="param">options: 即时请求选项，支持 metadata、max_concurrency、lease_timeout_msec 和 cancel_token。</tag>
+				<tag name="return">即时请求结果字典。</tag>
+				<tag name="schema">key: Variant，必须是 GFVariantKeyCodec 接受的稳定 key。</tag>
+				<tag name="schema">options: Dictionary，可包含 metadata: Dictionary、max_concurrency: int、lease_timeout_msec: int、cancel_token: GFCancellationToken。</tag>
+				<tag name="schema">return: Dictionary，包含 ok、status、queued、acquired、request_id、key、metadata 和 reason，所有分支 queued 均为 false；status 为 acquired 时包含 lease 和已成功完成的 completion，busy 时 request_id 为 0 且不包含 lease 或 completion，cancelled/invalid 不包含 lease 或 completion。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="wait_for_lease_async">
 			<signature>func wait_for_lease_async(key: Variant, options: Dictionary = {}) -&gt; GFAsyncGateLease:</signature>
 			<description>等待并返回租约。</description>
@@ -507,7 +534,7 @@ acquire/release 生命周期通知中的重入释放会延迟到最外层通知�
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">gate 状态快照。</tag>
-				<tag name="schema">return: Dictionary，包含 queued_count、active_count、key_count、max_active_leases、等待、key 与推进预算配置、high_watermark、key_high_watermark、rejected_count、dropped_count、acquired_count、released_count、cancelled_count、timeout_count、keys 和 recent_events。</tag>
+				<tag name="schema">return: Dictionary，包含 queued_count、active_count、key_count、max_active_leases、等待、key 与推进预算配置、high_watermark、key_high_watermark、busy_count、rejected_count、dropped_count、acquired_count、released_count、cancelled_count、timeout_count、keys 和 recent_events。</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFRenderWarmupUtility.xml
+++ b/docs/api_catalog/classes/GFRenderWarmupUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFRenderWarmupUtility" path="addons/gf/standard/utilities/display/gf_render_warmup_utility.gd" module="standard" extends="GFUtility" classDigest="1d20f7385b9533fa1ef68e5c31aa37dd3f96e16059797512d62bf507c6cae987">
+<class name="GFRenderWarmupUtility" path="addons/gf/standard/utilities/display/gf_render_warmup_utility.gd" module="standard" extends="GFUtility" classDigest="feaf28cb7fb9af71fa9769b711249b46627af1db4fd9ff37468d493966f2d7a8">
 	<description>GFRenderWarmupUtility: 通用渲染资源预热工具。
 通过清单或节点树收集 Mesh、Material、Texture 等渲染资源，并按帧预算提前加载和触碰 RID。
 它不决定项目何时预热、预热哪些场景或如何展示加载进度。</description>
@@ -59,9 +59,11 @@
 	<properties>
 		<member kind="property" name="default_entries_per_tick">
 			<signature>var default_entries_per_tick: int = 4</signature>
-			<description>每次 tick 默认处理的最大条目数。</description>
+			<description>每次 tick 默认处理的最大条目数。未显式覆盖清单预算时，小于等于 0 会暂停正常帧推进；
+恢复为正数后从原队列位置继续。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="default_max_seconds">
@@ -133,9 +135,9 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">manifest: 预热清单。</tag>
-				<tag name="param">options: 可选参数，支持 entries_per_tick、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation。</tag>
+				<tag name="param">options: 可选参数。显式 entries_per_tick 会在入队时钳制到最小 1 并固定；未提供时继续读取当前 default_entries_per_tick。其余支持 max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes 和 allow_scene_instantiation。</tag>
 				<tag name="return">队列标识；失败返回 -1。</tag>
-				<tag name="schema">options: Dictionary，包含 entries_per_tick、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation、temporary_parent 和 temporary_viewport_size。</tag>
+				<tag name="schema">options: Dictionary，可包含 entries_per_tick: int（显式值最小为 1，并在入队时固定）、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation、temporary_parent 和 temporary_viewport_size；缺少 entries_per_tick 时使用实时全局默认值。</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="1ea62deafe83d7ab6bcdd971f4a10ab07c344bf06cdbf5ffcde9eb38ad6a08f6" classCount="787" methodCount="7073">
-	<module id="kernel" label="Kernel" classCount="73" methodCount="744">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="49bbd19cd387db5d0f9b1fdb0d3b2dfa5c14aa119bbd8c6141460a45d972df72" classCount="787" methodCount="7077">
+	<module id="kernel" label="Kernel" classCount="73" methodCount="747">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
 		<class name="GFArtifactWriteTransaction" path="classes/GFArtifactWriteTransaction.xml" sourcePath="addons/gf/kernel/editor/gf_artifact_write_transaction.gd" extends="RefCounted" />
@@ -75,7 +75,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="440" methodCount="4416">
+	<module id="standard" label="Standard" classCount="440" methodCount="4417">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -24,7 +24,7 @@
 
 ## [未发布]
 
-**版本概述**：本轮新增类型化音频播放区间与循环点，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁；框架只提供可验证的通用契约，不内置部署协议、环境业务模型或轮询式音频模拟。
+**版本概述**：本轮新增类型化音频播放区间与循环点，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧可选依赖、后台回调所有权、按 key 并发、渲染预热和音频释放契约；框架只提供可验证的通用机制，不内置部署协议、环境业务模型或轮询式音频模拟。
 
 ### 🚀 新增特性 (Added)
 
@@ -34,6 +34,8 @@
 - 新增 Headless 服务健康/探针组合配方：组合惰性诊断 Provider、有界会话字段与类型化传输指标，由项目 Adapter 决定 liveness/readiness、传输协议、鉴权和部署政策；Backend 指标补充使用通用执行预算，并对总指标、自定义指标和 ID 长度设置绝对上限。
 - 新增周期环境表现组合配方：组合可注入时钟、项目环境样本、Shader Profile、接口快照与 Binder；周期、天气、天文、时区和持久化策略继续由项目负责。
 - AI Developer Capability / Recipe 知识目录升级到 `1.8.0`，加入两份组合配方的可搜索边界，并让音频能力目录认识类型化播放区间与循环点。
+- `GFArchitecture` 新增 `find_model()`、`find_system()` 与 `find_utility()` 静默可选查询：非严格模式复用普通父链和 alias 规则，严格模式停止本地但不报告 required miss。
+- `GFAsyncKeyedGate` 新增 `try_request_lease()` 与 `STATUS_BUSY`：无法在当前主线程边界立即提交时，不创建 waiter、请求 ID 或 completion，不发请求生命周期信号，也不改变公平游标。
 
 ### 🔄 机制更改 (Changed)
 
@@ -46,6 +48,8 @@
 - 新增 tracked-only `codeql_suppression_policy`：禁止 Python 源码中的全部内联 suppression，并拒绝 bracketed legacy、通配、多 query，以及 CodeQL 的路径过滤、查询过滤、自定义配置和自定义查询套件；YAML 约束只匹配真实 mapping key，区分规范注释、URL fragment、说明 scalar 与 block scalar，并通过受控 UTF-8 普通文件读取固定完整父目录链和文件身份。该策略与 GF 凭据门禁的豁免保持完全隔离，并进入 quick、full 与 release。
 - API baseline 现在比较公开成员的 `@schema` 契约；已有 free-text schema 的任何文本变化（包括追加、改写、重排或删除）都会 fail-closed 归入 breaking，只有稳定基线此前完全没有 schema、当前首次补充时才归入 compatible，避免 Dictionary 字段迁移绕过 SemVer 主版本门禁。
 - `GFNetworkBackend.get_transport_metrics()` 现在把基础计数与 Adapter 补充阶段隔离；补充 Hook 超过执行预算、未为新增指标消费步骤或突破指标容量时，本次调用失败关闭为基础快照，不把不可控工作带入探针路径。
+- `GFBackgroundWorkUtility` 在接受任务后强持有 `RefCounted` worker/apply callback target，并分别在线程 join 和任务终态释放，避免排队任务依赖调用方局部变量寿命。
+- `GFRenderWarmupUtility` 将清单显式提供的 `entries_per_tick` 在入队时钳制并固定；未覆盖时继续读取当前全局默认值，正常 `tick()` 只消费 FIFO 队首自己的预算，显式 `process_queue()` 继续提供跨清单总预算。
 
 ### 🐛 Bug 修复 (Fixed)
 
@@ -55,6 +59,10 @@
 - 修复 CodeQL 策略把普通 `LGTM`、步骤说明中的 `paths` / `queries` 和 shell block 行尾反斜杠误判为 suppression/config，以及把 URL fragment 的 `#` 错当注释后漏过禁用默认查询的问题；YAML key lexer 现在同时覆盖 block、flow、quoted、Unicode escape、quoted continuation 与多行显式 key，并在原始输入、线性 Unicode 解码后的原始文本及续行拼接后的逻辑行上累计冒号、引号与标签探测预算。续行改为分块后单次连接，编码或跨行构造的 probe 不能在 normalization 阶段恢复二次复杂度。
 - 修复 Utility 的有界 Bank resolver 用最右子串截断多字符 `fallback_separator`、导致结果偏离 `GFAudioBank.resolve_clip()` 的问题；运行时解析现在保留从左到右、非重叠且忽略空片段的既有分隔语义，同时继续限制标识长度、分隔符长度与最多 16 次回退。
 - 修复异步等待生命周期测试把 1ms 墙钟预算与 deferred free 调度顺序绑定的竞态；测试现在先用 timeout pause 建立等待已挂起的握手，再同步释放 continuation owner，稳定验证失效检查必须先于同轮已到期 timeout 仲裁。
+- 修复后台任务只保存 `Callable`、导致短生命周期 `RefCounted` worker 或 apply target 在线程执行前释放的问题；取消、失败和成功路径现在统一清理 callback 所有权。
+- 修复 `GFRenderWarmupUtility.queue_manifest()` 保存但正常帧推进忽略 `entries_per_tick` 的问题，并防止显式零或负清单预算永久停滞。
+- 修复 `GFDiagnosticsUtility` 在 strict architecture 中通过 reporting lookup 探测可选 Console、Log 和工具快照贡献者，导致合法缺失被误报为必需依赖的问题。
+- 修复场景树先释放 root-owned BGM 播放器后，`GFAudioUtility.dispose()` 在有效性检查前构造 typed array 而触发 freed-instance 转换错误的问题；两条 BGM 清理路径与重复 dispose 都收敛到幂等终态。
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
@@ -67,6 +75,8 @@
 - `GFAudioBackendCapability.supports_playback_region_contract`、`GFAudioBackend.evaluate_playback_region()`、`GFAudioUtility.playback_region_rejected` 与 `GFAudioUtility.get_last_playback_region_rejection()` 为新的公开 API。
 - `GFAudioUtility.get_debug_snapshot()` 用 `current_bgm_region` 和 `last_playback_region_rejection` 描述播放区间状态，不再提供 `current_bgm_loop`。
 - `GFNetworkBackend._enrich_transport_metrics()` 现在接收 `GFExecutionBudget`，属于有意的 protected 签名升级；新增 `MAX_TRANSPORT_METRICS_ENRICHMENT_MSEC`，`GFNetworkTransportMetrics` 新增总指标、自定义指标和 ID 长度绝对上限常量。`gf.network` 的 `extension_version` 因此提升到 `6.0.0`。
+- `GFArchitecture.find_model()`、`find_system()` 和 `find_utility()` 是新的公开可选解析入口。
+- `GFAsyncKeyedGate.try_request_lease()`、`STATUS_BUSY` 与调试快照中的 `busy_count` 是新的公开 fail-fast 并发契约。
 
 ### 📘 升级指南 (Migration Guide)
 
@@ -84,6 +94,12 @@
 - `addons/gf/standard/utilities/audio/gf_audio_backend.gd`
 - `addons/gf/standard/utilities/audio/gf_audio_backend_capability.gd`
 - `addons/gf/standard/utilities/audio/gf_audio_clip.gd`
+- `addons/gf/kernel/core/gf_architecture.gd`
+- `addons/gf/standard/common/gf_async_keyed_gate.gd`
+- `addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd`
+- `addons/gf/standard/utilities/display/gf_render_warmup_utility.gd`
+- `addons/gf/standard/utilities/jobs/gf_background_work_task.gd`
+- `addons/gf/standard/utilities/jobs/gf_background_work_utility.gd`
 - `addons/gf/extensions/network/backends/gf_network_backend.gd`
 - `addons/gf/extensions/network/runtime/gf_network_transport_metrics.gd`
 - `addons/gf/extensions/network/gf_extension.json`

--- a/docs/zh/kernel/architecture/assembly-diagnostics/dependency-diagnostics.md
+++ b/docs/zh/kernel/architecture/assembly-diagnostics/dependency-diagnostics.md
@@ -4,6 +4,21 @@
 
 诊断只读，不会自动注册缺失模块，也不会改变 `get_model()`、`get_system()`、`get_utility()` 和工厂创建的现有语义。
 
+## 必需查询与可选查询
+
+模块真正依赖某项能力时使用 `get_model()`、`get_system()` 或 `get_utility()`。开启 `strict_dependency_lookup` 后，这些入口只接受当前架构中的注册项，并会报告本地缺失；它们适合让错误装配尽早失败。
+
+能力只是可选集成时使用 `find_model()`、`find_system()` 或 `find_utility()`。三者与普通查询共用类型、alias、ready 和父链解析规则，唯一差异是未找到时不报告 required miss：非严格模式仍可回退父架构，严格模式仍停止在当前架构，但静默返回 `null`。
+
+```gdscript
+var console_value: Variant = architecture.find_utility(GFConsoleUtility)
+if console_value is GFConsoleUtility:
+	var console: GFConsoleUtility = console_value
+	# Console 存在时才绑定可选命令。
+```
+
+required/optional 是每个消费点的语义，不能固化到全局类型注册记录。同一个 Utility 可以被某个模块视为必需依赖，同时被另一个诊断或编辑器集成视为可选能力。
+
 ## 依赖声明
 
 模块可按需实现这些 hook：

--- a/docs/zh/reference/api/classes/GFArchitecture.md
+++ b/docs/zh/reference/api/classes/GFArchitecture.md
@@ -112,6 +112,9 @@
 | 方法 | [`get_system`](#member-gfarchitecture-methods-get_system) | `func get_system(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_model`](#member-gfarchitecture-methods-get_model) | `func get_model(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_utility`](#member-gfarchitecture-methods-get_utility) | `func get_utility(script_cls: Script, require_ready: bool = false) -> Object:` |
+| 方法 | [`find_system`](#member-gfarchitecture-methods-find_system) | `func find_system(script_cls: Script, require_ready: bool = false) -> Object:` |
+| 方法 | [`find_model`](#member-gfarchitecture-methods-find_model) | `func find_model(script_cls: Script, require_ready: bool = false) -> Object:` |
+| 方法 | [`find_utility`](#member-gfarchitecture-methods-find_utility) | `func find_utility(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_local_system`](#member-gfarchitecture-methods-get_local_system) | `func get_local_system(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_local_model`](#member-gfarchitecture-methods-get_local_model) | `func get_local_model(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_local_utility`](#member-gfarchitecture-methods-get_local_utility) | `func get_local_utility(script_cls: Script, require_ready: bool = false) -> Object:` |
@@ -1920,6 +1923,72 @@ func get_utility(script_cls: Script, require_ready: bool = false) -> Object:
 | `require_ready` | 为 true 时，仅返回已完成 ready 阶段的实例。 |
 
 返回：工具实例，如果未找到则返回 null。
+
+<a id="member-gfarchitecture-methods-find_system"></a>
+
+### `find_system`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func find_system(script_cls: Script, require_ready: bool = false) -> Object:
+```
+
+可选查找 System 实例，未找到时不输出严格依赖缺失错误。 非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `script_cls` | 脚本类。 |
+| `require_ready` | 为 true 时，仅返回已完成 ready 阶段的实例。 |
+
+返回：系统实例；可选依赖不存在或尚未 ready 时返回 null。
+
+<a id="member-gfarchitecture-methods-find_model"></a>
+
+### `find_model`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func find_model(script_cls: Script, require_ready: bool = false) -> Object:
+```
+
+可选查找 Model 实例，未找到时不输出严格依赖缺失错误。 非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `script_cls` | 脚本类。 |
+| `require_ready` | 为 true 时，仅返回已完成 ready 阶段的实例。 |
+
+返回：模型实例；可选依赖不存在或尚未 ready 时返回 null。
+
+<a id="member-gfarchitecture-methods-find_utility"></a>
+
+### `find_utility`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func find_utility(script_cls: Script, require_ready: bool = false) -> Object:
+```
+
+可选查找 Utility 实例，未找到时不输出严格依赖缺失错误。 非严格模式沿用普通查询的父级回退与 alias 遮蔽规则；严格模式只检查当前架构。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `script_cls` | 脚本类。 |
+| `require_ready` | 为 true 时，仅返回已完成 ready 阶段的实例。 |
+
+返回：工具实例；可选依赖不存在或尚未 ready 时返回 null。
 
 <a id="member-gfarchitecture-methods-get_local_system"></a>
 

--- a/docs/zh/reference/api/classes/GFAsyncKeyedGate.md
+++ b/docs/zh/reference/api/classes/GFAsyncKeyedGate.md
@@ -27,6 +27,7 @@
 | 常量 | [`STATUS_TIMEOUT`](#member-gfasynckeyedgate-constants-status_timeout) | `const STATUS_TIMEOUT: StringName = &"timeout"` |
 | 常量 | [`STATUS_INVALID`](#member-gfasynckeyedgate-constants-status_invalid) | `const STATUS_INVALID: StringName = &"invalid"` |
 | 常量 | [`STATUS_REJECTED`](#member-gfasynckeyedgate-constants-status_rejected) | `const STATUS_REJECTED: StringName = &"rejected"` |
+| 常量 | [`STATUS_BUSY`](#member-gfasynckeyedgate-constants-status_busy) | `const STATUS_BUSY: StringName = &"busy"` |
 | 常量 | [`DEFAULT_MAX_CONCURRENCY`](#member-gfasynckeyedgate-constants-default_max_concurrency) | `const DEFAULT_MAX_CONCURRENCY: int = 1` |
 | 常量 | [`ABSOLUTE_MAX_CONCURRENCY`](#member-gfasynckeyedgate-constants-absolute_max_concurrency) | `const ABSOLUTE_MAX_CONCURRENCY: int = 4096` |
 | 常量 | [`DEFAULT_MAX_RECENT_EVENTS`](#member-gfasynckeyedgate-constants-default_max_recent_events) | `const DEFAULT_MAX_RECENT_EVENTS: int = 64` |
@@ -53,6 +54,7 @@
 | 属性 | [`max_tracked_keys`](#member-gfasynckeyedgate-properties-max_tracked_keys) | `var max_tracked_keys: int:` |
 | 属性 | [`max_pump_work_items`](#member-gfasynckeyedgate-properties-max_pump_work_items) | `var max_pump_work_items: int:` |
 | 方法 | [`request_lease`](#member-gfasynckeyedgate-methods-request_lease) | `func request_lease(key: Variant, options: Dictionary = {}) -> Dictionary:` |
+| 方法 | [`try_request_lease`](#member-gfasynckeyedgate-methods-try_request_lease) | `func try_request_lease(key: Variant, options: Dictionary = {}) -> Dictionary:` |
 | 方法 | [`wait_for_lease_async`](#member-gfasynckeyedgate-methods-wait_for_lease_async) | `func wait_for_lease_async(key: Variant, options: Dictionary = {}) -> GFAsyncGateLease:` |
 | 方法 | [`release_lease`](#member-gfasynckeyedgate-methods-release_lease) | `func release_lease(lease: GFAsyncGateLease, reason: StringName = &"manual") -> bool:` |
 | 方法 | [`cancel_request`](#member-gfasynckeyedgate-methods-cancel_request) | `func cancel_request(request_id: int, reason: StringName = STATUS_CANCELLED, metadata: Dictionary = {}) -> bool:` |
@@ -280,6 +282,19 @@ const STATUS_REJECTED: StringName = &"rejected"
 ```
 
 请求因等待队列或 key 容量耗尽而被拒绝。
+
+<a id="member-gfasynckeyedgate-constants-status_busy"></a>
+
+### `STATUS_BUSY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_BUSY: StringName = &"busy"
+```
+
+fail-fast 请求未取得租约；请求未进入等待队列。
 
 <a id="member-gfasynckeyedgate-constants-default_max_concurrency"></a>
 
@@ -638,6 +653,34 @@ func request_lease(key: Variant, options: Dictionary = {}) -> Dictionary:
 - `options`: Dictionary，可包含 metadata: Dictionary、max_concurrency: int、timeout_msec: int、lease_timeout_msec: int、cancel_token: GFCancellationToken。
 - `return`: Dictionary，包含 ok、status、queued、acquired、request_id、key、lease、completion、metadata 和 reason。
 
+<a id="member-gfasynckeyedgate-methods-try_request_lease"></a>
+
+### `try_request_lease`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func try_request_lease(key: Variant, options: Dictionary = {}) -> Dictionary:
+```
+
+尝试立即取得一个 key 的执行租约。 合法且未取消的请求只有在不越过同 key waiter、未完成的公平推进周期或生命周期 通知边界时能够立即提交，才返回 acquired；容量或仲裁暂时不可用时返回 busy。 busy 不分配请求 ID 或 completion，不进入等待队列、不发出请求生命周期信号， 也不改变公平游标。非法调用返回 invalid；cancel_token 在租约提交前胜出时返回 cancelled，且按已接受请求记录取消终态。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `key` | 并发仲裁 key。 |
+| `options` | 即时请求选项，支持 metadata、max_concurrency、lease_timeout_msec 和 cancel_token。 |
+
+返回：即时请求结果字典。
+
+结构：
+
+- `key`: Variant，必须是 GFVariantKeyCodec 接受的稳定 key。
+- `options`: Dictionary，可包含 metadata: Dictionary、max_concurrency: int、lease_timeout_msec: int、cancel_token: GFCancellationToken。
+- `return`: Dictionary，包含 ok、status、queued、acquired、request_id、key、metadata 和 reason，所有分支 queued 均为 false；status 为 acquired 时包含 lease 和已成功完成的 completion，busy 时 request_id 为 0 且不包含 lease 或 completion，cancelled/invalid 不包含 lease 或 completion。
+
 <a id="member-gfasynckeyedgate-methods-wait_for_lease_async"></a>
 
 ### `wait_for_lease_async`
@@ -960,4 +1003,4 @@ func get_debug_snapshot() -> Dictionary:
 
 结构：
 
-- `return`: Dictionary，包含 queued_count、active_count、key_count、max_active_leases、等待、key 与推进预算配置、high_watermark、key_high_watermark、rejected_count、dropped_count、acquired_count、released_count、cancelled_count、timeout_count、keys 和 recent_events。
+- `return`: Dictionary，包含 queued_count、active_count、key_count、max_active_leases、等待、key 与推进预算配置、high_watermark、key_high_watermark、busy_count、rejected_count、dropped_count、acquired_count、released_count、cancelled_count、timeout_count、keys 和 recent_events。

--- a/docs/zh/reference/api/classes/GFRenderWarmupUtility.md
+++ b/docs/zh/reference/api/classes/GFRenderWarmupUtility.md
@@ -136,12 +136,13 @@ enum TouchMode {
 ### `default_entries_per_tick`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var default_entries_per_tick: int = 4
 ```
 
-每次 tick 默认处理的最大条目数。
+每次 tick 默认处理的最大条目数。未显式覆盖清单预算时，小于等于 0 会暂停正常帧推进； 恢复为正数后从原队列位置继续。
 
 <a id="member-gfrenderwarmuputility-properties-default_max_seconds"></a>
 
@@ -269,13 +270,13 @@ func queue_manifest(manifest: GFRenderWarmupManifest, options: Dictionary = {}) 
 | 名称 | 说明 |
 |---|---|
 | `manifest` | 预热清单。 |
-| `options` | 可选参数，支持 entries_per_tick、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation。 |
+| `options` | 可选参数。显式 entries_per_tick 会在入队时钳制到最小 1 并固定；未提供时继续读取当前 default_entries_per_tick。其余支持 max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes 和 allow_scene_instantiation。 |
 
 返回：队列标识；失败返回 -1。
 
 结构：
 
-- `options`: Dictionary，包含 entries_per_tick、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation、temporary_parent 和 temporary_viewport_size。
+- `options`: Dictionary，可包含 entries_per_tick: int（显式值最小为 1，并在入队时固定）、max_seconds、touch_mode、keep_cached、cache_group、max_cached_resources、instantiate_packed_scenes、allow_scene_instantiation、temporary_parent 和 temporary_viewport_size；缺少 entries_per_tick 时使用实时全局默认值。
 
 <a id="member-gfrenderwarmuputility-methods-warmup_manifest_now"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -6,8 +6,8 @@
 
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
-| Kernel | 73 | 1043 | [Kernel](#module-kernel) |
-| Standard | 440 | 7001 | [Standard](#module-standard) |
+| Kernel | 73 | 1046 | [Kernel](#module-kernel) |
+| Standard | 440 | 7003 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -35,7 +35,7 @@
 
 | 类 | 类别 | 继承 | 成员 | 源文件 |
 |---|---|---|---:|---|
-| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 116 | `addons/gf/kernel/core/gf_architecture.gd` |
+| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 119 | `addons/gf/kernel/core/gf_architecture.gd` |
 | [`GFDependencyGraphTools`](GFDependencyGraphTools.md#gfdependencygraphtools) | 运行时服务 (`runtime_service`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_dependency_graph_tools.gd` |
 | [`GFExtensionCatalog`](GFExtensionCatalog.md#gfextensioncatalog) | 运行时服务 (`runtime_service`) | `RefCounted` | 5 | `addons/gf/kernel/extension/gf_extension_catalog.gd` |
 | [`GFExtensionManifestDiscovery`](GFExtensionManifestDiscovery.md#gfextensionmanifestdiscovery) | 运行时服务 (`runtime_service`) | `RefCounted` | 2 | `addons/gf/kernel/extension/gf_extension_manifest_discovery.gd` |
@@ -453,7 +453,7 @@
 | [`GFAsyncBatch`](GFAsyncBatch.md#gfasyncbatch) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 31 | `addons/gf/standard/utilities/io/gf_async_batch.gd` |
 | [`GFAsyncChannel`](GFAsyncChannel.md#gfasyncchannel) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 33 | `addons/gf/standard/common/gf_async_channel.gd` |
 | [`GFAsyncGateLease`](GFAsyncGateLease.md#gfasyncgatelease) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 10 | `addons/gf/standard/common/gf_async_gate_lease.gd` |
-| [`GFAsyncKeyedGate`](GFAsyncKeyedGate.md#gfasynckeyedgate) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 52 | `addons/gf/standard/common/gf_async_keyed_gate.gd` |
+| [`GFAsyncKeyedGate`](GFAsyncKeyedGate.md#gfasynckeyedgate) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 54 | `addons/gf/standard/common/gf_async_keyed_gate.gd` |
 | [`GFAsyncProgress`](GFAsyncProgress.md#gfasyncprogress) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 13 | `addons/gf/standard/common/gf_async_progress.gd` |
 | [`GFAsyncProgressAggregator`](GFAsyncProgressAggregator.md#gfasyncprogressaggregator) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 21 | `addons/gf/standard/common/gf_async_progress_aggregator.gd` |
 | [`GFAudioBankMounter`](GFAudioBankMounter.md#gfaudiobankmounter) | 运行时句柄 (`runtime_handle`) | `Node` | 12 | `addons/gf/standard/utilities/audio/gf_audio_bank_mounter.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -6,15 +6,15 @@
 
 - 源码根目录：`addons/gf`
 - 公开类：`787`
-- 公开成员：`11517`
-- 公开方法：`7073`
+- 公开成员：`11522`
+- 公开方法：`7077`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
-| Kernel | 73 | 1043 | 744 | [kernel.md](kernel.md) |
-| Standard | 440 | 7001 | 4416 | [standard.md](standard.md) |
+| Kernel | 73 | 1046 | 747 | [kernel.md](kernel.md) |
+| Standard | 440 | 7003 | 4417 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/kernel.md
+++ b/docs/zh/reference/api/kernel.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 14 | 295 | 229 |
+| [运行时服务](#category-runtime_service) | 14 | 298 | 232 |
 | [协议与扩展点](#category-protocol) | 19 | 195 | 170 |
 | [资源定义](#category-resource_definition) | 2 | 45 | 15 |
 | [运行时句柄](#category-runtime_handle) | 9 | 86 | 70 |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -9,7 +9,7 @@
 | [运行时服务](#category-runtime_service) | 187 | 3366 | 2264 |
 | [协议与扩展点](#category-protocol) | 24 | 338 | 267 |
 | [资源定义](#category-resource_definition) | 120 | 1538 | 792 |
-| [运行时句柄](#category-runtime_handle) | 45 | 792 | 499 |
+| [运行时句柄](#category-runtime_handle) | 45 | 794 | 500 |
 | [值对象](#category-value_object) | 40 | 732 | 458 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |
 | [事件契约](#category-event_contract) | 6 | 61 | 23 |

--- a/docs/zh/standard/utilities/io/assets-jobs-warmup/background-work.md
+++ b/docs/zh/standard/utilities/io/assets-jobs-warmup/background-work.md
@@ -27,6 +27,8 @@ background.submit_cpu_work(
 
 默认情况下，`submit_cpu_work()` 和 `submit_io_work()` 会拒绝包含 `Object`、`Resource`、`Callable`、`Signal` 或 `RID` 的 payload，只接受标量、数学结构、PackedArray、Array 和 Dictionary 组成的纯 Variant 数据。这个限制是故意的：线程中不直接触碰场景树、Resource 实例或托管对象，才能避免把 Unity JobSystem 中“绕过托管类型检查却丢掉优化价值”的问题搬进 Godot。确实需要迁移旧代码时可以用 `options["allow_object_payloads"] = true` 或全局 `allow_object_payloads` 打开，但推荐做法仍是只传路径、ID、数值和结构化数据。
 
+已接受任务会强持有 `RefCounted` worker target，直到对应线程完成 join；主线程 `apply_callback` 的 `RefCounted` target 则持有到任务进入 completed、failed 或 cancelled 终态。这样局部创建的纯数据处理器不会在排队期间提前释放。框架不会据此延长 `Node` 的场景树生命周期：需要节点拥有任务时，仍应由项目在节点退出时取消任务，并让回调只写入仍有效的权威状态。
+
 ## 调度、取消与诊断
 
 资源加载使用 `submit_resource_load(path, type_hint, apply_callback)`。相同路径、兼容 `type_hint` 的请求会合并到同一个 threaded `ResourceLoader` operation；每个任务持有自己的消费者引用，取消某个任务只释放该引用并阻止 GF 侧应用和完成回调，不会强行中止 Godot 已经发起的加载线程。当最后一个消费者取消后，operation 会进入 drain 状态，迟到的成功或失败结果会被消费并 suppress，避免污染应用队列。CPU/IO 线程任务也是协作式取消：等待中的任务会立刻进入 `cancelled`，运行中的任务会等 worker 返回后再落到取消终态。`get_debug_snapshot()` 会报告等待、运行、资源请求、resource draining、threaded resource operation、应用队列和终态任务 ID，适合和运行时诊断面板或加载界面联动。

--- a/docs/zh/standard/utilities/io/assets-jobs-warmup/render-warmup.md
+++ b/docs/zh/standard/utilities/io/assets-jobs-warmup/render-warmup.md
@@ -11,9 +11,13 @@ manifest.add_resource_path("res://characters/hero_material.tres", &"material", "
 manifest.add_resource_path("res://ui/battle_icons.png", &"texture", "Texture2D")
 
 var warmup := Gf.get_utility(GFRenderWarmupUtility) as GFRenderWarmupUtility
-warmup.default_entries_per_tick = 2
-warmup.queue_manifest(manifest)
+warmup.default_entries_per_tick = 4
+warmup.queue_manifest(manifest, {
+	"entries_per_tick": 2,
+})
 ```
+
+清单显式提供 `entries_per_tick` 时，该值在入队时归一化并固定，最小为 1；没有显式覆盖时，清单继续读取当前 `default_entries_per_tick`，因此可用全局默认值 `0` 暂停正常帧推进并在恢复正数后继续。正常 `tick()` 每帧只推进 FIFO 队首，最多处理该清单自己的预算；即使队首在本帧完成，也不会把剩余预算转给下一个清单。需要由工具调用方显式支配一份跨清单总预算时，使用 `process_queue(max_entries)`。
 
 ## 从场景收集
 

--- a/docs/zh/standard/utilities/runtime/audio/playback/bgm-control.md
+++ b/docs/zh/standard/utilities/runtime/audio/playback/bgm-control.md
@@ -37,3 +37,5 @@ BGM transport 接口面向暂停菜单、剧情演出、音量淡入淡出和进
 crossfade 完成时会原子提交 incoming 的 key 与规范化播放区间；incoming 提前结束或请求失败时，会恢复 outgoing session 自己的 key、播放区间和目标增益。本地 BGM 自然结束时会按该 session 的 `history_key` 发出 `bgm_finished(history_key)`。第三方后端必须实现 `GFAudioBackend.is_bgm_playing()`；当 Utility 查询到稳定的 backend-owned session 已结束时，也会先提交 `stopped/none`，再按同一 history key 发出且只发出一次 `bgm_finished`。调试快照会执行这次收敛查询。
 
 `play_bgm("", crossfade_seconds)` 可按同一淡出参数停止当前 BGM。交叉淡化期间停止会终结 incoming 与 outgoing，完成后的 key、播放区间、owner 和状态统一回到空闲终态。
+
+场景树关闭时，root 可能先于 Utility 释放本地 BGM 播放器。`dispose()` 会把已经失效或仍存活的两个播放器都收敛为空引用，并保持重复调用幂等；项目不应缓存或直接拥有 Utility 的内部播放器。

--- a/docs/zh/standard/utilities/runtime/debug-observability/runtime-telemetry/build-diagnostics/diagnostics-commands/index.md
+++ b/docs/zh/standard/utilities/runtime/debug-observability/runtime-telemetry/build-diagnostics/diagnostics-commands/index.md
@@ -2,6 +2,8 @@
 
 `GFDiagnosticsUtility` 可在运行时聚合架构生命周期、事件系统、性能监视器、日志缓存、常见工具快照和外部贡献的诊断分区，并提供可注册的诊断命令入口。
 
+Console、Log、BuildInfo、Timer、ObjectPool、OperationDiagnostics 和 AsyncTracker 都是可选贡献者。`GFDiagnosticsUtility` 通过架构的静默可选查询解析这些能力；未安装时省略对应集成，即使架构启用了 `strict_dependency_lookup` 也不会产生 required miss。项目真正要求某项工具存在时，仍应在自己的 Installer 或模块依赖声明中显式验证。
+
 ## 阅读入口
 
 - [快照与场景树诊断](snapshot-scene.md)：`collect_snapshot()`、内置诊断命令和只读场景树快照。

--- a/docs/zh/standard/utilities/runtime/time-signal-pool/async-primitives.md
+++ b/docs/zh/standard/utilities/runtime/time-signal-pool/async-primitives.md
@@ -242,27 +242,7 @@ var report := requirement.evaluate({
 
 条件集合只读取传入的 `context`。需要更复杂的判断时可以添加谓词，但谓词应保持无副作用，让“能不能执行”和“执行时改变什么”分开。报告中的 `failed_count` / `raw_failed_count` 表示原始条件谓词返回 false 的数量，并不是最终失败原因计数；`MODE_NONE` 条件命中 true 时会让 `none_clear=false`，并进入 `none_matched_count` 与 `blocking_count`。UI、日志或工具按钮展示最终阻塞原因时，应优先读取 `blocking_count` 和每条 condition 的 `mode` / `ok`。
 
-按 key 限制并发时，gate 只发放租约，不执行任务本身：
-
-```gdscript
-var gate := GFAsyncKeyedGate.new()
-var first := gate.request_lease(&"profile-save")
-var first_lease := GFVariantData.get_option_value(first, "lease") as GFAsyncGateLease
-var second := gate.request_lease(&"profile-save")
-if GFVariantData.get_option_bool(second, "queued"):
-	print("save request queued")
-
-# 业务保存完成后释放租约；gate 会推进同 key 的下一个等待请求。
-first_lease.release(&"saved")
-```
-
-Gate 同时限制全局 active lease、等待总量、单 key 等待量和 tracked key 基数；各容量、每 key 并发与单次推进工作量都钳制到公开绝对上限。全局 active 槽位耗尽时，新请求先进入有界链式 FIFO；释放 lease 后按稳定 key slot 游标轮转，每个 slot（包括空 slot）和被处理的取消、超时请求都消耗 `max_pump_work_items`。continuation 只沿持久游标完成当前轮次，一整轮无进展即停止；当前轮有进展时保持原 request cutoff，新请求只能在旧快照完整结束后的 fresh continuation 中参与，因此持续繁忙、空 slot 或失效请求都不能形成无界同步扫描或主循环 livelock。active request limit 由增量聚合状态读取，不在 pump 热路径扫描全部 lease。
-
-`request_lease()` 不执行全队列过期扫描；调用方应在帧循环或明确边界调用 `expire_waiting_requests()` / `expire_active_leases()`。两种显式过期扫描都使用持久 slot 游标，每次最多检查 `max_pump_work_items` 个 slot，空 slot 也计入预算；批量终态先提交权威摘除，再统一执行一次有界推进。`clear()` 同样先事务式摘除调用开始时已有的等待项和 lease，但不在同步调用内夹带 key 全扫描，通知中新建的请求交给延迟有界推进。
-
-同一个 `GFCancellationToken` 在 Gate 内只建立一份 signal 订阅并维护 request-id 集合；主线程取消会先 O(N) 摘除该 token 的全部等待项，再发 completion 与 Gate signals，不为每个请求重复扫描队列或 pump。worker 回调只投递一个 token 级主线程任务：取消在该任务到达主线程时线性化，而 `_activate_request()` 在权威 lease 提交前再次读取 token 状态，明确决定 acquire 与 cancel 的先后。排队信号同步重入导致请求取消或取得租约时，入口返回已提交终态而不是旧 `queued` 快照。
-
-Gate 同时校验 lease ID 与对象身份；acquire、release、cancel 和 timeout completion/signals 共用可嵌套通知边界，权威状态和诊断事件先提交，通知中的释放延迟到最外层结束。每次释放在通知前冻结 eligible request cutoff，通知中新请求只能排队，不能越过通知前 waiter；若旧 cutoff 下没有 waiter，则由后续 fresh continuation 取得空闲槽位。终态 lease 会断开 owner callback。降低容量不会撤销既有 lease 或驱逐等待项，只会阻止继续接纳或激活，直到状态回落到新上限内。
+按稳定 key 限制并发、选择排队或 fail-fast、处理公平性和租约终态时，参见 [按 Key 的异步租约门禁](keyed-gate.md)。
 
 当一个流程需要“唯一 handler 返回结果”而不是广播事件时，使用请求注册表：
 

--- a/docs/zh/standard/utilities/runtime/time-signal-pool/index.md
+++ b/docs/zh/standard/utilities/runtime/time-signal-pool/index.md
@@ -7,6 +7,7 @@
 - [逻辑延迟定时器](timer-utility.md)：`GFTimerUtility` 的一次性延迟、重复任务、owner 清理和调试快照；需要测试、回放或模拟中手动推进整数 tick 时使用 `GFManualTimerQueue`。
 - [动态时间缩放](time-utility.md)：`GFTimeUtility` 的全局缩放、分组暂停和物理子步。
 - [异步取消、等待与进度](async-primitives.md)：Kernel 级 `GFCancellationToken`、`GFCancellationSource`、`GFAsyncCompletion`，以及标准层 `GFAsyncWaitUtility`、`GFMainThreadDispatchQueue`、`GFDeferredMutationQueue`、`GFExecutionRequirement`、`GFAsyncKeyedGate`、`GFRequestHandlerRegistry` 与 `GFExecutionLaneDiagnostics`。
+- [按 Key 的异步租约门禁](keyed-gate.md)：`GFAsyncKeyedGate` 的等待、fail-fast、公平推进、取消、超时和通知重入边界。
 - [原生信号连接工具](signal-utility/index.md)：`GFSignalUtility`、链式信号处理、owner 断开和信号桥接。
 - [节点对象池](object-pool.md)：`GFObjectPoolUtility` 的借出、归还、预热、hook 和调试计数。
 

--- a/docs/zh/standard/utilities/runtime/time-signal-pool/keyed-gate.md
+++ b/docs/zh/standard/utilities/runtime/time-signal-pool/keyed-gate.md
@@ -1,0 +1,63 @@
+# 按 Key 的异步租约门禁
+
+`GFAsyncKeyedGate` 按调用方提供的稳定 key 发放 `GFAsyncGateLease`。它只仲裁是否允许执行，不创建线程、不运行任务，也不解释 key 的业务含义；账号、存档、模态 UI、回放或编辑器事务可以共享同一套并发边界。
+
+## 等待模式
+
+需要排队时使用 `request_lease()`，或用 `wait_for_lease_async()` 直接等待终态：
+
+```gdscript
+var gate: GFAsyncKeyedGate = GFAsyncKeyedGate.new()
+var first: Dictionary = gate.request_lease(&"profile-save")
+var first_value: Variant = GFVariantData.get_option_value(first, "lease")
+if not (first_value is GFAsyncGateLease):
+	return
+var first_lease: GFAsyncGateLease = first_value
+
+var second: Dictionary = gate.request_lease(&"profile-save")
+if GFVariantData.get_option_bool(second, "queued"):
+	print("save request queued")
+
+# 业务保存完成后释放租约；gate 会推进同 key 的下一个 waiter。
+first_lease.release(&"saved")
+```
+
+Gate 同时限制全局 active lease、等待总量、单 key 等待量和 tracked key 基数；各容量、每 key 并发与单次推进工作量都钳制到公开绝对上限。全局槽位耗尽时，新请求进入有界链式 FIFO；释放后按稳定 key slot 游标轮转。每个 slot（包括空 slot）以及被处理的取消、超时请求都会消耗 `max_pump_work_items`，一整轮无进展即停止，避免无界同步扫描或主循环 livelock。
+
+## Fail-fast 模式
+
+调用方必须在繁忙时立即返回时使用 `try_request_lease()`：
+
+```gdscript
+var attempt: Dictionary = gate.try_request_lease(&"profile-save")
+if GFVariantData.get_option_string_name(attempt, "status") == GFAsyncKeyedGate.STATUS_BUSY:
+	return
+
+var lease_value: Variant = GFVariantData.get_option_value(attempt, "lease")
+if lease_value is GFAsyncGateLease:
+	var lease: GFAsyncGateLease = lease_value
+	# 完成本次工作后调用 lease.release()。
+```
+
+fail-fast 请求只有在当前主线程调用点能够立即提交，并且不会越过既有 waiter、公平推进周期或 acquire/release 通知边界时才取得租约。`STATUS_BUSY` 不分配请求 ID 或 `GFAsyncCompletion`，不进入队列、不发请求生命周期信号，也不改变公平游标；`get_debug_snapshot().busy_count` 只累计这种即时未取得次数。
+
+返回状态是闭合契约：
+
+- `STATUS_ACQUIRED`：请求已提交，返回正数 request ID、`GFAsyncGateLease` 和已经成功完成的 `GFAsyncCompletion`。
+- `STATUS_BUSY`：容量、同 key waiter 或未完成的公平/通知边界阻止即时提交；request ID 为 `0`，且没有 lease 或 completion。
+- `STATUS_CANCELLED`：gate 原本可以即时提交，但 `cancel_token` 在租约提交前胜出；该请求按真实取消终态记录，且没有 lease 或 completion。
+- `STATUS_INVALID`：调用线程、key 或取消订阅无效；不进入等待队列，也没有 lease 或 completion。
+
+其它 key 上仅因自身 per-key 上限而暂时不可执行的 waiter，不会占用空闲全局槽位；但只要 gate 已经启动旧 waiter 的有界公平推进周期，新 fail-fast 请求就返回 busy，不能在 continuation 之前窃取槽位。所有 fail-fast 返回都满足 `queued=false`。
+
+## 取消、超时与通知
+
+`request_lease()` 不执行全队列过期扫描。调用方应在帧循环或明确边界调用 `expire_waiting_requests()` / `expire_active_leases()`；两种扫描都使用持久 slot 游标，并受 `max_pump_work_items` 限制。`clear()` 会先事务式摘除调用开始时已有的等待项和 lease，再执行通知和有界推进。
+
+同一个 `GFCancellationToken` 在 Gate 内只建立一份 signal 订阅并维护 request-id 集合。主线程取消会先摘除该 token 的全部等待项，再发 completion 与 Gate signal；worker 取消在投递到主线程时线性化，权威 lease 提交前还会再次确认 token 状态。
+
+Gate 同时校验 lease ID 与对象身份。acquire、release、cancel 和 timeout 共用可嵌套通知边界：权威状态和诊断事件先提交，通知中的释放延迟到最外层结束。释放前已有的 waiter 保持优先级，通知中新请求不能窃取刚释放的槽位；终态 lease 会断开 owning gate callback。
+
+## 使用边界
+
+降低容量不会撤销既有 lease 或驱逐 waiter，只会阻止继续接纳或激活，直到状态回落到新上限内。Gate 不负责业务回滚、重试或任务取消；调用方必须把 lease 释放放进自身成功、失败和取消的共同终态路径。

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -1354,6 +1354,48 @@ func test_strict_dependency_lookup_blocks_parent_fallback() -> void:
 	parent_arch.dispose()
 
 
+## 验证可选查询复用父级解析规则，但严格模式缺失时保持静默。
+func test_optional_dependency_lookup_is_silent_and_respects_strict_scope() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	var parent_model: DummyModel = DummyModel.new()
+	var parent_system: DummySystem = DummySystem.new()
+	var parent_utility: DummyUtility = DummyUtility.new()
+	await parent_arch.register_model_instance(parent_model)
+	await parent_arch.register_system_instance(parent_system)
+	await parent_arch.register_utility_instance(parent_utility)
+
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+
+	assert_eq(
+		child_arch.find_model(DummyModel),
+		parent_model,
+		"非严格可选查询应沿用普通父级回退。"
+	)
+	assert_eq(
+		child_arch.find_system(DummySystem),
+		parent_system,
+		"非严格可选查询应沿用普通父级回退。"
+	)
+	assert_eq(
+		child_arch.find_utility(DummyUtility),
+		parent_utility,
+		"非严格可选查询应沿用普通父级回退。"
+	)
+
+	child_arch.strict_dependency_lookup = true
+
+	assert_null(child_arch.find_model(DummyModel))
+	assert_null(child_arch.find_system(DummySystem))
+	assert_null(child_arch.find_utility(DummyUtility))
+	assert_push_error_count(
+		0,
+		"严格模式的可选缺失应停止父级回退，但不得报告 required miss。"
+	)
+
+	child_arch.dispose()
+	parent_arch.dispose()
+
+
 ## 验证子架构中的失效 alias 会 hard fail，不回退父架构。
 func test_stale_child_alias_blocks_parent_fallback() -> void:
 	var parent_arch: GFArchitecture = GFArchitecture.new()

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -259,6 +259,7 @@
       "res://tests/gf_core/standard/utilities/storage/editor/test_gf_storage_editor_package.gd"
     ],
     "gf.standard.display": [
+      "res://tests/gf_core/standard/utilities/display/test_gf_render_warmup_utility.gd",
       "res://tests/gf_core/standard/utilities/display/test_gf_shader_interface_snapshot.gd",
       "res://tests/gf_core/standard/utilities/display/test_gf_shader_parameter_profile.gd",
       "res://tests/gf_core/standard/utilities/display/test_gf_viewport_utility.gd"

--- a/tests/gf_core/standard/common/test_gf_async_keyed_gate_and_requests.gd
+++ b/tests/gf_core/standard/common/test_gf_async_keyed_gate_and_requests.gd
@@ -43,6 +43,12 @@ class PumpProbeGate:
 	func get_scan_remaining_keys() -> int:
 		return _pump_scan_remaining_keys
 
+	func get_pump_key_cursor() -> int:
+		return _pump_key_cursor
+
+	func get_next_request_id() -> int:
+		return _next_request_id
+
 	func get_shared_token_request_count(
 		token: GFCancellationToken
 	) -> int:
@@ -93,6 +99,360 @@ func test_keyed_gate_queues_per_key_and_promotes_on_release() -> void:
 	assert_true(second_lease != null and second_lease.is_active(), "推进后的请求应获得新租约。")
 	assert_eq(GFVariantData.get_option_int(snapshot, "queued_count"), 0, "同 key 队列应清空。")
 	assert_eq(GFVariantData.get_option_int(snapshot, "active_count"), 1, "同 key 应只保留一个活跃租约。")
+
+
+func test_keyed_gate_try_request_is_fail_fast_without_queue_or_fairness_mutation() -> void:
+	var gate: PumpProbeGate = PumpProbeGate.new()
+	gate.max_active_leases = 1
+	var blocker: GFAsyncGateLease = _result_to_lease(
+		gate.request_lease(&"asset")
+	)
+	var waiting: Dictionary = gate.request_lease(&"asset")
+	var waiting_completion: GFAsyncCompletion = _result_to_completion(waiting)
+	var signal_state: Dictionary = { "queued_count": 0 }
+	var connect_error: Error = gate.request_queued.connect(
+		func(
+			_request_id: int,
+			_key: Variant,
+			_metadata: Dictionary
+		) -> void:
+			signal_state["queued_count"] = (
+				GFVariantData.get_option_int(signal_state, "queued_count")
+				+ 1
+			)
+	) as Error
+	assert_eq(connect_error, OK)
+	var before_snapshot: Dictionary = gate.get_debug_snapshot()
+	var before_event_count: int = gate.get_recent_events().size()
+	var before_request_id: int = gate.get_next_request_id()
+	var before_pump_cursor: int = gate.get_pump_key_cursor()
+
+	var same_key_result: Dictionary = gate.try_request_lease(&"asset")
+	var other_key_result: Dictionary = gate.try_request_lease(&"other")
+	var after_snapshot: Dictionary = gate.get_debug_snapshot()
+
+	assert_eq(
+		GFVariantData.get_option_string_name(same_key_result, "status"),
+		GFAsyncKeyedGate.STATUS_BUSY,
+		"同 key 已有活跃租约和 waiter 时应立即返回 busy。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(other_key_result, "status"),
+		GFAsyncKeyedGate.STATUS_BUSY,
+		"全局租约容量耗尽时其它 key 也应立即返回 busy。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(same_key_result, "request_id"),
+		0,
+		"busy 不得分配请求 ID。"
+	)
+	assert_false(same_key_result.has("completion"), "busy 不得分配 completion。")
+	assert_false(same_key_result.has("lease"), "busy 不得分配 lease。")
+	assert_eq(
+		GFVariantData.get_option_int(signal_state, "queued_count"),
+		0,
+		"fail-fast 拒绝不得发出排队信号。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(after_snapshot, "queued_count"),
+		GFVariantData.get_option_int(before_snapshot, "queued_count"),
+		"fail-fast 拒绝不得改变等待队列。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(after_snapshot, "key_count"),
+		GFVariantData.get_option_int(before_snapshot, "key_count"),
+		"全局繁忙时不得为探测 key 建立跟踪状态。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(after_snapshot, "busy_count"),
+		2,
+		"调试快照应累计 fail-fast busy 次数。"
+	)
+	assert_eq(
+		gate.get_recent_events().size(),
+		before_event_count,
+		"busy 不是请求生命周期事件，不应写入事件环。"
+	)
+	assert_eq(gate.get_next_request_id(), before_request_id)
+	assert_eq(gate.get_pump_key_cursor(), before_pump_cursor)
+
+	assert_true(blocker.release(&"done"))
+	assert_true(waiting_completion.is_successful())
+	var promoted_lease: GFAsyncGateLease = _result_to_lease(
+		GFVariantData.as_dictionary(waiting_completion.get_result())
+	)
+	if promoted_lease != null:
+		var _promoted_released: bool = promoted_lease.release(&"done")
+
+
+func test_keyed_gate_try_request_respects_per_key_active_limit() -> void:
+	var gate: PumpProbeGate = PumpProbeGate.new()
+	gate.max_active_leases = 2
+	var blocker: GFAsyncGateLease = _result_to_lease(
+		gate.request_lease(&"asset")
+	)
+	var before_snapshot: Dictionary = gate.get_debug_snapshot()
+	var before_request_id: int = gate.get_next_request_id()
+	var before_event_count: int = gate.get_recent_events().size()
+
+	var result: Dictionary = gate.try_request_lease(&"asset")
+	var after_snapshot: Dictionary = gate.get_debug_snapshot()
+
+	assert_eq(
+		GFVariantData.get_option_int(before_snapshot, "active_count"),
+		1,
+		"测试前提应保留一个未耗尽全局容量的活跃租约。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(result, "status"),
+		GFAsyncKeyedGate.STATUS_BUSY,
+		"全局仍有空位但同 key 达到并发上限时应返回 busy。"
+	)
+	assert_eq(GFVariantData.get_option_int(result, "request_id"), 0)
+	assert_false(result.has("completion"))
+	assert_false(result.has("lease"))
+	assert_eq(
+		GFVariantData.get_option_int(after_snapshot, "queued_count"),
+		GFVariantData.get_option_int(before_snapshot, "queued_count")
+	)
+	assert_eq(gate.get_next_request_id(), before_request_id)
+	assert_eq(gate.get_recent_events().size(), before_event_count)
+
+	var waiting: Dictionary = gate.request_lease(&"asset")
+	var waiting_completion: GFAsyncCompletion = _result_to_completion(waiting)
+	var unrelated_lease: GFAsyncGateLease = _result_to_lease(
+		gate.try_request_lease(&"other")
+	)
+	assert_true(
+		unrelated_lease != null,
+		"仅被自身 key 上限阻塞的 waiter 不得浪费其它 key 可用的全局槽位。"
+	)
+	assert_true(unrelated_lease.release(&"done"))
+	assert_true(blocker.release(&"done"))
+	assert_true(waiting_completion.is_successful())
+	var promoted_lease: GFAsyncGateLease = _result_to_lease(
+		GFVariantData.as_dictionary(waiting_completion.get_result())
+	)
+	if promoted_lease != null:
+		var _promoted_released: bool = promoted_lease.release(&"done")
+
+
+func test_keyed_gate_try_request_respects_tracked_key_capacity_without_request_state() -> void:
+	var gate: PumpProbeGate = PumpProbeGate.new()
+	gate.max_tracked_keys = 1
+	assert_eq(gate.set_key_max_concurrency(&"reserved", 1), 1)
+	var before_snapshot: Dictionary = gate.get_debug_snapshot()
+	var before_request_id: int = gate.get_next_request_id()
+	var before_event_count: int = gate.get_recent_events().size()
+
+	var result: Dictionary = gate.try_request_lease(&"new")
+	var after_snapshot: Dictionary = gate.get_debug_snapshot()
+
+	assert_eq(
+		GFVariantData.get_option_string_name(result, "status"),
+		GFAsyncKeyedGate.STATUS_BUSY,
+		"tracked key 容量耗尽时 fail-fast 请求应返回 busy。"
+	)
+	assert_eq(GFVariantData.get_option_int(result, "request_id"), 0)
+	assert_false(result.has("completion"))
+	assert_false(result.has("lease"))
+	assert_eq(
+		GFVariantData.get_option_int(after_snapshot, "key_count"),
+		GFVariantData.get_option_int(before_snapshot, "key_count"),
+		"容量探测不得创建新 key 状态。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(after_snapshot, "busy_count"),
+		GFVariantData.get_option_int(before_snapshot, "busy_count") + 1
+	)
+	assert_eq(gate.get_next_request_id(), before_request_id)
+	assert_eq(gate.get_recent_events().size(), before_event_count)
+
+
+func test_keyed_gate_try_request_reports_pre_cancelled_token() -> void:
+	var gate: GFAsyncKeyedGate = GFAsyncKeyedGate.new()
+	var source: GFCancellationSource = GFCancellationSource.new()
+	assert_true(source.cancel(&"caller_cancelled", { "scope": "try" }))
+
+	var result: Dictionary = gate.try_request_lease(&"asset", {
+		"cancel_token": source.get_token(),
+	})
+	var snapshot: Dictionary = gate.get_debug_snapshot()
+
+	assert_eq(
+		GFVariantData.get_option_string_name(result, "status"),
+		GFAsyncKeyedGate.STATUS_CANCELLED,
+		"可即时提交但 token 已取消时应返回真实 cancelled 终态。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(result, "reason"),
+		&"caller_cancelled"
+	)
+	assert_gt(
+		GFVariantData.get_option_int(result, "request_id"),
+		0,
+		"cancelled 表示 token 赢得了一个已接受请求的提交竞态。"
+	)
+	assert_false(GFVariantData.get_option_bool(result, "queued"))
+	assert_false(result.has("completion"))
+	assert_false(result.has("lease"))
+	assert_eq(GFVariantData.get_option_int(snapshot, "active_count"), 0)
+	assert_eq(GFVariantData.get_option_int(snapshot, "queued_count"), 0)
+	assert_eq(GFVariantData.get_option_int(snapshot, "cancelled_count"), 1)
+
+
+func test_keyed_gate_try_request_does_not_overtake_cross_key_waiter() -> void:
+	var gate: PumpProbeGate = PumpProbeGate.new()
+	gate.max_active_leases = 2
+	gate.max_pump_work_items = 1
+	var first_lease: GFAsyncGateLease = _result_to_lease(
+		gate.request_lease(&"first")
+	)
+	assert_eq(gate.set_key_max_concurrency(&"second", 2), 2)
+	var second_lease: GFAsyncGateLease = _result_to_lease(
+		gate.request_lease(&"second")
+	)
+	var waiting: Dictionary = gate.request_lease(&"second")
+	var waiting_completion: GFAsyncCompletion = _result_to_completion(waiting)
+
+	assert_true(first_lease.release(&"done"))
+	assert_true(
+		gate.is_deferred_pump_scheduled(),
+		"有界推进先扫描空 slot 后应保留旧 waiter 的 continuation。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(gate.get_debug_snapshot(), "active_count"),
+		1,
+		"释放后应存在一个可被错误窃取的全局空闲槽位。"
+	)
+
+	var result: Dictionary = gate.try_request_lease(&"third")
+
+	assert_eq(
+		GFVariantData.get_option_string_name(result, "status"),
+		GFAsyncKeyedGate.STATUS_BUSY,
+		"fail-fast 请求不得越过其它 key 尚未完成的公平推进周期。"
+	)
+	assert_eq(GFVariantData.get_option_int(result, "request_id"), 0)
+	assert_false(result.has("completion"))
+	assert_false(result.has("lease"))
+
+	assert_true(second_lease.release(&"done"))
+	assert_true(waiting_completion.is_successful())
+	var promoted_lease: GFAsyncGateLease = _result_to_lease(
+		GFVariantData.as_dictionary(waiting_completion.get_result())
+	)
+	if promoted_lease != null:
+		var _promoted_released: bool = promoted_lease.release(&"done")
+	await get_tree().process_frame
+
+
+func test_keyed_gate_try_request_ignores_stale_continuation_after_last_waiter_cancel() -> void:
+	var gate: PumpProbeGate = PumpProbeGate.new()
+	gate.max_active_leases = 2
+	gate.max_pump_work_items = 1
+	var first_lease: GFAsyncGateLease = _result_to_lease(
+		gate.request_lease(&"first")
+	)
+	assert_eq(gate.set_key_max_concurrency(&"second", 2), 2)
+	var second_lease: GFAsyncGateLease = _result_to_lease(
+		gate.request_lease(&"second")
+	)
+	var waiting: Dictionary = gate.request_lease(&"second")
+
+	assert_true(first_lease.release(&"done"))
+	assert_true(gate.is_deferred_pump_scheduled())
+	assert_true(
+		gate.cancel_request(
+			GFVariantData.get_option_int(waiting, "request_id"),
+			&"withdrawn"
+		)
+	)
+	assert_eq(
+		GFVariantData.get_option_int(gate.get_debug_snapshot(), "queued_count"),
+		0,
+		"取消最后一个 waiter 后应立即清空权威等待状态。"
+	)
+
+	var result: Dictionary = gate.try_request_lease(&"third")
+	var third_lease: GFAsyncGateLease = _result_to_lease(result)
+
+	assert_eq(
+		GFVariantData.get_option_string_name(result, "status"),
+		GFAsyncKeyedGate.STATUS_ACQUIRED,
+		"没有真实 waiter 时，旧 deferred 标志不得制造假 busy。"
+	)
+	assert_true(third_lease != null)
+
+	assert_true(second_lease.release(&"done"))
+	assert_true(third_lease.release(&"done"))
+	await get_tree().process_frame
+
+
+func test_keyed_gate_try_request_does_not_commit_inside_lifecycle_notification() -> void:
+	var gate: GFAsyncKeyedGate = GFAsyncKeyedGate.new()
+	gate.max_active_leases = 2
+	var callback_state: Dictionary = {
+		"queued_count": 0,
+		"result": {},
+	}
+	var queued_error: Error = gate.request_queued.connect(
+		func(
+			_request_id: int,
+			_key: Variant,
+			_metadata: Dictionary
+		) -> void:
+			callback_state["queued_count"] = (
+				GFVariantData.get_option_int(callback_state, "queued_count")
+				+ 1
+			)
+	) as Error
+	assert_eq(queued_error, OK)
+	var acquired_error: Error = gate.lease_acquired.connect(
+		func(_lease: GFAsyncGateLease) -> void:
+			callback_state["result"] = gate.try_request_lease(&"callback"),
+		CONNECT_ONE_SHOT
+	) as Error
+	assert_eq(acquired_error, OK)
+
+	var outer_result: Dictionary = gate.try_request_lease(&"outer")
+	var outer_lease: GFAsyncGateLease = _result_to_lease(outer_result)
+	var outer_completion: GFAsyncCompletion = _result_to_completion(outer_result)
+	var after_callback_result: Dictionary = gate.try_request_lease(&"callback")
+	var callback_lease: GFAsyncGateLease = _result_to_lease(
+		after_callback_result
+	)
+	var callback_result: Dictionary = GFVariantData.get_option_dictionary(
+		callback_state,
+		"result"
+	)
+
+	assert_true(outer_lease != null, "空闲 gate 的 fail-fast 请求应立即取得租约。")
+	assert_true(
+		outer_completion != null and outer_completion.is_successful(),
+		"acquired 结果应保留与 request_lease 一致的已完成 completion。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(callback_result, "status"),
+		GFAsyncKeyedGate.STATUS_BUSY,
+		"acquire 通知内不得重入提交另一租约。"
+	)
+	assert_true(
+		callback_lease != null,
+		"最外层通知结束后同一请求应能立即取得剩余槽位。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(callback_state, "queued_count"),
+		0,
+		"两个 fail-fast 请求都不得进入等待队列。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(gate.get_debug_snapshot(), "busy_count"),
+		1
+	)
+
+	var _outer_released: bool = outer_lease.release(&"done")
+	var _callback_released: bool = callback_lease.release(&"done")
 
 
 func test_keyed_gate_rejects_foreign_lease_with_colliding_local_id() -> void:
@@ -1148,6 +1508,10 @@ func test_keyed_gate_rejects_worker_thread_public_access_without_mutation() -> v
 		worker_result,
 		"request"
 	)
+	var try_result: Dictionary = GFVariantData.get_option_dictionary(
+		worker_result,
+		"try_request"
+	)
 	var key_snapshot: Dictionary = GFVariantData.get_option_dictionary(
 		worker_result,
 		"key_snapshot"
@@ -1162,6 +1526,11 @@ func test_keyed_gate_rejects_worker_thread_public_access_without_mutation() -> v
 		GFVariantData.get_option_string_name(request_result, "reason"),
 		&"wrong_thread",
 		"worker 请求应返回稳定线程拒绝原因。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(try_result, "reason"),
+		&"wrong_thread",
+		"worker fail-fast 请求也应返回稳定线程拒绝原因。"
 	)
 	assert_eq(
 		GFVariantData.get_option_string_name(key_snapshot, "reason"),
@@ -1479,6 +1848,7 @@ func _access_keyed_gate_from_worker(
 	gate.max_waiting_per_key = 1
 	gate.max_tracked_keys = 1
 	var request_result: Dictionary = gate.request_lease(&"worker")
+	var try_result: Dictionary = gate.try_request_lease(&"worker")
 	var released: bool = gate.release_lease(lease, &"worker")
 	var cancelled: bool = gate.cancel_request(waiting_request_id, &"worker")
 	var cleared: int = gate.clear(&"worker")
@@ -1500,6 +1870,7 @@ func _access_keyed_gate_from_worker(
 		"per_key_limit": per_key_limit,
 		"tracked_limit": tracked_limit,
 		"request": request_result,
+		"try_request": try_result,
 		"released": released,
 		"cancelled": cancelled,
 		"cleared": cleared,

--- a/tests/gf_core/standard/utilities/audio/test_gf_audio_utility.gd
+++ b/tests/gf_core/standard/utilities/audio/test_gf_audio_utility.gd
@@ -4541,6 +4541,42 @@ func test_architecture_dispose_forces_audio_terminal_state_and_restores_duck_bus
 	)
 
 
+func test_dispose_tolerates_both_root_owned_bgm_players_freed_first() -> void:
+	var bgm_player: AudioStreamPlayer = _audio._bgm_player
+	var bgm_fade_player: AudioStreamPlayer = _audio._bgm_fade_player
+	bgm_player.free()
+	bgm_fade_player.free()
+
+	_audio.dispose()
+
+	assert_null(_audio._bgm_player, "双播放器先于 Utility 释放后应清除主播放器引用。")
+	assert_null(_audio._bgm_fade_player, "双播放器先于 Utility 释放后应清除淡变播放器引用。")
+	assert_eq(_audio._bgm_state, &"stopped", "root-first teardown 后 BGM 状态必须收敛。")
+
+
+func test_dispose_tolerates_one_root_owned_bgm_player_freed_first() -> void:
+	var bgm_player: AudioStreamPlayer = _audio._bgm_player
+	var bgm_fade_player: AudioStreamPlayer = _audio._bgm_fade_player
+	bgm_player.free()
+
+	_audio.dispose()
+
+	assert_null(_audio._bgm_player, "已提前释放的播放器引用应清除。")
+	assert_null(_audio._bgm_fade_player, "仍存活的播放器进入释放流程后也应解除引用。")
+	assert_true(bgm_fade_player.is_queued_for_deletion(), "仍存活的淡变播放器应进入释放流程。")
+
+
+func test_dispose_is_idempotent_after_bgm_players_are_released() -> void:
+	_audio.dispose()
+	await get_tree().process_frame
+
+	_audio.dispose()
+
+	assert_null(_audio._bgm_player, "重复 dispose 不得保留已释放的主播放器引用。")
+	assert_null(_audio._bgm_fade_player, "重复 dispose 不得保留已释放的淡变播放器引用。")
+	assert_eq(_audio._bgm_owner, &"none", "重复 dispose 后 BGM owner 必须保持终态。")
+
+
 func test_bgm_backend_and_local_playback_switch_owner_atomically() -> void:
 	var backend: MockAudioBackend = MockAudioBackend.new()
 	backend.handle_bgm_paths = true

--- a/tests/gf_core/standard/utilities/debug/test_gf_diagnostics_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_diagnostics_utility.gd
@@ -16,6 +16,46 @@ func test_diagnostics_command_executes() -> void:
 	assert_true(diagnostics.has_command(&"diagnostics.signals"), "Diagnostics 应注册只读信号图快照命令。")
 
 
+func test_diagnostics_optional_console_lookup_is_silent_in_strict_architecture() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.strict_dependency_lookup = true
+	var diagnostics: GFDiagnosticsUtility = GFDiagnosticsUtility.new()
+	await architecture.register_utility_instance(diagnostics)
+
+	await architecture.init()
+
+	assert_true(
+		diagnostics.is_ready_in_architecture(),
+		"缺少可选 Console 不应阻止架构初始化。"
+	)
+	assert_push_error_count(
+		0,
+		"Diagnostics 的全部可选工具查询在严格模式下都必须保持静默。"
+	)
+	architecture.dispose()
+	await get_tree().process_frame
+
+
+func test_diagnostics_binds_console_when_optional_dependency_is_present() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.strict_dependency_lookup = true
+	var log_utility: GFLogUtility = GFLogUtility.new()
+	var console: GFConsoleUtility = GFConsoleUtility.new()
+	var diagnostics: GFDiagnosticsUtility = GFDiagnosticsUtility.new()
+	await architecture.register_utility_instance(log_utility)
+	await architecture.register_utility_instance(console)
+	await architecture.register_utility_instance(diagnostics)
+
+	await architecture.init()
+
+	assert_true(
+		console.get_command_names().has("diagnostics"),
+		"严格模式下本地 Console 仍应收到 Diagnostics 命令。"
+	)
+	architecture.dispose()
+	await get_tree().process_frame
+
+
 ## 验证场景树快照只采集结构摘要并遵守深度限制。
 func test_diagnostics_collects_read_only_scene_tree_snapshot() -> void:
 	var root: Node = Node.new()

--- a/tests/gf_core/standard/utilities/display/test_gf_render_warmup_utility.gd
+++ b/tests/gf_core/standard/utilities/display/test_gf_render_warmup_utility.gd
@@ -78,15 +78,112 @@ func test_render_warmup_queue_respects_entry_budget() -> void:
 	var manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
 	var _add_resource_result_38: Variant = manifest.add_resource(StandardMaterial3D.new(), &"material")
 	var _add_resource_result_39: Variant = manifest.add_resource(StandardMaterial3D.new(), &"material")
+	var tail_manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
+	var _add_tail_resource_result: Variant = tail_manifest.add_resource(StandardMaterial3D.new(), &"material")
 	var utility: GFRenderWarmupUtility = GFRenderWarmupUtility.new()
-	var _queue_manifest_result_41: Variant = utility.queue_manifest(manifest)
+	var _queue_manifest_result_41: Variant = utility.queue_manifest(manifest, { "entries_per_tick": 1 })
+	var _queue_tail_manifest_result: Variant = utility.queue_manifest(tail_manifest, { "entries_per_tick": 1 })
 
 	var first_count: int = utility.process_queue(1)
-	var second_count: int = utility.process_queue(1)
+	var second_count: int = utility.process_queue(2)
 
 	assert_eq(first_count, 1, "第一次只应处理一个条目。")
-	assert_eq(second_count, 1, "第二次处理剩余条目。")
+	assert_eq(second_count, 2, "显式全局预算应可处理队首剩余条目和后续清单。")
 	assert_eq(utility.get_queue_size(), 0, "全部处理后队列应为空。")
+
+
+## 验证正常 tick 只推进 FIFO 队首，并采用该清单自己的条目预算。
+func test_render_warmup_tick_respects_head_manifest_entry_budget() -> void:
+	var head_manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
+	var _add_head_first_result: Variant = head_manifest.add_resource(StandardMaterial3D.new(), &"material")
+	var _add_head_second_result: Variant = head_manifest.add_resource(StandardMaterial3D.new(), &"material")
+	var tail_manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
+	var _add_tail_first_result: Variant = tail_manifest.add_resource(StandardMaterial3D.new(), &"material")
+	var _add_tail_second_result: Variant = tail_manifest.add_resource(StandardMaterial3D.new(), &"material")
+	var utility: GFRenderWarmupUtility = GFRenderWarmupUtility.new()
+	utility.default_entries_per_tick = 4
+	var head_queue_id: int = utility.queue_manifest(head_manifest, { "entries_per_tick": 1 })
+	var tail_queue_id: int = utility.queue_manifest(tail_manifest, { "entries_per_tick": 2 })
+
+	utility.tick(0.0)
+	var first_snapshot: Dictionary = utility.get_debug_snapshot()
+	utility.tick(0.0)
+	var second_snapshot: Dictionary = utility.get_debug_snapshot()
+	utility.tick(0.0)
+	var third_snapshot: Dictionary = utility.get_debug_snapshot()
+
+	assert_gt(head_queue_id, 0, "队首清单应成功入队。")
+	assert_gt(tail_queue_id, head_queue_id, "队尾清单应在队首之后入队。")
+	assert_eq(GFVariantData.get_option_int(first_snapshot, "processed_entry_count"), 1, "首个 tick 应采用队首清单的一条预算。")
+	assert_eq(GFVariantData.get_option_int(first_snapshot, "queue_size"), 2, "首个 tick 后两个清单都应仍在队列中。")
+	assert_eq(GFVariantData.get_option_int(second_snapshot, "processed_entry_count"), 2, "第二个 tick 应只完成队首清单。")
+	assert_eq(GFVariantData.get_option_int(second_snapshot, "queue_size"), 1, "完成队首清单后应保留队尾清单。")
+	assert_eq(GFVariantData.get_option_int(third_snapshot, "processed_entry_count"), 4, "第三个 tick 应采用队尾清单的两条预算。")
+	assert_eq(GFVariantData.get_option_int(third_snapshot, "queue_size"), 0, "第三个 tick 后队列应处理完毕。")
+
+
+func test_render_warmup_tick_does_not_spill_unused_head_budget_into_tail() -> void:
+	var head_manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
+	var _add_head_result: Variant = head_manifest.add_resource(
+		StandardMaterial3D.new(),
+		&"material"
+	)
+	var tail_manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
+	var _add_tail_result: Variant = tail_manifest.add_resource(
+		StandardMaterial3D.new(),
+		&"material"
+	)
+	var utility: GFRenderWarmupUtility = GFRenderWarmupUtility.new()
+	var _head_queue_id: int = utility.queue_manifest(
+		head_manifest,
+		{ "entries_per_tick": 4 }
+	)
+	var _tail_queue_id: int = utility.queue_manifest(
+		tail_manifest,
+		{ "entries_per_tick": 1 }
+	)
+
+	utility.tick(0.0)
+	var first_snapshot: Dictionary = utility.get_debug_snapshot()
+
+	assert_eq(
+		GFVariantData.get_option_int(first_snapshot, "processed_entry_count"),
+		1,
+		"队首提前完成时，其未使用预算不得流入队尾。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(first_snapshot, "queue_size"),
+		1,
+		"同一 tick 应保留尚未开始的队尾清单。"
+	)
+
+	utility.tick(0.0)
+	assert_eq(utility.get_queue_size(), 0, "下一个 tick 才应推进队尾清单。")
+
+
+func test_render_warmup_tick_uses_live_default_without_manifest_override() -> void:
+	var manifest: GFRenderWarmupManifest = GFRenderWarmupManifest.new()
+	var _add_result: Variant = manifest.add_resource(
+		StandardMaterial3D.new(),
+		&"material"
+	)
+	var utility: GFRenderWarmupUtility = GFRenderWarmupUtility.new()
+	utility.default_entries_per_tick = 0
+	var _queue_id: int = utility.queue_manifest(manifest)
+
+	utility.tick(0.0)
+	var paused_snapshot: Dictionary = utility.get_debug_snapshot()
+
+	assert_eq(
+		GFVariantData.get_option_int(paused_snapshot, "processed_entry_count"),
+		0,
+		"未显式覆盖预算的清单应继续服从当前全局默认值。"
+	)
+	assert_eq(GFVariantData.get_option_int(paused_snapshot, "queue_size"), 1)
+
+	utility.default_entries_per_tick = 1
+	utility.tick(0.0)
+	assert_eq(utility.get_queue_size(), 0, "恢复全局默认预算后清单应继续推进。")
 
 
 ## 验证离屏临时渲染节点模式会创建并释放临时节点。

--- a/tests/gf_core/standard/utilities/jobs/test_gf_background_work_utility.gd
+++ b/tests/gf_core/standard/utilities/jobs/test_gf_background_work_utility.gd
@@ -40,6 +40,76 @@ func test_cpu_work_runs_on_thread_and_applies_on_tick() -> void:
 	utility.dispose()
 
 
+func test_paused_task_retains_scoped_ref_counted_callbacks_until_terminal() -> void:
+	var utility: GFBackgroundWorkUtility = GFBackgroundWorkUtility.new()
+	utility.init()
+	utility.pause()
+
+	var submission: ScopedCallbackSubmission = _submit_scoped_callbacks(utility)
+
+	assert_eq(submission.task.status, GFBackgroundWorkTask.Status.QUEUED, "暂停期间任务应保持 queued。")
+	assert_true(_weak_ref_is_alive(submission.worker_weak_ref), "已接受任务应强持有局部 worker target。")
+	assert_true(_weak_ref_is_alive(submission.apply_weak_ref), "已接受任务应强持有局部 apply target。")
+
+	utility.resume()
+	await _pump_until_finished(utility, submission.task)
+
+	assert_eq(submission.task.status, GFBackgroundWorkTask.Status.COMPLETED, "作用域退出后 worker 仍应能完成。")
+	assert_true(_variant_is_true(submission.task.apply_result), "作用域退出后 apply callback 仍应能执行。")
+	assert_false(_weak_ref_is_alive(submission.worker_weak_ref), "线程 join 后应释放 worker target。")
+	assert_false(_weak_ref_is_alive(submission.apply_weak_ref), "任务进入终态后应释放 apply target。")
+	utility.dispose()
+
+
+func test_cancelled_task_releases_scoped_ref_counted_callbacks() -> void:
+	var utility: GFBackgroundWorkUtility = GFBackgroundWorkUtility.new()
+	utility.init()
+	utility.pause()
+	var submission: ScopedCallbackSubmission = _submit_scoped_callbacks(utility)
+
+	assert_true(_weak_ref_is_alive(submission.worker_weak_ref))
+	assert_true(_weak_ref_is_alive(submission.apply_weak_ref))
+	assert_true(utility.cancel_work(submission.task.work_id))
+
+	assert_eq(submission.task.status, GFBackgroundWorkTask.Status.CANCELLED)
+	assert_false(_weak_ref_is_alive(submission.worker_weak_ref))
+	assert_false(_weak_ref_is_alive(submission.apply_weak_ref))
+	utility.dispose()
+
+
+func test_failed_task_releases_scoped_ref_counted_callbacks() -> void:
+	var utility: GFBackgroundWorkUtility = GFBackgroundWorkUtility.new()
+	utility.init()
+	var submission: ScopedCallbackSubmission = _submit_scoped_failure(utility)
+
+	assert_true(_weak_ref_is_alive(submission.worker_weak_ref))
+	assert_true(_weak_ref_is_alive(submission.apply_weak_ref))
+	await _pump_until_finished(utility, submission.task)
+
+	assert_eq(submission.task.status, GFBackgroundWorkTask.Status.FAILED)
+	assert_false(_weak_ref_is_alive(submission.worker_weak_ref))
+	assert_false(_weak_ref_is_alive(submission.apply_weak_ref))
+	utility.dispose()
+
+
+func test_shared_ref_counted_callback_target_survives_worker_release_window() -> void:
+	var utility: GFBackgroundWorkUtility = GFBackgroundWorkUtility.new()
+	utility.init()
+	utility.pause()
+	var submission: ScopedCallbackSubmission = _submit_shared_callback_target(
+		utility
+	)
+
+	assert_true(_weak_ref_is_alive(submission.worker_weak_ref))
+	utility.resume()
+	await _pump_until_finished(utility, submission.task)
+
+	assert_eq(submission.task.status, GFBackgroundWorkTask.Status.COMPLETED)
+	assert_true(_variant_is_true(submission.task.apply_result))
+	assert_false(_weak_ref_is_alive(submission.worker_weak_ref))
+	utility.dispose()
+
+
 func test_failed_worker_marks_task_failed() -> void:
 	var utility: GFBackgroundWorkUtility = GFBackgroundWorkUtility.new()
 	utility.init()
@@ -298,6 +368,18 @@ func _is_null(value: Variant) -> bool:
 	return value == null
 
 
+func _variant_is_true(value: Variant) -> bool:
+	if value is bool:
+		var bool_value: bool = value
+		return bool_value
+	return false
+
+
+func _weak_ref_is_alive(weak_ref_value: WeakRef) -> bool:
+	var target: Variant = weak_ref_value.get_ref()
+	return target is Object
+
+
 func _contains_object(value: Variant) -> bool:
 	if value is Object:
 		return true
@@ -320,6 +402,51 @@ func _make_apply_task(work_id: StringName) -> GFBackgroundWorkTask:
 	task.status = GFBackgroundWorkTask.Status.APPLYING
 	task.set_internal_callbacks(Callable(), Callable(self, "_apply_slow_task"))
 	return task
+
+
+func _submit_scoped_callbacks(utility: GFBackgroundWorkUtility) -> ScopedCallbackSubmission:
+	var worker: ScopedWorker = ScopedWorker.new()
+	var apply_receiver: ScopedApplyReceiver = ScopedApplyReceiver.new()
+	var submission: ScopedCallbackSubmission = ScopedCallbackSubmission.new()
+	submission.worker_weak_ref = weakref(worker)
+	submission.apply_weak_ref = weakref(apply_receiver)
+	submission.task = utility.submit_io_work(
+		Callable(worker, "produce_value"),
+		{ "value": 31 },
+		Callable(apply_receiver, "apply_value")
+	)
+	return submission
+
+
+func _submit_scoped_failure(
+	utility: GFBackgroundWorkUtility
+) -> ScopedCallbackSubmission:
+	var worker: ScopedFailingWorker = ScopedFailingWorker.new()
+	var apply_receiver: ScopedApplyReceiver = ScopedApplyReceiver.new()
+	var submission: ScopedCallbackSubmission = ScopedCallbackSubmission.new()
+	submission.worker_weak_ref = weakref(worker)
+	submission.apply_weak_ref = weakref(apply_receiver)
+	submission.task = utility.submit_io_work(
+		Callable(worker, "fail_value"),
+		{},
+		Callable(apply_receiver, "apply_value")
+	)
+	return submission
+
+
+func _submit_shared_callback_target(
+	utility: GFBackgroundWorkUtility
+) -> ScopedCallbackSubmission:
+	var target: ScopedDualCallbackTarget = ScopedDualCallbackTarget.new()
+	var submission: ScopedCallbackSubmission = ScopedCallbackSubmission.new()
+	submission.worker_weak_ref = weakref(target)
+	submission.apply_weak_ref = submission.worker_weak_ref
+	submission.task = utility.submit_io_work(
+		Callable(target, "produce_value"),
+		{ "value": 31 },
+		Callable(target, "apply_value")
+	)
+	return submission
 
 
 func _pump_until_finished(
@@ -364,6 +491,56 @@ class PureWorker:
 		return {
 			"value": GFVariantData.get_option_int(input, "value"),
 		}
+
+
+class ScopedCallbackSubmission:
+	extends RefCounted
+
+	var task: GFBackgroundWorkTask
+	var worker_weak_ref: WeakRef
+	var apply_weak_ref: WeakRef
+
+
+class ScopedWorker:
+	extends RefCounted
+
+	func produce_value(data: Variant) -> Dictionary:
+		var input: Dictionary = GFVariantData.as_dictionary(data)
+		return {
+			"value": GFVariantData.get_option_int(input, "value"),
+		}
+
+
+class ScopedFailingWorker:
+	extends RefCounted
+
+	func fail_value(_data: Variant) -> Dictionary:
+		return {
+			"ok": false,
+			"error": "scoped_worker_failed",
+		}
+
+
+class ScopedApplyReceiver:
+	extends RefCounted
+
+	func apply_value(task: GFBackgroundWorkTask) -> bool:
+		var result: Dictionary = GFVariantData.as_dictionary(task.result)
+		return GFVariantData.get_option_int(result, "value") == 31
+
+
+class ScopedDualCallbackTarget:
+	extends RefCounted
+
+	func produce_value(data: Variant) -> Dictionary:
+		var input: Dictionary = GFVariantData.as_dictionary(data)
+		return {
+			"value": GFVariantData.get_option_int(input, "value"),
+		}
+
+	func apply_value(task: GFBackgroundWorkTask) -> bool:
+		var result: Dictionary = GFVariantData.as_dictionary(task.result)
+		return GFVariantData.get_option_int(result, "value") == 31
 
 
 class SimulatedResourceBackgroundWorkUtility extends GFBackgroundWorkUtility:


### PR DESCRIPTION
## Summary

- Retain short-lived `RefCounted` background worker/apply callback targets through their required execution windows, then release them deterministically.
- Honor per-manifest render-warmup tick budgets with explicit FIFO-head semantics while preserving caller-controlled cross-manifest `process_queue()` behavior.
- Add silent optional architecture lookups and migrate Diagnostics optional integrations without weakening strict required-dependency reporting.
- Make local BGM teardown idempotent when SceneTree-owned players have already been freed.
- Add an atomic fail-fast keyed-gate request that returns `STATUS_BUSY` without allocating wait state, emitting lifecycle signals, or perturbing fairness.

## Issue closure

Closes #58.
Closes #59.
Closes #61.
Closes #62.
Closes #72.

## Contract and risk

- Adds `GFArchitecture.find_system()`, `find_model()`, and `find_utility()`.
- Adds `GFAsyncKeyedGate.STATUS_BUSY`, `try_request_lease()`, and `busy_count` in its debug snapshot.
- Existing required lookups, queued gate requests, explicit render-warmup processing, persisted data, package formats, and ProjectSettings remain unchanged.
- Background callback ownership is released after thread join/terminal state; fail-fast busy results allocate no request/completion/lease; warmup ticks do not spill head budget into the next manifest; BGM cleanup tolerates one or both stale players.
- New APIs remain `@since unreleased` on the `11.0.0-dev.0` line.

## Verification

- [x] `python tools/gf_maintenance.py check --suite full --jobs 1`: 41/41 checks passed.
- [x] Full GUT: 335 scripts, 5,364 tests, 44,151 assertions; lifecycle gate clean with 0 orphan and 0 unhandled warning.
- [x] Focused GUT: background work 14/14; render warmup 12/12; architecture 125/125; Diagnostics 45/45; audio 147/147; keyed gate 40/40.
- [x] Strict GDScript warnings/LSP, API and AI API freshness, API-since, AI Developer Kit, package contracts/smokes, docs, MkDocs, repository policy, credential gate, and `git diff --check` passed.

## Documentation and release

- [x] Relevant guides and the unreleased changelog are updated.
- [x] Generated API catalog/reference and AI Developer knowledge index are refreshed.
- [x] No release tag or package publication is performed.