### PR TITLE
Add transactional architecture activation and shutdown

### DIFF
--- a/addons/gf/extensions/save/extension.gd
+++ b/addons/gf/extensions/save/extension.gd
@@ -6,6 +6,7 @@ extends GFInstaller
 
 const _GF_SAVE_GRAPH_UTILITY_SCRIPT = preload("res://addons/gf/extensions/save/graph/gf_save_graph_utility.gd")
 const _GF_SAVE_PROFILE_UTILITY_SCRIPT = preload("res://addons/gf/extensions/save/profile/gf_save_profile_utility.gd")
+const _GF_STORAGE_UTILITY_SCRIPT = preload("res://addons/gf/standard/utilities/storage/gf_storage_utility.gd")
 
 
 # --- 框架内部方法 ---
@@ -20,6 +21,12 @@ const _GF_SAVE_PROFILE_UTILITY_SCRIPT = preload("res://addons/gf/extensions/save
 func install(architecture: GFArchitecture, _scope: GFAsyncScope) -> void:
 	if architecture == null:
 		return
+	if architecture.get_local_utility(_GF_STORAGE_UTILITY_SCRIPT) == null:
+		var registered_storage: bool = await architecture.register_utility_instance(
+			_GF_STORAGE_UTILITY_SCRIPT.new()
+		)
+		if not registered_storage:
+			push_error("[GFSaveExtension] GFStorageUtility registration failed.")
 	if architecture.get_local_utility(_GF_SAVE_GRAPH_UTILITY_SCRIPT) == null:
 		var registered_save_graph: bool = await architecture.register_utility_instance(_GF_SAVE_GRAPH_UTILITY_SCRIPT.new())
 		if not registered_save_graph:

--- a/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
@@ -149,6 +149,8 @@ var _pending_schedule_head: ProfileState = null
 var _pending_schedule_tail: ProfileState = null
 var _active_preparation_head: ProfileState = null
 var _active_preparation_tail: ProfileState = null
+var _admission_open: bool = true
+var _quiesce_completion: GFAsyncCompletion = null
 
 
 # --- Godot 生命周期方法 ---
@@ -180,6 +182,74 @@ func ready() -> void:
 		if time_value is GFTimeProvider:
 			var time_provider: GFTimeProvider = time_value
 			_clock = time_provider.get_clock()
+
+
+## 声明架构模式下必须显式注册的 Storage 依赖。
+##
+## `setup()` 仍可用于 standalone 测试与非 Architecture 所有权场景；进入 Architecture
+## 生命周期时不会因此绕过 GFStorageUtility 的显式注册要求。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 仅包含 GFStorageUtility 的依赖声明。
+func get_required_utilities() -> Array[Script]:
+	var dependencies: Array[Script] = [GFStorageUtility]
+	return dependencies
+
+
+## 激活 Profile 服务；底层 Storage 未配置时失败，不创建业务 profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前 Profile 服务激活阶段的取消作用域。
+## [br]
+## @return Storage 可用时成功，否则返回失败终态。
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	if _disposed:
+		var _failed_disposed: bool = completion.fail("Save Profile Utility is disposed.")
+		return completion
+	if _quiesce_completion != null:
+		var _failed_quiesced: bool = completion.fail(
+			"Save Profile Utility cannot reactivate after quiesce."
+		)
+		return completion
+	if _storage == null:
+		var _failed_storage: bool = completion.fail(
+			"GFStorageUtility must be configured before activation."
+		)
+		return completion
+	_quiesce_completion = null
+	_admission_open = true
+	var _succeeded: bool = completion.succeed()
+	return completion
+
+
+## 关闭新 profile 工作准入，并等待已接纳 operation、preparation、retry 与 detached 写入收敛。
+##
+## 静默期间不会注册业务 profile，也不会取消已接纳工作；这些工作继续由 lifecycle tick
+## 和底层 Storage 完成回调推进。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param scope: 当前 Profile 服务静默阶段的取消作用域。
+## [br]
+## @return 所有已接纳工作进入终态后成功的一次性完成源。
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+	_admission_open = false
+	if _quiesce_completion != null:
+		return _quiesce_completion
+	_quiesce_completion = GFAsyncCompletion.new()
+	if scope != null:
+		var _bound: bool = _quiesce_completion.bind_cancel_token(scope)
+	_try_complete_quiesce()
+	return _quiesce_completion
 
 
 ## 推进到期重试。
@@ -222,11 +292,13 @@ func tick(_delta: float) -> void:
 func dispose() -> void:
 	if _disposed:
 		return
+	_admission_open = false
 	if _processing_depth > 0:
 		_dispose_requested = true
 		return
 	_dispose_now()
 	_drain_completion_events()
+	_try_complete_quiesce()
 
 
 # --- 公共方法 ---
@@ -243,7 +315,13 @@ func dispose() -> void:
 ## [br]
 ## @return 当前 Utility；参数无效、已释放或已有注册 profile 时返回 null。
 func setup(storage: GFStorageUtility, clock: GFClock = null) -> GFSaveProfileUtility:
-	if _disposed or _unsafe_callback_depth > 0 or storage == null or not _states.is_empty():
+	if (
+		not _admission_open
+		or _disposed
+		or _unsafe_callback_depth > 0
+		or storage == null
+		or not _states.is_empty()
+	):
 		return null
 	_storage_explicit = true
 	_set_storage(storage)
@@ -277,6 +355,13 @@ func register_profile(
 		_append_registration_issue(report, &"missing_profile", "Profile is required.", "profile")
 	if _disposed:
 		_append_registration_issue(report, &"utility_disposed", "Save Profile Utility is disposed.", "utility")
+	if not _admission_open and not _disposed:
+		_append_registration_issue(
+			report,
+			&"utility_quiescing",
+			"Save Profile Utility is not accepting new registrations.",
+			"utility"
+		)
 	if _unsafe_callback_depth > 0:
 		_append_registration_issue(report, &"reentrant_registration", "Profile registration is not allowed from a Provider or state callback.", "utility")
 	if _storage == null:
@@ -327,7 +412,8 @@ func register_profile(
 func unregister_profile(profile_id: StringName) -> bool:
 	var state: ProfileState = _get_state(profile_id)
 	if (
-		_dispose_requested
+		not _admission_open
+		or _dispose_requested
 		or _unsafe_callback_depth > 0
 		or state == null
 		or state.mode != STATE_IDLE
@@ -359,6 +445,14 @@ func save_profile(
 	profile_id: StringName,
 	request: GFSaveProfileRequest = null
 ) -> GFSaveProfileOperation:
+	if not _admission_open:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save Profile Utility is quiescing."
+		)
 	var state: ProfileState = _get_state(profile_id)
 	if state == null or _disposed:
 		return _make_rejected_operation(
@@ -453,6 +547,14 @@ func load_profile(
 	context: Dictionary = {},
 	metadata: Dictionary = {}
 ) -> GFSaveProfileOperation:
+	if not _admission_open:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save Profile Utility is quiescing."
+		)
 	var state: ProfileState = _get_state(profile_id)
 	if state == null or _disposed:
 		return _make_rejected_operation(
@@ -509,6 +611,14 @@ func flush_profile(
 	profile_id: StringName,
 	metadata: Dictionary = {}
 ) -> GFSaveProfileOperation:
+	if not _admission_open:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save Profile Utility is quiescing."
+		)
 	var state: ProfileState = _get_state(profile_id)
 	if state == null or _disposed:
 		return _make_rejected_operation(
@@ -1814,6 +1924,7 @@ func _end_processing() -> void:
 	if _dispose_requested:
 		_dispose_now()
 	_drain_completion_events()
+	_try_complete_quiesce()
 
 
 func _enter_unsafe_callback() -> void:
@@ -1841,6 +1952,7 @@ func _dispose_now() -> void:
 	_active_preparation_head = null
 	_active_preparation_tail = null
 	_disconnect_storage()
+	_try_complete_quiesce()
 
 
 func _drain_completion_events() -> void:
@@ -2460,6 +2572,7 @@ func _finalize_registration_report(
 		"next_actions": {
 			"missing_profile": "Provide one valid GFSaveProfile.",
 			"utility_disposed": "Create a new Save Profile Utility.",
+			"utility_quiescing": "Wait for shutdown or create a new Save Profile Utility.",
 			"reentrant_registration": "Register Profiles outside Provider and state callbacks.",
 			"storage_unconfigured": "Call setup or register GFStorageUtility before registration.",
 			"invalid_storage_path": "Use one path accepted by the active Storage path policy.",
@@ -2562,6 +2675,34 @@ func _get_current_storage_duration(state: ProfileState) -> int:
 			0
 		)
 	return duration_msec
+
+
+func _try_complete_quiesce() -> void:
+	if (
+		_quiesce_completion == null
+		or not _quiesce_completion.is_pending()
+		or _processing_depth > 0
+		or _emitting_completions
+		or not _pending_completion_operations.is_empty()
+		or _pending_schedule_head != null
+		or _active_preparation_head != null
+	):
+		return
+	for state_value: Variant in _states.values():
+		var state: ProfileState = _get_state_value(state_value)
+		if (
+			state != null
+			and (
+				state.mode != STATE_IDLE
+				or _has_pending_operations(state)
+				or state.current_storage_operation != null
+				or not state.detached_write_operations.is_empty()
+				or state.pending_schedule_enqueued
+				or state.active_preparation_enqueued
+			)
+		):
+			return
+	var _succeeded: bool = _quiesce_completion.succeed()
 
 
 func _set_storage(storage: GFStorageUtility) -> void:

--- a/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
@@ -207,7 +207,7 @@ func get_required_utilities() -> Array[Script]:
 ## [br]
 ## @param _scope: 当前 Profile 服务激活阶段的取消作用域。
 ## [br]
-## @return Storage 可用时成功，否则返回失败终态。
+## @return Storage 可用且实例未 dispose/quiesce 时成功，否则返回失败终态。
 func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
 	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
 	if _disposed:
@@ -313,7 +313,7 @@ func dispose() -> void:
 ## [br]
 ## @param clock: 可选单调时钟；为空时保留当前时钟。
 ## [br]
-## @return 当前 Utility；参数无效、已释放或已有注册 profile 时返回 null。
+## @return 当前 Utility；准入关闭、参数无效、已释放、处于不安全回调或已有 profile 时返回 null。
 func setup(storage: GFStorageUtility, clock: GFClock = null) -> GFSaveProfileUtility:
 	if (
 		not _admission_open
@@ -408,7 +408,7 @@ func register_profile(
 ## [br]
 ## @param profile_id: profile ID。
 ## [br]
-## @return profile 存在且没有未完成操作时返回 true。
+## @return 准入开放、回调安全且 profile 空闲并无任何待处理工作时返回 true。
 func unregister_profile(profile_id: StringName) -> bool:
 	var state: ProfileState = _get_state(profile_id)
 	if (

--- a/addons/gf/kernel/base/gf_model.gd
+++ b/addons/gf/kernel/base/gf_model.gd
@@ -120,7 +120,7 @@ func async_init(_scope: GFAsyncScope) -> void:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 func ready() -> void:
 	pass
 

--- a/addons/gf/kernel/base/gf_model.gd
+++ b/addons/gf/kernel/base/gf_model.gd
@@ -1,12 +1,16 @@
 ## GFModel: 数据层抽象基类。
 ##
 ## 负责管理应用数据和业务状态。
-## 子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。
+## 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
+## 'begin_quiesce'、'dispose' 来管理其生命周期。
 ##
-## 三阶段初始化约定：
+## 四阶段启动与关闭约定：
 ##   - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。
 ##   - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。
-##   - 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。
+##   - 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。
+##   - 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。
+##   - 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。
+##   - 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。
 ## [br]
 ## @api public
 ## [br]
@@ -23,10 +27,13 @@ const _DEPENDENCY_SCOPE_SUPPORT = preload("res://addons/gf/kernel/base/gf_depend
 
 # --- 公共变量 ---
 
-## 生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。
-## 默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。
+## 生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大
+## 越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。
+## 默认 0 表示同一 frontier 内按稳定注册顺序执行。
 ## [br]
 ## @api public
+## [br]
+## @since 1.31.0
 var lifecycle_priority: int = 0
 
 
@@ -35,7 +42,55 @@ var lifecycle_priority: int = 0
 var _dependency_scope: Dictionary = _DEPENDENCY_SCOPE_SUPPORT._make_scope()
 
 
-# --- Godot 生命周期方法 ---
+# --- GF 生命周期方法 ---
+
+## 返回此模型声明依赖的 Model 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此模型激活前必须可解析的 Model 脚本。
+func get_required_models() -> Array[Script]:
+	return []
+
+
+## 返回此模型声明依赖的 System 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此模型激活前必须可解析的 System 脚本。
+func get_required_systems() -> Array[Script]:
+	return []
+
+
+## 返回此模型声明依赖的 Utility 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此模型激活前必须可解析的 Utility 脚本。
+func get_required_utilities() -> Array[Script]:
+	return []
+
+
+## 返回此模型声明依赖的 Factory 绑定类型。
+## Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此模型激活前必须可解析的 Factory 脚本。
+func get_required_factories() -> Array[Script]:
+	return []
+
 
 ## 第一阶段初始化。子类可以重写此方法。
 ## 约束：只允许初始化自身内部变量，不得跨模块获取依赖。
@@ -60,11 +115,50 @@ func async_init(_scope: GFAsyncScope) -> void:
 
 
 ## 第三阶段初始化。子类可以重写此方法。
-## 约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。
+## 约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖；
+## 未声明依赖没有可用性保证。
 ## [br]
 ## @api public
+## [br]
+## @since 5.0.0
 func ready() -> void:
 	pass
+
+
+## 开始激活模型的运行期能力。
+##
+## 重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。
+## 基类返回已经成功的完成源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前模型激活阶段的取消作用域。
+## [br]
+## @return 当前激活阶段的一次性完成源。
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _succeeded: bool = completion.succeed()
+	return completion
+
+
+## 开始静默模型并排空已经接纳的工作。
+##
+## 重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。
+## 基类返回已经成功的完成源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前模型静默阶段的取消作用域。
+## [br]
+## @return 当前静默阶段的一次性完成源。
+func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _succeeded: bool = completion.succeed()
+	return completion
 
 
 ## 销毁模型。子类可以重写此方法。
@@ -138,9 +232,13 @@ func inject_dependencies(architecture: GFArchitecture) -> void:
 
 
 ## 检查所属架构生命周期是否仍可安全继续异步写回。
-## async_init() 或其他 await 之后写入状态前建议检查该值。
+## async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。
+## QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+## GFArchitecture.is_accepting_runtime_work() 检查。
 ## [br]
 ## @api public
+## [br]
+## @since 3.0.0
 ## [br]
 ## @return 所属架构仍处于活动生命周期时返回 true。
 func is_lifecycle_active() -> bool:

--- a/addons/gf/kernel/base/gf_system.gd
+++ b/addons/gf/kernel/base/gf_system.gd
@@ -1,12 +1,16 @@
 ## GFSystem: 逻辑层抽象基类。
 ##
 ## 负责实现核心业务逻辑。
-## 子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。
+## 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
+## 'begin_quiesce'、'dispose' 来管理其生命周期。
 ##
-## 三阶段初始化约定：
+## 四阶段启动与关闭约定：
 ##   - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。
 ##   - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。
-##   - 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。
+##   - 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。
+##   - 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。
+##   - 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。
+##   - 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。
 ## [br]
 ## @api public
 ## [br]
@@ -50,10 +54,13 @@ var ignore_time_scale: bool = false:
 		ignore_time_scale = value
 		_request_tick_cache_refresh()
 
-## 生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。
-## 默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。
+## 生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大
+## 越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。
+## 默认 0 表示同一 frontier 内按稳定注册顺序执行。
 ## [br]
 ## @api public
+## [br]
+## @since 1.31.0
 var lifecycle_priority: int = 0
 
 ## 每帧 tick 优先级。数值越大越早执行 tick()。
@@ -110,7 +117,55 @@ var physics_tick_enabled: bool = false:
 var _dependency_scope: Dictionary = _DEPENDENCY_SCOPE_SUPPORT._make_scope()
 
 
-# --- Godot 生命周期方法 ---
+# --- GF 生命周期方法 ---
+
+## 返回此系统声明依赖的 Model 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此系统激活前必须可解析的 Model 脚本。
+func get_required_models() -> Array[Script]:
+	return []
+
+
+## 返回此系统声明依赖的 System 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此系统激活前必须可解析的 System 脚本。
+func get_required_systems() -> Array[Script]:
+	return []
+
+
+## 返回此系统声明依赖的 Utility 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此系统激活前必须可解析的 Utility 脚本。
+func get_required_utilities() -> Array[Script]:
+	return []
+
+
+## 返回此系统声明依赖的 Factory 绑定类型。
+## Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此系统激活前必须可解析的 Factory 脚本。
+func get_required_factories() -> Array[Script]:
+	return []
+
 
 ## 第一阶段初始化。子类可以重写此方法。
 ## 约束：只允许初始化自身内部变量，不得跨模块获取依赖。
@@ -135,11 +190,50 @@ func async_init(_scope: GFAsyncScope) -> void:
 
 
 ## 第三阶段初始化。子类可以重写此方法。
-## 约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。
+## 约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖；
+## 未声明依赖没有可用性保证。
 ## [br]
 ## @api public
+## [br]
+## @since 5.0.0
 func ready() -> void:
 	pass
+
+
+## 开始激活系统的运行期能力。
+##
+## 重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。
+## 基类返回已经成功的完成源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前系统激活阶段的取消作用域。
+## [br]
+## @return 当前激活阶段的一次性完成源。
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _succeeded: bool = completion.succeed()
+	return completion
+
+
+## 开始静默系统并排空已经接纳的工作。
+##
+## 重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。
+## 基类返回已经成功的完成源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前系统静默阶段的取消作用域。
+## [br]
+## @return 当前静默阶段的一次性完成源。
+func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _succeeded: bool = completion.succeed()
+	return completion
 
 
 ## 销毁系统。子类可以重写此方法。
@@ -191,9 +285,13 @@ func inject_dependencies(architecture: GFArchitecture) -> void:
 
 
 ## 检查所属架构生命周期是否仍可安全继续异步写回。
-## async_init() 或其他 await 之后写入状态前建议检查该值。
+## async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。
+## QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+## GFArchitecture.is_accepting_runtime_work() 检查。
 ## [br]
 ## @api public
+## [br]
+## @since 3.0.0
 ## [br]
 ## @return 所属架构仍处于活动生命周期时返回 true。
 func is_lifecycle_active() -> bool:

--- a/addons/gf/kernel/base/gf_system.gd
+++ b/addons/gf/kernel/base/gf_system.gd
@@ -195,7 +195,7 @@ func async_init(_scope: GFAsyncScope) -> void:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 func ready() -> void:
 	pass
 

--- a/addons/gf/kernel/base/gf_utility.gd
+++ b/addons/gf/kernel/base/gf_utility.gd
@@ -1,12 +1,16 @@
 ## GFUtility: 工具组件抽象基类。
 ##
-## 提供不依赖其他架构组件的独立工具功能。
-## 子类可以实现 'init'、'async_init'、'ready'、 'dispose' 来管理其生命周期。
+## 提供可复用的工具能力；需要其它架构组件时必须通过类型化 Hook 显式声明依赖。
+## 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
+## 'begin_quiesce'、'dispose' 来管理其生命周期。
 ##
-## 三阶段初始化约定：
+## 四阶段启动与关闭约定：
 ##   - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。
 ##   - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。
-##   - 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。
+##   - 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。
+##   - 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。
+##   - 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。
+##   - 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。
 ## [br]
 ## @api public
 ## [br]
@@ -49,10 +53,13 @@ var ignore_time_scale: bool = false:
 		ignore_time_scale = value
 		_request_tick_cache_refresh()
 
-## 生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。
-## 默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。
+## 生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大
+## 越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。
+## 默认 0 表示同一 frontier 内按稳定注册顺序执行。
 ## [br]
 ## @api public
+## [br]
+## @since 1.31.0
 var lifecycle_priority: int = 0
 
 ## 每帧 tick 优先级。数值越大越早执行 tick()。
@@ -109,7 +116,55 @@ var physics_tick_enabled: bool = false:
 var _dependency_scope: Dictionary = _DEPENDENCY_SCOPE_SUPPORT._make_scope()
 
 
-# --- Godot 生命周期方法 ---
+# --- GF 生命周期方法 ---
+
+## 返回此工具声明依赖的 Model 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此工具激活前必须可解析的 Model 脚本。
+func get_required_models() -> Array[Script]:
+	return []
+
+
+## 返回此工具声明依赖的 System 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此工具激活前必须可解析的 System 脚本。
+func get_required_systems() -> Array[Script]:
+	return []
+
+
+## 返回此工具声明依赖的 Utility 类型。
+## 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此工具激活前必须可解析的 Utility 脚本。
+func get_required_utilities() -> Array[Script]:
+	return []
+
+
+## 返回此工具声明依赖的 Factory 绑定类型。
+## Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 此工具激活前必须可解析的 Factory 脚本。
+func get_required_factories() -> Array[Script]:
+	return []
+
 
 ## 第一阶段初始化。子类可以重写此方法。
 ## 约束：只允许初始化自身内部变量，不得跨模块获取依赖。
@@ -134,11 +189,50 @@ func async_init(_scope: GFAsyncScope) -> void:
 
 
 ## 第三阶段初始化。子类可以重写此方法。
-## 约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。
+## 约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖；
+## 未声明依赖没有可用性保证。
 ## [br]
 ## @api public
+## [br]
+## @since 5.0.0
 func ready() -> void:
 	pass
+
+
+## 开始激活工具的运行期能力。
+##
+## 重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。
+## 基类返回已经成功的完成源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前工具激活阶段的取消作用域。
+## [br]
+## @return 当前激活阶段的一次性完成源。
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _succeeded: bool = completion.succeed()
+	return completion
+
+
+## 开始静默工具并排空已经接纳的工作。
+##
+## 重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。
+## 基类返回已经成功的完成源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前工具静默阶段的取消作用域。
+## [br]
+## @return 当前静默阶段的一次性完成源。
+func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _succeeded: bool = completion.succeed()
+	return completion
 
 
 ## 销毁工具。子类可以重写此方法。
@@ -170,9 +264,13 @@ func inject_dependencies(architecture: GFArchitecture) -> void:
 
 
 ## 检查所属架构生命周期是否仍可安全继续异步写回。
-## async_init() 或其他 await 之后写入状态前建议检查该值。
+## async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。
+## QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+## GFArchitecture.is_accepting_runtime_work() 检查。
 ## [br]
 ## @api public
+## [br]
+## @since 3.0.0
 ## [br]
 ## @return 所属架构仍处于活动生命周期时返回 true。
 func is_lifecycle_active() -> bool:

--- a/addons/gf/kernel/base/gf_utility.gd
+++ b/addons/gf/kernel/base/gf_utility.gd
@@ -194,7 +194,7 @@ func async_init(_scope: GFAsyncScope) -> void:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 func ready() -> void:
 	pass
 

--- a/addons/gf/kernel/core/gf.gd
+++ b/addons/gf/kernel/core/gf.gd
@@ -134,6 +134,7 @@ func _exit_tree() -> void:
 func has_architecture() -> bool:
 	return (
 		_architecture != null
+		and not _architecture.is_quiescing()
 		and not _architecture.is_disposing()
 		and not _architecture.is_disposed()
 	)
@@ -154,7 +155,7 @@ func create_architecture() -> GFArchitecture:
 	if _tree_exit_in_progress:
 		return null
 	if _architecture != null:
-		if _architecture.is_disposing():
+		if _architecture.is_quiescing() or _architecture.is_disposing():
 			return null
 		if not _architecture.is_disposed():
 			return _architecture
@@ -168,7 +169,7 @@ func create_architecture() -> GFArchitecture:
 	):
 		return _get_available_architecture_or_null()
 	if _architecture != null:
-		if _architecture.is_disposing():
+		if _architecture.is_quiescing() or _architecture.is_disposing():
 			return null
 		if _architecture.is_disposed():
 			_commit_architecture_identity(null)
@@ -220,6 +221,8 @@ func get_architecture() -> GFArchitecture:
 ## 若本次赋值被更新赋值、尚无已提交架构时由 create_architecture() 创建的默认架构，
 ## 或 Gf 退出场景树替代，框架会取消本次异步作用域并 dispose 未提交候选；
 ## 调用方不得假定该候选仍可复用。
+## 替换已有架构时会先等待旧架构的 shutdown_async()；只有 typed shutdown 结果成功，
+## 才会发布候选。失败结果会拒绝候选、强制清理候选并清除已经终结的旧 identity。
 ## 同一候选已有 pending 赋值时，并发重复调用会返回 false，且不会取消首个赋值。
 ## [br]
 ## @api public
@@ -249,18 +252,18 @@ func set_architecture(architecture_instance: GFArchitecture) -> bool:
 		assignment_scope,
 		assignment_serial
 	):
-		_reject_inactive_pending_architecture_assignment_if_owned(
+		_reject_pending_architecture_assignment_if_owned(
 			architecture_instance,
 			assignment_scope,
 			assignment_serial
 		)
 		return false
 	if not installers_ready:
-		_finish_pending_architecture_assignment(
+		_reject_pending_architecture_assignment_if_owned(
 			architecture_instance,
 			assignment_scope,
 			assignment_serial,
-			false
+			"[GF] 架构赋值失败：项目 Installer 未完成。"
 		)
 		return false
 	if not architecture_instance.is_inited():
@@ -270,38 +273,56 @@ func set_architecture(architecture_instance: GFArchitecture) -> bool:
 			assignment_scope,
 			assignment_serial
 		):
-			_reject_inactive_pending_architecture_assignment_if_owned(
+			_reject_pending_architecture_assignment_if_owned(
 				architecture_instance,
 				assignment_scope,
 				assignment_serial
 			)
 			return false
 		if not initialized:
-			_finish_pending_architecture_assignment(
+			_reject_pending_architecture_assignment_if_owned(
 				architecture_instance,
 				assignment_scope,
 				assignment_serial,
-				false
+				"[GF] 架构赋值失败：候选架构未完成四阶段初始化。"
 			)
 			return false
-	if architecture_instance.has_initialization_failed():
-		_finish_pending_architecture_assignment(
+	if (
+		architecture_instance.has_initialization_failed()
+		or not architecture_instance.is_inited()
+		or not architecture_instance.is_accepting_runtime_work()
+	):
+		_reject_pending_architecture_assignment_if_owned(
 			architecture_instance,
 			assignment_scope,
 			assignment_serial,
-			false
+			"[GF] 架构赋值失败：候选架构未提交 READY。"
 		)
 		return false
 	if previous_architecture != null and previous_architecture != architecture_instance:
-		previous_architecture.dispose()
+		var shutdown_result: GFArchitectureShutdownResult = (
+			await previous_architecture.shutdown_async()
+		)
 		if not _is_pending_architecture_assignment_current(
 			architecture_instance,
 			assignment_scope,
 			assignment_serial
 		):
-			_reject_inactive_pending_architecture_assignment_if_owned(
+			_reject_pending_architecture_assignment_if_owned(
 				architecture_instance,
 				assignment_scope,
+				assignment_serial
+			)
+			return false
+		if shutdown_result == null or not shutdown_result.is_successful():
+			_reject_pending_architecture_assignment_if_owned(
+				architecture_instance,
+				assignment_scope,
+				assignment_serial,
+				"[GF] 架构赋值失败：旧架构未能正常关闭。"
+			)
+			_clear_terminal_architecture_identity_if_current(
+				previous_architecture,
 				assignment_serial
 			)
 			return false
@@ -319,6 +340,7 @@ func set_architecture(architecture_instance: GFArchitecture) -> bool:
 
 
 ## 初始化当前架构。若尚未创建架构，则自动创建默认 GFArchitecture。
+## 只有 init、async_init、ready 与 activation 四阶段全部提交后才返回成功。
 ## [br]
 ## @api public
 ## [br]
@@ -343,6 +365,7 @@ func init() -> bool:
 	return (
 		initialized
 		and current_arch.is_inited()
+		and current_arch.is_accepting_runtime_work()
 		and not current_arch.has_initialization_failed()
 		and not current_arch.is_disposing()
 		and not current_arch.is_disposed()
@@ -451,7 +474,7 @@ func replace_utility(instance: Object) -> bool:
 ## [br]
 ## @since 5.0.0
 ## [br]
-## @param script_cls: 要注册、查询或创建的脚本类型。
+## @param script_cls: 工厂绑定使用的脚本类型键。
 ## [br]
 ## @param factory: 用于创建实例的工厂绑定。
 ## [br]
@@ -474,7 +497,7 @@ func register_factory(
 ## [br]
 ## @since 5.0.0
 ## [br]
-## @param script_cls: 要注册、查询或创建的脚本类型。
+## @param script_cls: 工厂入口使用的脚本类型键。
 ## [br]
 ## @param instance: 要注册、替换或注入的实例。
 ## [br]
@@ -491,7 +514,7 @@ func register_factory_instance(script_cls: Script, instance: Object) -> bool:
 ## [br]
 ## @since 5.0.0
 ## [br]
-## @param script_cls: 要注册、查询或创建的脚本类型。
+## @param script_cls: 要替换的工厂绑定脚本类型键。
 ## [br]
 ## @param factory: 用于创建实例的工厂绑定。
 ## [br]
@@ -556,12 +579,15 @@ func has_factory(script_cls: Script) -> bool:
 
 
 ## 创建短生命周期对象实例。
+## 只有当前架构已提交 READY 且仍开放运行时准入时才会调用工厂 provider。
 ## [br]
 ## @api public
 ## [br]
+## @since 1.9.0
+## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
 ## [br]
-## @return 创建出的实例；架构不可用或工厂不存在时返回 null。
+## @return 创建出的实例；架构未开放准入或工厂不存在时返回 null。
 func create_instance(script_cls: Script) -> Object:
 	var arch: GFArchitecture = _get_architecture_or_null("create_instance")
 	if arch == null:
@@ -1241,31 +1267,46 @@ func unlisten_owner(listener_owner: Object) -> void:
 ## [br]
 ## @api public
 ## [br]
+## @since 5.0.0
+## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
-func unregister_system(script_cls: Script) -> void:
+## [br]
+## @return 模块完成 quiesce 并从活动拓扑移除时返回 true。
+func unregister_system(script_cls: Script) -> bool:
 	var arch: GFArchitecture = _get_architecture_or_null("unregister_system")
-	if arch != null:
-		arch.unregister_system(script_cls)
+	if arch == null:
+		return false
+	return await arch.unregister_system(script_cls)
 
 ## 注销 Model 实例。
 ## [br]
 ## @api public
 ## [br]
+## @since 5.0.0
+## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
-func unregister_model(script_cls: Script) -> void:
+## [br]
+## @return 模块完成 quiesce 并从活动拓扑移除时返回 true。
+func unregister_model(script_cls: Script) -> bool:
 	var arch: GFArchitecture = _get_architecture_or_null("unregister_model")
-	if arch != null:
-		arch.unregister_model(script_cls)
+	if arch == null:
+		return false
+	return await arch.unregister_model(script_cls)
 
 ## 注销 Utility 实例。
 ## [br]
 ## @api public
 ## [br]
+## @since 5.0.0
+## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
-func unregister_utility(script_cls: Script) -> void:
+## [br]
+## @return 模块完成 quiesce 并从活动拓扑移除时返回 true。
+func unregister_utility(script_cls: Script) -> bool:
 	var arch: GFArchitecture = _get_architecture_or_null("unregister_utility")
-	if arch != null:
-		arch.unregister_utility(script_cls)
+	if arch == null:
+		return false
+	return await arch.unregister_utility(script_cls)
 
 
 # --- 私有/辅助方法 ---
@@ -1352,10 +1393,11 @@ func _finish_pending_architecture_assignment(
 		)
 
 
-func _reject_inactive_pending_architecture_assignment_if_owned(
+func _reject_pending_architecture_assignment_if_owned(
 	architecture_instance: GFArchitecture,
 	assignment_scope: GFAsyncScope,
-	assignment_serial: int
+	assignment_serial: int,
+	reason: String = "[GF] 架构赋值未能提交。"
 ) -> void:
 	if not _owns_pending_architecture_assignment(
 		architecture_instance,
@@ -1363,14 +1405,33 @@ func _reject_inactive_pending_architecture_assignment_if_owned(
 		assignment_serial
 	):
 		return
-	_finish_pending_architecture_assignment(
-		architecture_instance,
-		assignment_scope,
-		assignment_serial,
-		false
-	)
+
+	_pending_architecture_assignment = null
+	_pending_architecture_assignment_scope = null
+	architecture_instance.untrack_framework_async_scope(assignment_scope)
 	if architecture_instance != _architecture:
 		architecture_instance.dispose()
+	if not assignment_scope.is_cancel_requested():
+		var _cancelled_scope: bool = assignment_scope.cancel(reason)
+
+
+func _clear_terminal_architecture_identity_if_current(
+	architecture_instance: GFArchitecture,
+	assignment_serial: int
+) -> void:
+	if (
+		not _is_architecture_assignment_serial_current(assignment_serial)
+		or _architecture != architecture_instance
+	):
+		return
+	if not architecture_instance.is_disposed():
+		architecture_instance.dispose()
+	if (
+		not _is_architecture_assignment_serial_current(assignment_serial)
+		or _architecture != architecture_instance
+	):
+		return
+	_commit_architecture_identity(null)
 
 
 func _is_pending_architecture_assignment_current(

--- a/addons/gf/kernel/core/gf.gd
+++ b/addons/gf/kernel/core/gf.gd
@@ -124,13 +124,13 @@ func _exit_tree() -> void:
 
 # --- 公共方法 ---
 
-## 检查当前是否已有架构实例。
+## 检查当前架构 identity 是否仍可供 facade 使用。
 ## [br]
 ## @api public
 ## [br]
 ## @since 1.5.0
 ## [br]
-## @return 已存在架构时返回 true。
+## @return identity 已存在且未进入 quiesce 或 dispose 阶段时返回 true。
 func has_architecture() -> bool:
 	return (
 		_architecture != null
@@ -143,8 +143,8 @@ func has_architecture() -> bool:
 ## 获取当前架构；若尚未创建，则自动创建一个默认 GFArchitecture。
 ## 若同步取消旧 assignment 的 cleanup 触发更新架构操作，较新的操作拥有提交权，
 ## 本次调用返回其最终提交结果，不会用陈旧默认实例覆盖。Gf 正在退出场景树，
-## 或当前 identity 正在 dispose 时返回 null；已完成 dispose 的 identity 会先被
-## 清除，再创建新的默认架构。
+## 或当前 identity 正在 quiesce/dispose 时返回 null；已完成 dispose 的 identity
+## 会先被清除，再创建新的默认架构。
 ## [br]
 ## @api public
 ## [br]
@@ -206,7 +206,7 @@ func create_binder() -> Variant:
 ## [br]
 ## @since 3.17.0
 ## [br]
-## @return GFArchitecture 实例，如果未注册则返回 null。
+## @return 当前可用的 GFArchitecture；未注册或 identity 正在 quiesce/dispose 时返回 null。
 func get_architecture() -> GFArchitecture:
 	if not has_architecture():
 		push_error("[GF] 架构尚未初始化或正在释放，请先注册可用架构。")
@@ -224,6 +224,8 @@ func get_architecture() -> GFArchitecture:
 ## 替换已有架构时会先等待旧架构的 shutdown_async()；只有 typed shutdown 结果成功，
 ## 才会发布候选。失败结果会拒绝候选、强制清理候选并清除已经终结的旧 identity。
 ## 同一候选已有 pending 赋值时，并发重复调用会返回 false，且不会取消首个赋值。
+## 已进入 QUIESCING、DISPOSING 或 DISPOSED 的候选会在事务开始前被拒绝，也不会
+## 改变当前 pending 赋值。
 ## [br]
 ## @api public
 ## [br]
@@ -238,7 +240,11 @@ func set_architecture(architecture_instance: GFArchitecture) -> bool:
 		return false
 	if _tree_exit_in_progress:
 		return false
-	if architecture_instance.is_disposing() or architecture_instance.is_disposed():
+	if (
+		architecture_instance.is_quiescing()
+		or architecture_instance.is_disposing()
+		or architecture_instance.is_disposed()
+	):
 		return false
 
 	var assignment_scope: GFAsyncScope = _begin_architecture_assignment(architecture_instance)
@@ -1267,7 +1273,7 @@ func unlisten_owner(listener_owner: Object) -> void:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 1.9.0
 ## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
 ## [br]
@@ -1282,7 +1288,7 @@ func unregister_system(script_cls: Script) -> bool:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 1.9.0
 ## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
 ## [br]
@@ -1297,7 +1303,7 @@ func unregister_model(script_cls: Script) -> bool:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 1.9.0
 ## [br]
 ## @param script_cls: 要注册、查询或创建的脚本类型。
 ## [br]
@@ -1425,7 +1431,7 @@ func _clear_terminal_architecture_identity_if_current(
 	):
 		return
 	if not architecture_instance.is_disposed():
-		architecture_instance.dispose()
+		return
 	if (
 		not _is_architecture_assignment_serial_current(assignment_serial)
 		or _architecture != architecture_instance

--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -119,7 +119,7 @@ const _MAX_TOPOLOGY_SERVICE_INTENTS: int = 64
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 1.23.0
 var module_async_init_timeout_seconds: float = 0.0:
 	set(value):
 		if (
@@ -137,7 +137,7 @@ var module_async_init_timeout_seconds: float = 0.0:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 1.23.0
 var strict_dependency_lookup: bool = false
 
 ## 架构激活阶段的总等待上限（秒）。
@@ -253,7 +253,7 @@ func _init(parent_architecture: GFArchitecture = null) -> void:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 ## [br]
 ## @return 四阶段启动全部完成且 activation 已提交时返回 true，否则返回 false。
 func is_inited() -> bool:
@@ -383,11 +383,7 @@ func is_module_ready(instance: Object) -> bool:
 ## [br]
 ## @return 模块属于当前架构且已完成第四阶段激活时返回 true。
 func is_module_active(instance: Object) -> bool:
-	return (
-		instance != null
-		and _runtime.is_lifecycle_active()
-		and _GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0) >= 4
-	)
+	return _is_committed_module_at_lifecycle_stage(instance, 4)
 
 
 ## 获取最近一次关闭结果的隔离副本。
@@ -1964,7 +1960,7 @@ func register_utility_instance_as(instance: Object, alias_cls: Script) -> bool:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 ## [br]
 ## @param script_cls: 系统的脚本类。
 ## [br]
@@ -1983,7 +1979,7 @@ func unregister_system(script_cls: Script) -> bool:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 ## [br]
 ## @param script_cls: 模型的脚本类。
 ## [br]
@@ -1996,7 +1992,7 @@ func unregister_model(script_cls: Script) -> bool:
 ## [br]
 ## @api public
 ## [br]
-## @since 5.0.0
+## @since 11.0.0
 ## [br]
 ## @param script_cls: 工具的脚本类。
 ## [br]
@@ -4122,7 +4118,7 @@ func _register_initialized_module(
 		and not _runtime.is_transaction_invalidated(
 			runtime_transaction
 		)
-		and is_module_active(instance)
+		and _has_module_reached_lifecycle_stage(instance, 4)
 		and _validate_topology_service_intents(topology_transaction)
 	)
 	if committed:
@@ -4796,24 +4792,6 @@ func _has_live_child_external_dependency_leases(
 		var consumer_ref: WeakRef = consumer_ref_value
 		var consumer_value: Variant = consumer_ref.get_ref()
 		if not consumer_value is GFArchitecture:
-			stale_lease_ids.append(
-				_GF_VARIANT_ACCESS_SCRIPT.to_int(lease_id, -1)
-			)
-			continue
-		var consumer: GFArchitecture = consumer_value
-		var consumer_lifecycle_serial: int = (
-			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
-				record,
-				"consumer_lifecycle_serial",
-				-1
-			)
-		)
-		if (
-			consumer_lifecycle_serial < 0
-			or not consumer.is_lifecycle_generation_active(
-				consumer_lifecycle_serial
-			)
-		):
 			stale_lease_ids.append(
 				_GF_VARIANT_ACCESS_SCRIPT.to_int(lease_id, -1)
 			)
@@ -7305,8 +7283,10 @@ func _clear_injected_scope(instance: Object) -> void:
 func _release_module_dependencies(instance: Object) -> void:
 	if instance == null:
 		return
+	_lifecycle_hook_depth += 1
 	_call_module_release_dependencies(instance)
 	_clear_injected_scope(instance)
+	_lifecycle_hook_depth -= 1
 
 
 func _stop_project_installers_after_failure() -> void:
@@ -7459,10 +7439,28 @@ func _get_module_label_for_instance(instance: Object) -> String:
 
 
 func _is_module_ready_for_lookup(instance: Object) -> bool:
+	return _is_committed_module_at_lifecycle_stage(instance, 3)
+
+
+func _is_committed_module_at_lifecycle_stage(
+	instance: Object,
+	target_stage: int
+) -> bool:
+	return (
+		_get_module_registry_for_instance(instance) != null
+		and _has_module_reached_lifecycle_stage(instance, target_stage)
+	)
+
+
+func _has_module_reached_lifecycle_stage(instance: Object, target_stage: int) -> bool:
 	return (
 		instance != null
 		and _runtime.is_lifecycle_active()
-		and _GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0) >= 3
+		and _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			_module_lifecycle_stages,
+			instance,
+			0
+		) >= target_stage
 	)
 
 

--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -1,9 +1,10 @@
 ## GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。
 ##
-## 生命周期遵循三阶段初始化协议：
-##   阶段一 (init)       ：所有模块执行自身内部变量初始化。
-##   阶段二 (async_init) ：所有模块串行执行异步初始化（可使用 await）。
-##   阶段三 (ready)      ：所有模块均已完成 init，可安全进行跨模块依赖获取。
+## 生命周期遵循四阶段初始化协议：
+##   阶段一 (init)       ：各模块按声明依赖 DAG 执行自身内部变量初始化。
+##   阶段二 (async_init) ：按同一 DAG 串行执行异步准备（可使用 await）。
+##   阶段三 (ready)      ：当前模块的声明依赖已 ready，可完成同步装配。
+##   阶段四 (activation) ：按依赖顺序完成异步启动，全部成功后才开放运行时准入。
 ## [br]
 ## @api public
 ## [br]
@@ -28,6 +29,15 @@ signal initialization_finished
 ## [br]
 ## @param reason: 初始化失败原因。
 signal initialization_failed(reason: String)
+
+## 当异步关闭流程或同步强制释放发布类型化终态时发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param result: 类型化关闭结果快照。
+signal shutdown_finished(result: GFArchitectureShutdownResult)
 
 ## 当项目级 Installer 应用完成或被 dispose() 中断后发出。
 ## [br]
@@ -65,6 +75,8 @@ const GFBindingLifetimesBase = preload("res://addons/gf/kernel/core/gf_binding_l
 ## @layer kernel/core
 const GFTimeProviderBase = preload("res://addons/gf/kernel/base/gf_time_provider.gd")
 const _GF_ASYNC_CALL_SCRIPT = preload("res://addons/gf/kernel/core/gf_async_call.gd")
+const _GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = preload("res://addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd")
+const _GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT = preload("res://addons/gf/kernel/core/gf_architecture_shutdown_result.gd")
 const _GF_ARCHITECTURE_SNAPSHOT_COORDINATOR_SCRIPT = preload("res://addons/gf/kernel/core/gf_architecture_snapshot_coordinator.gd")
 const _GF_ARCHITECTURE_TICK_SCHEDULER_SCRIPT = preload("res://addons/gf/kernel/core/gf_architecture_tick_scheduler.gd")
 const _GF_KERNEL_RUNTIME_SCRIPT = preload("res://addons/gf/kernel/core/gf_kernel_runtime.gd")
@@ -89,69 +101,82 @@ const _PARENT_CHAIN_TRUNCATED_KEY: String = "truncated"
 ## @since 8.0.0
 const SERVICE_COMMAND_HISTORY_STORE: StringName = &"gf.kernel.command_history_store"
 
-## 声明式依赖聚合 Hook 名称。
-## [br]
-## @api public
-const HOOK_GET_REQUIRED_DEPENDENCIES: StringName = &"get_required_dependencies"
-
-## 声明式 Model 依赖 Hook 名称。
-## [br]
-## @api public
-const HOOK_GET_REQUIRED_MODELS: StringName = &"get_required_models"
-
-## 声明式 System 依赖 Hook 名称。
-## [br]
-## @api public
-const HOOK_GET_REQUIRED_SYSTEMS: StringName = &"get_required_systems"
-
-## 声明式 Utility 依赖 Hook 名称。
-## [br]
-## @api public
-const HOOK_GET_REQUIRED_UTILITIES: StringName = &"get_required_utilities"
-
-## 声明式工厂依赖 Hook 名称。
-## [br]
-## @api public
-const HOOK_GET_REQUIRED_FACTORIES: StringName = &"get_required_factories"
-
 ## 分帧快照 API 默认每帧处理的 Model 数量。
 ## [br]
 ## @api public
 ## [br]
 ## @since 5.0.0
 const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8
+const _MAX_LIFECYCLE_TIMEOUT_SECONDS: float = 86_400.0
+const _MAX_LIFECYCLE_PARENT_DEPTH: int = 64
+const _MAX_TOPOLOGY_SERVICE_INTENTS: int = 64
 
 
 # --- 公共变量 ---
 
-## 单个模块 async_init() 的最长等待时间。小于等于 0 时不启用超时。
+## 单个模块 async_init() 的最长等待时间。0 时不启用超时。
 ## 默认关闭；项目可按自身加载预算显式启用。
-## [br]
-## @api public
-var module_async_init_timeout_seconds: float = 0.0:
-	set(value):
-		module_async_init_timeout_seconds = maxf(value, 0.0)
-
-## 单个生命周期阶段最多扫描模块注册表的次数，避免模块在生命周期中无限注册新模块。
-## [br]
-## @api public
-var module_lifecycle_max_stage_passes: int = 256:
-	set(value):
-		module_lifecycle_max_stage_passes = maxi(value, 1)
-
-## 严格依赖查询模式。开启后本架构查询不到本地模块时不会回退父级架构。
-## [br]
-## @api public
-var strict_dependency_lookup: bool = false
-
-## 声明式依赖缺失时是否直接使初始化失败。
-## 模块可通过 get_required_dependencies() 或 get_required_models/systems/utilities/factories() 声明依赖。
-## 开启后，init() 会在模块生命周期推进前校验依赖图，缺失依赖会中止本次初始化。
 ## [br]
 ## @api public
 ## [br]
 ## @since 5.0.0
-var fail_on_missing_declared_dependencies: bool = false
+var module_async_init_timeout_seconds: float = 0.0:
+	set(value):
+		if (
+			not is_finite(value)
+			or value < 0.0
+			or value > _MAX_LIFECYCLE_TIMEOUT_SECONDS
+		):
+			push_error(
+				"[GFArchitecture] module_async_init_timeout_seconds 必须是 0 到 86400 之间的有限值。"
+			)
+			return
+		module_async_init_timeout_seconds = value
+
+## 严格依赖查询模式。开启后本架构查询不到本地模块时不会回退父级架构。
+## [br]
+## @api public
+## [br]
+## @since 5.0.0
+var strict_dependency_lookup: bool = false
+
+## 架构激活阶段的总等待上限（秒）。
+## 0 时不启用 deadline；默认 30 秒。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var activation_timeout_seconds: float = 30.0:
+	set(value):
+		if (
+			not is_finite(value)
+			or value < 0.0
+			or value > _MAX_LIFECYCLE_TIMEOUT_SECONDS
+		):
+			push_error(
+				"[GFArchitecture] activation_timeout_seconds 必须是 0 到 86400 之间的有限值。"
+			)
+			return
+		activation_timeout_seconds = value
+
+## 架构 quiesce 阶段的总等待上限（秒）。
+## 0 时不启用 deadline；默认 10 秒。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var shutdown_timeout_seconds: float = 10.0:
+	set(value):
+		if (
+			not is_finite(value)
+			or value < 0.0
+			or value > _MAX_LIFECYCLE_TIMEOUT_SECONDS
+		):
+			push_error(
+				"[GFArchitecture] shutdown_timeout_seconds 必须是 0 到 86400 之间的有限值。"
+			)
+			return
+		shutdown_timeout_seconds = value
 
 ## 最近一次初始化失败原因；没有失败时为空字符串。
 ## [br]
@@ -181,6 +206,22 @@ var _project_installers_applied: bool = false
 var _project_installers_running: bool = false
 var _stale_async_write_block_count: int = 0
 var _active_async_scopes: Array[GFAsyncScope] = []
+var _active_lifecycle_plan: GFArchitectureLifecyclePlan = null
+var _lifecycle_plan_in_progress: GFArchitectureLifecyclePlan = null
+var _activation_scope: GFAsyncScope = null
+var _shutdown_scope: GFAsyncScope = null
+var _shutdown_completion: GFAsyncCompletion = null
+var _last_shutdown_result: GFArchitectureShutdownResult = null
+var _shutdown_duplicate_request_count: int = 0
+var _lifecycle_hook_depth: int = 0
+var _topology_mutation: TopologyMutation = null
+var _next_topology_mutation_id: int = 1
+var _last_lifecycle_plan_error: String = ""
+var _module_disposal_claims: Dictionary = {}
+var _module_disposal_session_depth: int = 0
+var _active_external_dependency_leases: Array[Dictionary] = []
+var _child_external_dependency_leases: Dictionary = {}
+var _next_child_external_dependency_lease_id: int = 1
 
 
 # --- Godot 生命周期方法 ---
@@ -208,11 +249,13 @@ func _init(parent_architecture: GFArchitecture = null) -> void:
 
 # --- 公共方法 ---
 
-## 检查架构是否已初始化。
+## 检查架构是否已完成四阶段启动并提交 READY。
 ## [br]
 ## @api public
 ## [br]
-## @return 已初始化返回 true，否则返回 false。
+## @since 5.0.0
+## [br]
+## @return 四阶段启动全部完成且 activation 已提交时返回 true，否则返回 false。
 func is_inited() -> bool:
 	return _runtime.is_ready()
 
@@ -226,13 +269,50 @@ func has_initialization_failed() -> bool:
 	return _runtime.has_failed()
 
 
-## 检查当前架构生命周期是否仍处于可安全继续异步写回的活动状态。
+## 检查当前架构生命周期是否仍处于可安全继续已接纳异步写回的活动状态。
+## QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+## is_accepting_runtime_work() 检查。
 ## [br]
 ## @api public
 ## [br]
-## @return 正在初始化或已完成初始化，且未被 dispose() 或失败保护中断时返回 true。
+## @since 1.23.2
+## [br]
+## @return 正在初始化、已完成初始化或正在收敛已接纳工作，且未被 dispose() 或失败保护中断时返回 true。
 func is_lifecycle_active() -> bool:
 	return _runtime.is_lifecycle_active()
+
+
+## 检查架构是否正在执行第四阶段激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 架构正在执行第四阶段激活时返回 true。
+func is_activating() -> bool:
+	return _runtime.is_activating()
+
+
+## 检查架构是否已经关闭新工作、正在等待已接纳工作收敛。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 架构正在 quiesce 且尚未进入同步释放阶段时返回 true。
+func is_quiescing() -> bool:
+	return _runtime.is_quiescing()
+
+
+## 检查架构是否仍接纳新的运行时工作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 仅在完整激活并处于 READY 时返回 true。
+func is_accepting_runtime_work() -> bool:
+	return _runtime.is_ready() and _topology_mutation == null
 
 
 ## 检查架构是否已经完成释放并进入不可恢复终态。
@@ -291,6 +371,36 @@ func is_lifecycle_generation_active(lifecycle_generation: int) -> bool:
 ## @return 模块完成 ready 阶段时返回 true。
 func is_module_ready(instance: Object) -> bool:
 	return _is_module_ready_for_lookup(instance)
+
+
+## 检查模块是否已经完成第四阶段激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param instance: 由当前架构本地注册的模块实例。
+## [br]
+## @return 模块属于当前架构且已完成第四阶段激活时返回 true。
+func is_module_active(instance: Object) -> bool:
+	return (
+		instance != null
+		and _runtime.is_lifecycle_active()
+		and _GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0) >= 4
+	)
+
+
+## 获取最近一次关闭结果的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未关闭时返回 null。
+func get_last_shutdown_result() -> GFArchitectureShutdownResult:
+	if _last_shutdown_result == null:
+		return null
+	return _last_shutdown_result.duplicate_result()
 
 
 ## 将当前架构标记为初始化失败，并唤醒等待初始化或 Installer 的调用方。
@@ -393,44 +503,110 @@ func create_binder() -> GFBinder:
 	return GFBinderBase.new(self)
 
 
-## 初始化架构及所有注册的组件（三阶段）。
-## 阶段一：调用所有模块的 init()，用于初始化自身内部变量。
-## 阶段二：串行 await 所有模块的 async_init()，用于异步资源加载等操作。
-## 阶段三：调用所有模块的 ready()，此时跨模块依赖获取是安全的。
+## 初始化架构及所有注册的组件（四阶段）。
+## 阶段一：按声明依赖 DAG 调用模块的 init()，用于初始化自身内部变量。
+## 阶段二：按同一 DAG 串行 await 模块的 async_init()，用于异步准备。
+## 阶段三：调用模块的 ready()；当前模块声明的依赖已 ready，未声明依赖无可用保证。
+## 阶段四：按声明依赖顺序调用 begin_activation()，全部成功后才提交 READY。
+## 并发调用复用同一初始化事务；首个调用拥有共享流程的取消策略，后续调用的
+## token 只取消自身等待，不会中断共享初始化。架构已经 READY 时幂等成功优先于
+## 调用方 token 的取消状态。
 ## [br]
 ## @api public
 ## [br]
 ## @since 5.0.0
 ## [br]
+## @param cancellation_token: 可选的初始化取消令牌。
+## [br]
 ## @return 初始化完成且架构处于 ready 状态时返回 true。
-func init() -> bool:
-	if _runtime.is_disposing() or _runtime.is_disposed():
+func init(cancellation_token: GFCancellationToken = null) -> bool:
+	if _runtime.is_quiescing() or _runtime.is_disposing() or _runtime.is_disposed():
 		push_error("[GFArchitecture] init 失败：架构正在或已经 dispose，不能重新初始化。")
 		return false
 	if _runtime.is_ready():
 		return true
 
-	if _runtime.is_initializing():
+	if _runtime.is_initializing() or _runtime.is_activating():
 		var waiting_serial: int = _runtime.get_lifecycle_generation()
-		while _runtime.is_initializing() and _runtime.is_generation_current(waiting_serial):
-			await initialization_finished
-		return _runtime.is_ready()
+		return await _await_existing_initialization(
+			waiting_serial,
+			cancellation_token
+		)
 
 	if _runtime.has_failed() and _stale_async_write_block_count > 0:
 		return false
+	if _runtime.has_failed():
+		if not _runtime.clear_failure():
+			return false
+		last_initialization_error = ""
 
 	var current_serial: int = _runtime.begin_initialization()
 	if current_serial < 0:
 		return false
 	last_initialization_error = ""
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		_fail_initialization(
+			"[GFArchitecture] 初始化已取消：%s。" % String(cancellation_token.get_cancel_reason()),
+			current_serial
+		)
+		return false
+	_lifecycle_hook_depth += 1
 	_on_init()
-	if fail_on_missing_declared_dependencies and not _validate_declared_dependencies_or_fail(current_serial):
+	_lifecycle_hook_depth -= 1
+	if (
+		not _runtime.is_initializing()
+		or not _is_lifecycle_current(current_serial)
+		or _runtime.has_failed()
+	):
 		return false
-	if not await _advance_all_modules_to_stage(1, current_serial):
+
+	var lifecycle_plan: GFArchitectureLifecyclePlan = _compile_lifecycle_plan_or_fail(current_serial)
+	if lifecycle_plan == null:
 		return false
-	if not await _advance_all_modules_to_stage(2, current_serial):
+	if (
+		not _runtime.is_initializing()
+		or not _is_lifecycle_current(current_serial)
+		or _runtime.has_failed()
+	):
 		return false
-	if not await _advance_all_modules_to_stage(3, current_serial):
+	_lifecycle_plan_in_progress = lifecycle_plan
+	var lease_report: Dictionary = _acquire_external_dependency_leases(
+		lifecycle_plan,
+		current_serial
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		lease_report,
+		"ok",
+		false
+	):
+		_fail_initialization(
+			"[GFArchitecture] 初始化失败：无法冻结父级外部依赖。",
+			current_serial
+		)
+		return false
+	_active_external_dependency_leases = (
+		_get_external_dependency_lease_array(lease_report)
+	)
+	if not await _advance_lifecycle_plan_to_stage(
+		lifecycle_plan,
+		1,
+		current_serial,
+		cancellation_token
+	):
+		return false
+	if not await _advance_lifecycle_plan_to_stage(
+		lifecycle_plan,
+		2,
+		current_serial,
+		cancellation_token
+	):
+		return false
+	if not await _advance_lifecycle_plan_to_stage(
+		lifecycle_plan,
+		3,
+		current_serial,
+		cancellation_token
+	):
 		return false
 	if not _all_registered_modules_reached_stage(3):
 		_fail_initialization(
@@ -440,7 +616,39 @@ func init() -> bool:
 		return false
 
 	_refresh_cached_utility_refs()
-	if _runtime.finish_initialization(current_serial):
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		_fail_initialization(
+			"[GFArchitecture] 初始化已取消：%s。" % String(
+				cancellation_token.get_cancel_reason()
+			),
+			current_serial
+		)
+		return false
+	if not _runtime.begin_activation(current_serial):
+		_fail_initialization(
+			"[GFArchitecture] 初始化提交失败：无法进入 activation 状态。",
+			current_serial
+		)
+		return false
+	var activated: bool = await _activate_lifecycle_plan(
+		lifecycle_plan,
+		current_serial,
+		cancellation_token
+	)
+	if not activated:
+		return false
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		_fail_initialization(
+			"[GFArchitecture] 初始化已取消：%s。" % String(
+				cancellation_token.get_cancel_reason()
+			),
+			current_serial
+		)
+		return false
+	if _runtime.finish_activation(current_serial):
+		_active_lifecycle_plan = lifecycle_plan
+		_lifecycle_plan_in_progress = null
+		_refresh_tick_caches()
 		initialization_finished.emit()
 		return (
 			_runtime.is_ready()
@@ -449,38 +657,207 @@ func init() -> bool:
 	return false
 
 
-## 销毁架构及所有注册的组件。
+## 异步关闭架构。
+##
+## 若活动子架构仍持有本架构的外部依赖租约，本方法会在改变任何生命周期
+## 状态前返回失败；否则新工作准入会不可逆关闭，已接纳工作按激活计划逆序
+## quiesce，随后每个模块的同步 dispose/release hook 恰好执行一次。并发调用共享
+## 同一流程；首个调用拥有共享流程的 cancellation token 与 deadline 策略，后续
+## 调用在参数校验通过后只等待并复制同一终态结果。
 ## [br]
 ## @api public
-func dispose() -> void:
-	var was_initializing: bool = _runtime.is_initializing()
-	if not _runtime.begin_dispose():
-		return
-	_cancel_active_async_scopes("[GFArchitecture] 架构已 dispose。")
+## [br]
+## @since unreleased
+## [br]
+## @param cancellation_token: 可选关闭取消令牌。
+## [br]
+## @param timeout_seconds: cooperative quiesce 与异步等待预算；仅 -1 使用 shutdown_timeout_seconds。最终同步释放不承诺墙钟硬上限。
+## [br]
+## @return 类型化关闭结果。
+func shutdown_async(
+	cancellation_token: GFCancellationToken = null,
+	timeout_seconds: float = -1.0
+) -> GFArchitectureShutdownResult:
+	if (
+		not is_finite(timeout_seconds)
+		or (timeout_seconds < 0.0 and timeout_seconds != -1.0)
+		or timeout_seconds > _MAX_LIFECYCLE_TIMEOUT_SECONDS
+	):
+		var invalid_timeout_msec: int = Time.get_ticks_msec()
+		return _GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.failed(
+			ERR_INVALID_PARAMETER,
+			"shutdown_async timeout_seconds must be -1 or a finite value from 0 to 86400.",
+			[],
+			[],
+			invalid_timeout_msec,
+			invalid_timeout_msec
+		)
+	if _runtime.is_disposed():
+		return _GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.already_disposed()
+	if _shutdown_completion != null and _shutdown_completion.is_pending():
+		_shutdown_duplicate_request_count += 1
+		await _shutdown_completion.completed
+		var shared_result_value: Variant = _shutdown_completion.get_result()
+		if shared_result_value is GFArchitectureShutdownResult:
+			var shared_result: GFArchitectureShutdownResult = shared_result_value
+			return shared_result.duplicate_result()
+		return _GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.forced(
+			"Shared shutdown completed without a typed result."
+		)
+	if _runtime.is_ready() and _has_live_child_external_dependency_leases():
+		var blocked_at_msec: int = Time.get_ticks_msec()
+		return _GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.failed(
+			ERR_BUSY,
+			(
+				"Architecture shutdown requires child architectures with "
+				+ "external dependency leases to close first."
+			),
+			[],
+			[],
+			blocked_at_msec,
+			blocked_at_msec
+		)
+	var started_at_msec: int = Time.get_ticks_msec()
+	_shutdown_duplicate_request_count = 0
+	_shutdown_completion = GFAsyncCompletion.new()
+	if _runtime.is_initializing() or _runtime.is_activating():
+		var interrupted_reason: String = (
+			"Shutdown interrupted architecture initialization or activation."
+		)
+		var interrupted_unfinished: Array[Dictionary] = (
+			_snapshot_forced_unfinished_modules(interrupted_reason)
+		)
+		_cancel_active_async_scopes("[GFArchitecture] shutdown_async 中断了尚未完成的初始化。")
+		_force_dispose_internal()
+		var interrupted_result: GFArchitectureShutdownResult = (
+			_GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.forced(
+				interrupted_reason,
+				[],
+				interrupted_unfinished,
+				started_at_msec,
+				Time.get_ticks_msec(),
+				_shutdown_duplicate_request_count
+			)
+		)
+		_publish_shutdown_result(interrupted_result)
+		initialization_finished.emit()
+		return interrupted_result.duplicate_result()
 
-	_on_dispose()
-	_dispose_module_registry(_system_registry)
-	_dispose_module_registry(_model_registry)
-	_dispose_module_registry(_utility_registry)
-	for binding_variant: Variant in _factories.values():
-		var binding: GFBinding = _variant_to_binding(binding_variant)
-		if binding != null:
-			binding.dispose_cached_instance()
-	_model_registry._clear()
-	_system_registry._clear()
-	_utility_registry._clear()
-	_factories.clear()
-	_module_lifecycle_stages.clear()
-	_services.clear()
-	_event_system.clear()
-	_time_provider = null
-	last_initialization_error = ""
-	_reset_project_installers()
-	_refresh_tick_caches()
-	_parent_architecture = null
+	if not _runtime.begin_quiesce():
+		var transition_reason: String = (
+			"Architecture could not enter quiesce."
+		)
+		var transition_unfinished: Array[Dictionary] = (
+			_snapshot_forced_unfinished_modules(transition_reason)
+		)
+		var transition_result: GFArchitectureShutdownResult = (
+			_GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.forced(
+				transition_reason,
+				[],
+				transition_unfinished,
+				started_at_msec,
+				Time.get_ticks_msec(),
+				_shutdown_duplicate_request_count
+			)
+		)
+		_force_dispose_internal()
+		_publish_shutdown_result(transition_result)
+		return transition_result.duplicate_result()
+	_fail_active_factory_resolution_contexts()
+
+	var effective_timeout_seconds: float = (
+		shutdown_timeout_seconds
+		if timeout_seconds < 0.0
+		else timeout_seconds
+	)
+	var deadline_msec: int = _make_deadline_msec(
+		started_at_msec,
+		effective_timeout_seconds
+	)
+	var topology_wait_report: Dictionary = await _await_topology_stability(
+		cancellation_token,
+		deadline_msec
+	)
+	if _runtime.is_disposed() and _last_shutdown_result != null:
+		return _last_shutdown_result.duplicate_result()
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		topology_wait_report,
+		"succeeded",
+		false
+	):
+		var topology_shutdown_report: Dictionary = (
+			_make_topology_wait_shutdown_report(topology_wait_report)
+		)
+		_force_dispose_internal()
+		var topology_result: GFArchitectureShutdownResult = (
+			_make_shutdown_result(
+				topology_shutdown_report,
+				started_at_msec,
+				Time.get_ticks_msec()
+			)
+		)
+		_publish_shutdown_result(topology_result)
+		return topology_result.duplicate_result()
+
+	_shutdown_scope = _begin_module_async_scope()
+	var quiesce_report: Dictionary = await _quiesce_active_modules(
+		cancellation_token,
+		deadline_msec
+	)
+	if _runtime.is_disposed() and _last_shutdown_result != null:
+		return _last_shutdown_result.duplicate_result()
+	if _shutdown_scope != null:
+		if _shutdown_scope.is_active():
+			_shutdown_scope.complete()
+		_untrack_async_scope(_shutdown_scope)
+		_shutdown_scope = null
+
+	_force_dispose_internal()
+	var completed_at_msec: int = Time.get_ticks_msec()
+	var shutdown_result: GFArchitectureShutdownResult = _make_shutdown_result(
+		quiesce_report,
+		started_at_msec,
+		completed_at_msec
+	)
+	_publish_shutdown_result(shutdown_result)
+	return shutdown_result.duplicate_result()
+
+
+## 强制同步销毁架构及所有注册组件。
+##
+## 该方法用于 SceneTree 退出等无法等待的终止路径；正常退出应优先 await
+## shutdown_async()，以便已接纳工作先收敛。
+## [br]
+## @api public
+## [br]
+## @since 3.17.0
+func dispose() -> void:
+	if _runtime.is_disposing() or _runtime.is_disposed():
+		return
+	var started_at_msec: int = Time.get_ticks_msec()
+	var was_initializing: bool = _runtime.is_initializing() or _runtime.is_activating()
+	if _shutdown_completion == null or not _shutdown_completion.is_pending():
+		_shutdown_duplicate_request_count = 0
+		_shutdown_completion = GFAsyncCompletion.new()
+	var forced_reason: String = "Architecture was synchronously disposed."
+	var forced_unfinished: Array[Dictionary] = (
+		_snapshot_forced_unfinished_modules(forced_reason)
+	)
+	_cancel_active_async_scopes("[GFArchitecture] 架构已强制 dispose。")
+	_force_dispose_internal()
+	var forced_result: GFArchitectureShutdownResult = (
+		_GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.forced(
+			forced_reason,
+			[],
+			forced_unfinished,
+			started_at_msec,
+			Time.get_ticks_msec(),
+			_shutdown_duplicate_request_count
+		)
+	)
+	_publish_shutdown_result(forced_result)
 	if was_initializing:
 		initialization_finished.emit()
-	_runtime.finish_dispose()
 
 
 ## 驱动所有参与 tick 的 System 与 Utility 的每帧更新。
@@ -493,7 +870,7 @@ func dispose() -> void:
 ## [br]
 ## @param delta: 距上一帧的时间（秒）。
 func tick(delta: float) -> void:
-	if not _runtime.is_ready():
+	if not is_accepting_runtime_work():
 		return
 	var time_provider: Object = _get_time_provider()
 	_tick_scheduler.drive_tick(delta, time_provider)
@@ -509,7 +886,7 @@ func tick(delta: float) -> void:
 ## [br]
 ## @param delta: 距上一物理帧的时间（秒）。
 func physics_tick(delta: float) -> void:
-	if not _runtime.is_ready():
+	if not is_accepting_runtime_work():
 		return
 	var time_provider: Object = _get_time_provider()
 	_tick_scheduler.drive_physics_tick(delta, time_provider)
@@ -992,16 +1369,19 @@ func clear_event_dispatch_trace() -> void:
 ## [br]
 ## @return 注册成功、且运行时热注册完成生命周期推进时返回 true。
 func register_system(script_cls: Script, instance: Object) -> bool:
+	if _runtime.is_ready():
+		var hot_registered: bool = await _register_initialized_module(
+			_system_registry,
+			script_cls,
+			instance
+		)
+		if hot_registered:
+			_refresh_tick_caches()
+		return hot_registered
 	if not _register_module(_system_registry, script_cls, instance):
 		return false
 
 	_refresh_tick_caches()
-	if _runtime.is_ready():
-		var initialized: bool = await _initialize_registered_module(_system_registry, instance)
-		if not initialized:
-			_rollback_registered_module_if_current(_system_registry, script_cls, instance)
-		_refresh_tick_caches()
-		return initialized
 	return true
 
 
@@ -1017,14 +1397,15 @@ func register_system(script_cls: Script, instance: Object) -> bool:
 ## [br]
 ## @return 注册成功、且运行时热注册完成生命周期推进时返回 true。
 func register_model(script_cls: Script, instance: Object) -> bool:
+	if _runtime.is_ready():
+		return await _register_initialized_module(
+			_model_registry,
+			script_cls,
+			instance
+		)
 	if not _register_module(_model_registry, script_cls, instance):
 		return false
 
-	if _runtime.is_ready():
-		var initialized: bool = await _initialize_registered_module(_model_registry, instance)
-		if not initialized:
-			_rollback_registered_module_if_current(_model_registry, script_cls, instance)
-		return initialized
 	return true
 
 
@@ -1040,18 +1421,21 @@ func register_model(script_cls: Script, instance: Object) -> bool:
 ## [br]
 ## @return 注册成功、且运行时热注册完成生命周期推进时返回 true。
 func register_utility(script_cls: Script, instance: Object) -> bool:
+	if _runtime.is_ready():
+		var hot_registered: bool = await _register_initialized_module(
+			_utility_registry,
+			script_cls,
+			instance
+		)
+		if hot_registered:
+			_refresh_cached_utility_refs()
+			_refresh_tick_caches()
+		return hot_registered
 	if not _register_module(_utility_registry, script_cls, instance):
 		return false
 
 	_refresh_cached_utility_refs()
 	_refresh_tick_caches()
-	if _runtime.is_ready():
-		var initialized: bool = await _initialize_registered_module(_utility_registry, instance)
-		if not initialized:
-			_rollback_registered_module_if_current(_utility_registry, script_cls, instance)
-		_refresh_cached_utility_refs()
-		_refresh_tick_caches()
-		return initialized
 	return true
 
 
@@ -1127,6 +1511,8 @@ func register_factory(
 ) -> bool:
 	if not _can_mutate_registration_state("register_factory"):
 		return false
+	if not _can_mutate_factory_topology("register_factory"):
+		return false
 	if script_cls == null:
 		push_error("[GFArchitecture] register_factory 失败：脚本类型为空。")
 		return false
@@ -1155,6 +1541,8 @@ func register_factory(
 ## @return 工厂入口注册成功时返回 true。
 func register_factory_instance(script_cls: Script, instance: Object) -> bool:
 	if not _can_mutate_registration_state("register_factory_instance"):
+		return false
+	if not _can_mutate_factory_topology("register_factory_instance"):
 		return false
 	if script_cls == null:
 		push_error("[GFArchitecture] register_factory_instance 失败：脚本类型为空。")
@@ -1189,6 +1577,8 @@ func replace_factory(
 ) -> bool:
 	if not _can_mutate_registration_state("replace_factory"):
 		return false
+	if not _can_mutate_factory_topology("replace_factory"):
+		return false
 	if script_cls == null:
 		push_error("[GFArchitecture] replace_factory 失败：脚本类型为空。")
 		return false
@@ -1216,6 +1606,8 @@ func replace_factory(
 func replace_factory_instance(script_cls: Script, instance: Object) -> bool:
 	if not _can_mutate_registration_state("replace_factory_instance"):
 		return false
+	if not _can_mutate_factory_topology("replace_factory_instance"):
+		return false
 	if script_cls == null:
 		push_error("[GFArchitecture] replace_factory_instance 失败：脚本类型为空。")
 		return false
@@ -1238,6 +1630,8 @@ func replace_factory_instance(script_cls: Script, instance: Object) -> bool:
 ## @return 存在并成功注销工厂时返回 true。
 func unregister_factory(script_cls: Script) -> bool:
 	if not _can_mutate_registration_state("unregister_factory"):
+		return false
+	if not _can_mutate_factory_topology("unregister_factory"):
 		return false
 	if script_cls == null or not _factories.has(script_cls):
 		return false
@@ -1277,7 +1671,7 @@ func has_factory(script_cls: Script) -> bool:
 ## [br]
 ## @return 注册成功时返回 true。
 func register_service(service_key: StringName, provider: Object) -> bool:
-	if not _can_mutate_registration_state("register_service"):
+	if not _can_mutate_runtime("register_service"):
 		return false
 	if service_key == &"":
 		push_error("[GFArchitecture] register_service 失败：service_key 为空。")
@@ -1285,6 +1679,12 @@ func register_service(service_key: StringName, provider: Object) -> bool:
 	if provider == null:
 		push_error("[GFArchitecture] register_service 失败：provider 为空。")
 		return false
+	if _topology_mutation != null:
+		return _stage_topology_service_registration(
+			_topology_mutation,
+			service_key,
+			provider
+		)
 	if _services.has(service_key):
 		var existing_provider: Object = _get_dictionary_object(_services, service_key)
 		if existing_provider == provider:
@@ -1307,11 +1707,17 @@ func register_service(service_key: StringName, provider: Object) -> bool:
 ## [br]
 ## @return 注销成功时返回 true。
 func unregister_service(service_key: StringName, provider: Object = null) -> bool:
-	if not _can_mutate_registration_state("unregister_service"):
+	if not _can_mutate_runtime("unregister_service"):
 		return false
 	if service_key == &"":
 		push_error("[GFArchitecture] unregister_service 失败：service_key 为空。")
 		return false
+	if _topology_mutation != null:
+		return _stage_topology_service_unregistration(
+			_topology_mutation,
+			service_key,
+			provider
+		)
 	if not _services.has(service_key):
 		return false
 	var existing_provider: Object = _get_dictionary_object(_services, service_key)
@@ -1491,6 +1897,9 @@ func register_utility_instance(instance: Object) -> bool:
 ## [br]
 ## @return 注册成功并写入 alias 时返回 true。
 func register_system_instance_as(instance: Object, alias_cls: Script) -> bool:
+	if _runtime.is_ready():
+		push_error("[GFArchitecture] register_system_instance_as 失败：activation 后 alias 拓扑不可变。")
+		return false
 	var script: Script = _get_instance_script_or_null(instance, "register_system_instance_as")
 	if script == null:
 		return false
@@ -1513,6 +1922,9 @@ func register_system_instance_as(instance: Object, alias_cls: Script) -> bool:
 ## [br]
 ## @return 注册成功并写入 alias 时返回 true。
 func register_model_instance_as(instance: Object, alias_cls: Script) -> bool:
+	if _runtime.is_ready():
+		push_error("[GFArchitecture] register_model_instance_as 失败：activation 后 alias 拓扑不可变。")
+		return false
 	var script: Script = _get_instance_script_or_null(instance, "register_model_instance_as")
 	if script == null:
 		return false
@@ -1535,6 +1947,9 @@ func register_model_instance_as(instance: Object, alias_cls: Script) -> bool:
 ## [br]
 ## @return 注册成功并写入 alias 时返回 true。
 func register_utility_instance_as(instance: Object, alias_cls: Script) -> bool:
+	if _runtime.is_ready():
+		push_error("[GFArchitecture] register_utility_instance_as 失败：activation 后 alias 拓扑不可变。")
+		return false
 	var script: Script = _get_instance_script_or_null(instance, "register_utility_instance_as")
 	if script == null:
 		return false
@@ -1549,30 +1964,52 @@ func register_utility_instance_as(instance: Object, alias_cls: Script) -> bool:
 ## [br]
 ## @api public
 ## [br]
+## @since 5.0.0
+## [br]
 ## @param script_cls: 系统的脚本类。
-func unregister_system(script_cls: Script) -> void:
-	if _unregister_module(_system_registry, script_cls):
+## [br]
+## @return 模块完成 quiesce 并从活动拓扑移除时返回 true。
+func unregister_system(script_cls: Script) -> bool:
+	var unregistered: bool = await _unregister_module(
+		_system_registry,
+		script_cls
+	)
+	if unregistered:
 		_refresh_tick_caches()
+	return unregistered
 
 
 ## 注销 Model 实例。
 ## [br]
 ## @api public
 ## [br]
+## @since 5.0.0
+## [br]
 ## @param script_cls: 模型的脚本类。
-func unregister_model(script_cls: Script) -> void:
-	var _unregistered: bool = _unregister_module(_model_registry, script_cls)
+## [br]
+## @return 模块完成 quiesce 并从活动拓扑移除时返回 true。
+func unregister_model(script_cls: Script) -> bool:
+	return await _unregister_module(_model_registry, script_cls)
 
 
 ## 注销 Utility 实例。
 ## [br]
 ## @api public
 ## [br]
+## @since 5.0.0
+## [br]
 ## @param script_cls: 工具的脚本类。
-func unregister_utility(script_cls: Script) -> void:
-	if _unregister_module(_utility_registry, script_cls):
+## [br]
+## @return 模块完成 quiesce 并从活动拓扑移除时返回 true。
+func unregister_utility(script_cls: Script) -> bool:
+	var unregistered: bool = await _unregister_module(
+		_utility_registry,
+		script_cls
+	)
+	if unregistered:
 		_refresh_cached_utility_refs()
 		_refresh_tick_caches()
+	return unregistered
 
 
 # --- 公共方法（获取） ---
@@ -1722,18 +2159,21 @@ func get_local_utility(script_cls: Script, require_ready: bool = false) -> Objec
 
 
 ## 通过已注册工厂创建短生命周期对象。
+## 仅在架构已经提交 READY 且没有热拓扑事务时接纳；其它生命周期状态会在
+## 调用 provider 前返回 null。
 ## [br]
 ## @api public
 ## [br]
+## @since 1.9.0
+## [br]
 ## @param script_cls: 要创建的脚本类型。
 ## [br]
-## @return 新对象实例；没有工厂或工厂返回非对象时返回 null。
+## @return 新对象实例；运行时未开放、没有工厂或工厂返回非对象时返回 null。
 func create_instance(script_cls: Script) -> Object:
 	if script_cls == null:
 		push_error("[GFArchitecture] create_instance 失败：脚本类型为空。")
 		return null
-	if _runtime.is_disposed() or _runtime.is_disposing():
-		push_error("[GFArchitecture] create_instance 失败：架构已 dispose。")
+	if not _can_execute_runtime("create_instance"):
 		return null
 
 	return _create_instance_for_requester(script_cls, self)
@@ -2042,76 +2482,26 @@ func get_binding_diagnostics(options: Dictionary = {}) -> Dictionary:
 
 
 ## 获取架构中已注册模块的声明式依赖诊断报告。
-## 模块可选择实现 get_required_dependencies() 或 get_required_models/systems/utilities/factories()。
+## 模块通过 get_required_models/systems/utilities/factories() 分别声明依赖。
 ## [br]
 ## @api public
 ## [br]
 ## @since 7.0.0
 ## [br]
-## @param options: 可选参数，支持 include_parent_lookup 与 include_factories。
-## [br]
-## @schema options: Dictionary with optional bool keys include_parent_lookup and include_factories.
-## [br]
 ## @return 统一诊断报告字典。
 ## [br]
 ## @schema return: Dictionary dependency diagnostics report with modules, resolved_dependencies, missing_dependencies, parent-chain cycle issue records, issue counts, and next_action.
-func get_dependency_diagnostics(options: Dictionary = {}) -> Dictionary:
-	var include_parent_lookup: bool = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "include_parent_lookup", not strict_dependency_lookup)
-	var include_factories: bool = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "include_factories", true)
-	var report: DependencyDiagnosticsReport = DependencyDiagnosticsReport.new("Architecture dependencies")
-	var modules: Array[Dictionary] = []
-	var resolved_dependencies: Array[Dictionary] = []
-	var missing_dependencies: Array[Dictionary] = []
-
-	_collect_registry_dependency_diagnostics(
-		"model",
-		_model_registry,
-		report,
-		include_parent_lookup,
-		include_factories,
-		modules,
-		resolved_dependencies,
-		missing_dependencies
-	)
-	_collect_registry_dependency_diagnostics(
-		"utility",
-		_utility_registry,
-		report,
-		include_parent_lookup,
-		include_factories,
-		modules,
-		resolved_dependencies,
-		missing_dependencies
-	)
-	_collect_registry_dependency_diagnostics(
-		"system",
-		_system_registry,
-		report,
-		include_parent_lookup,
-		include_factories,
-		modules,
-		resolved_dependencies,
-		missing_dependencies
-	)
-
-	return report.to_dict(
-		{
-			"module_count": modules.size(),
-			"modules": modules,
-			"resolved_dependencies": resolved_dependencies,
-			"missing_dependencies": missing_dependencies,
-			"include_parent_lookup": include_parent_lookup,
-			"include_factories": include_factories,
-		},
-		{
-			"include_subject": false,
-			"include_metadata": false,
-			"include_info_count": false,
-			"include_issue_count": false,
-			"next_actions": _get_dependency_diagnostics_next_actions(),
-			"fallback_action": "Review the first reported architecture dependency issue.",
-		}
-	)
+func get_dependency_diagnostics() -> Dictionary:
+	var plan: GFArchitectureLifecyclePlan = _active_lifecycle_plan
+	if plan == null:
+		plan = _lifecycle_plan_in_progress
+	if plan == null:
+		plan = _build_candidate_lifecycle_plan_snapshot(
+			_models,
+			_utilities,
+			_systems
+		)
+	return _build_dependency_diagnostics_from_plan(plan)
 
 
 # --- 可重写钩子 / 虚方法 ---
@@ -2156,387 +2546,322 @@ func untrack_framework_async_scope(scope: GFAsyncScope) -> void:
 
 # --- 私有/辅助方法 ---
 
-func _validate_declared_dependencies_or_fail(lifecycle_serial: int) -> bool:
-	var diagnostics: Dictionary = get_dependency_diagnostics({
-		"include_parent_lookup": not strict_dependency_lookup,
-		"include_factories": true,
-	})
-	var error_count: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(diagnostics, "error_count", 0)
-	if error_count <= 0:
-		return true
-	var summary: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
-		diagnostics,
-		"summary",
-		"Declared dependency validation failed."
-	)
-	_fail_initialization("[GFArchitecture] 声明式依赖校验失败：%s" % summary, lifecycle_serial)
-	return false
+func _await_existing_initialization(
+	waiting_serial: int,
+	cancellation_token: GFCancellationToken
+) -> bool:
+	if not _runtime.is_generation_current(waiting_serial):
+		return false
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		return false
 
-func _collect_registry_dependency_diagnostics(
-	module_kind: String,
-	module_registry: ModuleRegistry,
-	report: DependencyDiagnosticsReport,
-	include_parent_lookup: bool,
-	include_factories: bool,
-	modules: Array[Dictionary],
-	resolved_dependencies: Array[Dictionary],
-	missing_dependencies: Array[Dictionary]
-) -> void:
-	for script_cls: Script in module_registry.instances.keys():
-		var instance: Object = _get_dictionary_object(module_registry.instances, script_cls)
-		var module_key: String = _get_script_debug_key(script_cls, instance)
-		var declared_dependencies: Dictionary = _collect_declared_dependencies(
-			instance,
-			report,
-			module_key,
-			include_factories
+	var wait_completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var initialization_callback: Callable = Callable(
+		wait_completion,
+		&"succeed"
+	)
+	var connect_error: Error = initialization_finished.connect(
+		initialization_callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	if connect_error != OK:
+		return false
+	if (
+		cancellation_token != null
+		and not wait_completion.bind_cancel_token(cancellation_token)
+	):
+		if initialization_finished.is_connected(initialization_callback):
+			initialization_finished.disconnect(initialization_callback)
+		return false
+	if wait_completion.is_pending():
+		await wait_completion.completed
+	if initialization_finished.is_connected(initialization_callback):
+		initialization_finished.disconnect(initialization_callback)
+	return (
+		wait_completion.is_successful()
+		and _runtime.is_ready()
+		and _runtime.is_generation_current(waiting_serial)
+	)
+
+
+func _build_dependency_diagnostics_from_plan(
+	plan: GFArchitectureLifecyclePlan
+) -> Dictionary:
+	var report: DependencyDiagnosticsReport = DependencyDiagnosticsReport.new(
+		"Architecture dependencies"
+	)
+	var modules: Array[Dictionary] = []
+	var modules_by_key: Dictionary = {}
+	var resolved_dependencies: Array[Dictionary] = []
+	var missing_dependencies: Array[Dictionary] = []
+	if plan == null:
+		var _missing_plan_issue: Dictionary = report.add_error(
+			&"missing_lifecycle_plan",
+			"Architecture dependency diagnostics could not build a lifecycle plan."
+		)
+		return report.to_dict(
+			{
+				"module_count": 0,
+				"modules": modules,
+				"resolved_dependencies": resolved_dependencies,
+				"missing_dependencies": missing_dependencies,
+			},
+			_get_dependency_diagnostics_report_options()
+		)
+
+	for snapshot: Dictionary in plan.get_dependency_snapshot():
+		var module_key: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			snapshot,
+			"module_key"
+		)
+		var module_script: Script = _get_dictionary_script(
+			snapshot,
+			"module_script"
+		)
+		var module_instance: Object = _get_dictionary_object(
+			snapshot,
+			"module_instance"
+		)
+		var dependency_map: Dictionary = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+				snapshot,
+				"dependencies"
+			)
 		)
 		var module_record: Dictionary = {
-			"kind": module_kind,
-			"script": module_key,
-			"instance": _get_instance_debug_key(instance),
-			"dependencies": _dependency_map_to_keys(declared_dependencies),
+			"kind": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+				snapshot,
+				"module_kind"
+			),
+			"module_key": module_key,
+			"script": _get_script_debug_key(
+				module_script,
+				module_instance
+			),
+			"instance": _get_instance_debug_key(module_instance),
+			"dependencies": _dependency_map_to_keys(dependency_map),
 			"resolved_dependencies": [],
 			"missing_dependencies": [],
 		}
-		_collect_dependency_resolution_records(
-			module_kind,
-			module_key,
-			declared_dependencies,
-			report,
-			include_parent_lookup,
-			include_factories,
-			module_record,
-			resolved_dependencies,
-			missing_dependencies
-		)
 		modules.append(module_record)
+		modules_by_key[module_key] = module_record
 
-
-func _collect_declared_dependencies(
-	instance: Object,
-	report: DependencyDiagnosticsReport,
-	module_key: String,
-	include_factories: bool
-) -> Dictionary:
-	var dependencies: Dictionary = _make_dependency_map()
-	if instance == null:
-		return dependencies
-
-	if instance.has_method(HOOK_GET_REQUIRED_DEPENDENCIES):
-		var raw_dependencies: Variant = instance.call(HOOK_GET_REQUIRED_DEPENDENCIES)
-		_merge_dependency_dictionary(
-			dependencies,
-			raw_dependencies,
-			report,
-			module_key,
-			String(HOOK_GET_REQUIRED_DEPENDENCIES),
-			include_factories
+	for source_record: Dictionary in plan.get_dependency_records():
+		var dependency_record: Dictionary = (
+			_make_plan_dependency_diagnostic_record(source_record)
 		)
-
-	_append_dependency_hook_array(
-		_get_dependency_script_array(dependencies, "models"),
-		instance,
-		HOOK_GET_REQUIRED_MODELS,
-		report,
-		module_key
-	)
-	_append_dependency_hook_array(
-		_get_dependency_script_array(dependencies, "systems"),
-		instance,
-		HOOK_GET_REQUIRED_SYSTEMS,
-		report,
-		module_key
-	)
-	_append_dependency_hook_array(
-		_get_dependency_script_array(dependencies, "utilities"),
-		instance,
-		HOOK_GET_REQUIRED_UTILITIES,
-		report,
-		module_key
-	)
-	if include_factories:
-		_append_dependency_hook_array(
-			_get_dependency_script_array(dependencies, "factories"),
-			instance,
-			HOOK_GET_REQUIRED_FACTORIES,
-			report,
-			module_key
+		var module_key: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source_record,
+			"module_key"
 		)
-	return dependencies
-
-
-func _collect_dependency_resolution_records(
-	module_kind: String,
-	module_key: String,
-	declared_dependencies: Dictionary,
-	report: DependencyDiagnosticsReport,
-	include_parent_lookup: bool,
-	include_factories: bool,
-	module_record: Dictionary,
-	resolved_dependencies: Array[Dictionary],
-	missing_dependencies: Array[Dictionary]
-) -> void:
-	for dependency_kind: String in ["models", "systems", "utilities", "factories"]:
-		if dependency_kind == "factories" and not include_factories:
-			continue
-
-		var dependency_scripts: Array = _get_dependency_script_array(declared_dependencies, dependency_kind)
-		for dependency_variant: Variant in dependency_scripts:
-			if not dependency_variant is Script:
-				continue
-			var dependency_script: Script = dependency_variant
-			var dependency_record: Dictionary = _make_dependency_diagnostic_record(
-				module_kind,
-				module_key,
-				dependency_kind,
-				dependency_script,
-				include_parent_lookup,
-				include_factories
+		var module_record: Dictionary = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+				modules_by_key,
+				module_key
 			)
-			if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(dependency_record, "resolved", false):
-				var resolved_records: Array = _GF_VARIANT_ACCESS_SCRIPT.as_array(
-					_GF_VARIANT_ACCESS_SCRIPT.get_option_value(module_record, "resolved_dependencies")
+		)
+		if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			dependency_record,
+			"resolved"
+		):
+			resolved_dependencies.append(dependency_record)
+			if not module_record.is_empty():
+				var module_resolved: Array = (
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_array(
+						module_record,
+						"resolved_dependencies"
+					)
 				)
-				resolved_records.append(dependency_record)
-				resolved_dependencies.append(dependency_record)
-				continue
-
-			var missing_records: Array = _GF_VARIANT_ACCESS_SCRIPT.as_array(
-				_GF_VARIANT_ACCESS_SCRIPT.get_option_value(module_record, "missing_dependencies")
-			)
-			missing_records.append(dependency_record)
+				module_resolved.append(dependency_record)
+		else:
 			missing_dependencies.append(dependency_record)
-			if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(dependency_record, "parent_chain_cycle_detected", false):
-				var _cycle_issue: Dictionary = report.add_error(
-					&"dependency_parent_chain_cycle",
-					"Architecture parent chain contains a cycle while resolving a declared dependency.",
-					module_key,
-					_get_script_debug_key(dependency_script),
-					{
-						"module_kind": module_kind,
-						"dependency_kind": dependency_kind,
-						"cycle_architecture": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(dependency_record, "cycle_architecture", ""),
-						"cycle_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(dependency_record, "cycle_depth", -1),
-						"cycle_start_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(dependency_record, "cycle_start_depth", -1),
-					}
+			if not module_record.is_empty():
+				var module_missing: Array = (
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_array(
+						module_record,
+						"missing_dependencies"
+					)
 				)
-				continue
-			var _missing_issue: Dictionary = report.add_error(
-				StringName("missing_%s_dependency" % _dependency_kind_to_singular(dependency_kind)),
-				"Architecture module declares a missing %s dependency." % _dependency_kind_to_singular(dependency_kind),
-				module_key,
-				_get_script_debug_key(dependency_script),
-				{
-					"module_kind": module_kind,
-					"dependency_kind": dependency_kind,
-				}
-			)
+				module_missing.append(dependency_record)
+
+	for diagnostic: Dictionary in plan.get_diagnostics():
+		_append_lifecycle_plan_dependency_issue(report, diagnostic)
+
+	return report.to_dict(
+		{
+			"module_count": modules.size(),
+			"modules": modules,
+			"resolved_dependencies": resolved_dependencies,
+			"missing_dependencies": missing_dependencies,
+			"diagnostics_truncated": plan.were_diagnostics_truncated(),
+		},
+		_get_dependency_diagnostics_report_options()
+	)
 
 
-func _make_dependency_diagnostic_record(
-	module_kind: String,
-	module_key: String,
-	dependency_kind: String,
-	dependency_script: Script,
-	include_parent_lookup: bool,
-	include_factories: bool
+func _make_plan_dependency_diagnostic_record(
+	source: Dictionary
 ) -> Dictionary:
-	var status: Dictionary = _resolve_dependency_diagnostic_status(
-		dependency_kind,
-		dependency_script,
-		include_parent_lookup,
-		include_factories
+	var status: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		source,
+		"status",
+		"invalid"
+	)
+	var scope: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		source,
+		"scope",
+		"missing"
+	)
+	if status == "parent_cycle":
+		scope = "parent_cycle"
+	var dependency_script: Script = _get_dictionary_script(
+		source,
+		"dependency_script"
+	)
+	var resolved_instance: Object = _get_dictionary_object(
+		source,
+		"resolved_instance"
+	)
+	var registered_script: Script = _get_dictionary_script(
+		source,
+		"registered_script"
 	)
 	return {
-		"module_kind": module_kind,
-		"module": module_key,
-		"kind": dependency_kind,
+		"module_kind": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source,
+			"module_kind"
+		),
+		"module": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source,
+			"module_key"
+		),
+		"kind": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source,
+			"dependency_kind"
+		),
 		"script": _get_script_debug_key(dependency_script),
-		"resolved": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(status, "resolved", false),
-		"scope": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(status, "scope", "missing"),
-		"architecture_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(status, "architecture_depth", -1),
-		"parent_chain_cycle_detected": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(status, _PARENT_CHAIN_CYCLE_DETECTED_KEY, false),
-		"cycle_architecture": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(status, _PARENT_CHAIN_CYCLE_ARCHITECTURE_KEY, ""),
-		"cycle_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(status, _PARENT_CHAIN_CYCLE_DEPTH_KEY, -1),
-		"cycle_start_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(status, _PARENT_CHAIN_CYCLE_START_DEPTH_KEY, -1),
-	}
-
-
-func _resolve_dependency_diagnostic_status(
-	dependency_kind: String,
-	dependency_script: Script,
-	include_parent_lookup: bool,
-	include_factories: bool,
-	architecture_depth: int = 0,
-	visited: Dictionary = {}
-) -> Dictionary:
-	var active_visited: Dictionary = visited
-	if active_visited.is_empty():
-		active_visited = _create_parent_lookup_visited()
-
-	if dependency_script == null:
-		return {
-			"resolved": false,
-			"scope": "invalid",
-			"architecture_depth": architecture_depth,
-		}
-
-	var local_resolved: bool = false
-	match dependency_kind:
-		"models":
-			local_resolved = _get_local_registered_instance(_model_registry, dependency_script) != null
-		"systems":
-			local_resolved = _get_local_registered_instance(_system_registry, dependency_script) != null
-		"utilities":
-			local_resolved = _get_local_registered_instance(_utility_registry, dependency_script) != null
-		"factories":
-			local_resolved = include_factories and _factories.has(dependency_script)
-
-	if local_resolved:
-		return {
-			"resolved": true,
-			"scope": _get_dependency_scope_name(architecture_depth),
-			"architecture_depth": architecture_depth,
-		}
-
-	if include_parent_lookup:
-		var parent: GFArchitecture = _get_next_parent_for_lookup(self, active_visited, "get_dependency_diagnostics", false)
-		if parent == null:
-			if _has_parent_lookup_cycle(active_visited):
-				return _make_parent_lookup_cycle_status(active_visited, architecture_depth + 1)
-			return {
-				"resolved": false,
-				"scope": "missing",
-				"architecture_depth": architecture_depth,
-			}
-		return parent._resolve_dependency_diagnostic_status(
-			dependency_kind,
-			dependency_script,
-			include_parent_lookup,
-			include_factories,
-			architecture_depth + 1,
-			active_visited
-		)
-
-	return {
-		"resolved": false,
-		"scope": "missing",
-		"architecture_depth": architecture_depth,
-	}
-
-
-func _merge_dependency_dictionary(
-	dependencies: Dictionary,
-	raw_dependencies: Variant,
-	report: DependencyDiagnosticsReport,
-	module_key: String,
-	hook_name: String,
-	include_factories: bool
-) -> void:
-	if raw_dependencies == null:
-		return
-	if not raw_dependencies is Dictionary:
-		var _invalid_return_issue: Dictionary = report.add_warning(
-			&"invalid_dependency_hook_return",
-			"%s() must return a Dictionary." % hook_name,
-			module_key,
-			"",
-			{ "hook": hook_name }
-		)
-		return
-
-	var source: Dictionary = raw_dependencies
-	for raw_key: Variant in source.keys():
-		var dependency_kind: String = _normalize_dependency_kind_key(_GF_VARIANT_ACCESS_SCRIPT.to_text(raw_key))
-		if dependency_kind.is_empty():
-			var _invalid_kind_issue: Dictionary = report.add_warning(
-				&"invalid_dependency_kind",
-				"Dependency declaration contains an unknown dependency kind.",
-				module_key,
-				"",
-				{
-					"hook": hook_name,
-					"dependency_kind": _GF_VARIANT_ACCESS_SCRIPT.to_text(raw_key),
-				}
+		"resolved": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			source,
+			"resolved"
+		),
+		"status": status,
+		"scope": scope,
+		"resolved_instance": _get_instance_debug_key(resolved_instance),
+		"architecture_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			source,
+			"architecture_depth",
+			-1
+		),
+		"resolution_kind": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source,
+			"resolution_kind"
+		),
+		"registered_script": _get_script_debug_key(registered_script),
+		"parent_chain_cycle_detected": (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+				source,
+				"parent_chain_cycle_detected"
 			)
-			continue
-		if dependency_kind == "factories" and not include_factories:
-			continue
-		_append_dependency_items(
-			_get_dependency_script_array(dependencies, dependency_kind),
-			source[raw_key],
-			report,
-			module_key,
-			hook_name
+		),
+		"cycle_architecture": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source,
+			"cycle_architecture"
+		),
+		"cycle_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			source,
+			"cycle_depth",
+			-1
+		),
+		"cycle_start_depth": _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			source,
+			"cycle_start_depth",
+			-1
+		),
+		"reason": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			source,
+			"reason"
+		),
+	}
+
+
+func _append_lifecycle_plan_dependency_issue(
+	report: DependencyDiagnosticsReport,
+	diagnostic: Dictionary
+) -> void:
+	var source_code: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		diagnostic,
+		"code",
+		"invalid_dependency_resolution"
+	)
+	var dependency_kind: String = (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			diagnostic,
+			"dependency_kind"
 		)
+	)
+	var public_code: StringName = StringName(source_code)
+	if source_code == "missing_dependency":
+		public_code = StringName(
+			"missing_%s_dependency" % _dependency_kind_to_singular(
+				dependency_kind
+			)
+		)
+	elif source_code == "parent_dependency_cycle":
+		public_code = &"dependency_parent_chain_cycle"
+	var metadata: Dictionary = diagnostic.duplicate(true)
+	for field_name: String in [
+		"code",
+		"severity",
+		"module_key",
+		"dependency_key",
+		"message",
+	]:
+		var _removed_field: bool = metadata.erase(field_name)
+	var _issue: Dictionary = report.add_error(
+		public_code,
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			diagnostic,
+			"message",
+			"Architecture lifecycle dependency plan is invalid."
+		),
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			diagnostic,
+			"module_key"
+		),
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			diagnostic,
+			"dependency_key"
+		),
+		metadata
+	)
 
 
-func _get_dependency_script_array(dependencies: Dictionary, dependency_kind: String) -> Array:
-	var raw_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(dependencies, dependency_kind, [])
+func _get_dependency_diagnostics_report_options() -> Dictionary:
+	return {
+		"include_subject": false,
+		"include_metadata": false,
+		"include_info_count": false,
+		"include_issue_count": false,
+		"next_actions": _get_dependency_diagnostics_next_actions(),
+		"fallback_action": (
+			"Review the first reported architecture dependency issue."
+		),
+	}
+
+
+func _get_dependency_script_array(
+	dependencies: Dictionary,
+	dependency_kind: String
+) -> Array:
+	var raw_value: Variant = _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+		dependencies,
+		dependency_kind,
+		[]
+	)
 	if raw_value is Array:
 		var dependency_scripts: Array = raw_value
 		return dependency_scripts
 	return []
-
-
-func _append_dependency_hook_array(
-	target: Array,
-	instance: Object,
-	hook_name: StringName,
-	report: DependencyDiagnosticsReport,
-	module_key: String
-) -> void:
-	if instance == null or not instance.has_method(hook_name):
-		return
-
-	var raw_value: Variant = instance.call(hook_name)
-	_append_dependency_items(target, raw_value, report, module_key, String(hook_name))
-
-
-func _append_dependency_items(
-	target: Array,
-	raw_value: Variant,
-	report: DependencyDiagnosticsReport,
-	module_key: String,
-	hook_name: String
-) -> void:
-	if raw_value == null:
-		return
-	if not raw_value is Array:
-		var _invalid_return_issue: Dictionary = report.add_warning(
-			&"invalid_dependency_hook_return",
-			"%s() must return an Array of Script values." % hook_name,
-			module_key,
-			"",
-			{ "hook": hook_name }
-		)
-		return
-
-	for dependency_variant: Variant in raw_value:
-		if dependency_variant is Script:
-			var dependency_script: Script = dependency_variant
-			_append_unique_script(target, dependency_script)
-		elif dependency_variant != null:
-			var _invalid_type_issue: Dictionary = report.add_warning(
-				&"invalid_dependency_type",
-				"Dependency declaration contains a non-Script value.",
-				module_key,
-				"",
-				{
-					"hook": hook_name,
-					"value": str(dependency_variant),
-				}
-			)
-
-
-func _make_dependency_map() -> Dictionary:
-	return {
-		"models": [],
-		"systems": [],
-		"utilities": [],
-		"factories": [],
-	}
 
 
 func _variant_to_object(value: Variant) -> Object:
@@ -2630,11 +2955,6 @@ func _script_array_to_debug_keys(scripts: Array) -> PackedStringArray:
 	return result
 
 
-func _append_unique_script(target: Array, script: Script) -> void:
-	if script != null and not target.has(script):
-		target.append(script)
-
-
 func _append_packed_string(target: PackedStringArray, value: String) -> void:
 	var _added: bool = target.append(value)
 
@@ -2646,6 +2966,7 @@ func _call_module_void(instance: Object, method_name: StringName, arguments: Arr
 
 
 func _call_module_init(instance: Object) -> void:
+	_lifecycle_hook_depth += 1
 	if instance is GFModel:
 		var model: GFModel = instance
 		model.init()
@@ -2655,6 +2976,7 @@ func _call_module_init(instance: Object) -> void:
 	elif instance is GFUtility:
 		var utility: GFUtility = instance
 		utility.init()
+	_lifecycle_hook_depth -= 1
 
 
 func _call_module_async_init(instance: Object, async_scope: GFAsyncScope) -> void:
@@ -2669,10 +2991,13 @@ func _call_module_async_init(instance: Object, async_scope: GFAsyncScope) -> voi
 		var utility: GFUtility = instance
 		async_init_callback = Callable(utility, &"async_init")
 	if async_init_callback.is_valid():
+		_lifecycle_hook_depth += 1
 		await async_init_callback.call(async_scope)
+		_lifecycle_hook_depth -= 1
 
 
 func _call_module_ready(instance: Object) -> void:
+	_lifecycle_hook_depth += 1
 	if instance is GFModel:
 		var model: GFModel = instance
 		model.ready()
@@ -2682,9 +3007,49 @@ func _call_module_ready(instance: Object) -> void:
 	elif instance is GFUtility:
 		var utility: GFUtility = instance
 		utility.ready()
+	_lifecycle_hook_depth -= 1
+
+
+func _call_module_begin_activation(
+	instance: Object,
+	scope: GFAsyncScope
+) -> GFAsyncCompletion:
+	_lifecycle_hook_depth += 1
+	var completion: GFAsyncCompletion = null
+	if instance is GFModel:
+		var model: GFModel = instance
+		completion = model.begin_activation(scope)
+	elif instance is GFSystem:
+		var system: GFSystem = instance
+		completion = system.begin_activation(scope)
+	elif instance is GFUtility:
+		var utility: GFUtility = instance
+		completion = utility.begin_activation(scope)
+	_lifecycle_hook_depth -= 1
+	return completion
+
+
+func _call_module_begin_quiesce(
+	instance: Object,
+	scope: GFAsyncScope
+) -> GFAsyncCompletion:
+	_lifecycle_hook_depth += 1
+	var completion: GFAsyncCompletion = null
+	if instance is GFModel:
+		var model: GFModel = instance
+		completion = model.begin_quiesce(scope)
+	elif instance is GFSystem:
+		var system: GFSystem = instance
+		completion = system.begin_quiesce(scope)
+	elif instance is GFUtility:
+		var utility: GFUtility = instance
+		completion = utility.begin_quiesce(scope)
+	_lifecycle_hook_depth -= 1
+	return completion
 
 
 func _call_module_dispose(instance: Object) -> void:
+	_lifecycle_hook_depth += 1
 	if instance is GFModel:
 		var model: GFModel = instance
 		model.dispose()
@@ -2694,6 +3059,7 @@ func _call_module_dispose(instance: Object) -> void:
 	elif instance is GFUtility:
 		var utility: GFUtility = instance
 		utility.dispose()
+	_lifecycle_hook_depth -= 1
 
 
 func _call_module_release_dependencies(instance: Object) -> void:
@@ -2843,20 +3209,6 @@ func _get_architecture_debug_key(architecture: GFArchitecture) -> String:
 	return "GFArchitecture:%d" % architecture.get_instance_id()
 
 
-func _normalize_dependency_kind_key(key: String) -> String:
-	match key.to_lower():
-		"model", "models":
-			return "models"
-		"system", "systems":
-			return "systems"
-		"utility", "utilities":
-			return "utilities"
-		"factory", "factories":
-			return "factories"
-		_:
-			return ""
-
-
 func _dependency_kind_to_singular(dependency_kind: String) -> String:
 	match dependency_kind:
 		"models":
@@ -2871,23 +3223,19 @@ func _dependency_kind_to_singular(dependency_kind: String) -> String:
 			return "dependency"
 
 
-func _get_dependency_scope_name(architecture_depth: int) -> String:
-	if architecture_depth <= 0:
-		return "local"
-	if architecture_depth == 1:
-		return "parent"
-	return "ancestor"
-
-
 func _get_dependency_diagnostics_next_actions() -> Dictionary:
 	return {
 		"missing_model_dependency": "Register the required Model locally or in an allowed parent architecture.",
 		"missing_system_dependency": "Register the required System locally or in an allowed parent architecture.",
 		"missing_utility_dependency": "Register the required Utility locally or in an allowed parent architecture.",
 		"missing_factory_dependency": "Register the required factory before the dependent module requests it.",
-		"invalid_dependency_hook_return": "Return a Dictionary or Array shape that matches the dependency hook contract.",
+		"stale_alias_dependency": "Repair or remove the stale local alias before resolving the dependency.",
+		"ambiguous_dependency": "Register an explicit alias that selects one local implementation.",
+		"dependency_parent_chain_cycle": "Repair the architecture parent chain before compiling lifecycle dependencies.",
+		"dependency_cycle": "Remove the local lifecycle dependency cycle.",
+		"invalid_dependency_hook_return": "Return Array[Script] from the typed dependency hook.",
 		"invalid_dependency_type": "Declared dependencies should contain only Script values.",
-		"invalid_dependency_kind": "Use models, systems, utilities, or factories for dependency declaration keys.",
+		"invalid_dependency_resolution": "Repair the dependency resolver contract before initialization.",
 	}
 
 
@@ -2900,14 +3248,18 @@ func _reset_project_installers() -> void:
 
 
 func _assign_parent_architecture(parent_architecture: GFArchitecture, context: String) -> void:
+	if _runtime.get_state() not in [
+		GFKernelRuntime.LifecycleState.NEW,
+		GFKernelRuntime.LifecycleState.FAILED,
+	]:
+		push_error(
+			"[GFArchitecture] %s 失败：生命周期计划开始后父级架构关系不可变。" % (
+				context
+			)
+		)
+		return
 	if parent_architecture == null:
 		_parent_architecture = null
-		return
-	if _runtime.is_disposing() or _runtime.is_disposed():
-		push_error(
-			"[GFArchitecture] %s 失败：架构正在 dispose 或已 dispose，不能设置父级架构。"
-			% context
-		)
 		return
 	if parent_architecture == self:
 		push_error("[GFArchitecture] %s 失败：父级架构不能是自身。" % context)
@@ -2993,6 +3345,7 @@ func _collect_module_debug_state(registry: Dictionary) -> Dictionary:
 			"stage": stage,
 			"stage_name": _get_lifecycle_stage_name(stage),
 			"ready": stage >= 3,
+			"active": stage >= 4,
 			"lifecycle_priority": _get_module_priority(instance, &"lifecycle_priority"),
 		}
 		module_state.merge(_tick_scheduler.get_module_debug_fields(instance), true)
@@ -3196,9 +3549,30 @@ func _clear_factory_binding(script_cls: Script) -> void:
 
 
 func _clear_failed_initialization_state() -> void:
-	_dispose_module_registry(_system_registry)
-	_dispose_module_registry(_model_registry)
-	_dispose_module_registry(_utility_registry)
+	var disposed_instances: Dictionary = _begin_module_disposal_session()
+	var cleanup_plan: GFArchitectureLifecyclePlan = (
+		_active_lifecycle_plan
+		if _active_lifecycle_plan != null
+		else _lifecycle_plan_in_progress
+	)
+	if cleanup_plan != null:
+		for instance: Object in cleanup_plan.get_shutdown_order():
+			_dispose_module_once(instance, disposed_instances)
+	for instance: Object in _get_modules_by_lifecycle_priority(
+		_system_registry.instances,
+		true
+	):
+		_dispose_module_once(instance, disposed_instances)
+	for instance: Object in _get_modules_by_lifecycle_priority(
+		_model_registry.instances,
+		true
+	):
+		_dispose_module_once(instance, disposed_instances)
+	for instance: Object in _get_modules_by_lifecycle_priority(
+		_utility_registry.instances,
+		true
+	):
+		_dispose_module_once(instance, disposed_instances)
 	for binding_variant: Variant in _factories.values():
 		var binding: GFBinding = _variant_to_binding(binding_variant)
 		if binding != null:
@@ -3212,7 +3586,15 @@ func _clear_failed_initialization_state() -> void:
 	_services.clear()
 	_event_system.clear()
 	_time_provider = null
+	_active_lifecycle_plan = null
+	_lifecycle_plan_in_progress = null
+	_activation_scope = null
 	_refresh_tick_caches()
+	_release_external_dependency_leases(
+		_active_external_dependency_leases
+	)
+	_active_external_dependency_leases.clear()
+	_end_module_disposal_session()
 
 
 func _collect_factory_debug_state() -> Dictionary:
@@ -3240,6 +3622,8 @@ func _get_lifecycle_stage_name(stage: int) -> String:
 			return "async_init"
 		3:
 			return "ready"
+		4:
+			return "active"
 		_:
 			return "unknown"
 
@@ -3304,31 +3688,549 @@ func _get_model_key(script_cls: Script, model: GFModel = null) -> String:
 	return ""
 
 
-func _initialize_registered_module(module_registry: ModuleRegistry, instance: Object) -> bool:
-	if instance == null:
+func _begin_topology_mutation(
+	operation: StringName,
+	module_registry: ModuleRegistry,
+	script_cls: Script,
+	candidate: Object,
+	previous: Object = null
+) -> TopologyMutation:
+	if _topology_mutation != null:
+		return null
+	var transaction: TopologyMutation = TopologyMutation.new(
+		_next_topology_mutation_id,
+		operation,
+		module_registry,
+		script_cls,
+		candidate,
+		previous
+	)
+	_next_topology_mutation_id += 1
+	_topology_mutation = transaction
+	return transaction
+
+
+func _stage_topology_service_registration(
+	transaction: TopologyMutation,
+	service_key: StringName,
+	provider: Object
+) -> bool:
+	if (
+		not _is_topology_mutation_current(transaction)
+		or provider == null
+		or provider != transaction._candidate
+	):
+		push_error(
+			"[GFArchitecture] register_service 失败：拓扑事务期间仅候选模块可暂存自身服务。"
+		)
 		return false
-	var current_serial: int = _runtime.get_lifecycle_generation()
-	await _advance_module_to_stage(module_registry, instance, 3, current_serial)
+	if transaction._service_intents.has(service_key):
+		return (
+			_get_dictionary_object(
+				transaction._service_intents,
+				service_key
+			) == provider
+		)
+	if (
+		transaction._service_intents.size()
+		>= _MAX_TOPOLOGY_SERVICE_INTENTS
+	):
+		push_error(
+			"[GFArchitecture] register_service 失败：拓扑事务服务意图超过上限。"
+		)
+		return false
+	var current_present: bool = _services.has(service_key)
+	var current_provider: Object = _get_dictionary_object(
+		_services,
+		service_key
+	)
+	if (
+		current_present
+		and current_provider != provider
+		and current_provider != transaction._previous
+	):
+		push_error(
+			"[GFArchitecture] register_service 失败：service_key 已由拓扑事务之外的 provider 占用：%s。"
+			% String(service_key)
+		)
+		return false
+	transaction._expected_service_presence[service_key] = current_present
+	transaction._expected_service_providers[service_key] = current_provider
+	transaction._service_intents[service_key] = provider
+	return true
+
+
+func _stage_topology_service_unregistration(
+	transaction: TopologyMutation,
+	service_key: StringName,
+	provider: Object
+) -> bool:
+	if not _is_topology_mutation_current(transaction):
+		return false
+	if provider == null:
+		push_error(
+			"[GFArchitecture] unregister_service 失败：拓扑事务期间必须显式提供 provider。"
+		)
+		return false
+	if provider == transaction._candidate:
+		if (
+			not transaction._service_intents.has(service_key)
+			or _get_dictionary_object(
+				transaction._service_intents,
+				service_key
+			) != provider
+		):
+			return false
+		var _removed_intent: bool = (
+			transaction._service_intents.erase(service_key)
+		)
+		var _removed_presence: bool = (
+			transaction._expected_service_presence.erase(service_key)
+		)
+		var _removed_provider: bool = (
+			transaction._expected_service_providers.erase(service_key)
+		)
+		return true
+	if provider == transaction._previous:
+		return (
+			_services.has(service_key)
+			and _get_dictionary_object(_services, service_key) == provider
+		)
+	push_error(
+		"[GFArchitecture] unregister_service 失败：provider 不属于当前拓扑事务。"
+	)
+	return false
+
+
+func _validate_topology_service_intents(
+	transaction: TopologyMutation
+) -> bool:
+	if not _is_topology_mutation_current(transaction):
+		return false
+	for service_key: Variant in transaction._service_intents.keys():
+		var expected_present: bool = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+				transaction._expected_service_presence,
+				service_key,
+				false
+			)
+		)
+		if _services.has(service_key) != expected_present:
+			push_error(
+				"[GFArchitecture] 拓扑事务提交失败：service_key 的存在状态已漂移：%s。"
+				% _GF_VARIANT_ACCESS_SCRIPT.to_text(service_key)
+			)
+			return false
+		if (
+			expected_present
+			and _get_dictionary_object(_services, service_key)
+			!= _get_dictionary_object(
+				transaction._expected_service_providers,
+				service_key
+			)
+		):
+			push_error(
+				"[GFArchitecture] 拓扑事务提交失败：service_key 的 provider 已漂移：%s。"
+				% _GF_VARIANT_ACCESS_SCRIPT.to_text(service_key)
+			)
+			return false
+	return true
+
+
+func _commit_topology_service_intents(
+	transaction: TopologyMutation
+) -> void:
+	for service_key: Variant in transaction._service_intents.keys():
+		var provider: Object = _get_dictionary_object(
+			transaction._service_intents,
+			service_key
+		)
+		if provider != null:
+			_services[service_key] = provider
+
+
+func _is_topology_mutation_current(
+	transaction: TopologyMutation
+) -> bool:
 	return (
-		_is_lifecycle_current(current_serial)
-		and not _runtime.has_failed()
-		and _is_module_ready_for_lookup(instance)
+		transaction != null
+		and transaction == _topology_mutation
+		and transaction._owner == TopologyMutation._OWNER_CONTINUATION
+		and transaction._phase != TopologyMutation._PHASE_ABORTED
+		and transaction._phase != TopologyMutation._PHASE_FINISHED
 	)
 
 
-func _rollback_registered_module_if_current(
+func _finish_topology_mutation(
+	transaction: TopologyMutation
+) -> void:
+	if not _is_topology_mutation_current(transaction):
+		return
+	if transaction._outcome == TopologyMutation._OUTCOME_PENDING:
+		transaction._outcome = TopologyMutation._OUTCOME_ROLLED_BACK
+	_release_topology_external_dependency_leases(transaction)
+	transaction._phase = TopologyMutation._PHASE_FINISHED
+	_topology_mutation = null
+	if transaction._gate.is_pending():
+		var _completed_topology: bool = transaction._gate.succeed()
+
+
+func _abort_topology_mutation(
+	_reason: StringName
+) -> TopologyMutation:
+	var transaction: TopologyMutation = _topology_mutation
+	if transaction == null:
+		return null
+	transaction._owner = TopologyMutation._OWNER_SHUTDOWN
+	transaction._outcome = TopologyMutation._OUTCOME_ABORTED
+	transaction._phase = TopologyMutation._PHASE_ABORTED
+	_topology_mutation = null
+	return transaction
+
+
+func _finalize_aborted_topology_mutation(
+	transaction: TopologyMutation,
+	reason: StringName
+) -> void:
+	if transaction != null and transaction._gate.is_pending():
+		var _cancelled_topology: bool = transaction._gate.cancel(reason)
+
+
+func _fail_topology_mutation(
+	transaction: TopologyMutation,
+	error: String
+) -> void:
+	if not _is_topology_mutation_current(transaction):
+		return
+	transaction._outcome = TopologyMutation._OUTCOME_FATAL
+	transaction._phase = TopologyMutation._PHASE_ABORTED
+	_cleanup_topology_candidate(transaction)
+	_topology_mutation = null
+	if transaction._gate.is_pending():
+		var _failed_topology: bool = transaction._gate.fail(error)
+
+
+func _cleanup_topology_candidate(
+	transaction: TopologyMutation
+) -> void:
+	_release_topology_external_dependency_leases(transaction)
+	if (
+		transaction == null
+		or transaction._candidate == null
+		or transaction._candidate_cleanup_state
+		!= TopologyMutation._CLEANUP_PENDING
+	):
+		return
+	transaction._candidate_cleanup_state = TopologyMutation._CLEANUP_CLAIMED
+	var module_registry: ModuleRegistry = null
+	if transaction._module_registry is ModuleRegistry:
+		module_registry = transaction._module_registry
+	if (
+		module_registry != null
+		and _get_dictionary_object(
+			module_registry.instances,
+			transaction._script_cls
+		) == transaction._candidate
+	):
+		var _removed_candidate: Object = _remove_registered_module(
+			module_registry,
+			transaction._script_cls,
+			true,
+			false
+		)
+		transaction._candidate_cleanup_state = TopologyMutation._CLEANUP_DONE
+		return
+	_cleanup_uncommitted_module(transaction._candidate)
+	transaction._candidate_cleanup_state = TopologyMutation._CLEANUP_DONE
+
+
+func _rollback_topology_candidate(
+	topology_transaction: TopologyMutation,
+	runtime_transaction: Dictionary
+) -> void:
+	_cleanup_topology_candidate(topology_transaction)
+	if (
+		topology_transaction != null
+		and topology_transaction._outcome
+		== TopologyMutation._OUTCOME_PENDING
+	):
+		topology_transaction._outcome = (
+			TopologyMutation._OUTCOME_ROLLED_BACK
+		)
+	_runtime.finish_transaction(runtime_transaction)
+	_finish_topology_mutation(topology_transaction)
+
+
+func _register_initialized_module(
 	module_registry: ModuleRegistry,
 	script_cls: Script,
 	instance: Object
-) -> void:
-	if _get_dictionary_object(module_registry.instances, script_cls) != instance:
-		return
-	var _removed_instance: Object = _remove_registered_module(
+) -> bool:
+	var operation_name: String = (
+		"register_%s" % module_registry._label_key()
+	)
+	if not _can_mutate_registration_state(operation_name):
+		return false
+	if not _validate_registration(
+		script_cls,
+		instance,
+		module_registry.label
+	):
+		return false
+	if module_registry._has_direct(script_cls):
+		push_warning(
+			"[GFArchitecture] %s：类型已注册，已忽略重复注册；如需替换请使用 replace_%s()。"
+			% [
+				operation_name,
+				module_registry._label_key(),
+			]
+		)
+		return false
+	var existing_key: Script = module_registry._get_key_for_instance(
+		instance
+	)
+	if existing_key != null:
+		push_error(
+			"[GFArchitecture] %s 失败：同一实例已注册为 %s。"
+			% [
+				operation_name,
+				_get_script_debug_key(existing_key, instance),
+			]
+		)
+		return false
+	var topology_transaction: TopologyMutation = _begin_topology_mutation(
+		&"register",
 		module_registry,
 		script_cls,
-		true,
-		false
+		instance
 	)
+	if topology_transaction == null:
+		return false
+	topology_transaction._previous_plan = _active_lifecycle_plan
+	var current_serial: int = _runtime.get_lifecycle_generation()
+	topology_transaction._lifecycle_serial = current_serial
+	var runtime_transaction: Dictionary = _runtime.begin_transaction(
+		operation_name
+	)
+	topology_transaction._candidate_cleanup_state = (
+		TopologyMutation._CLEANUP_PENDING
+	)
+	var candidate_models: Dictionary = _models.duplicate()
+	var candidate_utilities: Dictionary = _utilities.duplicate()
+	var candidate_systems: Dictionary = _systems.duplicate()
+	var candidate_registry: Dictionary = (
+		_get_candidate_registry_dictionary(
+			module_registry,
+			candidate_models,
+			candidate_utilities,
+			candidate_systems
+		)
+	)
+	candidate_registry[script_cls] = instance
+	var candidate_plan: GFArchitectureLifecyclePlan = (
+		_compile_candidate_lifecycle_plan(
+			candidate_models,
+			candidate_utilities,
+			candidate_systems,
+			"hot register",
+			true,
+			_create_lifecycle_plan_validity_guard(
+				current_serial,
+				topology_transaction,
+				runtime_transaction
+			)
+		)
+	)
+	if (
+		candidate_plan == null
+		or not _is_topology_mutation_current(topology_transaction)
+		or not _is_lifecycle_current(current_serial)
+		or not _runtime.is_ready()
+		or _runtime.has_failed()
+		or _runtime.is_transaction_invalidated(runtime_transaction)
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			runtime_transaction
+		)
+		return false
+	if not _validate_candidate_plan_stability(
+		topology_transaction._previous_plan,
+		candidate_plan,
+		{},
+		"hot register"
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			runtime_transaction
+		)
+		return false
+	topology_transaction._candidate_plan = candidate_plan
+	if not _stage_topology_external_dependency_leases(
+		topology_transaction,
+		candidate_plan,
+		current_serial
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			runtime_transaction
+		)
+		return false
+	_module_lifecycle_stages[instance] = 0
+	var prepared: bool = await _prepare_replacement_module(
+		instance,
+		current_serial
+	)
+	if (
+		not prepared
+		or not _is_lifecycle_current(current_serial)
+		or _runtime.is_transaction_invalidated(runtime_transaction)
+		or not _is_topology_mutation_current(topology_transaction)
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			runtime_transaction
+		)
+		return false
+	_module_lifecycle_stages[instance] = 2
+	_call_module_ready(instance)
+	if (
+		not _is_lifecycle_current(current_serial)
+		or _runtime.has_failed()
+		or _runtime.is_transaction_invalidated(runtime_transaction)
+		or not _is_topology_mutation_current(topology_transaction)
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			runtime_transaction
+		)
+		return false
+	_module_lifecycle_stages[instance] = 3
+	topology_transaction._phase = TopologyMutation._PHASE_ACTIVATING
+	var activated: bool = await _activate_topology_candidate(
+		instance,
+		candidate_plan,
+		current_serial,
+		true,
+		topology_transaction
+	)
+	var committed: bool = (
+		activated
+		and _is_lifecycle_current(current_serial)
+		and _is_topology_mutation_current(topology_transaction)
+		and not _runtime.has_failed()
+		and not _runtime.is_transaction_invalidated(
+			runtime_transaction
+		)
+		and is_module_active(instance)
+		and _validate_topology_service_intents(topology_transaction)
+	)
+	if committed:
+		topology_transaction._phase = TopologyMutation._PHASE_COMMITTING
+		module_registry.instances[script_cls] = instance
+		module_registry._track_instance_key(instance, script_cls)
+		module_registry._clear_assignable_cache()
+		_commit_topology_service_intents(topology_transaction)
+		_promote_topology_external_dependency_leases(
+			topology_transaction
+		)
+		_active_lifecycle_plan = candidate_plan
+		topology_transaction._candidate_cleanup_state = (
+			TopologyMutation._CLEANUP_TRANSFERRED
+		)
+		topology_transaction._outcome = TopologyMutation._OUTCOME_COMMITTED
+		topology_transaction._phase = TopologyMutation._PHASE_COMMITTED
+		_refresh_tick_caches()
+	else:
+		_cleanup_topology_candidate(topology_transaction)
+		topology_transaction._outcome = (
+			TopologyMutation._OUTCOME_ROLLED_BACK
+		)
+	_runtime.finish_transaction(runtime_transaction)
+	_finish_topology_mutation(topology_transaction)
+	return committed
+
+
+func _activate_topology_candidate(
+	instance: Object,
+	candidate_plan: GFArchitectureLifecyclePlan,
+	lifecycle_serial: int,
+	ephemeral_tick_candidate: bool,
+	topology_transaction: TopologyMutation = null
+) -> bool:
+	if instance == null or candidate_plan == null:
+		return false
+	var scope: GFAsyncScope = _begin_module_async_scope()
+	if _is_topology_mutation_current(topology_transaction):
+		topology_transaction._active_scope = scope
+	if ephemeral_tick_candidate:
+		var _candidate_added: bool = (
+			_tick_scheduler.add_lifecycle_candidate(instance)
+		)
+	var deadline_msec: int = _make_deadline_msec(
+		Time.get_ticks_msec(),
+		activation_timeout_seconds
+	)
+	var completion: GFAsyncCompletion = _call_module_begin_activation(
+		instance,
+		scope
+	)
+	var activated: bool = false
+	if completion != null:
+		var wait_report: Dictionary = await _await_lifecycle_completion(
+			completion,
+			scope,
+			null,
+			deadline_msec,
+			candidate_plan.get_dependency_closure(instance),
+			lifecycle_serial
+		)
+		activated = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			wait_report,
+			"succeeded",
+			false
+		)
+		if not activated:
+			push_error(
+				"[GFArchitecture] 热模块 activation 失败：%s：%s" % [
+					_get_instance_debug_key(instance),
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+						wait_report,
+						"reason",
+						"activation failed"
+					),
+				]
+			)
+	else:
+		push_error(
+			"[GFArchitecture] 热模块 activation 失败：%s 返回空 completion。" % (
+				_get_instance_debug_key(instance)
+			)
+		)
+	if ephemeral_tick_candidate:
+		_tick_scheduler.remove_lifecycle_candidate(instance)
+	if scope.is_active():
+		scope.complete()
+	_untrack_async_scope(scope)
+	if (
+		topology_transaction != null
+		and topology_transaction._active_scope == scope
+	):
+		topology_transaction._active_scope = null
+	if (
+		activated
+		and (
+			not _is_lifecycle_current(lifecycle_serial)
+			or _runtime.has_failed()
+			or not _is_topology_mutation_current(
+				topology_transaction
+			)
+		)
+	):
+		activated = false
+	if activated:
+		_module_lifecycle_stages[instance] = 4
+	return activated
 
 
 func _get_or_create_factory_resolution_context(resolution_context: Dictionary) -> Dictionary:
@@ -3501,8 +4403,30 @@ func _create_instance_for_requester(
 	var pushed_context: bool = _push_factory_resolution_context_if_needed(active_context)
 	var resolved_instance: Object = null
 
+	if _factory_resolution_context_has_failed(active_context):
+		if pushed_context:
+			var _removed_failed_context: Dictionary = (
+				_factory_resolution_context_stack.pop_back()
+			)
+		if is_root_context:
+			_rollback_factory_resolution_context(active_context)
+		return null
+
 	if _factories.has(script_cls):
-		resolved_instance = _create_instance_from_local_factory(script_cls, requesting_architecture, active_context)
+		if not _is_runtime_execution_admitted():
+			_mark_factory_resolution_failed(active_context)
+			push_error(
+				(
+					"[GFArchitecture] create_instance 失败："
+					+ "工厂所属架构未开放运行时准入。"
+				)
+			)
+		else:
+			resolved_instance = _create_instance_from_local_factory(
+				script_cls,
+				requesting_architecture,
+				active_context
+			)
 	elif not strict_dependency_lookup:
 		var parent: GFArchitecture = _get_next_parent_for_lookup(self, active_parent_lookup_visited, "create_instance")
 		if parent != null:
@@ -3528,38 +4452,1776 @@ func _create_instance_for_requester(
 	return resolved_instance
 
 
-func _advance_all_modules_to_stage(target_stage: int, lifecycle_serial: int) -> bool:
-	var pass_count: int = 0
-	while true:
+func _compile_lifecycle_plan_or_fail(
+	lifecycle_serial: int
+) -> GFArchitectureLifecyclePlan:
+	var plan: GFArchitectureLifecyclePlan = _compile_candidate_lifecycle_plan(
+		_models,
+		_utilities,
+		_systems,
+		"init",
+		false,
+		_create_lifecycle_plan_validity_guard(lifecycle_serial)
+	)
+	if plan != null:
+		return plan
+	if (
+		not _runtime.is_initializing()
+		or not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.has_failed()
+	):
+		return null
+	var reason: String = "[GFArchitecture] 生命周期依赖计划编译失败：%s" % (
+		_last_lifecycle_plan_error
+		if not _last_lifecycle_plan_error.is_empty()
+		else "invalid dependency graph"
+	)
+	_fail_initialization(reason, lifecycle_serial)
+	return null
+
+
+func _compile_candidate_lifecycle_plan(
+	model_instances: Dictionary,
+	utility_instances: Dictionary,
+	system_instances: Dictionary,
+	context: String,
+	report_error: bool = true,
+	validity_guard: Callable = Callable()
+) -> GFArchitectureLifecyclePlan:
+	_last_lifecycle_plan_error = ""
+	var plan: GFArchitectureLifecyclePlan = (
+		_build_candidate_lifecycle_plan_snapshot(
+			model_instances,
+			utility_instances,
+			system_instances,
+			validity_guard
+		)
+	)
+	if not _is_lifecycle_plan_compilation_valid(validity_guard):
+		return null
+	if plan.is_valid():
+		return plan
+	var diagnostics: Array[Dictionary] = plan.get_diagnostics()
+	var detail: String = "invalid dependency graph"
+	if not diagnostics.is_empty():
+		detail = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			diagnostics[0],
+			"message",
+			detail
+		)
+	_last_lifecycle_plan_error = detail
+	if report_error:
+		push_error(
+			"[GFArchitecture] %s 失败：生命周期依赖计划无效：%s" % [
+				context,
+				detail,
+			]
+		)
+	return null
+
+
+func _build_candidate_lifecycle_plan_snapshot(
+	model_instances: Dictionary,
+	utility_instances: Dictionary,
+	system_instances: Dictionary,
+	validity_guard: Callable = Callable()
+) -> GFArchitectureLifecyclePlan:
+	var plan: GFArchitectureLifecyclePlan = (
+		_GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	)
+	var _compiled: bool = plan.compile(
+		model_instances,
+		utility_instances,
+		system_instances,
+		_create_candidate_lifecycle_dependency_resolvers(
+			model_instances,
+			utility_instances,
+			system_instances
+		),
+		validity_guard
+	)
+	return plan
+
+
+func _create_lifecycle_plan_validity_guard(
+	lifecycle_serial: int,
+	topology_transaction: TopologyMutation = null,
+	runtime_transaction: Dictionary = {}
+) -> Callable:
+	return func() -> bool:
+		if (
+			not _is_lifecycle_current(lifecycle_serial)
+			or _runtime.has_failed()
+			or _runtime.is_quiescing()
+			or _runtime.is_disposing()
+			or _runtime.is_disposed()
+		):
+			return false
+		if (
+			not runtime_transaction.is_empty()
+			and _runtime.is_transaction_invalidated(runtime_transaction)
+		):
+			return false
+		if topology_transaction != null:
+			return (
+				_runtime.is_ready()
+				and _is_topology_mutation_current(topology_transaction)
+			)
+		return _runtime.is_initializing()
+
+
+func _is_lifecycle_plan_compilation_valid(validity_guard: Callable) -> bool:
+	if not validity_guard.is_valid():
+		return true
+	return _GF_VARIANT_ACCESS_SCRIPT.to_bool(validity_guard.call())
+
+
+func _acquire_external_dependency_leases(
+	plan: GFArchitectureLifecyclePlan,
+	lifecycle_serial: int
+) -> Dictionary:
+	var leases: Array[Dictionary] = []
+	if plan == null:
+		return {
+			"ok": false,
+			"leases": leases,
+		}
+	if not Thread.is_main_thread():
+		push_error(
+			"[GFArchitecture] 外部依赖租约只能在主线程获取。"
+		)
+		return {
+			"ok": false,
+			"leases": leases,
+		}
+	var lease_owners: Array[GFArchitecture] = []
+	var owner_ids: Dictionary = {}
+	var owner_module_topology_blocks: Dictionary = {}
+	for record: Dictionary in plan.get_dependency_records():
+		var status: StringName = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				record,
+				"status",
+				&"missing"
+			)
+		)
+		var dependency_kind: StringName = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				record,
+				"dependency_kind",
+				&""
+			)
+		)
+		if (
+			status != &"external"
+			or dependency_kind not in [
+				&"models",
+				&"systems",
+				&"utilities",
+				&"factories",
+			]
+		):
+			continue
+		var blocks_module_topology: bool = (
+			dependency_kind != &"factories"
+		)
+		var architecture_depth: int = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+				record,
+				"architecture_depth",
+				0
+			)
+		)
+		if architecture_depth <= 0:
+			_release_external_dependency_leases(leases)
+			return {
+				"ok": false,
+				"leases": [],
+			}
+		var owner: GFArchitecture = _parent_architecture
+		for _depth: int in range(architecture_depth):
+			if owner == null:
+				_release_external_dependency_leases(leases)
+				return {
+					"ok": false,
+					"leases": [],
+				}
+			var owner_id: int = owner.get_instance_id()
+			if not owner_ids.has(owner_id):
+				owner_ids[owner_id] = true
+				lease_owners.append(owner)
+				owner_module_topology_blocks[owner_id] = (
+					blocks_module_topology
+				)
+			elif blocks_module_topology:
+				owner_module_topology_blocks[owner_id] = true
+			owner = owner._parent_architecture
+	for owner: GFArchitecture in lease_owners:
+		var lease_id: int = owner._acquire_child_external_dependency_lease(
+			self,
+			lifecycle_serial,
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+				owner_module_topology_blocks,
+				owner.get_instance_id(),
+				false
+			)
+		)
+		if lease_id < 0:
+			_release_external_dependency_leases(leases)
+			return {
+				"ok": false,
+				"leases": [],
+			}
+		leases.append({
+			"owner_ref": weakref(owner),
+			"lease_id": lease_id,
+		})
+	return {
+		"ok": true,
+		"leases": leases,
+	}
+
+
+func _get_external_dependency_lease_array(
+	report: Dictionary
+) -> Array[Dictionary]:
+	var leases: Array[Dictionary] = []
+	var raw_leases: Variant = report.get("leases", [])
+	if not raw_leases is Array:
+		return leases
+	for raw_lease: Variant in raw_leases:
+		if raw_lease is Dictionary:
+			var lease: Dictionary = raw_lease
+			leases.append(lease)
+	return leases
+
+
+func _acquire_child_external_dependency_lease(
+	consumer: GFArchitecture,
+	consumer_lifecycle_serial: int,
+	blocks_module_topology: bool
+) -> int:
+	if not Thread.is_main_thread():
+		push_error(
+			"[GFArchitecture] 子架构外部依赖租约只能在主线程获取。"
+		)
+		return -1
+	if (
+		consumer == null
+		or not consumer.is_lifecycle_generation_active(
+			consumer_lifecycle_serial
+		)
+		or not _runtime.is_ready()
+		or _topology_mutation != null
+	):
+		return -1
+	var lease_id: int = _next_child_external_dependency_lease_id
+	_next_child_external_dependency_lease_id += 1
+	_child_external_dependency_leases[lease_id] = {
+		"consumer_ref": weakref(consumer),
+		"consumer_lifecycle_serial": consumer_lifecycle_serial,
+		"blocks_module_topology": blocks_module_topology,
+	}
+	return lease_id
+
+
+func _release_child_external_dependency_lease(
+	lease_id: int,
+	consumer: GFArchitecture
+) -> void:
+	if not Thread.is_main_thread():
+		push_error(
+			"[GFArchitecture] 子架构外部依赖租约只能在主线程释放。"
+		)
+		return
+	if not _child_external_dependency_leases.has(lease_id):
+		return
+	var record: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(
+		_child_external_dependency_leases.get(lease_id)
+	)
+	var consumer_ref_value: Variant = record.get("consumer_ref")
+	if consumer_ref_value is WeakRef:
+		var consumer_ref: WeakRef = consumer_ref_value
+		var current_consumer: Variant = consumer_ref.get_ref()
+		if current_consumer != null and current_consumer != consumer:
+			return
+	var _removed_lease: bool = (
+		_child_external_dependency_leases.erase(lease_id)
+	)
+
+
+func _release_external_dependency_leases(
+	leases: Array[Dictionary]
+) -> void:
+	if leases.is_empty():
+		return
+	var releasing_leases: Array[Dictionary] = leases.duplicate()
+	leases.clear()
+	for lease: Dictionary in releasing_leases:
+		var owner_ref_value: Variant = lease.get("owner_ref")
+		if not owner_ref_value is WeakRef:
+			continue
+		var owner_ref: WeakRef = owner_ref_value
+		var owner_value: Variant = owner_ref.get_ref()
+		if not owner_value is GFArchitecture:
+			continue
+		var owner: GFArchitecture = owner_value
+		owner._release_child_external_dependency_lease(
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+				lease,
+				"lease_id",
+				-1
+			),
+			self
+		)
+
+
+func _has_live_child_external_dependency_leases(
+	require_module_topology_block: bool = false
+) -> bool:
+	if not Thread.is_main_thread():
+		return true
+	var stale_lease_ids: Array[int] = []
+	var has_matching_lease: bool = false
+	for lease_id: Variant in _child_external_dependency_leases.keys():
+		var record: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(
+			_child_external_dependency_leases.get(lease_id)
+		)
+		var consumer_ref_value: Variant = record.get("consumer_ref")
+		if not consumer_ref_value is WeakRef:
+			stale_lease_ids.append(
+				_GF_VARIANT_ACCESS_SCRIPT.to_int(lease_id, -1)
+			)
+			continue
+		var consumer_ref: WeakRef = consumer_ref_value
+		var consumer_value: Variant = consumer_ref.get_ref()
+		if not consumer_value is GFArchitecture:
+			stale_lease_ids.append(
+				_GF_VARIANT_ACCESS_SCRIPT.to_int(lease_id, -1)
+			)
+			continue
+		var consumer: GFArchitecture = consumer_value
+		var consumer_lifecycle_serial: int = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+				record,
+				"consumer_lifecycle_serial",
+				-1
+			)
+		)
+		if (
+			consumer_lifecycle_serial < 0
+			or not consumer.is_lifecycle_generation_active(
+				consumer_lifecycle_serial
+			)
+		):
+			stale_lease_ids.append(
+				_GF_VARIANT_ACCESS_SCRIPT.to_int(lease_id, -1)
+			)
+			continue
+		if (
+			not require_module_topology_block
+			or _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+				record,
+				"blocks_module_topology",
+				false
+			)
+		):
+			has_matching_lease = true
+	for stale_lease_id: int in stale_lease_ids:
+		var _removed_stale_lease: bool = (
+			_child_external_dependency_leases.erase(stale_lease_id)
+		)
+	return has_matching_lease
+
+
+func _stage_topology_external_dependency_leases(
+	transaction: TopologyMutation,
+	plan: GFArchitectureLifecyclePlan,
+	lifecycle_serial: int
+) -> bool:
+	if not _is_topology_mutation_current(transaction):
+		return false
+	_release_topology_external_dependency_leases(transaction)
+	var report: Dictionary = _acquire_external_dependency_leases(
+		plan,
+		lifecycle_serial
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		report,
+		"ok",
+		false
+	):
+		return false
+	transaction._candidate_external_dependency_leases = (
+		_get_external_dependency_lease_array(report)
+	)
+	return true
+
+
+func _promote_topology_external_dependency_leases(
+	transaction: TopologyMutation
+) -> void:
+	if transaction == null:
+		return
+	var candidate_leases: Array[Dictionary] = (
+		transaction._candidate_external_dependency_leases
+	)
+	transaction._candidate_external_dependency_leases = []
+	var previous_leases: Array[Dictionary] = (
+		_active_external_dependency_leases
+	)
+	_active_external_dependency_leases = candidate_leases
+	_release_external_dependency_leases(previous_leases)
+
+
+func _release_topology_external_dependency_leases(
+	transaction: TopologyMutation
+) -> void:
+	if transaction == null:
+		return
+	_release_external_dependency_leases(
+		transaction._candidate_external_dependency_leases
+	)
+
+
+func _validate_candidate_plan_stability(
+	previous_plan: GFArchitectureLifecyclePlan,
+	candidate_plan: GFArchitectureLifecyclePlan,
+	excluded_instances: Dictionary,
+	context: String
+) -> bool:
+	if previous_plan == null or candidate_plan == null:
+		push_error(
+			"[GFArchitecture] %s 失败：缺少可比较的生命周期计划。"
+			% context
+		)
+		return false
+	var previous_index: Dictionary = _index_plan_dependency_signatures(
+		previous_plan
+	)
+	var candidate_index: Dictionary = _index_plan_dependency_signatures(
+		candidate_plan
+	)
+	for instance: Object in previous_plan.get_activation_order():
+		if instance == null or excluded_instances.has(instance):
+			continue
+		if (
+			not previous_index.has(instance)
+			or not candidate_index.has(instance)
+		):
+			push_error(
+				"[GFArchitecture] %s 失败：既有活动模块离开了候选依赖计划：%s。"
+				% [
+					context,
+					_get_instance_debug_key(instance),
+				]
+			)
+			return false
+		var previous_signature: Dictionary = _variant_to_dictionary(
+			previous_index.get(instance, {})
+		)
+		var candidate_signature: Dictionary = _variant_to_dictionary(
+			candidate_index.get(instance, {})
+		)
+		if previous_signature != candidate_signature:
+			push_error(
+				"[GFArchitecture] %s 失败：既有活动模块的声明或解析目标发生漂移：%s；请构造新的 Architecture 完成重绑定。"
+				% [
+					context,
+					_get_instance_debug_key(instance),
+				]
+			)
+			return false
+	return true
+
+
+func _index_plan_dependency_signatures(
+	plan: GFArchitectureLifecyclePlan
+) -> Dictionary:
+	var result: Dictionary = {}
+	if plan == null:
+		return result
+	for snapshot: Dictionary in plan.get_dependency_snapshot():
+		var instance: Object = _get_dictionary_object(
+			snapshot,
+			"module_instance"
+		)
+		if instance == null:
+			continue
+		var stable_snapshot: Dictionary = snapshot.duplicate(true)
+		var _removed_snapshot_key: bool = stable_snapshot.erase(
+			"module_key"
+		)
+		result[instance] = {
+			"snapshot": stable_snapshot,
+			"records": [],
+		}
+	for record: Dictionary in plan.get_dependency_records():
+		var instance: Object = _get_dictionary_object(
+			record,
+			"module_instance"
+		)
+		if instance == null or not result.has(instance):
+			continue
+		var signature: Dictionary = _variant_to_dictionary(
+			result.get(instance, {})
+		)
+		var records_value: Variant = signature.get("records", [])
+		if records_value is Array:
+			var records: Array = records_value
+			var stable_record: Dictionary = record.duplicate(true)
+			var _removed_record_key: bool = stable_record.erase(
+				"module_key"
+			)
+			records.append(stable_record)
+	return result
+
+
+func _create_candidate_lifecycle_dependency_resolvers(
+	model_instances: Dictionary,
+	utility_instances: Dictionary,
+	system_instances: Dictionary
+) -> Dictionary:
+	return {
+		&"models": func(script_cls: Script) -> Dictionary:
+			return _resolve_candidate_lifecycle_dependency_status(
+				"model",
+				script_cls,
+				model_instances
+			),
+		&"utilities": func(script_cls: Script) -> Dictionary:
+			return _resolve_candidate_lifecycle_dependency_status(
+				"utility",
+				script_cls,
+				utility_instances
+			),
+		&"systems": func(script_cls: Script) -> Dictionary:
+			return _resolve_candidate_lifecycle_dependency_status(
+				"system",
+				script_cls,
+				system_instances
+			),
+		&"factories": func(script_cls: Script) -> Dictionary:
+			return _resolve_candidate_factory_dependency_status(script_cls),
+	}
+
+
+func _resolve_candidate_lifecycle_dependency_status(
+	registry_kind: String,
+	script_cls: Script,
+	candidate_instances: Dictionary
+) -> Dictionary:
+	if script_cls == null:
+		return _make_lifecycle_dependency_status(
+			&"missing",
+			&"invalid_script"
+		)
+	var local_status: Dictionary = _resolve_local_lifecycle_dependency_status(
+		registry_kind,
+		script_cls,
+		candidate_instances,
+		0
+	)
+	var local_status_name: StringName = (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+			local_status,
+			"status",
+			&"missing"
+		)
+	)
+	if local_status_name != &"missing":
+		return local_status
+	if strict_dependency_lookup:
+		return _make_lifecycle_dependency_status(
+			&"missing",
+			&"strict_local_miss"
+		)
+	return _resolve_parent_lifecycle_dependency_status(
+		registry_kind,
+		script_cls
+	)
+
+
+func _resolve_local_lifecycle_dependency_status(
+	registry_kind: String,
+	script_cls: Script,
+	candidate_instances: Dictionary,
+	architecture_depth: int
+) -> Dictionary:
+	var module_registry: ModuleRegistry = _get_module_registry_by_kind(
+		registry_kind
+	)
+	if module_registry == null:
+		return _make_lifecycle_dependency_status(
+			&"missing",
+			&"invalid_registry",
+			architecture_depth
+		)
+	if candidate_instances.has(script_cls):
+		return _make_lifecycle_dependency_status(
+			&"local",
+			&"exact",
+			architecture_depth,
+			_get_dictionary_object(candidate_instances, script_cls),
+			script_cls
+		)
+	if module_registry.aliases.has(script_cls):
+		var alias_target: Script = _get_dictionary_script(
+			module_registry.aliases,
+			script_cls
+		)
+		if alias_target != null and candidate_instances.has(alias_target):
+			return _make_lifecycle_dependency_status(
+				&"local",
+				&"alias",
+				architecture_depth,
+				_get_dictionary_object(candidate_instances, alias_target),
+				alias_target
+			)
+		return _make_lifecycle_dependency_status(
+			&"stale_alias",
+			&"stale_alias",
+			architecture_depth,
+			null,
+			alias_target
+		)
+	var assignable_instances: Array[Object] = []
+	var assignable_scripts: Array[Script] = []
+	for registered_script: Script in candidate_instances.keys():
+		if not GFScriptTypeInspector.script_extends_or_equals(
+			registered_script,
+			script_cls
+		):
+			continue
+		var match_instance: Object = _get_dictionary_object(
+			candidate_instances,
+			registered_script
+		)
+		if match_instance != null:
+			assignable_instances.append(match_instance)
+			assignable_scripts.append(registered_script)
+	if assignable_instances.size() == 1:
+		return _make_lifecycle_dependency_status(
+			&"local",
+			&"assignable",
+			architecture_depth,
+			assignable_instances[0],
+			assignable_scripts[0]
+		)
+	if assignable_instances.size() > 1:
+		return _make_lifecycle_dependency_status(
+			&"ambiguous",
+			&"ambiguous_assignable",
+			architecture_depth
+		)
+	return _make_lifecycle_dependency_status(
+		&"missing",
+		&"local_miss",
+		architecture_depth
+	)
+
+
+func _resolve_parent_lifecycle_dependency_status(
+	registry_kind: String,
+	script_cls: Script
+) -> Dictionary:
+	var parent_chain_issue: Dictionary = (
+		_get_lifecycle_parent_chain_issue()
+	)
+	if not parent_chain_issue.is_empty():
+		return parent_chain_issue
+	var visited: Dictionary = {get_instance_id(): 0}
+	var current: GFArchitecture = _parent_architecture
+	var architecture_depth: int = 1
+	while current != null:
+		if visited.has(current.get_instance_id()):
+			return {
+				"status": &"parent_cycle",
+				"scope": &"missing",
+				"architecture_depth": architecture_depth,
+				"resolution_kind": &"parent_cycle",
+				"cycle_architecture": current._get_architecture_debug_key(
+					current
+				),
+				"cycle_depth": architecture_depth,
+				"cycle_start_depth": (
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+						visited,
+						current.get_instance_id(),
+						-1
+					)
+				),
+			}
+		visited[current.get_instance_id()] = architecture_depth
+		if (
+			not current._runtime.is_ready()
+			or current._topology_mutation != null
+		):
+			return _make_lifecycle_dependency_status(
+				&"missing",
+				&"inactive_parent",
+				architecture_depth
+			)
+		var module_registry: ModuleRegistry = (
+			current._get_module_registry_by_kind(registry_kind)
+		)
+		if module_registry == null:
+			return _make_lifecycle_dependency_status(
+				&"missing",
+				&"invalid_registry",
+				architecture_depth
+			)
+		var local_status: Dictionary = (
+			current._resolve_local_lifecycle_dependency_status(
+				registry_kind,
+				script_cls,
+				module_registry.instances,
+				architecture_depth
+			)
+		)
+		var status_name: StringName = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+				local_status,
+				"status",
+				&"missing"
+			)
+		)
+		if status_name == &"local":
+			var instance: Object = _get_dictionary_object(
+				local_status,
+				"instance"
+			)
+			if instance == null or not current.is_module_active(instance):
+				return _make_lifecycle_dependency_status(
+					&"missing",
+					&"inactive_parent_module",
+					architecture_depth
+				)
+			local_status["status"] = &"external"
+			local_status["scope"] = &"parent"
+			return local_status
+		if status_name != &"missing":
+			return local_status
+		if current.strict_dependency_lookup:
+			return _make_lifecycle_dependency_status(
+				&"missing",
+				&"strict_parent_miss",
+				architecture_depth
+			)
+		current = current._parent_architecture
+		architecture_depth += 1
+	return _make_lifecycle_dependency_status(
+		&"missing",
+		&"parent_miss",
+		architecture_depth
+	)
+
+
+func _resolve_candidate_factory_dependency_status(
+	script_cls: Script
+) -> Dictionary:
+	if script_cls == null:
+		return _make_lifecycle_dependency_status(
+			&"missing",
+			&"invalid_script"
+		)
+	if _factories.has(script_cls):
+		return _make_lifecycle_dependency_status(
+			&"local",
+			&"exact_factory"
+		)
+	if strict_dependency_lookup:
+		return _make_lifecycle_dependency_status(
+			&"missing",
+			&"strict_local_miss"
+		)
+	var parent_chain_issue: Dictionary = (
+		_get_lifecycle_parent_chain_issue()
+	)
+	if not parent_chain_issue.is_empty():
+		return parent_chain_issue
+	var visited: Dictionary = {get_instance_id(): 0}
+	var current: GFArchitecture = _parent_architecture
+	var architecture_depth: int = 1
+	while current != null:
+		if visited.has(current.get_instance_id()):
+			return {
+				"status": &"parent_cycle",
+				"scope": &"missing",
+				"architecture_depth": architecture_depth,
+				"resolution_kind": &"parent_cycle",
+				"cycle_architecture": current._get_architecture_debug_key(
+					current
+				),
+				"cycle_depth": architecture_depth,
+				"cycle_start_depth": (
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+						visited,
+						current.get_instance_id(),
+						-1
+					)
+				),
+			}
+		visited[current.get_instance_id()] = architecture_depth
+		if (
+			not current._runtime.is_ready()
+			or current._topology_mutation != null
+		):
+			return _make_lifecycle_dependency_status(
+				&"missing",
+				&"inactive_parent",
+				architecture_depth
+			)
+		if current._factories.has(script_cls):
+			var external_status: Dictionary = (
+				_make_lifecycle_dependency_status(
+					&"external",
+					&"exact_factory",
+					architecture_depth
+				)
+			)
+			external_status["scope"] = &"parent"
+			return external_status
+		if current.strict_dependency_lookup:
+			return _make_lifecycle_dependency_status(
+				&"missing",
+				&"strict_parent_miss",
+				architecture_depth
+			)
+		current = current._parent_architecture
+		architecture_depth += 1
+	return _make_lifecycle_dependency_status(
+		&"missing",
+		&"parent_miss",
+		architecture_depth
+	)
+
+
+func _get_lifecycle_parent_chain_issue() -> Dictionary:
+	var visited: Dictionary = {get_instance_id(): 0}
+	var current: GFArchitecture = _parent_architecture
+	var architecture_depth: int = 1
+	while (
+		current != null
+		and architecture_depth <= _MAX_LIFECYCLE_PARENT_DEPTH
+	):
+		var instance_id: int = current.get_instance_id()
+		if visited.has(instance_id):
+			return {
+				"status": &"parent_cycle",
+				"scope": &"missing",
+				"architecture_depth": architecture_depth,
+				"resolution_kind": &"parent_cycle",
+				"cycle_architecture": _get_architecture_debug_key(current),
+				"cycle_depth": architecture_depth,
+				"cycle_start_depth": (
+					_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+						visited,
+						instance_id,
+						-1
+					)
+				),
+			}
+		visited[instance_id] = architecture_depth
+		current = current._parent_architecture
+		architecture_depth += 1
+	if current != null:
+		return _make_lifecycle_dependency_status(
+			&"missing",
+			&"parent_chain_truncated",
+			_MAX_LIFECYCLE_PARENT_DEPTH
+		)
+	return {}
+
+
+func _make_lifecycle_dependency_status(
+	status: StringName,
+	resolution_kind: StringName,
+	architecture_depth: int = 0,
+	instance: Object = null,
+	registered_script: Script = null
+) -> Dictionary:
+	var result: Dictionary = {
+		"status": status,
+		"scope": (
+			&"local"
+			if status == &"local"
+			else (&"parent" if status == &"external" else &"missing")
+		),
+		"architecture_depth": maxi(architecture_depth, 0),
+		"resolution_kind": resolution_kind,
+	}
+	if instance != null:
+		result["instance"] = instance
+	if registered_script != null:
+		result["registered_script"] = registered_script
+	return result
+
+
+func _advance_lifecycle_plan_to_stage(
+	plan: GFArchitectureLifecyclePlan,
+	target_stage: int,
+	lifecycle_serial: int,
+	cancellation_token: GFCancellationToken = null
+) -> bool:
+	if plan == null or not plan.is_valid():
+		return false
+	for instance: Object in plan.get_activation_order():
 		if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
 			return false
-		if pass_count >= module_lifecycle_max_stage_passes:
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
 			_fail_initialization(
-				"[GFArchitecture] 生命周期阶段推进超过上限：stage=%d, max_passes=%d。" % [
-					target_stage,
-					module_lifecycle_max_stage_passes,
+				"[GFArchitecture] 初始化已取消：%s。" % String(
+					cancellation_token.get_cancel_reason()
+				),
+				lifecycle_serial
+			)
+			return false
+		var module_registry: ModuleRegistry = _get_module_registry_for_instance(instance)
+		if module_registry == null:
+			_fail_initialization(
+				"[GFArchitecture] 生命周期计划包含已离开注册表的模块。",
+				lifecycle_serial
+			)
+			return false
+		var current_stage: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			_module_lifecycle_stages,
+			instance,
+			0
+		)
+		if current_stage >= target_stage:
+			continue
+		var advanced: bool = await _advance_module_to_stage(
+			module_registry,
+			instance,
+			target_stage,
+			lifecycle_serial,
+			cancellation_token
+		)
+		if not advanced and current_stage < target_stage:
+			if (
+				_runtime.is_initializing()
+				and _is_lifecycle_current(lifecycle_serial)
+				and not _runtime.has_failed()
+			):
+				_fail_initialization(
+					"[GFArchitecture] 生命周期阶段推进失败：%s 未完成 stage=%d。" % [
+						_get_instance_debug_key(instance),
+						target_stage,
+					],
+					lifecycle_serial
+				)
+			return false
+	return _all_registered_modules_reached_stage(target_stage)
+
+
+func _get_module_registry_for_instance(instance: Object) -> ModuleRegistry:
+	if _module_registry_contains_instance(_model_registry, instance):
+		return _model_registry
+	if _module_registry_contains_instance(_utility_registry, instance):
+		return _utility_registry
+	if _module_registry_contains_instance(_system_registry, instance):
+		return _system_registry
+	return null
+
+
+func _activate_lifecycle_plan(
+	plan: GFArchitectureLifecyclePlan,
+	lifecycle_serial: int,
+	cancellation_token: GFCancellationToken
+) -> bool:
+	var started_at_msec: int = Time.get_ticks_msec()
+	var deadline_msec: int = _make_deadline_msec(
+		started_at_msec,
+		activation_timeout_seconds
+	)
+	_activation_scope = _begin_module_async_scope()
+	for instance: Object in plan.get_activation_order():
+		if not _runtime.is_activating() or not _is_lifecycle_current(lifecycle_serial):
+			return false
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			var cancel_reason: String = String(cancellation_token.get_cancel_reason())
+			_cancel_module_async_scope(_activation_scope, cancel_reason)
+			_fail_initialization(
+				"[GFArchitecture] activation 已取消：%s。" % cancel_reason,
+				lifecycle_serial
+			)
+			return false
+		var completion: GFAsyncCompletion = _call_module_begin_activation(
+			instance,
+			_activation_scope
+		)
+		if completion == null:
+			_fail_initialization(
+				"[GFArchitecture] activation 失败：%s 返回了空 completion。" % (
+					_get_instance_debug_key(instance)
+				),
+				lifecycle_serial
+			)
+			return false
+		var wait_report: Dictionary = await _await_lifecycle_completion(
+			completion,
+			_activation_scope,
+			cancellation_token,
+			deadline_msec,
+			plan.get_dependency_closure(instance),
+			lifecycle_serial
+		)
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			var post_activation_cancel_reason: String = String(
+				cancellation_token.get_cancel_reason()
+			)
+			_cancel_module_async_scope(
+				_activation_scope,
+				post_activation_cancel_reason
+			)
+			_fail_initialization(
+				"[GFArchitecture] activation 已取消：%s。" % (
+					post_activation_cancel_reason
+				),
+				lifecycle_serial
+			)
+			return false
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(wait_report, "succeeded", false):
+			var failure_reason: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+				wait_report,
+				"reason",
+				"activation did not succeed"
+			)
+			_fail_initialization(
+				"[GFArchitecture] activation 失败：%s：%s" % [
+					_get_instance_debug_key(instance),
+					failure_reason,
 				],
 				lifecycle_serial
 			)
 			return false
+		_module_lifecycle_stages[instance] = 4
+	if _activation_scope != null:
+		_activation_scope.complete()
+		_untrack_async_scope(_activation_scope)
+		_activation_scope = null
+	return true
 
-		var progressed: bool = false
-		if await _advance_module_registry_to_stage(_model_registry, target_stage, lifecycle_serial):
-			progressed = true
-		if await _advance_module_registry_to_stage(_utility_registry, target_stage, lifecycle_serial):
-			progressed = true
-		if await _advance_module_registry_to_stage(_system_registry, target_stage, lifecycle_serial):
-			progressed = true
-		if not progressed:
-			if _all_registered_modules_reached_stage(target_stage):
-				return true
-			_fail_initialization(
-				"[GFArchitecture] 生命周期阶段推进停滞：stage=%d，仍有已注册模块未完成该阶段。" % target_stage,
-				lifecycle_serial
+
+func _await_lifecycle_completion(
+	completion: GFAsyncCompletion,
+	scope: GFAsyncScope,
+	cancellation_token: GFCancellationToken,
+	deadline_msec: int,
+	allowed_instances: Dictionary,
+	lifecycle_serial: int
+) -> Dictionary:
+	if completion == null:
+		return {
+			"succeeded": false,
+			"status": "failed",
+			"reason": "Lifecycle hook returned a null completion.",
+		}
+	var scene_tree: SceneTree = _get_scene_tree_or_null()
+	var last_tick_msec: int = Time.get_ticks_msec()
+	while completion.is_pending():
+		if not _is_lifecycle_current(lifecycle_serial):
+			var _interrupted_completion: bool = completion.cancel(
+				&"lifecycle_interrupted"
 			)
-			return false
-		pass_count += 1
-	return false
+			return {
+				"succeeded": false,
+				"status": "interrupted",
+				"reason": "Architecture lifecycle generation changed.",
+			}
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			var external_reason: StringName = cancellation_token.get_cancel_reason()
+			if scope != null:
+				var _cancelled_scope: bool = scope.cancel(String(external_reason))
+			var _cancelled_completion: bool = completion.cancel(external_reason)
+			return {
+				"succeeded": false,
+				"status": "cancelled",
+				"reason": String(external_reason),
+			}
+		if scope != null and scope.is_cancel_requested():
+			var scope_reason: StringName = scope.get_cancel_reason()
+			var _cancelled_scoped_completion: bool = completion.cancel(scope_reason)
+			return {
+				"succeeded": false,
+				"status": "cancelled",
+				"reason": String(scope_reason),
+			}
+		var now_msec: int = Time.get_ticks_msec()
+		if deadline_msec >= 0 and now_msec >= deadline_msec:
+			if scope != null:
+				var _timed_out_scope: bool = scope.cancel("lifecycle_timeout")
+			var _timed_out_completion: bool = completion.cancel(&"lifecycle_timeout")
+			return {
+				"succeeded": false,
+				"status": "timed_out",
+				"reason": "Lifecycle deadline exceeded.",
+			}
+		if scene_tree == null:
+			var _unavailable_completion: bool = completion.fail(
+				"Pending lifecycle completion requires an active SceneTree."
+			)
+			return {
+				"succeeded": false,
+				"status": "failed",
+				"reason": "Pending lifecycle completion requires an active SceneTree.",
+			}
+		var delta: float = float(maxi(now_msec - last_tick_msec, 0)) / 1000.0
+		last_tick_msec = now_msec
+		_tick_scheduler.drive_lifecycle_tick(delta, allowed_instances)
+		if not completion.is_pending():
+			continue
+		await scene_tree.process_frame
+	if not _is_lifecycle_current(lifecycle_serial):
+		var _interrupted_terminal_completion: bool = completion.cancel(
+			&"lifecycle_interrupted"
+		)
+		return {
+			"succeeded": false,
+			"status": "interrupted",
+			"reason": "Architecture lifecycle generation changed.",
+		}
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		var terminal_external_reason: StringName = (
+			cancellation_token.get_cancel_reason()
+		)
+		if scope != null:
+			var _cancelled_terminal_scope: bool = scope.cancel(
+				String(terminal_external_reason)
+			)
+		var _cancelled_terminal_completion: bool = completion.cancel(
+			terminal_external_reason
+		)
+		return {
+			"succeeded": false,
+			"status": "cancelled",
+			"reason": String(terminal_external_reason),
+		}
+	if scope != null and scope.is_cancel_requested():
+		var terminal_scope_reason: StringName = scope.get_cancel_reason()
+		var _cancelled_terminal_scoped_completion: bool = (
+			completion.cancel(terminal_scope_reason)
+		)
+		return {
+			"succeeded": false,
+			"status": "cancelled",
+			"reason": String(terminal_scope_reason),
+		}
+	if deadline_msec >= 0 and Time.get_ticks_msec() >= deadline_msec:
+		if scope != null:
+			var _timed_out_terminal_scope: bool = scope.cancel(
+				"lifecycle_timeout"
+			)
+		var _timed_out_terminal_completion: bool = completion.cancel(
+			&"lifecycle_timeout"
+		)
+		return {
+			"succeeded": false,
+			"status": "timed_out",
+			"reason": "Lifecycle deadline exceeded.",
+		}
+	if completion.is_successful():
+		return {
+			"succeeded": true,
+			"status": "succeeded",
+			"reason": "",
+		}
+	if completion.is_cancelled():
+		return {
+			"succeeded": false,
+			"status": "cancelled",
+			"reason": String(completion.get_cancel_reason()),
+		}
+	return {
+		"succeeded": false,
+		"status": "failed",
+		"reason": completion.get_error(),
+	}
+
+
+func _make_deadline_msec(started_at_msec: int, timeout_seconds: float) -> int:
+	if timeout_seconds <= 0.0:
+		return -1
+	var timeout_msec: float = ceil(timeout_seconds * 1000.0)
+	return started_at_msec + int(timeout_msec)
+
+
+func _await_topology_stability(
+	cancellation_token: GFCancellationToken,
+	deadline_msec: int
+) -> Dictionary:
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		return {
+			"succeeded": false,
+			"status": "cancelled",
+			"reason": String(cancellation_token.get_cancel_reason()),
+		}
+	if deadline_msec >= 0 and Time.get_ticks_msec() >= deadline_msec:
+		return {
+			"succeeded": false,
+			"status": "timed_out",
+			"reason": "Shutdown deadline exceeded before topology stability.",
+		}
+	var transaction: TopologyMutation = _topology_mutation
+	if transaction == null:
+		return {
+			"succeeded": true,
+			"status": "succeeded",
+			"reason": "",
+		}
+	var completion: GFAsyncCompletion = transaction._gate
+	if completion == null:
+		return {
+			"succeeded": false,
+			"status": "failed",
+			"reason": "Active topology transaction has no completion gate.",
+		}
+	var scene_tree: SceneTree = _get_scene_tree_or_null()
+	while (
+		_is_topology_mutation_current(transaction)
+		and completion.is_pending()
+	):
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			return {
+				"succeeded": false,
+				"status": "cancelled",
+				"reason": String(cancellation_token.get_cancel_reason()),
+			}
+		if deadline_msec >= 0 and Time.get_ticks_msec() >= deadline_msec:
+			return {
+				"succeeded": false,
+				"status": "timed_out",
+				"reason": "Shutdown deadline exceeded while waiting for an accepted topology transaction.",
+			}
+		if scene_tree == null:
+			return {
+				"succeeded": false,
+				"status": "failed",
+				"reason": "Pending topology transaction requires an active SceneTree.",
+			}
+		await scene_tree.process_frame
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		return {
+			"succeeded": false,
+			"status": "cancelled",
+			"reason": String(cancellation_token.get_cancel_reason()),
+		}
+	if deadline_msec >= 0 and Time.get_ticks_msec() >= deadline_msec:
+		return {
+			"succeeded": false,
+			"status": "timed_out",
+			"reason": "Shutdown deadline exceeded while waiting for an accepted topology transaction.",
+		}
+	if (
+		completion.is_successful()
+		and not _is_topology_mutation_current(transaction)
+	):
+		return {
+			"succeeded": true,
+			"status": "succeeded",
+			"reason": "",
+		}
+	if completion.is_cancelled():
+		return {
+			"succeeded": false,
+			"status": "cancelled",
+			"reason": String(completion.get_cancel_reason()),
+		}
+	return {
+		"succeeded": false,
+		"status": "failed",
+		"reason": completion.get_error(),
+	}
+
+
+func _make_topology_wait_shutdown_report(
+	topology_wait_report: Dictionary
+) -> Dictionary:
+	var status: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		topology_wait_report,
+		"status",
+		"failed"
+	)
+	var reason: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		topology_wait_report,
+		"reason",
+		"Accepted topology transaction did not reach a stable point."
+	)
+	var unfinished_modules: Array[Dictionary] = []
+	if _active_lifecycle_plan != null:
+		_append_unfinished_modules(
+			unfinished_modules,
+			_active_lifecycle_plan.get_shutdown_order(),
+			0,
+			reason
+		)
+	_append_topology_mutation_unfinished(
+		unfinished_modules,
+		_topology_mutation,
+		reason
+	)
+	return {
+		"status": status,
+		"reason": reason,
+		"module_results": [],
+		"unfinished_modules": unfinished_modules,
+	}
+
+
+func _append_topology_mutation_unfinished(
+	target: Array[Dictionary],
+	transaction: TopologyMutation,
+	reason: String
+) -> void:
+	if (
+		transaction == null
+		or transaction._candidate == null
+		or transaction._outcome == TopologyMutation._OUTCOME_COMMITTED
+		or transaction._candidate_cleanup_state
+		!= TopologyMutation._CLEANUP_PENDING
+	):
+		return
+	var candidate_stage: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+		_module_lifecycle_stages,
+		transaction._candidate,
+		0
+	)
+	var candidate_id: int = transaction._candidate.get_instance_id()
+	for existing: Dictionary in target:
+		if _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			existing,
+			"instance_id"
+		) == candidate_id:
+			return
+	var entry: Dictionary = _make_shutdown_module_entry(
+		transaction._candidate,
+		"skipped",
+		"%s (topology_phase=%s, lifecycle_stage=%d)" % [
+			reason,
+			String(transaction._phase),
+			candidate_stage,
+		],
+		0
+	)
+	target.append(entry)
+
+
+func _quiesce_active_modules(
+	cancellation_token: GFCancellationToken,
+	deadline_msec: int
+) -> Dictionary:
+	var module_results: Array[Dictionary] = []
+	var unfinished_modules: Array[Dictionary] = []
+	var top_status: String = "succeeded"
+	var top_reason: String = ""
+	var lifecycle_serial: int = _runtime.get_lifecycle_generation()
+	var shutdown_order: Array[Object] = []
+	if _active_lifecycle_plan != null:
+		shutdown_order = _active_lifecycle_plan.get_shutdown_order()
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		var initial_cancel_reason: String = String(
+			cancellation_token.get_cancel_reason()
+		)
+		_append_unfinished_modules(
+			unfinished_modules,
+			shutdown_order,
+			0,
+			"Shutdown was cancelled before module quiesce."
+		)
+		return {
+			"status": "cancelled",
+			"reason": initial_cancel_reason,
+			"module_results": module_results,
+			"unfinished_modules": unfinished_modules,
+		}
+	if deadline_msec >= 0 and Time.get_ticks_msec() >= deadline_msec:
+		var initial_timeout_reason: String = (
+			"Architecture shutdown deadline exceeded before module quiesce."
+		)
+		_append_unfinished_modules(
+			unfinished_modules,
+			shutdown_order,
+			0,
+			initial_timeout_reason
+		)
+		return {
+			"status": "timed_out",
+			"reason": initial_timeout_reason,
+			"module_results": module_results,
+			"unfinished_modules": unfinished_modules,
+		}
+	for index: int in range(shutdown_order.size()):
+		var instance: Object = shutdown_order[index]
+		if instance == null:
+			continue
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			top_status = "cancelled"
+			top_reason = String(cancellation_token.get_cancel_reason())
+			_append_unfinished_modules(
+				unfinished_modules,
+				shutdown_order,
+				index,
+				"Shutdown was cancelled before module quiesce."
+			)
+			break
+		var module_started_at_msec: int = Time.get_ticks_msec()
+		if deadline_msec >= 0 and module_started_at_msec >= deadline_msec:
+			top_status = "timed_out"
+			top_reason = "Architecture shutdown deadline exceeded."
+			_append_unfinished_modules(
+				unfinished_modules,
+				shutdown_order,
+				index,
+				top_reason
+			)
+			break
+		var completion: GFAsyncCompletion = _call_module_begin_quiesce(
+			instance,
+			_shutdown_scope
+		)
+		var allowed_instances: Dictionary = {instance: true}
+		if _active_lifecycle_plan != null:
+			allowed_instances = _active_lifecycle_plan.get_dependency_closure(instance)
+		var wait_report: Dictionary = await _await_lifecycle_completion(
+			completion,
+			_shutdown_scope,
+			cancellation_token,
+			deadline_msec,
+			allowed_instances,
+			lifecycle_serial
+		)
+		var module_status: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			wait_report,
+			"status",
+			"failed"
+		)
+		var module_reason: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			wait_report,
+			"reason",
+			""
+		)
+		var module_entry: Dictionary = _make_shutdown_module_entry(
+			instance,
+			module_status,
+			module_reason,
+			Time.get_ticks_msec() - module_started_at_msec
+		)
+		module_results.append(module_entry)
+		if module_status != "succeeded":
+			unfinished_modules.append(module_entry.duplicate(true))
+		if module_status == "timed_out":
+			top_status = "timed_out"
+			top_reason = module_reason
+			_append_unfinished_modules(
+				unfinished_modules,
+				shutdown_order,
+				index + 1,
+				"Skipped after shutdown timeout."
+			)
+			break
+		if (
+			module_status == "cancelled"
+			and (
+				(_shutdown_scope != null and _shutdown_scope.is_cancel_requested())
+				or (
+					cancellation_token != null
+					and cancellation_token.is_cancel_requested()
+				)
+			)
+		):
+			top_status = "cancelled"
+			top_reason = module_reason
+			_append_unfinished_modules(
+				unfinished_modules,
+				shutdown_order,
+				index + 1,
+				"Skipped after shutdown cancellation."
+			)
+			break
+		if module_status != "succeeded":
+			top_status = "failed"
+			if top_reason.is_empty():
+				top_reason = "%s failed to quiesce: %s" % [
+					_get_instance_debug_key(instance),
+					module_reason,
+				]
+	if cancellation_token != null and cancellation_token.is_cancel_requested():
+		top_status = "cancelled"
+		top_reason = String(cancellation_token.get_cancel_reason())
+	elif deadline_msec >= 0 and Time.get_ticks_msec() >= deadline_msec:
+		top_status = "timed_out"
+		top_reason = "Architecture shutdown deadline exceeded."
+	return {
+		"status": top_status,
+		"reason": top_reason,
+		"module_results": module_results,
+		"unfinished_modules": unfinished_modules,
+	}
+
+
+func _append_unfinished_modules(
+	target: Array[Dictionary],
+	shutdown_order: Array[Object],
+	start_index: int,
+	reason: String
+) -> void:
+	for index: int in range(start_index, shutdown_order.size()):
+		var instance: Object = shutdown_order[index]
+		if instance == null:
+			continue
+		target.append(
+			_make_shutdown_module_entry(instance, "skipped", reason, 0)
+		)
+
+
+func _make_shutdown_module_entry(
+	instance: Object,
+	status: String,
+	reason: String,
+	duration_msec: int
+) -> Dictionary:
+	return {
+		"kind": _get_module_label_for_instance(instance),
+		"script": _get_instance_debug_key(instance),
+		"instance_id": instance.get_instance_id() if instance != null else 0,
+		"status": status,
+		"reason": reason,
+		"duration_msec": maxi(duration_msec, 0),
+	}
+
+
+func _make_shutdown_result(
+	report: Dictionary,
+	started_at_msec: int,
+	completed_at_msec: int
+) -> GFArchitectureShutdownResult:
+	var status_name: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		report,
+		"status",
+		"failed"
+	)
+	var reason: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+		report,
+		"reason",
+		"Architecture shutdown failed."
+	)
+	var module_results: Array[Dictionary] = _get_shutdown_report_entries(
+		report,
+		"module_results"
+	)
+	var unfinished_modules: Array[Dictionary] = _get_shutdown_report_entries(
+		report,
+		"unfinished_modules"
+	)
+	var status: GFArchitectureShutdownResult.Status = (
+		GFArchitectureShutdownResult.Status.SUCCEEDED
+	)
+	var error_code: Error = OK
+	var cancel_reason: String = ""
+	match status_name:
+		"succeeded":
+			status = GFArchitectureShutdownResult.Status.SUCCEEDED
+		"cancelled":
+			status = GFArchitectureShutdownResult.Status.CANCELLED
+			error_code = ERR_SKIP
+			cancel_reason = reason
+		"timed_out":
+			status = GFArchitectureShutdownResult.Status.TIMED_OUT
+			error_code = ERR_TIMEOUT
+		_:
+			status = GFArchitectureShutdownResult.Status.FAILED
+			error_code = FAILED
+	return _GF_ARCHITECTURE_SHUTDOWN_RESULT_SCRIPT.create(
+		status,
+		started_at_msec,
+		completed_at_msec,
+		module_results,
+		unfinished_modules,
+		_shutdown_duplicate_request_count,
+		error_code,
+		reason,
+		cancel_reason
+	)
+
+
+func _get_shutdown_report_entries(
+	report: Dictionary,
+	key: String
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	var raw_entries: Variant = report.get(key, [])
+	if not raw_entries is Array:
+		return result
+	for raw_entry: Variant in raw_entries:
+		if raw_entry is Dictionary:
+			var entry: Dictionary = raw_entry
+			result.append(entry)
+	return result
+
+
+func _snapshot_forced_unfinished_modules(
+	reason: String
+) -> Array[Dictionary]:
+	var unfinished_modules: Array[Dictionary] = []
+	var seen_instances: Dictionary = {}
+	var snapshot_plan: GFArchitectureLifecyclePlan = (
+		_active_lifecycle_plan
+		if _active_lifecycle_plan != null
+		else _lifecycle_plan_in_progress
+	)
+	if snapshot_plan != null:
+		for instance: Object in snapshot_plan.get_shutdown_order():
+			if instance == null or seen_instances.has(instance):
+				continue
+			var lifecycle_stage: int = (
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+					_module_lifecycle_stages,
+					instance,
+					0
+				)
+			)
+			if lifecycle_stage <= 0:
+				continue
+			seen_instances[instance] = true
+			unfinished_modules.append(
+				_make_shutdown_module_entry(
+					instance,
+					"skipped",
+					"%s (lifecycle_stage=%d)" % [
+						reason,
+						lifecycle_stage,
+					],
+					0
+				)
+			)
+	_append_topology_mutation_unfinished(
+		unfinished_modules,
+		_topology_mutation,
+		reason
+	)
+	return unfinished_modules
+
+
+func _force_dispose_internal() -> void:
+	_fail_active_factory_resolution_contexts()
+	if not _runtime.begin_dispose():
+		return
+	var disposed_instances: Dictionary = _begin_module_disposal_session()
+	var aborted_topology: TopologyMutation = _abort_topology_mutation(
+		&"architecture_disposed"
+	)
+	if (
+		aborted_topology != null
+		and aborted_topology._active_scope != null
+		and aborted_topology._active_scope.is_active()
+	):
+		var _cancelled_topology_scope: bool = (
+			aborted_topology._active_scope.cancel(
+				"[GFArchitecture] 架构已 dispose。"
+			)
+		)
+	_cancel_active_async_scopes("[GFArchitecture] 架构已 dispose。")
+	_cleanup_topology_candidate(aborted_topology)
+	_finalize_aborted_topology_mutation(
+		aborted_topology,
+		&"architecture_disposed"
+	)
+	_lifecycle_hook_depth += 1
+	_on_dispose()
+	_lifecycle_hook_depth -= 1
+	var disposal_plan: GFArchitectureLifecyclePlan = (
+		_active_lifecycle_plan
+		if _active_lifecycle_plan != null
+		else _lifecycle_plan_in_progress
+	)
+	if disposal_plan != null:
+		for instance: Object in disposal_plan.get_shutdown_order():
+			_dispose_module_once(instance, disposed_instances)
+	for instance: Object in _get_modules_by_lifecycle_priority(
+		_system_registry.instances,
+		true
+	):
+		_dispose_module_once(instance, disposed_instances)
+	for instance: Object in _get_modules_by_lifecycle_priority(
+		_model_registry.instances,
+		true
+	):
+		_dispose_module_once(instance, disposed_instances)
+	for instance: Object in _get_modules_by_lifecycle_priority(
+		_utility_registry.instances,
+		true
+	):
+		_dispose_module_once(instance, disposed_instances)
+	for binding_variant: Variant in _factories.values():
+		var binding: GFBinding = _variant_to_binding(binding_variant)
+		if binding != null:
+			binding.dispose_cached_instance()
+	_model_registry._clear()
+	_system_registry._clear()
+	_utility_registry._clear()
+	_factories.clear()
+	_module_lifecycle_stages.clear()
+	_services.clear()
+	_event_system.clear()
+	_time_provider = null
+	last_initialization_error = ""
+	_reset_project_installers()
+	_active_lifecycle_plan = null
+	_lifecycle_plan_in_progress = null
+	_activation_scope = null
+	_shutdown_scope = null
+	_refresh_tick_caches()
+	_release_external_dependency_leases(
+		_active_external_dependency_leases
+	)
+	_active_external_dependency_leases.clear()
+	_child_external_dependency_leases.clear()
+	_parent_architecture = null
+	_runtime.finish_dispose()
+	_end_module_disposal_session()
+
+
+func _dispose_module_once(
+	instance: Object,
+	disposed_instances: Dictionary
+) -> void:
+	if instance == null or disposed_instances.has(instance):
+		return
+	disposed_instances[instance] = true
+	_event_system.unregister_owner(instance)
+	_unregister_services_for_owner(instance)
+	_call_module_dispose(instance)
+	_release_module_dependencies(instance)
+
+
+func _begin_module_disposal_session() -> Dictionary:
+	_module_disposal_session_depth += 1
+	return _module_disposal_claims
+
+
+func _end_module_disposal_session() -> void:
+	_module_disposal_session_depth = maxi(
+		_module_disposal_session_depth - 1,
+		0
+	)
+	if _module_disposal_session_depth == 0:
+		_module_disposal_claims.clear()
+
+
+func _publish_shutdown_result(result: GFArchitectureShutdownResult) -> void:
+	if result == null:
+		return
+	if _shutdown_completion == null:
+		_shutdown_completion = GFAsyncCompletion.new()
+	elif not _shutdown_completion.is_pending():
+		return
+	_last_shutdown_result = result.duplicate_result()
+	if _shutdown_completion.is_pending():
+		var _completed_shutdown: bool = _shutdown_completion.succeed(
+			result.duplicate_result()
+		)
+	shutdown_finished.emit(result.duplicate_result())
 
 
 func _all_registered_modules_reached_stage(target_stage: int) -> bool:
@@ -3578,38 +6240,22 @@ func _module_registry_reached_stage(module_registry: ModuleRegistry, target_stag
 	return true
 
 
-func _advance_module_registry_to_stage(module_registry: ModuleRegistry, target_stage: int, lifecycle_serial: int) -> bool:
-	var progressed: bool = false
-	for instance: Object in _get_modules_by_lifecycle_priority(module_registry.instances):
-		if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
-			return progressed
-		if not _module_registry_contains_instance(module_registry, instance):
-			continue
-
-		var current_stage: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0)
-		if current_stage < target_stage:
-			var advanced: bool = await _advance_module_to_stage(module_registry, instance, target_stage, lifecycle_serial)
-			if advanced:
-				progressed = true
-	return progressed
-
-
 func _advance_module_to_stage(
 	module_registry: ModuleRegistry,
 	instance: Object,
 	target_stage: int,
-	lifecycle_serial: int
+	lifecycle_serial: int,
+	cancellation_token: GFCancellationToken = null
 ) -> bool:
 	if instance == null:
 		return false
 
 	var current_stage: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0)
-	var advanced: bool = false
 	while current_stage < target_stage:
 		if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
-			return advanced
+			return false
 		if not _module_registry_contains_instance(module_registry, instance):
-			return advanced
+			return false
 
 		current_stage += 1
 		_bind_dependency_scope_if_needed(instance, lifecycle_serial)
@@ -3617,31 +6263,54 @@ func _advance_module_to_stage(
 			1:
 				_call_module_init(instance)
 			2:
-				var async_completed: bool = await _await_module_async_init(instance, lifecycle_serial)
+				var async_completed: bool = await _await_module_async_init(
+					instance,
+					lifecycle_serial,
+					cancellation_token
+				)
 				if not async_completed:
-					return advanced
+					return false
 			3:
 				_call_module_ready(instance)
 
 		if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
-			return advanced
+			return false
 		if not _module_registry_contains_instance(module_registry, instance):
-			return advanced
+			return false
 
 		_module_lifecycle_stages[instance] = current_stage
-		advanced = true
-	return advanced
+	return current_stage >= target_stage
 
 
-func _await_module_async_init(instance: Object, lifecycle_serial: int) -> bool:
+func _await_module_async_init(
+	instance: Object,
+	lifecycle_serial: int,
+	cancellation_token: GFCancellationToken = null
+) -> bool:
 	var async_scope: GFAsyncScope = _begin_module_async_scope()
-	if module_async_init_timeout_seconds <= 0.0:
-		await _call_module_async_init(instance, async_scope)
-		return _complete_module_async_scope(async_scope, lifecycle_serial)
-
 	var scene_tree: SceneTree = _get_scene_tree_or_null()
 	if scene_tree == null:
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			var pre_cancel_reason: String = String(
+				cancellation_token.get_cancel_reason()
+			)
+			_cancel_module_async_scope(async_scope, pre_cancel_reason)
+			_fail_initialization(
+				"[GFArchitecture] 初始化已取消：%s。" % pre_cancel_reason,
+				lifecycle_serial
+			)
+			return false
 		await _call_module_async_init(instance, async_scope)
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			var post_cancel_reason: String = String(
+				cancellation_token.get_cancel_reason()
+			)
+			_cancel_module_async_scope(async_scope, post_cancel_reason)
+			_fail_initialization(
+				"[GFArchitecture] 初始化已取消：%s。" % post_cancel_reason,
+				lifecycle_serial
+			)
+			return false
 		return _complete_module_async_scope(async_scope, lifecycle_serial)
 
 	var completion_state: Dictionary = {
@@ -3650,13 +6319,29 @@ func _await_module_async_init(instance: Object, lifecycle_serial: int) -> bool:
 	}
 	_GF_ASYNC_CALL_SCRIPT.run_detached(Callable(self, &"_complete_module_async_init"), [instance, completion_state, async_scope])
 	var start_msec: int = Time.get_ticks_msec()
-	var timeout_msec: int = int(module_async_init_timeout_seconds * 1000.0)
+	var timeout_msec: int = (
+		int(module_async_init_timeout_seconds * 1000.0)
+		if module_async_init_timeout_seconds > 0.0
+		else -1
+	)
 	while not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(completion_state, "done", false):
 		if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
 			_cancel_module_async_scope(async_scope, last_initialization_error)
 			return false
+		if cancellation_token != null and cancellation_token.is_cancel_requested():
+			var cancel_reason: String = String(
+				cancellation_token.get_cancel_reason()
+			)
+			_cancel_module_async_scope(async_scope, cancel_reason)
+			_fail_initialization(
+				"[GFArchitecture] 初始化已取消：%s。" % cancel_reason,
+				lifecycle_serial
+			)
+			return false
+		if async_scope.is_cancel_requested():
+			return false
 		var elapsed_msec: int = Time.get_ticks_msec() - start_msec
-		if elapsed_msec >= timeout_msec:
+		if timeout_msec >= 0 and elapsed_msec >= timeout_msec:
 			completion_state["write_blocked"] = true
 			_begin_stale_async_write_block()
 			var timeout_reason: String = "[GFArchitecture] async_init 超时：%s 超过 %.2f 秒。" % [
@@ -3678,18 +6363,11 @@ func _complete_module_async_init(instance: Object, completion_state: Dictionary,
 	completion_state["done"] = true
 
 
-func _dispose_module_registry(module_registry: ModuleRegistry) -> void:
-	for instance: Object in _get_modules_by_lifecycle_priority(module_registry.instances, true):
-		_event_system.unregister_owner(instance)
-		_unregister_services_for_owner(instance)
-		_call_module_dispose(instance)
-		_release_module_dependencies(instance)
-
-
 func _fail_initialization(reason: String, lifecycle_serial: int) -> void:
 	if not _runtime.fail_initialization(lifecycle_serial):
 		return
 
+	_fail_active_factory_resolution_contexts()
 	last_initialization_error = reason
 	_cancel_active_async_scopes(reason)
 	_stop_project_installers_after_failure()
@@ -3866,138 +6544,280 @@ func _replace_uninitialized_module(
 
 func _replace_initialized_module(module_registry: ModuleRegistry, script_cls: Script, instance: Object) -> bool:
 	var previous_instance: Object = _get_dictionary_object(module_registry.instances, script_cls)
-	var previous_stage: int = 3
-	if previous_instance != null and _module_lifecycle_stages.has(previous_instance):
-		previous_stage = _GF_VARIANT_ACCESS_SCRIPT.to_int(
-			_module_lifecycle_stages[previous_instance],
-			previous_stage
-		)
-
-	var transaction: Dictionary = _runtime.begin_transaction("replace_%s" % module_registry._label_key())
-	var lifecycle_serial: int = _runtime.get_lifecycle_generation()
-	var prepared: bool = await _prepare_replacement_module(instance, lifecycle_serial)
-	if not prepared:
-		_cleanup_uncommitted_module_if_unregistered(module_registry, instance)
-		_runtime.finish_transaction(transaction)
+	var topology_transaction: TopologyMutation = _begin_topology_mutation(
+		&"replace",
+		module_registry,
+		script_cls,
+		instance,
+		previous_instance
+	)
+	if topology_transaction == null:
 		return false
-	if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
-		_cleanup_uncommitted_module_if_unregistered(module_registry, instance)
-		_runtime.finish_transaction(transaction)
+	var previous_plan: GFArchitectureLifecyclePlan = _active_lifecycle_plan
+	topology_transaction._previous_plan = previous_plan
+	var transaction: Dictionary = _runtime.begin_transaction(
+		"replace_%s" % module_registry._label_key()
+	)
+	var lifecycle_serial: int = _runtime.get_lifecycle_generation()
+	topology_transaction._lifecycle_serial = lifecycle_serial
+	topology_transaction._candidate_cleanup_state = (
+		TopologyMutation._CLEANUP_PENDING
+	)
+	var candidate_models: Dictionary = _models.duplicate()
+	var candidate_utilities: Dictionary = _utilities.duplicate()
+	var candidate_systems: Dictionary = _systems.duplicate()
+	var candidate_registry: Dictionary = _get_candidate_registry_dictionary(
+		module_registry,
+		candidate_models,
+		candidate_utilities,
+		candidate_systems
+	)
+	candidate_registry[script_cls] = instance
+	var candidate_plan: GFArchitectureLifecyclePlan = (
+		_compile_candidate_lifecycle_plan(
+			candidate_models,
+			candidate_utilities,
+			candidate_systems,
+			"hot replace",
+			true,
+			_create_lifecycle_plan_validity_guard(
+				lifecycle_serial,
+				topology_transaction,
+				transaction
+			)
+		)
+	)
+	if (
+		candidate_plan == null
+		or not _is_topology_mutation_current(topology_transaction)
+		or not _is_lifecycle_current(lifecycle_serial)
+		or not _runtime.is_ready()
+		or _runtime.has_failed()
+		or _runtime.is_transaction_invalidated(transaction)
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			transaction
+		)
+		return false
+	var excluded_instances: Dictionary = {}
+	if previous_instance != null:
+		excluded_instances[previous_instance] = true
+	if not _validate_candidate_plan_stability(
+		previous_plan,
+		candidate_plan,
+		excluded_instances,
+		"hot replace"
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			transaction
+		)
+		return false
+	topology_transaction._candidate_plan = candidate_plan
+	if not _stage_topology_external_dependency_leases(
+		topology_transaction,
+		candidate_plan,
+		lifecycle_serial
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			transaction
+		)
+		return false
+	_module_lifecycle_stages[instance] = 0
+	var prepared: bool = await _prepare_replacement_module(instance, lifecycle_serial)
+	if (
+		not prepared
+		or not _is_topology_mutation_current(topology_transaction)
+	):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	if (
+		not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.has_failed()
+		or _runtime.is_transaction_invalidated(transaction)
+	):
+		_rollback_topology_candidate(topology_transaction, transaction)
 		return false
 	if _get_dictionary_object(module_registry.instances, script_cls) != previous_instance:
-		_cleanup_uncommitted_module_if_unregistered(module_registry, instance)
-		_runtime.finish_transaction(transaction)
+		_rollback_topology_candidate(topology_transaction, transaction)
 		return false
 	if module_registry._get_key_for_instance(instance) != null:
-		_runtime.finish_transaction(transaction)
+		_rollback_topology_candidate(topology_transaction, transaction)
 		return false
-
+	_module_lifecycle_stages[instance] = 2
+	_call_module_ready(instance)
+	if (
+		not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.has_failed()
+		or _runtime.is_transaction_invalidated(transaction)
+		or not _is_topology_mutation_current(topology_transaction)
+	):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	_module_lifecycle_stages[instance] = 3
+	topology_transaction._phase = TopologyMutation._PHASE_ACTIVATING
+	var activated: bool = await _activate_topology_candidate(
+		instance,
+		candidate_plan,
+		lifecycle_serial,
+		true,
+		topology_transaction
+	)
+	if (
+		not activated
+		or not _is_topology_mutation_current(topology_transaction)
+		or not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.is_transaction_invalidated(transaction)
+	):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	if not _validate_topology_service_intents(topology_transaction):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	topology_transaction._phase = (
+		TopologyMutation._PHASE_QUIESCING_PREVIOUS
+	)
+	if (
+		previous_instance != null
+		and not await _quiesce_topology_module(
+			previous_instance,
+			previous_plan,
+			lifecycle_serial,
+			topology_transaction
+		)
+	):
+		_cleanup_topology_candidate(topology_transaction)
+		_runtime.finish_transaction(transaction)
+		if _runtime.is_ready():
+			dispose()
+		else:
+			_fail_topology_mutation(
+				topology_transaction,
+				"Accepted topology replacement failed while quiescing the previous module."
+			)
+		return false
+	if not _is_topology_mutation_current(topology_transaction):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	if not _validate_topology_service_intents(topology_transaction):
+		_cleanup_topology_candidate(topology_transaction)
+		_runtime.finish_transaction(transaction)
+		dispose()
+		return false
+	topology_transaction._phase = TopologyMutation._PHASE_COMMITTING
 	if previous_instance != null:
 		module_registry._untrack_instance(previous_instance)
-		var _detached_previous_instance: bool = module_registry.instances.erase(script_cls)
+		var _detached_previous_instance: bool = (
+			module_registry.instances.erase(script_cls)
+		)
 	module_registry.instances[script_cls] = instance
 	module_registry._track_instance_key(instance, script_cls)
 	module_registry._clear_assignable_cache()
-	_track_registered_module(instance)
-	_module_lifecycle_stages[instance] = 2
-	_call_module_ready(instance)
-	if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
-		if _runtime.is_transaction_invalidated(transaction):
-			_cleanup_failed_replacement(module_registry, instance, previous_instance)
-		else:
-			_rollback_initialized_replacement(module_registry, script_cls, instance, previous_instance, previous_stage)
-		_runtime.finish_transaction(transaction)
-		return false
-	if _get_dictionary_object(module_registry.instances, script_cls) != instance:
-		_cleanup_superseded_initialized_replacement(
-			module_registry,
-			instance,
-			previous_instance
-		)
-		_runtime.finish_transaction(transaction)
-		return false
+	_commit_topology_service_intents(topology_transaction)
+	_promote_topology_external_dependency_leases(
+		topology_transaction
+	)
+	_active_lifecycle_plan = candidate_plan
+	topology_transaction._candidate_cleanup_state = (
+		TopologyMutation._CLEANUP_TRANSFERRED
+	)
+	topology_transaction._outcome = TopologyMutation._OUTCOME_COMMITTED
+	topology_transaction._phase = (
+		TopologyMutation._PHASE_CLEANING_DETACHED
+	)
 	if previous_instance != null:
 		_cleanup_uncommitted_module(previous_instance)
-	if not _is_lifecycle_current(lifecycle_serial) or _runtime.has_failed():
-		_cleanup_failed_replacement(module_registry, instance, null)
+	if (
+		not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.is_transaction_invalidated(transaction)
+		or not _is_topology_mutation_current(topology_transaction)
+	):
 		_runtime.finish_transaction(transaction)
+		_fail_topology_mutation(
+			topology_transaction,
+			"Accepted topology replacement was invalidated during detached cleanup."
+		)
 		return false
-	if _get_dictionary_object(module_registry.instances, script_cls) != instance:
-		var _removed_superseded_stage: bool = _module_lifecycle_stages.erase(instance)
-		module_registry._clear_assignable_cache()
-		_refresh_cached_utility_refs()
-		_refresh_tick_caches()
-		_runtime.finish_transaction(transaction)
-		return false
-	_module_lifecycle_stages[instance] = 3
+	topology_transaction._phase = TopologyMutation._PHASE_COMMITTED
+	_refresh_cached_utility_refs()
+	_refresh_tick_caches()
 	_runtime.finish_transaction(transaction)
+	_finish_topology_mutation(topology_transaction)
 	return true
 
 
-func _rollback_initialized_replacement(
+func _get_candidate_registry_dictionary(
 	module_registry: ModuleRegistry,
-	script_cls: Script,
-	replacement_instance: Object,
-	previous_instance: Object,
-	previous_stage: int
-) -> void:
-	var replacement_key: Script = module_registry._get_key_for_instance(replacement_instance)
-	var replacement_needs_cleanup: bool = replacement_key != null or _module_lifecycle_stages.has(replacement_instance)
-	if replacement_key != null:
-		module_registry._untrack_instance(replacement_instance)
-		var _removed_replacement: bool = module_registry.instances.erase(replacement_key)
-	if replacement_needs_cleanup:
-		_cleanup_uncommitted_module(replacement_instance)
-
-	if previous_instance != null:
-		module_registry.instances[script_cls] = previous_instance
-		module_registry._track_instance_key(previous_instance, script_cls)
-		_track_registered_module(previous_instance)
-		_module_lifecycle_stages[previous_instance] = previous_stage
-	module_registry._clear_assignable_cache()
-	_refresh_cached_utility_refs()
-	_refresh_tick_caches()
+	model_instances: Dictionary,
+	utility_instances: Dictionary,
+	system_instances: Dictionary
+) -> Dictionary:
+	if module_registry == _model_registry:
+		return model_instances
+	if module_registry == _utility_registry:
+		return utility_instances
+	if module_registry == _system_registry:
+		return system_instances
+	return {}
 
 
-func _cleanup_failed_replacement(
-	module_registry: ModuleRegistry,
-	replacement_instance: Object,
-	previous_instance: Object
-) -> void:
-	var replacement_key: Script = module_registry._get_key_for_instance(replacement_instance)
-	var replacement_needs_cleanup: bool = replacement_key != null or _module_lifecycle_stages.has(replacement_instance)
-	if replacement_key != null:
-		module_registry._untrack_instance(replacement_instance)
-		var _removed_replacement: bool = module_registry.instances.erase(replacement_key)
-	module_registry._clear_assignable_cache()
-	if replacement_instance != null and replacement_needs_cleanup:
-		_cleanup_uncommitted_module(replacement_instance)
-	if previous_instance != null:
-		_event_system.unregister_owner(previous_instance)
-		_unregister_services_for_owner(previous_instance)
-		_call_module_dispose(previous_instance)
-		_release_module_dependencies(previous_instance)
-		var _removed_previous_stage: bool = _module_lifecycle_stages.erase(previous_instance)
-
-
-func _cleanup_superseded_initialized_replacement(
-	module_registry: ModuleRegistry,
-	replacement_instance: Object,
-	previous_instance: Object
-) -> void:
-	if not _module_registry_contains_instance(module_registry, replacement_instance):
-		var _removed_replacement_stage: bool = _module_lifecycle_stages.erase(
-			replacement_instance
+func _quiesce_topology_module(
+	instance: Object,
+	plan: GFArchitectureLifecyclePlan,
+	lifecycle_serial: int,
+	topology_transaction: TopologyMutation = null
+) -> bool:
+	if instance == null:
+		return true
+	var scope: GFAsyncScope = _begin_module_async_scope()
+	if _is_topology_mutation_current(topology_transaction):
+		topology_transaction._active_scope = scope
+	var deadline_msec: int = _make_deadline_msec(
+		Time.get_ticks_msec(),
+		shutdown_timeout_seconds
+	)
+	var completion: GFAsyncCompletion = _call_module_begin_quiesce(
+		instance,
+		scope
+	)
+	var allowed_instances: Dictionary = {instance: true}
+	if plan != null:
+		allowed_instances = plan.get_dependency_closure(instance)
+	var wait_report: Dictionary = await _await_lifecycle_completion(
+		completion,
+		scope,
+		null,
+		deadline_msec,
+		allowed_instances,
+		lifecycle_serial
+	)
+	var succeeded: bool = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		wait_report,
+		"succeeded",
+		false
+	)
+	if not succeeded:
+		push_error(
+			"[GFArchitecture] 模块拓扑事务 quiesce 失败：%s：%s" % [
+				_get_instance_debug_key(instance),
+				_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+					wait_report,
+					"reason",
+					"quiesce failed"
+				),
+			]
 		)
+	if scope.is_active():
+		scope.complete()
+	_untrack_async_scope(scope)
 	if (
-		previous_instance != null
-		and not _module_registry_contains_instance(module_registry, previous_instance)
-		and _module_lifecycle_stages.has(previous_instance)
+		topology_transaction != null
+		and topology_transaction._active_scope == scope
 	):
-		_cleanup_uncommitted_module(previous_instance)
-	module_registry._clear_assignable_cache()
-	_refresh_cached_utility_refs()
-	_refresh_tick_caches()
+		topology_transaction._active_scope = null
+	return succeeded
 
 
 func _cleanup_uncommitted_module_if_unregistered(
@@ -4012,10 +6832,7 @@ func _cleanup_uncommitted_module_if_unregistered(
 func _cleanup_uncommitted_module(instance: Object) -> void:
 	if instance == null:
 		return
-	_event_system.unregister_owner(instance)
-	_unregister_services_for_owner(instance)
-	_call_module_dispose(instance)
-	_release_module_dependencies(instance)
+	_dispose_module_once(instance, {})
 	var _removed_stage: bool = _module_lifecycle_stages.erase(instance)
 
 
@@ -4083,18 +6900,71 @@ func _can_mutate_registration_state(context: String) -> bool:
 	if _runtime.is_disposed() or _runtime.is_disposing():
 		push_error("[GFArchitecture] %s 失败：架构已 dispose，不能继续修改注册表。" % context)
 		return false
+	if _runtime.is_quiescing():
+		push_error("[GFArchitecture] %s 失败：架构正在 quiesce，注册表已经冻结。" % context)
+		return false
 	if _runtime.has_failed():
 		push_error("[GFArchitecture] %s 失败：架构初始化已失败，已拒绝迟到写入。" % context)
 		return false
 	if _stale_async_write_block_count > 0:
 		push_error("[GFArchitecture] %s 失败：架构存在已超时的异步流程尚未结束，已拒绝迟到写入。" % context)
 		return false
+	if _runtime.is_initializing():
+		push_error("[GFArchitecture] %s 失败：生命周期计划已经冻结，初始化期间禁止修改注册表。" % context)
+		return false
+	if _runtime.is_activating():
+		push_error("[GFArchitecture] %s 失败：架构正在 activation，注册表已经冻结。" % context)
+		return false
+	if not _factory_resolution_context_stack.is_empty():
+		var resolution_context: Dictionary = (
+			_factory_resolution_context_stack.back()
+		)
+		_mark_factory_resolution_failed(resolution_context)
+		push_error(
+			"[GFArchitecture] %s 失败：工厂解析期间禁止重入修改模块拓扑。"
+			% context
+		)
+		return false
+	if (
+		_runtime.is_ready()
+		and _has_live_child_external_dependency_leases(true)
+	):
+		push_error(
+			"[GFArchitecture] %s 失败：活动子架构仍持有父级外部模块依赖租约。"
+			% context
+		)
+		return false
+	if _topology_mutation != null:
+		push_error("[GFArchitecture] %s 失败：另一项模块拓扑事务尚未完成。" % context)
+		return false
+	if _lifecycle_hook_depth > 0:
+		push_error("[GFArchitecture] %s 失败：生命周期 Hook 内禁止重入修改注册表。" % context)
+		return false
 	return true
+
+
+func _fail_active_factory_resolution_contexts() -> void:
+	for resolution_context: Dictionary in _factory_resolution_context_stack:
+		_mark_factory_resolution_failed(resolution_context)
+
+
+func _can_mutate_factory_topology(context: String) -> bool:
+	if not _runtime.is_ready():
+		return true
+	push_error(
+		"[GFArchitecture] %s 失败：activation 后 factory 拓扑不可变。" % (
+			context
+		)
+	)
+	return false
 
 
 func _can_mutate_runtime(context: String) -> bool:
 	if _runtime.is_disposed() or _runtime.is_disposing():
 		push_error("[GFArchitecture] %s 失败：架构已 dispose，不能继续修改运行时状态。" % context)
+		return false
+	if _runtime.is_quiescing():
+		push_error("[GFArchitecture] %s 失败：架构正在 quiesce，已拒绝新的运行时写入。" % context)
 		return false
 	if _runtime.has_failed():
 		push_error("[GFArchitecture] %s 失败：架构初始化已失败，已拒绝运行时写入。" % context)
@@ -4106,10 +6976,23 @@ func _can_execute_runtime(context: String) -> bool:
 	if _runtime.is_disposed() or _runtime.is_disposing():
 		push_error("[GFArchitecture] %s 失败：架构已 dispose，不能继续执行。" % context)
 		return false
+	if _runtime.is_quiescing():
+		push_error("[GFArchitecture] %s 失败：架构正在 quiesce，已经关闭新的运行时准入。" % context)
+		return false
 	if _runtime.has_failed():
 		push_error("[GFArchitecture] %s 失败：架构初始化已失败，已拒绝执行。" % context)
 		return false
+	if _topology_mutation != null:
+		push_error("[GFArchitecture] %s 失败：模块拓扑事务尚未完成。" % context)
+		return false
+	if not _runtime.is_ready():
+		push_error("[GFArchitecture] %s 失败：架构尚未完成 activation。" % context)
+		return false
 	return true
+
+
+func _is_runtime_execution_admitted() -> bool:
+	return _runtime.is_ready() and _topology_mutation == null
 
 
 func _begin_stale_async_write_block() -> void:
@@ -4183,6 +7066,11 @@ func _unregister_module(module_registry: ModuleRegistry, script_cls: Script) -> 
 	if script_cls == null:
 		return false
 	if module_registry._has_direct(script_cls):
+		if _runtime.is_ready():
+			return await _unregister_active_module(
+				module_registry,
+				script_cls
+			)
 		var _removed_instance: Object = _remove_registered_module(module_registry, script_cls, true, true)
 		return true
 	if module_registry.aliases.has(script_cls):
@@ -4192,6 +7080,145 @@ func _unregister_module(module_registry: ModuleRegistry, script_cls: Script) -> 
 		])
 		return false
 	return false
+
+
+func _unregister_active_module(
+	module_registry: ModuleRegistry,
+	script_cls: Script
+) -> bool:
+	var instance: Object = _get_dictionary_object(
+		module_registry.instances,
+		script_cls
+	)
+	var topology_transaction: TopologyMutation = _begin_topology_mutation(
+		&"unregister",
+		module_registry,
+		script_cls,
+		null,
+		instance
+	)
+	if topology_transaction == null:
+		return false
+	topology_transaction._previous_plan = _active_lifecycle_plan
+	var transaction: Dictionary = _runtime.begin_transaction(
+		"unregister_%s" % module_registry._label_key()
+	)
+	var lifecycle_serial: int = _runtime.get_lifecycle_generation()
+	topology_transaction._lifecycle_serial = lifecycle_serial
+	var candidate_models: Dictionary = _models.duplicate()
+	var candidate_utilities: Dictionary = _utilities.duplicate()
+	var candidate_systems: Dictionary = _systems.duplicate()
+	var candidate_registry: Dictionary = _get_candidate_registry_dictionary(
+		module_registry,
+		candidate_models,
+		candidate_utilities,
+		candidate_systems
+	)
+	var _removed_candidate: bool = candidate_registry.erase(script_cls)
+	var candidate_plan: GFArchitectureLifecyclePlan = (
+		_compile_candidate_lifecycle_plan(
+			candidate_models,
+			candidate_utilities,
+			candidate_systems,
+			"hot unregister",
+			true,
+			_create_lifecycle_plan_validity_guard(
+				lifecycle_serial,
+				topology_transaction,
+				transaction
+			)
+		)
+	)
+	if (
+		candidate_plan == null
+		or not _is_topology_mutation_current(topology_transaction)
+		or not _is_lifecycle_current(lifecycle_serial)
+		or not _runtime.is_ready()
+		or _runtime.has_failed()
+		or _runtime.is_transaction_invalidated(transaction)
+	):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	var excluded_instances: Dictionary = {}
+	if instance != null:
+		excluded_instances[instance] = true
+	if not _validate_candidate_plan_stability(
+		topology_transaction._previous_plan,
+		candidate_plan,
+		excluded_instances,
+		"hot unregister"
+	):
+		_rollback_topology_candidate(topology_transaction, transaction)
+		return false
+	topology_transaction._candidate_plan = candidate_plan
+	if not _stage_topology_external_dependency_leases(
+		topology_transaction,
+		candidate_plan,
+		lifecycle_serial
+	):
+		_rollback_topology_candidate(
+			topology_transaction,
+			transaction
+		)
+		return false
+	topology_transaction._phase = (
+		TopologyMutation._PHASE_QUIESCING_PREVIOUS
+	)
+	var quiesced: bool = await _quiesce_topology_module(
+		instance,
+		_active_lifecycle_plan,
+		lifecycle_serial,
+		topology_transaction
+	)
+	if (
+		not quiesced
+		or not _is_topology_mutation_current(topology_transaction)
+		or not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.is_transaction_invalidated(transaction)
+	):
+		_runtime.finish_transaction(transaction)
+		if _runtime.is_ready():
+			dispose()
+		else:
+			_fail_topology_mutation(
+				topology_transaction,
+				"Accepted topology unregister failed during quiesce."
+			)
+		return false
+	if _get_dictionary_object(module_registry.instances, script_cls) != instance:
+		_runtime.finish_transaction(transaction)
+		_finish_topology_mutation(topology_transaction)
+		return false
+	topology_transaction._phase = TopologyMutation._PHASE_COMMITTING
+	_promote_topology_external_dependency_leases(
+		topology_transaction
+	)
+	_active_lifecycle_plan = candidate_plan
+	topology_transaction._outcome = TopologyMutation._OUTCOME_COMMITTED
+	topology_transaction._phase = (
+		TopologyMutation._PHASE_CLEANING_DETACHED
+	)
+	var _removed_instance: Object = _remove_registered_module(
+		module_registry,
+		script_cls,
+		true,
+		true
+	)
+	if (
+		not _is_lifecycle_current(lifecycle_serial)
+		or _runtime.is_transaction_invalidated(transaction)
+		or not _is_topology_mutation_current(topology_transaction)
+	):
+		_runtime.finish_transaction(transaction)
+		_fail_topology_mutation(
+			topology_transaction,
+			"Accepted topology unregister was invalidated during detached cleanup."
+		)
+		return false
+	topology_transaction._phase = TopologyMutation._PHASE_COMMITTED
+	_runtime.finish_transaction(transaction)
+	_finish_topology_mutation(topology_transaction)
+	return true
 
 
 func _remove_registered_module(
@@ -4206,13 +7233,13 @@ func _remove_registered_module(
 	if remove_aliases:
 		_remove_aliases_for(module_registry, registered_key)
 	module_registry._clear_assignable_cache()
-	if instance != null:
+	if instance != null and dispose_instance:
+		_dispose_module_once(instance, {})
+	elif instance != null:
 		_event_system.unregister_owner(instance)
 		_unregister_services_for_owner(instance)
-	if instance != null and dispose_instance:
-		_call_module_dispose(instance)
-	if instance != null:
 		_release_module_dependencies(instance)
+	if instance != null:
 		var _removed_stage: bool = _module_lifecycle_stages.erase(instance)
 	return instance
 
@@ -4224,6 +7251,8 @@ func _inject_dependencies_if_needed(
 ) -> bool:
 	if instance == null:
 		return true
+	if not _is_dependency_injection_current(lifecycle_serial):
+		return false
 	var execution_scope_bound: bool = false
 	if execution_context and instance.has_method("_gf_begin_execution_scope"):
 		var begin_result: Variant = instance.call("_gf_begin_execution_scope", self, lifecycle_serial)
@@ -4234,9 +7263,27 @@ func _inject_dependencies_if_needed(
 		_bind_dependency_scope_if_needed(instance, lifecycle_serial)
 	if instance != null and instance.has_method("inject_dependencies"):
 		var _inject_dependencies_result: Variant = instance.call("inject_dependencies", self)
+		if not _is_dependency_injection_current(lifecycle_serial):
+			return false
 	if instance != null and instance.has_method("inject"):
 		var _inject_result: Variant = instance.call("inject", self)
-	return true
+	return _is_dependency_injection_current(lifecycle_serial)
+
+
+func _is_dependency_injection_current(lifecycle_serial: int) -> bool:
+	if lifecycle_serial < 0:
+		return (
+			not _runtime.has_failed()
+			and not _runtime.is_disposing()
+			and not _runtime.is_disposed()
+		)
+	return (
+		_is_lifecycle_current(lifecycle_serial)
+		and _runtime.is_lifecycle_active()
+		and not _runtime.has_failed()
+		and not _runtime.is_disposing()
+		and not _runtime.is_disposed()
+	)
 
 
 func _bind_dependency_scope_if_needed(instance: Object, lifecycle_serial: int = -1) -> void:
@@ -4286,7 +7333,6 @@ func _validate_registration(script_cls: Script, instance: Object, label: String)
 	if not _instance_matches_registration_label(instance, label):
 		push_error("[GFArchitecture] register_%s 失败：实例类型必须继承 GF%s。" % [label.to_lower(), label])
 		return false
-
 	var instance_script: Script = _get_instance_script(instance)
 	if instance_script == null:
 		push_error("[GFArchitecture] register_%s 失败：实例未附加脚本。" % label.to_lower())
@@ -4423,6 +7469,13 @@ func _is_module_ready_for_lookup(instance: Object) -> bool:
 func _register_module_alias(module_registry: ModuleRegistry, alias_cls: Script, target_cls: Script) -> void:
 	if not _can_mutate_registration_state("register_%s_alias" % module_registry._label_key()):
 		return
+	if _runtime.is_ready():
+		push_error(
+			"[GFArchitecture] register_%s_alias 失败：activation 后 alias 拓扑不可变。" % (
+				module_registry._label_key()
+			)
+		)
+		return
 	if alias_cls == null or target_cls == null:
 		push_error("[GFArchitecture] register_%s_alias 失败：alias 或 target 为空。" % module_registry._label_key())
 		return
@@ -4437,6 +7490,13 @@ func _register_module_alias(module_registry: ModuleRegistry, alias_cls: Script, 
 
 func _unregister_module_alias(module_registry: ModuleRegistry, alias_cls: Script) -> bool:
 	if not _can_mutate_registration_state("unregister_%s_alias" % module_registry._label_key()):
+		return false
+	if _runtime.is_ready():
+		push_error(
+			"[GFArchitecture] unregister_%s_alias 失败：activation 后 alias 拓扑不可变。" % (
+				module_registry._label_key()
+			)
+		)
 		return false
 	if alias_cls == null:
 		push_error("[GFArchitecture] unregister_%s_alias 失败：alias 为空。" % module_registry._label_key())
@@ -4546,6 +7606,72 @@ func _has_assignable_instance(module_registry: ModuleRegistry, script_cls: Scrip
 
 # --- 内部类 ---
 
+## TopologyMutation: 已接纳模块拓扑事务的所有权与终态描述符。
+##
+## shutdown 可在 deadline 或取消时同步接管未提交候选；原 coroutine 保留同一
+## 描述符并通过 identity guard 识别失效，不能再提交候选。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/core
+class TopologyMutation:
+	extends RefCounted
+
+	const _PHASE_PREPARING: StringName = &"preparing"
+	const _PHASE_ACTIVATING: StringName = &"activating"
+	const _PHASE_QUIESCING_PREVIOUS: StringName = &"quiescing_previous"
+	const _PHASE_COMMITTING: StringName = &"committing"
+	const _PHASE_CLEANING_DETACHED: StringName = &"cleaning_detached"
+	const _PHASE_COMMITTED: StringName = &"committed"
+	const _PHASE_ABORTED: StringName = &"aborted"
+	const _PHASE_FINISHED: StringName = &"finished"
+	const _OWNER_CONTINUATION: StringName = &"continuation"
+	const _OWNER_SHUTDOWN: StringName = &"shutdown"
+	const _OUTCOME_PENDING: StringName = &"pending"
+	const _OUTCOME_COMMITTED: StringName = &"committed"
+	const _OUTCOME_ROLLED_BACK: StringName = &"rolled_back"
+	const _OUTCOME_ABORTED: StringName = &"aborted"
+	const _OUTCOME_FATAL: StringName = &"fatal"
+	const _CLEANUP_NOT_REQUIRED: StringName = &"not_required"
+	const _CLEANUP_PENDING: StringName = &"pending"
+	const _CLEANUP_CLAIMED: StringName = &"claimed"
+	const _CLEANUP_DONE: StringName = &"done"
+	const _CLEANUP_TRANSFERRED: StringName = &"transferred"
+
+	var _id: int = 0
+	var _operation: StringName = &""
+	var _module_registry: Variant = null
+	var _script_cls: Script = null
+	var _candidate: Object = null
+	var _previous: Object = null
+	var _previous_plan: GFArchitectureLifecyclePlan = null
+	var _candidate_plan: GFArchitectureLifecyclePlan = null
+	var _lifecycle_serial: int = -1
+	var _phase: StringName = _PHASE_PREPARING
+	var _owner: StringName = _OWNER_CONTINUATION
+	var _outcome: StringName = _OUTCOME_PENDING
+	var _gate: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _active_scope: GFAsyncScope = null
+	var _candidate_cleanup_state: StringName = _CLEANUP_NOT_REQUIRED
+	var _service_intents: Dictionary = {}
+	var _expected_service_presence: Dictionary = {}
+	var _expected_service_providers: Dictionary = {}
+	var _candidate_external_dependency_leases: Array[Dictionary] = []
+
+	func _init(
+		p_id: int,
+		p_operation: StringName,
+		p_module_registry: Variant,
+		p_script_cls: Script,
+		p_candidate: Object,
+		p_previous: Object
+	) -> void:
+		_id = p_id
+		_operation = p_operation
+		_module_registry = p_module_registry
+		_script_cls = p_script_cls
+		_candidate = p_candidate
+		_previous = p_previous
 ## DependencyDiagnosticsReport: 架构依赖诊断报告构建器。
 ## [br]
 ## @api framework_internal

--- a/addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd
+++ b/addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd
@@ -1,0 +1,1278 @@
+## GFArchitectureLifecyclePlan: GFArchitecture 的确定性生命周期依赖计划。
+##
+## 从本地 Model、Utility、System 注册快照构建依赖 DAG，并保存激活顺序、
+## 严格逆序的关闭快照与有界诊断。父架构解析到的依赖仅视为外部满足项，
+## 不会成为本地 DAG 节点。
+## [br]
+## @api framework_internal
+## [br]
+## @category internal_helper
+## [br]
+## @since unreleased
+## [br]
+## @layer kernel/core
+class_name GFArchitectureLifecyclePlan
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _DIAGNOSTIC_LIMIT: int = 64
+const _MAX_CYCLE_MEMBERS_PER_DIAGNOSTIC: int = 32
+
+const _GF_SCRIPT_TYPE_INSPECTOR_SCRIPT = preload("res://addons/gf/kernel/core/gf_script_type_inspector.gd")
+
+const _KIND_MODEL: StringName = &"Model"
+const _KIND_UTILITY: StringName = &"Utility"
+const _KIND_SYSTEM: StringName = &"System"
+
+const _REGISTRY_MODELS: StringName = &"models"
+const _REGISTRY_UTILITIES: StringName = &"utilities"
+const _REGISTRY_SYSTEMS: StringName = &"systems"
+const _REGISTRY_FACTORIES: StringName = &"factories"
+
+const _HOOK_REQUIRED_MODELS: StringName = &"get_required_models"
+const _HOOK_REQUIRED_UTILITIES: StringName = &"get_required_utilities"
+const _HOOK_REQUIRED_SYSTEMS: StringName = &"get_required_systems"
+const _HOOK_REQUIRED_FACTORIES: StringName = &"get_required_factories"
+
+const _STATUS_LOCAL: StringName = &"local"
+const _STATUS_EXTERNAL: StringName = &"external"
+const _STATUS_MISSING: StringName = &"missing"
+const _STATUS_STALE_ALIAS: StringName = &"stale_alias"
+const _STATUS_AMBIGUOUS: StringName = &"ambiguous"
+const _STATUS_PARENT_CYCLE: StringName = &"parent_cycle"
+const _STATUS_INVALID: StringName = &"invalid"
+
+
+# --- 私有变量 ---
+
+var _valid: bool = false
+var _activation_order: Array[Object] = []
+var _shutdown_order: Array[Object] = []
+var _diagnostics: Array[Dictionary] = []
+var _diagnostics_truncated: bool = false
+var _external_dependency_count: int = 0
+var _node_id_by_instance: Dictionary = {}
+var _local_dependencies_by_instance: Dictionary = {}
+var _dependency_snapshot: Array[Dictionary] = []
+var _dependency_records: Array[Dictionary] = []
+
+
+# --- 框架内部方法 ---
+
+## 编译当前注册快照的生命周期依赖计划。
+## [br]
+## 权威 resolver 应采用 GFArchitecture 的 exact、alias、唯一 assignable 与
+## parent lookup 规则，并返回结构化 status。Model、Utility、System 的 local
+## 结果会建立 DAG 边；external 结果只记录为外部满足项。Factory 只校验
+## binding availability，不会建立 DAG 边或触发实例化。未提供 resolver 时，
+## 模块依赖仅使用注册快照进行 exact / 唯一 assignable 本地解析，Factory
+## 依赖按 missing 处理。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param model_instances: 本地 Model 注册快照。
+## [br]
+## @schema model_instances: Dictionary keyed by Script, storing GFModel instances in registration order.
+## [br]
+## @param utility_instances: 本地 Utility 注册快照。
+## [br]
+## @schema utility_instances: Dictionary keyed by Script, storing GFUtility instances in registration order.
+## [br]
+## @param system_instances: 本地 System 注册快照。
+## [br]
+## @schema system_instances: Dictionary keyed by Script, storing GFSystem instances in registration order.
+## [br]
+## @param dependency_resolvers: 按依赖类别提供的权威解析 Callable。
+## [br]
+## @schema dependency_resolvers: Dictionary with models, utilities, systems, and factories Callable values. Each Callable receives a required Script and returns a Dictionary with status plus optional instance, scope, architecture_depth, resolution_kind, registered_script, and parent-cycle fields.
+## [br]
+## @param validity_guard: 可选同步有效性检查；返回 false 后立即停止调用后续依赖 Hook。
+## [br]
+## @return: 计划有效且可用于激活时返回 true。
+func compile(
+	model_instances: Dictionary,
+	utility_instances: Dictionary,
+	system_instances: Dictionary,
+	dependency_resolvers: Dictionary = {},
+	validity_guard: Callable = Callable()
+) -> bool:
+	_reset()
+	var nodes: Array[Dictionary] = []
+	var node_ids_by_kind: Dictionary = {
+		_REGISTRY_MODELS: {},
+		_REGISTRY_UTILITIES: {},
+		_REGISTRY_SYSTEMS: {},
+	}
+	_collect_registry_nodes(model_instances, _KIND_MODEL, _REGISTRY_MODELS, nodes, node_ids_by_kind)
+	_collect_registry_nodes(utility_instances, _KIND_UTILITY, _REGISTRY_UTILITIES, nodes, node_ids_by_kind)
+	_collect_registry_nodes(system_instances, _KIND_SYSTEM, _REGISTRY_SYSTEMS, nodes, node_ids_by_kind)
+
+	if not _is_compilation_valid(validity_guard):
+		return false
+	if not _collect_dependency_declarations(nodes, validity_guard):
+		return false
+	if not _collect_dependency_edges(
+		nodes,
+		node_ids_by_kind,
+		dependency_resolvers,
+		validity_guard
+	):
+		return false
+	if not _is_compilation_valid(validity_guard):
+		return false
+	var ordered_node_ids: Array[int] = _build_kahn_order(nodes)
+	if ordered_node_ids.size() != nodes.size():
+		_append_cycle_diagnostics(nodes, ordered_node_ids)
+
+	_valid = _diagnostics.is_empty() and ordered_node_ids.size() == nodes.size()
+	if not _valid:
+		_activation_order.clear()
+		_shutdown_order.clear()
+		return false
+
+	for node_id: int in ordered_node_ids:
+		var instance: Object = _get_node_instance(nodes[node_id])
+		if instance != null:
+			_activation_order.append(instance)
+	_shutdown_order = _activation_order.duplicate()
+	_shutdown_order.reverse()
+	return true
+
+
+## 返回计划是否有效。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 计划可用于生命周期执行时返回 true。
+func is_valid() -> bool:
+	return _valid
+
+
+## 返回激活顺序的防御性副本。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return compile 时冻结的激活顺序副本。
+func get_activation_order() -> Array[Object]:
+	return _activation_order.duplicate()
+
+
+## 返回 compile 时保存的严格逆序关闭快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return compile 时冻结的严格逆序关闭顺序副本。
+func get_shutdown_order() -> Array[Object]:
+	return _shutdown_order.duplicate()
+
+
+## 返回本地传递依赖的 identity set。
+## 父架构或其它 external 依赖不会进入结果；未知实例返回空字典。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param instance: 要查询的本地模块实例。
+## [br]
+## @param include_self: 是否把 instance 本身加入结果。
+## [br]
+## @return: 新建的 Object identity set。
+## [br]
+## @schema return: Dictionary keyed by local module Object, storing true.
+func get_dependency_closure(instance: Object, include_self: bool = true) -> Dictionary:
+	var result: Dictionary = {}
+	if instance == null or not _node_id_by_instance.has(instance):
+		return result
+	var pending: Array[Object] = [instance]
+	while not pending.is_empty():
+		var current: Object = pending.pop_back()
+		if current == null or result.has(current):
+			continue
+		result[current] = true
+		var dependencies: Array[Object] = _get_object_array(
+			_local_dependencies_by_instance.get(current, [])
+		)
+		for dependency: Object in dependencies:
+			if dependency != null and not result.has(dependency):
+				pending.append(dependency)
+	if not include_self:
+		var _removed_self: bool = result.erase(instance)
+	return result
+
+
+## 返回有界诊断的深拷贝。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 有界依赖诊断的深层容器副本。
+## [br]
+## @schema return: Array of Dictionary entries describing missing, invalid, ambiguous, stale alias, parent cycle, or local cycle dependency failures.
+func get_diagnostics() -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for diagnostic: Dictionary in _diagnostics:
+		result.append(diagnostic.duplicate(true))
+	return result
+
+
+## 返回诊断是否因数量上限而截断。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 诊断超过容量并被截断时返回 true。
+func were_diagnostics_truncated() -> bool:
+	return _diagnostics_truncated
+
+
+## 返回由父架构或其它 resolver 外部实例满足的声明数量。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 由父架构或其它外部 resolver 满足的声明数量。
+func get_external_dependency_count() -> int:
+	return _external_dependency_count
+
+
+## 返回 compile 时捕获的模块依赖声明快照。
+## 每次读取都会返回新的深层容器副本；Script 与模块 Object 只作为身份引用保留。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 每个本地模块及其四类声明的稳定快照。
+## [br]
+## @schema return: Array of Dictionaries with module_kind, module_script, module_instance, module_key, and dependencies. dependencies contains models, utilities, systems, and factories Array[Script] values.
+func get_dependency_snapshot() -> Array[Dictionary]:
+	return _duplicate_dictionary_array(_dependency_snapshot)
+
+
+## 返回 compile 时捕获的扁平依赖解析记录。
+## invalid plan 同样保留记录，供诊断层渲染具体失败原因。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 防御性复制后的依赖解析记录。
+## [br]
+## @schema return: Array of Dictionaries with module identity, dependency_kind, dependency_script, status, resolved, scope, resolved_instance, architecture_depth, resolution_kind, registered_script, and parent-cycle fields.
+func get_dependency_records() -> Array[Dictionary]:
+	return _duplicate_dictionary_array(_dependency_records)
+
+
+# --- 私有/辅助方法 ---
+
+func _reset() -> void:
+	_valid = false
+	_activation_order.clear()
+	_shutdown_order.clear()
+	_diagnostics.clear()
+	_diagnostics_truncated = false
+	_external_dependency_count = 0
+	_node_id_by_instance.clear()
+	_local_dependencies_by_instance.clear()
+	_dependency_snapshot.clear()
+	_dependency_records.clear()
+
+
+func _collect_registry_nodes(
+	registry: Dictionary,
+	kind: StringName,
+	registry_key: StringName,
+	nodes: Array[Dictionary],
+	node_ids_by_kind: Dictionary
+) -> void:
+	var ordinal: int = 0
+	for script_variant: Variant in registry.keys():
+		if not script_variant is Script:
+			_append_diagnostic(
+				&"invalid_registration_script",
+				kind,
+				"%s[%d]" % [kind, ordinal],
+				&"",
+				"",
+				"Registration key must be a Script."
+			)
+			ordinal += 1
+			continue
+		var script_cls: Script = script_variant
+		var instance: Object = _as_object(registry.get(script_cls))
+		var module_key: String = _make_module_key(kind, script_cls, ordinal)
+		if instance == null or not _is_expected_module_kind(instance, kind):
+			_append_diagnostic(
+				&"invalid_registration_instance",
+				kind,
+				module_key,
+				&"",
+				"",
+				"Registration value does not match its module kind."
+			)
+			ordinal += 1
+			continue
+		if _node_id_by_instance.has(instance):
+			_append_diagnostic(
+				&"duplicate_registration_instance",
+				kind,
+				module_key,
+				&"",
+				"",
+				"The same instance appears in more than one registration entry."
+			)
+			ordinal += 1
+			continue
+
+		var node_id: int = nodes.size()
+		var node: Dictionary = {
+			"id": node_id,
+			"kind": kind,
+			"kind_rank": _get_kind_rank(kind),
+			"registry_key": registry_key,
+			"script": script_cls,
+			"instance": instance,
+			"module_key": module_key,
+			"priority": _get_lifecycle_priority(instance),
+			"ordinal": ordinal,
+			"declarations": _make_dependency_map(),
+			"dependencies": [],
+			"dependents": [],
+		}
+		nodes.append(node)
+		_node_id_by_instance[instance] = node_id
+		_local_dependencies_by_instance[instance] = []
+		var ids_for_kind: Dictionary = _get_dictionary(node_ids_by_kind, registry_key)
+		ids_for_kind[script_cls] = node_id
+		ordinal += 1
+
+
+func _collect_dependency_declarations(
+	nodes: Array[Dictionary],
+	validity_guard: Callable
+) -> bool:
+	for node: Dictionary in nodes:
+		if not _is_compilation_valid(validity_guard):
+			return false
+		var declarations: Dictionary = _make_dependency_map()
+		_capture_dependency_hook(
+			node,
+			declarations,
+			_REGISTRY_MODELS,
+			_HOOK_REQUIRED_MODELS
+		)
+		if not _is_compilation_valid(validity_guard):
+			return false
+		_capture_dependency_hook(
+			node,
+			declarations,
+			_REGISTRY_SYSTEMS,
+			_HOOK_REQUIRED_SYSTEMS
+		)
+		if not _is_compilation_valid(validity_guard):
+			return false
+		_capture_dependency_hook(
+			node,
+			declarations,
+			_REGISTRY_UTILITIES,
+			_HOOK_REQUIRED_UTILITIES
+		)
+		if not _is_compilation_valid(validity_guard):
+			return false
+		_capture_dependency_hook(
+			node,
+			declarations,
+			_REGISTRY_FACTORIES,
+			_HOOK_REQUIRED_FACTORIES
+		)
+		if not _is_compilation_valid(validity_guard):
+			return false
+		node["declarations"] = declarations
+		_dependency_snapshot.append({
+			"module_kind": _registry_key_to_module_kind(
+				_get_node_registry_key(node)
+			),
+			"module_script": _get_node_script(node),
+			"module_instance": _get_node_instance(node),
+			"module_key": _get_node_key(node),
+			"dependencies": _duplicate_dependency_map(declarations),
+		})
+	return true
+
+
+func _capture_dependency_hook(
+	node: Dictionary,
+	declarations: Dictionary,
+	dependency_kind: StringName,
+	hook: StringName
+) -> void:
+	var instance: Object = _get_node_instance(node)
+	if instance == null:
+		return
+	var raw_dependencies: Variant = instance.call(hook)
+	if not raw_dependencies is Array:
+		_append_diagnostic(
+			&"invalid_dependency_hook_return",
+			_get_node_kind(node),
+			_get_node_key(node),
+			dependency_kind,
+			"",
+			"%s() must return an Array of Script values." % hook
+		)
+		return
+
+	var dependencies: Array[Script] = []
+	var seen_scripts: Dictionary = {}
+	var raw_array: Array = raw_dependencies
+	for dependency_variant: Variant in raw_array:
+		if not dependency_variant is Script:
+			_append_diagnostic(
+				&"invalid_dependency_type",
+				_get_node_kind(node),
+				_get_node_key(node),
+				dependency_kind,
+				"",
+				"%s() contains a non-Script dependency." % hook
+			)
+			continue
+		var dependency_script: Script = dependency_variant
+		if seen_scripts.has(dependency_script):
+			continue
+		seen_scripts[dependency_script] = true
+		dependencies.append(dependency_script)
+	declarations[dependency_kind] = dependencies
+
+
+func _collect_dependency_edges(
+	nodes: Array[Dictionary],
+	node_ids_by_kind: Dictionary,
+	resolvers: Dictionary,
+	validity_guard: Callable
+) -> bool:
+	var dependency_kinds: Array[StringName] = [
+		_REGISTRY_MODELS,
+		_REGISTRY_SYSTEMS,
+		_REGISTRY_UTILITIES,
+		_REGISTRY_FACTORIES,
+	]
+	for node: Dictionary in nodes:
+		if not _is_compilation_valid(validity_guard):
+			return false
+		var declarations: Dictionary = _get_dictionary(node, "declarations")
+		for dependency_kind: StringName in dependency_kinds:
+			var dependency_scripts: Array[Script] = _get_script_array(
+				declarations.get(dependency_kind, [])
+			)
+			for dependency_script: Script in dependency_scripts:
+				if not _is_compilation_valid(validity_guard):
+					return false
+				var resolution: Dictionary = _resolve_dependency(
+					dependency_script,
+					dependency_kind,
+					nodes,
+					node_ids_by_kind,
+					resolvers
+				)
+				if not _is_compilation_valid(validity_guard):
+					return false
+				_dependency_records.append(
+					_make_dependency_record(
+						node,
+						dependency_kind,
+						dependency_script,
+						resolution
+					)
+				)
+				var status: StringName = _get_resolution_status(resolution)
+				if status == _STATUS_LOCAL:
+					if dependency_kind != _REGISTRY_FACTORIES:
+						_add_local_edge(
+							nodes,
+							node,
+							_get_resolution_node_id(resolution)
+						)
+					continue
+				if status == _STATUS_EXTERNAL:
+					_external_dependency_count += 1
+					continue
+				_append_resolution_diagnostic(
+					node,
+					dependency_kind,
+					dependency_script,
+					resolution
+				)
+	return true
+
+
+func _is_compilation_valid(validity_guard: Callable) -> bool:
+	if not validity_guard.is_valid():
+		return true
+	return _to_bool(validity_guard.call(), false)
+
+
+func _resolve_dependency(
+	dependency_script: Script,
+	dependency_kind: StringName,
+	nodes: Array[Dictionary],
+	node_ids_by_kind: Dictionary,
+	resolvers: Dictionary
+) -> Dictionary:
+	if resolvers.has(dependency_kind):
+		var resolver_variant: Variant = resolvers.get(dependency_kind)
+		if not resolver_variant is Callable:
+			return _make_invalid_resolution(
+				"Dependency resolver must be a valid Callable."
+			)
+		var resolver: Callable = resolver_variant
+		if not resolver.is_valid():
+			return _make_invalid_resolution(
+				"Dependency resolver Callable is not valid."
+			)
+		return _normalize_dependency_resolution(
+			resolver.call(dependency_script),
+			dependency_kind,
+			nodes
+		)
+
+	if dependency_kind == _REGISTRY_FACTORIES:
+		return _make_resolution(_STATUS_MISSING)
+	var ids_for_kind: Dictionary = _get_dictionary(
+		node_ids_by_kind,
+		dependency_kind
+	)
+	return _resolve_local_dependency(
+		dependency_script,
+		dependency_kind,
+		nodes,
+		ids_for_kind
+	)
+
+
+func _resolve_local_dependency(
+	dependency_script: Script,
+	dependency_kind: StringName,
+	nodes: Array[Dictionary],
+	ids_by_script: Dictionary
+) -> Dictionary:
+	if ids_by_script.has(dependency_script):
+		var exact_id: int = _to_int(
+			ids_by_script.get(dependency_script),
+			-1
+		)
+		return _make_local_resolution(
+			nodes,
+			exact_id,
+			dependency_kind,
+			dependency_script,
+			&"exact"
+		)
+
+	var match_ids: Array[int] = []
+	for registered_variant: Variant in ids_by_script.keys():
+		if not registered_variant is Script:
+			continue
+		var registered_script: Script = registered_variant
+		if _GF_SCRIPT_TYPE_INSPECTOR_SCRIPT.script_extends_or_equals(
+			registered_script,
+			dependency_script
+		):
+			match_ids.append(
+				_to_int(ids_by_script.get(registered_script), -1)
+			)
+	if match_ids.size() > 1:
+		return _make_resolution(
+			_STATUS_AMBIGUOUS,
+			{
+				"reason": "More than one local registration is assignable to the dependency.",
+			}
+		)
+	if match_ids.size() == 1:
+		var match_id: int = match_ids[0]
+		return _make_local_resolution(
+			nodes,
+			match_id,
+			dependency_kind,
+			_get_node_script(nodes[match_id]),
+			&"assignable"
+		)
+	return _make_resolution(_STATUS_MISSING)
+
+
+func _make_local_resolution(
+	nodes: Array[Dictionary],
+	node_id: int,
+	dependency_kind: StringName,
+	registered_script: Script,
+	resolution_kind: StringName
+) -> Dictionary:
+	if node_id < 0 or node_id >= nodes.size():
+		return _make_invalid_resolution(
+			"Local dependency resolver returned an invalid node id."
+		)
+	var resolved_node: Dictionary = nodes[node_id]
+	if _get_node_registry_key(resolved_node) != dependency_kind:
+		return _make_invalid_resolution(
+			"Local dependency resolver returned a module from the wrong registry."
+		)
+	return _make_resolution(
+		_STATUS_LOCAL,
+		{
+			"instance": _get_node_instance(resolved_node),
+			"node_id": node_id,
+			"registered_script": registered_script,
+			"resolution_kind": resolution_kind,
+			"scope": _STATUS_LOCAL,
+		}
+	)
+
+
+func _normalize_dependency_resolution(
+	raw_resolution: Variant,
+	dependency_kind: StringName,
+	nodes: Array[Dictionary]
+) -> Dictionary:
+	if not raw_resolution is Dictionary:
+		return _make_invalid_resolution(
+			"Dependency resolver must return a Dictionary."
+		)
+	var source: Dictionary = raw_resolution
+	var status: StringName = _to_string_name(source.get("status"))
+	if status not in [
+		_STATUS_LOCAL,
+		_STATUS_EXTERNAL,
+		_STATUS_MISSING,
+		_STATUS_STALE_ALIAS,
+		_STATUS_AMBIGUOUS,
+		_STATUS_PARENT_CYCLE,
+	]:
+		return _make_invalid_resolution(
+			"Dependency resolver returned an unknown status."
+		)
+
+	var resolution: Dictionary = _make_resolution(
+		status,
+		{
+			"scope": _to_string_name(
+				source.get("scope"),
+				status
+			),
+			"architecture_depth": _to_int(
+				source.get("architecture_depth"),
+				0
+			),
+			"resolution_kind": _to_string_name(
+				source.get("resolution_kind")
+			),
+			"parent_chain_cycle_detected": _to_bool(
+				source.get("parent_chain_cycle_detected"),
+				status == _STATUS_PARENT_CYCLE
+			),
+			"cycle_architecture": _variant_to_string(
+				source.get("cycle_architecture")
+			),
+			"cycle_depth": _to_int(source.get("cycle_depth"), -1),
+			"cycle_start_depth": _to_int(
+				source.get("cycle_start_depth"),
+				-1
+			),
+			"reason": _variant_to_string(source.get("reason")),
+		}
+	)
+	var registered_script: Script = _as_script(
+		source.get("registered_script")
+	)
+	if registered_script != null:
+		resolution["registered_script"] = registered_script
+	var resolved_instance: Object = _as_object(source.get("instance"))
+	if resolved_instance != null:
+		resolution["instance"] = resolved_instance
+
+	if status == _STATUS_LOCAL:
+		if dependency_kind == _REGISTRY_FACTORIES:
+			return resolution
+		if resolved_instance == null or not _node_id_by_instance.has(
+			resolved_instance
+		):
+			return _make_invalid_resolution(
+				"Local dependency resolution must identify a local module instance."
+			)
+		var node_id: int = _to_int(
+			_node_id_by_instance.get(resolved_instance),
+			-1
+		)
+		if node_id < 0 or node_id >= nodes.size():
+			return _make_invalid_resolution(
+				"Local dependency resolution points outside the plan snapshot."
+			)
+		if _get_node_registry_key(nodes[node_id]) != dependency_kind:
+			return _make_invalid_resolution(
+				"Local dependency resolution returned a module from the wrong registry."
+			)
+		resolution["node_id"] = node_id
+	elif status == _STATUS_EXTERNAL and dependency_kind != _REGISTRY_FACTORIES:
+		if (
+			resolved_instance != null
+			and (
+				_node_id_by_instance.has(resolved_instance)
+				or not _is_expected_dependency_kind(
+					resolved_instance,
+					dependency_kind
+				)
+			)
+		):
+			return _make_invalid_resolution(
+				"External dependency resolution returned an invalid module instance."
+			)
+	return resolution
+
+
+func _make_resolution(
+	status: StringName,
+	fields: Dictionary = {}
+) -> Dictionary:
+	var result: Dictionary = {
+		"status": status,
+		"scope": status,
+		"architecture_depth": 0,
+		"resolution_kind": &"",
+		"parent_chain_cycle_detected": status == _STATUS_PARENT_CYCLE,
+		"cycle_architecture": "",
+		"cycle_depth": -1,
+		"cycle_start_depth": -1,
+		"reason": "",
+	}
+	result.merge(fields, true)
+	return result
+
+
+func _make_invalid_resolution(reason: String) -> Dictionary:
+	return _make_resolution(
+		_STATUS_INVALID,
+		{
+			"scope": _STATUS_INVALID,
+			"reason": reason,
+		}
+	)
+
+
+func _make_dependency_record(
+	node: Dictionary,
+	dependency_kind: StringName,
+	dependency_script: Script,
+	resolution: Dictionary
+) -> Dictionary:
+	var status: StringName = _get_resolution_status(resolution)
+	return {
+		"module_kind": _registry_key_to_module_kind(
+			_get_node_registry_key(node)
+		),
+		"module_script": _get_node_script(node),
+		"module_instance": _get_node_instance(node),
+		"module_key": _get_node_key(node),
+		"dependency_kind": dependency_kind,
+		"dependency_script": dependency_script,
+		"resolved": status == _STATUS_LOCAL or status == _STATUS_EXTERNAL,
+		"status": status,
+		"scope": _to_string_name(resolution.get("scope"), status),
+		"resolved_instance": _as_object(resolution.get("instance")),
+		"architecture_depth": _to_int(
+			resolution.get("architecture_depth"),
+			0
+		),
+		"resolution_kind": _to_string_name(
+			resolution.get("resolution_kind")
+		),
+		"registered_script": _as_script(
+			resolution.get("registered_script")
+		),
+		"parent_chain_cycle_detected": _to_bool(
+			resolution.get("parent_chain_cycle_detected"),
+			status == _STATUS_PARENT_CYCLE
+		),
+		"cycle_architecture": _variant_to_string(
+			resolution.get("cycle_architecture")
+		),
+		"cycle_depth": _to_int(resolution.get("cycle_depth"), -1),
+		"cycle_start_depth": _to_int(
+			resolution.get("cycle_start_depth"),
+			-1
+		),
+		"reason": _variant_to_string(resolution.get("reason")),
+	}
+
+
+func _append_resolution_diagnostic(
+	node: Dictionary,
+	dependency_kind: StringName,
+	dependency_script: Script,
+	resolution: Dictionary
+) -> void:
+	var status: StringName = _get_resolution_status(resolution)
+	var code: StringName = &"missing_dependency"
+	var message: String = "Declared dependency could not be resolved."
+	match status:
+		_STATUS_STALE_ALIAS:
+			code = &"stale_alias_dependency"
+			message = "Declared dependency is blocked by a stale local alias."
+		_STATUS_AMBIGUOUS:
+			code = &"ambiguous_dependency"
+			message = "Declared dependency matches more than one local registration."
+		_STATUS_PARENT_CYCLE:
+			code = &"parent_dependency_cycle"
+			message = "Declared dependency resolution encountered a parent cycle."
+		_STATUS_INVALID:
+			code = &"invalid_dependency_resolution"
+			message = "Declared dependency resolver returned an invalid result."
+	_append_diagnostic(
+		code,
+		_get_node_kind(node),
+		_get_node_key(node),
+		dependency_kind,
+		_get_script_key(dependency_script),
+		message,
+		{
+			"resolution_status": status,
+			"reason": _variant_to_string(resolution.get("reason")),
+			"architecture_depth": _to_int(
+				resolution.get("architecture_depth"),
+				0
+			),
+			"parent_chain_cycle_detected": _to_bool(
+				resolution.get("parent_chain_cycle_detected"),
+				false
+			),
+			"cycle_architecture": _variant_to_string(
+				resolution.get("cycle_architecture")
+			),
+			"cycle_depth": _to_int(
+				resolution.get("cycle_depth"),
+				-1
+			),
+			"cycle_start_depth": _to_int(
+				resolution.get("cycle_start_depth"),
+				-1
+			),
+		}
+	)
+
+
+func _get_resolution_status(resolution: Dictionary) -> StringName:
+	return _to_string_name(resolution.get("status"), _STATUS_INVALID)
+
+
+func _get_resolution_node_id(resolution: Dictionary) -> int:
+	return _to_int(resolution.get("node_id"), -1)
+
+
+func _add_local_edge(nodes: Array[Dictionary], node: Dictionary, dependency_id: int) -> void:
+	if dependency_id < 0 or dependency_id >= nodes.size():
+		return
+	var dependencies: Array[int] = _get_int_array(node.get("dependencies", []))
+	if dependencies.has(dependency_id):
+		return
+	dependencies.append(dependency_id)
+	node["dependencies"] = dependencies
+	var dependent_id: int = _to_int(node.get("id"), -1)
+	var dependency_node: Dictionary = nodes[dependency_id]
+	var dependents: Array[int] = _get_int_array(dependency_node.get("dependents", []))
+	dependents.append(dependent_id)
+	dependency_node["dependents"] = dependents
+	var instance: Object = _get_node_instance(node)
+	var dependency_instance: Object = _get_node_instance(dependency_node)
+	var local_dependencies: Array[Object] = _get_object_array(
+		_local_dependencies_by_instance.get(instance, [])
+	)
+	local_dependencies.append(dependency_instance)
+	_local_dependencies_by_instance[instance] = local_dependencies
+
+
+func _build_kahn_order(nodes: Array[Dictionary]) -> Array[int]:
+	var indegrees: Array[int] = []
+	var ready: Array[int] = []
+	for node_id: int in range(nodes.size()):
+		var dependencies: Array[int] = _get_int_array(nodes[node_id].get("dependencies", []))
+		indegrees.append(dependencies.size())
+		if dependencies.is_empty():
+			ready.append(node_id)
+
+	var result: Array[int] = []
+	while not ready.is_empty():
+		ready.sort_custom(func(left_id: int, right_id: int) -> bool:
+			return _node_precedes(nodes[left_id], nodes[right_id])
+		)
+		var current_id: int = ready.pop_front()
+		result.append(current_id)
+		var dependents: Array[int] = _get_int_array(nodes[current_id].get("dependents", []))
+		for dependent_id: int in dependents:
+			indegrees[dependent_id] -= 1
+			if indegrees[dependent_id] == 0:
+				ready.append(dependent_id)
+	return result
+
+
+func _node_precedes(left: Dictionary, right: Dictionary) -> bool:
+	var left_kind_rank: int = _to_int(left.get("kind_rank"))
+	var right_kind_rank: int = _to_int(right.get("kind_rank"))
+	if left_kind_rank != right_kind_rank:
+		return left_kind_rank < right_kind_rank
+	var left_priority: int = _to_int(left.get("priority"))
+	var right_priority: int = _to_int(right.get("priority"))
+	if left_priority != right_priority:
+		return left_priority > right_priority
+	var left_ordinal: int = _to_int(left.get("ordinal"))
+	var right_ordinal: int = _to_int(right.get("ordinal"))
+	if left_ordinal != right_ordinal:
+		return left_ordinal < right_ordinal
+	return _get_node_key(left) < _get_node_key(right)
+
+
+func _append_cycle_diagnostics(nodes: Array[Dictionary], ordered_node_ids: Array[int]) -> void:
+	var remaining: Dictionary = {}
+	for node_id: int in range(nodes.size()):
+		remaining[node_id] = true
+	for node_id: int in ordered_node_ids:
+		var _removed_ordered: bool = remaining.erase(node_id)
+	var remaining_ids: Array[int] = []
+	for node_id_variant: Variant in remaining.keys():
+		if node_id_variant is int:
+			var remaining_node_id: int = node_id_variant
+			remaining_ids.append(remaining_node_id)
+	remaining_ids.sort_custom(func(left_id: int, right_id: int) -> bool:
+		return _node_precedes(nodes[left_id], nodes[right_id])
+	)
+
+	var assigned: Dictionary = {}
+	for seed_id: int in remaining_ids:
+		if assigned.has(seed_id):
+			continue
+		var component: Array[int] = []
+		for candidate_id: int in remaining_ids:
+			if assigned.has(candidate_id):
+				continue
+			if (
+				_is_reachable(seed_id, candidate_id, nodes, remaining)
+				and _is_reachable(candidate_id, seed_id, nodes, remaining)
+			):
+				component.append(candidate_id)
+		var is_self_cycle: bool = (
+			component.size() == 1
+			and _get_int_array(nodes[seed_id].get("dependencies", [])).has(seed_id)
+		)
+		if component.size() <= 1 and not is_self_cycle:
+			continue
+		component.sort_custom(func(left_id: int, right_id: int) -> bool:
+			return _node_precedes(nodes[left_id], nodes[right_id])
+		)
+		for component_id: int in component:
+			assigned[component_id] = true
+		var cycle_members: Array[String] = []
+		var member_limit: int = mini(component.size(), _MAX_CYCLE_MEMBERS_PER_DIAGNOSTIC)
+		for member_index: int in range(member_limit):
+			cycle_members.append(_get_node_key(nodes[component[member_index]]))
+		var seed_node: Dictionary = nodes[component[0]]
+		_append_diagnostic(
+			&"dependency_cycle",
+			_get_node_kind(seed_node),
+			_get_node_key(seed_node),
+			&"",
+			"",
+			"Local lifecycle dependency cycle detected.",
+			{
+				"cycle_members": cycle_members,
+				"cycle_member_count": component.size(),
+				"cycle_members_truncated": component.size() > member_limit,
+			}
+		)
+
+
+func _is_reachable(
+	from_id: int,
+	target_id: int,
+	nodes: Array[Dictionary],
+	allowed_ids: Dictionary
+) -> bool:
+	if from_id == target_id:
+		return true
+	var visited: Dictionary = {from_id: true}
+	var pending: Array[int] = [from_id]
+	while not pending.is_empty():
+		var current_id: int = pending.pop_back()
+		var dependencies: Array[int] = _get_int_array(nodes[current_id].get("dependencies", []))
+		for dependency_id: int in dependencies:
+			if not allowed_ids.has(dependency_id) or visited.has(dependency_id):
+				continue
+			if dependency_id == target_id:
+				return true
+			visited[dependency_id] = true
+			pending.append(dependency_id)
+	return false
+
+
+func _append_diagnostic(
+	code: StringName,
+	module_kind: StringName,
+	module_key: String,
+	dependency_kind: StringName,
+	dependency_key: String,
+	message: String,
+	details: Dictionary = {}
+) -> void:
+	if _diagnostics.size() >= _DIAGNOSTIC_LIMIT:
+		_diagnostics_truncated = true
+		return
+	var diagnostic: Dictionary = {
+		"code": code,
+		"severity": &"error",
+		"module_kind": module_kind,
+		"module_key": module_key,
+		"dependency_kind": dependency_kind,
+		"dependency_key": dependency_key,
+		"message": message,
+	}
+	diagnostic.merge(details, true)
+	_diagnostics.append(diagnostic)
+
+
+func _is_expected_module_kind(instance: Object, kind: StringName) -> bool:
+	match kind:
+		_KIND_MODEL:
+			return instance is GFModel
+		_KIND_UTILITY:
+			return instance is GFUtility
+		_KIND_SYSTEM:
+			return instance is GFSystem
+		_:
+			return false
+
+
+func _is_expected_dependency_kind(
+	instance: Object,
+	dependency_kind: StringName
+) -> bool:
+	match dependency_kind:
+		_REGISTRY_MODELS:
+			return instance is GFModel
+		_REGISTRY_UTILITIES:
+			return instance is GFUtility
+		_REGISTRY_SYSTEMS:
+			return instance is GFSystem
+		_:
+			return false
+
+
+func _get_kind_rank(kind: StringName) -> int:
+	match kind:
+		_KIND_MODEL:
+			return 0
+		_KIND_UTILITY:
+			return 1
+		_KIND_SYSTEM:
+			return 2
+		_:
+			return 3
+
+
+func _get_lifecycle_priority(instance: Object) -> int:
+	if instance is GFModel:
+		var model: GFModel = instance
+		return model.lifecycle_priority
+	if instance is GFUtility:
+		var utility: GFUtility = instance
+		return utility.lifecycle_priority
+	if instance is GFSystem:
+		var system: GFSystem = instance
+		return system.lifecycle_priority
+	return 0
+
+
+func _make_module_key(kind: StringName, script_cls: Script, ordinal: int) -> String:
+	return "%s[%d]:%s" % [kind, ordinal, _get_script_key(script_cls)]
+
+
+func _get_script_key(script_cls: Script) -> String:
+	if script_cls == null:
+		return "<null>"
+	var global_name: StringName = script_cls.get_global_name()
+	if not global_name.is_empty():
+		return String(global_name)
+	if not script_cls.resource_path.is_empty():
+		return script_cls.resource_path
+	return "<anonymous>"
+
+
+func _get_node_instance(node: Dictionary) -> Object:
+	return _as_object(node.get("instance"))
+
+
+func _get_node_kind(node: Dictionary) -> StringName:
+	return _to_string_name(node.get("kind"))
+
+
+func _get_node_registry_key(node: Dictionary) -> StringName:
+	return _to_string_name(node.get("registry_key"))
+
+
+func _get_node_script(node: Dictionary) -> Script:
+	return _as_script(node.get("script"))
+
+
+func _get_node_key(node: Dictionary) -> String:
+	return _variant_to_string(node.get("module_key"))
+
+
+func _registry_key_to_module_kind(registry_key: StringName) -> StringName:
+	match registry_key:
+		_REGISTRY_MODELS:
+			return &"model"
+		_REGISTRY_UTILITIES:
+			return &"utility"
+		_REGISTRY_SYSTEMS:
+			return &"system"
+		_:
+			return &""
+
+
+func _make_dependency_map() -> Dictionary:
+	return {
+		_REGISTRY_MODELS: [],
+		_REGISTRY_SYSTEMS: [],
+		_REGISTRY_UTILITIES: [],
+		_REGISTRY_FACTORIES: [],
+	}
+
+
+func _duplicate_dependency_map(source: Dictionary) -> Dictionary:
+	return {
+		_REGISTRY_MODELS: _get_script_array(
+			source.get(_REGISTRY_MODELS, [])
+		),
+		_REGISTRY_SYSTEMS: _get_script_array(
+			source.get(_REGISTRY_SYSTEMS, [])
+		),
+		_REGISTRY_UTILITIES: _get_script_array(
+			source.get(_REGISTRY_UTILITIES, [])
+		),
+		_REGISTRY_FACTORIES: _get_script_array(
+			source.get(_REGISTRY_FACTORIES, [])
+		),
+	}
+
+
+func _duplicate_dictionary_array(
+	source: Array[Dictionary]
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for entry: Dictionary in source:
+		result.append(entry.duplicate(true))
+	return result
+
+
+func _as_object(value: Variant) -> Object:
+	if value is Object:
+		var object_value: Object = value
+		return object_value
+	return null
+
+
+func _as_script(value: Variant) -> Script:
+	if value is Script:
+		var script_value: Script = value
+		return script_value
+	return null
+
+
+func _to_string_name(
+	value: Variant,
+	default_value: StringName = &""
+) -> StringName:
+	if value is StringName:
+		var string_name_value: StringName = value
+		return string_name_value
+	if value is String:
+		var string_value: String = value
+		return StringName(string_value)
+	return default_value
+
+
+func _variant_to_string(
+	value: Variant,
+	default_value: String = ""
+) -> String:
+	if value is String:
+		var string_value: String = value
+		return string_value
+	if value is StringName:
+		var string_name_value: StringName = value
+		return String(string_name_value)
+	return default_value
+
+
+func _to_int(value: Variant, default_value: int = 0) -> int:
+	if value is int:
+		var int_value: int = value
+		return int_value
+	return default_value
+
+
+func _to_bool(value: Variant, default_value: bool = false) -> bool:
+	if value is bool:
+		var bool_value: bool = value
+		return bool_value
+	return default_value
+
+
+func _get_dictionary(source: Dictionary, key: Variant) -> Dictionary:
+	var value: Variant = source.get(key, {})
+	if value is Dictionary:
+		var dictionary_value: Dictionary = value
+		return dictionary_value
+	return {}
+
+
+func _get_int_array(value: Variant) -> Array[int]:
+	var result: Array[int] = []
+	if not value is Array:
+		return result
+	var source: Array = value
+	for item: Variant in source:
+		if item is int:
+			result.append(item)
+	return result
+
+
+func _get_object_array(value: Variant) -> Array[Object]:
+	var result: Array[Object] = []
+	if not value is Array:
+		return result
+	var source: Array = value
+	for item: Variant in source:
+		var object_value: Object = _as_object(item)
+		if object_value != null:
+			result.append(object_value)
+	return result
+
+
+func _get_script_array(value: Variant) -> Array[Script]:
+	var result: Array[Script] = []
+	if not value is Array:
+		return result
+	var source: Array = value
+	for item: Variant in source:
+		if item is Script:
+			var script_value: Script = item
+			result.append(script_value)
+	return result

--- a/addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd.uid
+++ b/addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://c3gflifecycleplan

--- a/addons/gf/kernel/core/gf_architecture_shutdown_result.gd
+++ b/addons/gf/kernel/core/gf_architecture_shutdown_result.gd
@@ -1,0 +1,644 @@
+## GFArchitectureShutdownResult: 架构关闭流程的不可变终态快照。
+##
+## 结果显式区分正常完成、失败、取消、超时、强制释放和重复释放，并以有界、
+## JSON-safe 的模块条目保留关闭证据。所有集合在写入和读取边界都会重新复制，
+## 调用方不能借由返回值修改已提交终态。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+## [br]
+## @layer kernel/core
+class_name GFArchitectureShutdownResult
+extends RefCounted
+
+
+# --- 枚举 ---
+
+## 架构关闭终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum Status {
+	## 所有关闭阶段正常完成。
+	SUCCEEDED,
+	## 至少一个关闭阶段失败。
+	FAILED,
+	## 调用方取消了关闭流程。
+	CANCELLED,
+	## 关闭流程超过了时间预算。
+	TIMED_OUT,
+	## 框架跳过未完成的静默工作并执行了强制释放。
+	FORCED,
+	## 架构在本次请求前已经释放。
+	ALREADY_DISPOSED,
+}
+
+
+# --- 常量 ---
+
+const _MAX_MODULE_ENTRIES: int = 256
+const _MAX_IDENTIFIER_LENGTH: int = 128
+const _MAX_SCRIPT_LENGTH: int = 512
+const _MAX_REASON_LENGTH: int = 1024
+const _MAX_ERROR_LENGTH: int = 2048
+
+
+# --- 私有变量 ---
+
+var _status: Status = Status.FAILED
+var _started_at_msec: int = 0
+var _completed_at_msec: int = 0
+var _module_results: Array[Dictionary] = []
+var _unfinished_modules: Array[Dictionary] = []
+var _duplicate_request_count: int = 0
+var _error_code: Error = FAILED
+var _error: String = ""
+var _cancel_reason: String = ""
+
+
+# --- 公共方法 ---
+
+## 创建一个规范化的架构关闭结果。
+##
+## 模块条目最多各保留 256 项，并且只保留 kind、script、instance_id、status、
+## reason 和 duration_msec 字段。字符串和非负 duration 会被限制到固定预算；
+## instance_id 保留 Godot 返回的有符号 int 身份值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param status: `Status` 终态。
+## [br]
+## @param started_at_msec: 单调开始时间；负值归零。
+## [br]
+## @param completed_at_msec: 单调完成时间；早于开始时间时收敛到开始时间。
+## [br]
+## @param module_results: 已进入终态的模块关闭结果。
+## [br]
+## @param unfinished_modules: 强制释放时仍未完成的模块快照。
+## [br]
+## @param duplicate_request_count: 复用同一关闭流程的并发重复请求数量。
+## [br]
+## @param error_code: 关闭错误码；成功终态强制归一为 OK。
+## [br]
+## @param error: 稳定失败说明；最多保留 2048 个字符。
+## [br]
+## @param cancel_reason: 取消原因；仅取消终态保留，最多 1024 个字符。
+## [br]
+## @return 新的不可变结果。
+## [br]
+## @schema module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+## [br]
+## @schema unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+static func create(
+	status: Status,
+	started_at_msec: int,
+	completed_at_msec: int,
+	module_results: Array[Dictionary] = [],
+	unfinished_modules: Array[Dictionary] = [],
+	duplicate_request_count: int = 0,
+	error_code: Error = OK,
+	error: String = "",
+	cancel_reason: String = ""
+) -> GFArchitectureShutdownResult:
+	var result: GFArchitectureShutdownResult = GFArchitectureShutdownResult.new()
+	result._status = _normalize_status(status)
+	result._started_at_msec = maxi(started_at_msec, 0)
+	result._completed_at_msec = maxi(completed_at_msec, result._started_at_msec)
+	result._module_results = _normalize_module_entries(module_results)
+	result._unfinished_modules = _normalize_module_entries(unfinished_modules)
+	result._duplicate_request_count = maxi(duplicate_request_count, 0)
+	result._error_code = (
+		OK
+		if result.is_successful()
+		else error_code
+	)
+	result._error = error.left(_MAX_ERROR_LENGTH)
+	result._cancel_reason = (
+		cancel_reason.left(_MAX_REASON_LENGTH)
+		if result._status == Status.CANCELLED and not cancel_reason.is_empty()
+		else ("cancelled" if result._status == Status.CANCELLED else "")
+	)
+	return result
+
+
+## 创建正常完成结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param module_results: 已完成的模块关闭结果。
+## [br]
+## @param started_at_msec: 单调开始时间。
+## [br]
+## @param completed_at_msec: 单调完成时间。
+## [br]
+## @param duplicate_request_count: 并发重复请求数量。
+## [br]
+## @return 新的成功结果。
+## [br]
+## @schema module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+static func succeeded(
+	module_results: Array[Dictionary] = [],
+	started_at_msec: int = 0,
+	completed_at_msec: int = 0,
+	duplicate_request_count: int = 0
+) -> GFArchitectureShutdownResult:
+	return create(
+		Status.SUCCEEDED,
+		started_at_msec,
+		completed_at_msec,
+		module_results,
+		[],
+		duplicate_request_count
+	)
+
+
+## 创建失败结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param error_code: 关闭错误码。
+## [br]
+## @param error: 稳定失败说明。
+## [br]
+## @param module_results: 已完成的模块关闭结果。
+## [br]
+## @param unfinished_modules: 尚未完成的模块快照。
+## [br]
+## @param started_at_msec: 单调开始时间。
+## [br]
+## @param completed_at_msec: 单调完成时间。
+## [br]
+## @param duplicate_request_count: 并发重复请求数量。
+## [br]
+## @return 新的失败结果。
+## [br]
+## @schema module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+## [br]
+## @schema unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+static func failed(
+	error_code: Error,
+	error: String,
+	module_results: Array[Dictionary] = [],
+	unfinished_modules: Array[Dictionary] = [],
+	started_at_msec: int = 0,
+	completed_at_msec: int = 0,
+	duplicate_request_count: int = 0
+) -> GFArchitectureShutdownResult:
+	return create(
+		Status.FAILED,
+		started_at_msec,
+		completed_at_msec,
+		module_results,
+		unfinished_modules,
+		duplicate_request_count,
+		error_code,
+		error
+	)
+
+
+## 创建取消结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param reason: 稳定取消原因。
+## [br]
+## @param module_results: 已完成的模块关闭结果。
+## [br]
+## @param unfinished_modules: 尚未完成的模块快照。
+## [br]
+## @param started_at_msec: 单调开始时间。
+## [br]
+## @param completed_at_msec: 单调完成时间。
+## [br]
+## @param duplicate_request_count: 并发重复请求数量。
+## [br]
+## @return 新的取消结果。
+## [br]
+## @schema module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+## [br]
+## @schema unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+static func cancelled(
+	reason: String = "cancelled",
+	module_results: Array[Dictionary] = [],
+	unfinished_modules: Array[Dictionary] = [],
+	started_at_msec: int = 0,
+	completed_at_msec: int = 0,
+	duplicate_request_count: int = 0
+) -> GFArchitectureShutdownResult:
+	return create(
+		Status.CANCELLED,
+		started_at_msec,
+		completed_at_msec,
+		module_results,
+		unfinished_modules,
+		duplicate_request_count,
+		ERR_SKIP,
+		"",
+		reason
+	)
+
+
+## 创建超时结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param error: 稳定超时说明。
+## [br]
+## @param module_results: 已完成的模块关闭结果。
+## [br]
+## @param unfinished_modules: 超时时尚未完成的模块快照。
+## [br]
+## @param started_at_msec: 单调开始时间。
+## [br]
+## @param completed_at_msec: 单调完成时间。
+## [br]
+## @param duplicate_request_count: 并发重复请求数量。
+## [br]
+## @return 新的超时结果。
+## [br]
+## @schema module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+## [br]
+## @schema unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+static func timed_out(
+	error: String,
+	module_results: Array[Dictionary] = [],
+	unfinished_modules: Array[Dictionary] = [],
+	started_at_msec: int = 0,
+	completed_at_msec: int = 0,
+	duplicate_request_count: int = 0
+) -> GFArchitectureShutdownResult:
+	return create(
+		Status.TIMED_OUT,
+		started_at_msec,
+		completed_at_msec,
+		module_results,
+		unfinished_modules,
+		duplicate_request_count,
+		ERR_TIMEOUT,
+		error
+	)
+
+
+## 创建强制释放结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param error: 强制释放原因。
+## [br]
+## @param module_results: 已完成的模块关闭结果。
+## [br]
+## @param unfinished_modules: 被强制跳过的模块快照。
+## [br]
+## @param started_at_msec: 单调开始时间。
+## [br]
+## @param completed_at_msec: 单调完成时间。
+## [br]
+## @param duplicate_request_count: 并发重复请求数量。
+## [br]
+## @return 新的强制释放结果。
+## [br]
+## @schema module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+## [br]
+## @schema unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+static func forced(
+	error: String,
+	module_results: Array[Dictionary] = [],
+	unfinished_modules: Array[Dictionary] = [],
+	started_at_msec: int = 0,
+	completed_at_msec: int = 0,
+	duplicate_request_count: int = 0
+) -> GFArchitectureShutdownResult:
+	return create(
+		Status.FORCED,
+		started_at_msec,
+		completed_at_msec,
+		module_results,
+		unfinished_modules,
+		duplicate_request_count,
+		FAILED,
+		error
+	)
+
+
+## 创建已释放幂等结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param started_at_msec: 单调开始时间。
+## [br]
+## @param completed_at_msec: 单调完成时间。
+## [br]
+## @param duplicate_request_count: 并发重复请求数量。
+## [br]
+## @return 新的已释放结果。
+static func already_disposed(
+	started_at_msec: int = 0,
+	completed_at_msec: int = 0,
+	duplicate_request_count: int = 0
+) -> GFArchitectureShutdownResult:
+	return create(
+		Status.ALREADY_DISPOSED,
+		started_at_msec,
+		completed_at_msec,
+		[],
+		[],
+		duplicate_request_count
+	)
+
+
+## 检查关闭是否以正常或幂等成功结束。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正常完成或此前已释放时返回 true。
+func is_successful() -> bool:
+	return _status == Status.SUCCEEDED or _status == Status.ALREADY_DISPOSED
+
+
+## 获取关闭终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `Status` 终态。
+func get_status() -> Status:
+	return _status
+
+
+## 获取关闭终态名称。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 小写稳定状态名称。
+func get_status_name() -> StringName:
+	return _status_name(_status)
+
+
+## 获取关闭开始时间。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非负单调毫秒时间。
+func get_started_at_msec() -> int:
+	return _started_at_msec
+
+
+## 获取关闭完成时间。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 不早于开始时间的单调毫秒时间。
+func get_completed_at_msec() -> int:
+	return _completed_at_msec
+
+
+## 获取关闭耗时。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非负单调毫秒耗时。
+func get_duration_msec() -> int:
+	return maxi(_completed_at_msec - _started_at_msec, 0)
+
+
+## 获取已完成模块结果的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 最多 256 个规范化模块条目。
+## [br]
+## @schema return: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+func get_module_results() -> Array[Dictionary]:
+	return _duplicate_module_entries(_module_results)
+
+
+## 获取未完成模块快照的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 最多 256 个规范化模块条目。
+## [br]
+## @schema return: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+func get_unfinished_modules() -> Array[Dictionary]:
+	return _duplicate_module_entries(_unfinished_modules)
+
+
+## 获取复用同一关闭流程的重复请求数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非负重复请求数量。
+func get_duplicate_request_count() -> int:
+	return _duplicate_request_count
+
+
+## 获取关闭错误码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功终态为 OK。
+func get_error_code() -> Error:
+	return _error_code
+
+
+## 获取稳定失败说明。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 最多 2048 个字符的失败说明。
+func get_error() -> String:
+	return _error
+
+
+## 获取取消原因。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 最多 1024 个字符的取消原因；非取消终态为空。
+func get_cancel_reason() -> String:
+	return _cancel_reason
+
+
+## 创建隔离结果副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新的不可变结果对象。
+func duplicate_result() -> GFArchitectureShutdownResult:
+	return create(
+		_status,
+		_started_at_msec,
+		_completed_at_msec,
+		_module_results,
+		_unfinished_modules,
+		_duplicate_request_count,
+		_error_code,
+		_error,
+		_cancel_reason
+	)
+
+
+## 转换为可报告字典。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 关闭终态、时间、模块结果和错误证据的隔离快照。
+## [br]
+## @schema return: Dictionary with ok, status, status_name, started_at_msec, completed_at_msec, duration_msec, module_results, unfinished_modules, duplicate_request_count, error_code, error, and cancel_reason.
+func to_dict() -> Dictionary:
+	return {
+		"ok": is_successful(),
+		"status": _status,
+		"status_name": _status_name(_status),
+		"started_at_msec": _started_at_msec,
+		"completed_at_msec": _completed_at_msec,
+		"duration_msec": get_duration_msec(),
+		"module_results": _duplicate_module_entries(_module_results),
+		"unfinished_modules": _duplicate_module_entries(_unfinished_modules),
+		"duplicate_request_count": _duplicate_request_count,
+		"error_code": int(_error_code),
+		"error": _error,
+		"cancel_reason": _cancel_reason,
+	}
+
+
+# --- 私有/辅助方法 ---
+
+static func _normalize_status(status: Status) -> Status:
+	if status in [
+		Status.SUCCEEDED,
+		Status.FAILED,
+		Status.CANCELLED,
+		Status.TIMED_OUT,
+		Status.FORCED,
+		Status.ALREADY_DISPOSED,
+	]:
+		return status
+	return Status.FAILED
+
+
+static func _status_name(status: Status) -> StringName:
+	match status:
+		Status.SUCCEEDED:
+			return &"succeeded"
+		Status.FAILED:
+			return &"failed"
+		Status.CANCELLED:
+			return &"cancelled"
+		Status.TIMED_OUT:
+			return &"timed_out"
+		Status.FORCED:
+			return &"forced"
+		Status.ALREADY_DISPOSED:
+			return &"already_disposed"
+		_:
+			return &"failed"
+
+
+static func _normalize_module_entries(entries: Array[Dictionary]) -> Array[Dictionary]:
+	var normalized_entries: Array[Dictionary] = []
+	var entry_count: int = mini(entries.size(), _MAX_MODULE_ENTRIES)
+	var _resize_error: Error = normalized_entries.resize(entry_count) as Error
+	for index: int in range(entry_count):
+		var entry: Dictionary = entries[index]
+		var normalized_entry: Dictionary = {
+			"kind": _get_bounded_string_name(entry, "kind", _MAX_IDENTIFIER_LENGTH),
+			"script": _get_bounded_string(entry, "script", _MAX_SCRIPT_LENGTH),
+			"instance_id": _get_int(entry, "instance_id"),
+			"status": _get_bounded_string_name(entry, "status", _MAX_IDENTIFIER_LENGTH),
+			"reason": _get_bounded_string(entry, "reason", _MAX_REASON_LENGTH),
+			"duration_msec": _get_non_negative_int(entry, "duration_msec"),
+		}
+		normalized_entries[index] = normalized_entry
+	return normalized_entries
+
+
+static func _duplicate_module_entries(entries: Array[Dictionary]) -> Array[Dictionary]:
+	var duplicated_entries: Array[Dictionary] = []
+	var _resize_error: Error = duplicated_entries.resize(entries.size()) as Error
+	for index: int in range(entries.size()):
+		duplicated_entries[index] = entries[index].duplicate(true)
+	return duplicated_entries
+
+
+static func _get_bounded_string(
+	entry: Dictionary,
+	key: String,
+	max_length: int
+) -> String:
+	var value: Variant = entry.get(key)
+	if value is String:
+		var text: String = value
+		return text.left(max_length)
+	if value is StringName:
+		var text_name: StringName = value
+		return String(text_name).left(max_length)
+	return ""
+
+
+static func _get_bounded_string_name(
+	entry: Dictionary,
+	key: String,
+	max_length: int
+) -> StringName:
+	return StringName(_get_bounded_string(entry, key, max_length))
+
+
+static func _get_non_negative_int(entry: Dictionary, key: String) -> int:
+	var value: Variant = entry.get(key)
+	if value is int:
+		var int_value: int = value
+		return maxi(int_value, 0)
+	return 0
+
+
+static func _get_int(entry: Dictionary, key: String) -> int:
+	var value: Variant = entry.get(key)
+	if value is int:
+		return value
+	return 0

--- a/addons/gf/kernel/core/gf_architecture_shutdown_result.gd.uid
+++ b/addons/gf/kernel/core/gf_architecture_shutdown_result.gd.uid
@@ -1,0 +1,1 @@
+uid://ben2r7rjt4emq

--- a/addons/gf/kernel/core/gf_architecture_tick_scheduler.gd
+++ b/addons/gf/kernel/core/gf_architecture_tick_scheduler.gd
@@ -2,6 +2,7 @@
 ##
 ## 持有 tick 缓存记录、模块参与判断、排序和时间策略调用，避免
 ## GFArchitecture 同时承担注册表门面与每帧调度细节。
+## 同一缓存也为生命周期事务提供显式实例集合限定的普通 tick 推进。
 ## [br]
 ## @api framework_internal
 ## [br]
@@ -18,6 +19,9 @@ extends RefCounted
 
 const _GF_ARCHITECTURE_TICK_RECORD_SCRIPT = preload("res://addons/gf/kernel/core/gf_architecture_tick_record.gd")
 const _GF_VARIANT_ACCESS_SCRIPT = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
+const _LIFECYCLE_STAGE_READY: int = 3
+const _LIFECYCLE_STAGE_ACTIVE: int = 4
+const _MAX_LIFECYCLE_TICK_DELTA_SECONDS: float = 0.1
 
 
 # --- 私有变量 ---
@@ -31,6 +35,7 @@ var _tick_utilities: Array[GFArchitectureTickRecord] = []
 var _physics_utilities: Array[GFArchitectureTickRecord] = []
 var _tick_records: Array[GFArchitectureTickRecord] = []
 var _physics_records: Array[GFArchitectureTickRecord] = []
+var _lifecycle_candidate_records: Dictionary = {}
 var _drive_depth: int = 0
 var _tick_caches_dirty: bool = false
 
@@ -98,6 +103,74 @@ func drive_tick(delta: float, time_provider: Object) -> void:
 	var time_paused: bool = _is_time_paused(time_provider)
 	_drive_records(_tick_records, delta, scaled_delta, time_paused)
 	_end_drive()
+
+
+## 在架构生命周期事务内推进显式允许模块的普通 tick。
+## 该入口只复用当前 tick 缓存，不扩张允许集合，也不调用 physics_tick。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param delta: 调用方基于单调时钟计算的帧间隔；会收束到 0.0 至 0.1 秒。
+## [br]
+## @param allowed_instances: 当前生命周期事务允许推进的本地模块实例集合。
+## [br]
+## @schema allowed_instances: Dictionary keyed by local module Object instances; values are ignored, and only cached GFSystem or GFUtility tick records are eligible.
+func drive_lifecycle_tick(delta: float, allowed_instances: Dictionary) -> void:
+	if not _begin_drive():
+		return
+	if allowed_instances.is_empty():
+		_end_drive()
+		return
+	var lifecycle_delta: float = _normalize_lifecycle_delta(delta)
+	_drive_lifecycle_records(_tick_records, lifecycle_delta, allowed_instances)
+	_drive_lifecycle_candidate_records(lifecycle_delta, allowed_instances)
+	_end_drive()
+
+
+## 临时登记尚未提交到注册表的生命周期候选模块。
+## 候选只会被 drive_lifecycle_tick() 驱动，不会进入普通 tick/physics_tick。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param instance: 已完成 ready、等待 activation 提交的 System 或 Utility。
+## [br]
+## @return 成功登记或无需重复登记时返回 true。
+func add_lifecycle_candidate(instance: Object) -> bool:
+	if instance == null:
+		return false
+	if _lifecycle_candidate_records.has(instance):
+		return true
+	for record: GFArchitectureTickRecord in _tick_records:
+		if record != null and record.module == instance:
+			return true
+	var candidate_record: GFArchitectureTickRecord = _make_tick_record(
+		instance,
+		&"tick",
+		&"tick_enabled",
+		&"tick_priority",
+		_tick_records.size() + _lifecycle_candidate_records.size()
+	)
+	if candidate_record == null:
+		return true
+	_lifecycle_candidate_records[instance] = candidate_record
+	return true
+
+
+## 移除未提交生命周期候选的临时 tick 记录。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param instance: 要移除临时 tick 记录的未提交模块实例。
+func remove_lifecycle_candidate(instance: Object) -> void:
+	if instance == null:
+		return
+	var _removed_candidate: bool = _lifecycle_candidate_records.erase(instance)
 
 
 ## 驱动所有参与 physics_tick 的 System 与 Utility。
@@ -190,6 +263,28 @@ func _drive_records(
 	for record: GFArchitectureTickRecord in records:
 		if _is_tick_record_ready_for_tick(record):
 			record.invoke(raw_delta, scaled_delta, time_paused)
+
+
+func _drive_lifecycle_records(
+	records: Array[GFArchitectureTickRecord],
+	delta: float,
+	allowed_instances: Dictionary
+) -> void:
+	for record: GFArchitectureTickRecord in records:
+		if _is_tick_record_ready_for_lifecycle_tick(record, allowed_instances):
+			record.invoke(delta, delta, false)
+
+
+func _drive_lifecycle_candidate_records(
+	delta: float,
+	allowed_instances: Dictionary
+) -> void:
+	for record_value: Variant in _lifecycle_candidate_records.values():
+		if not record_value is GFArchitectureTickRecord:
+			continue
+		var record: GFArchitectureTickRecord = record_value
+		if _is_tick_record_ready_for_lifecycle_tick(record, allowed_instances):
+			record.invoke(delta, delta, false)
 
 
 func _begin_drive() -> bool:
@@ -305,11 +400,38 @@ func _sort_tick_records_for_tick(records: Array[GFArchitectureTickRecord]) -> vo
 func _is_tick_record_ready_for_tick(record: GFArchitectureTickRecord) -> bool:
 	if record == null or not record.is_valid_record():
 		return false
-	return _is_module_ready_for_tick(record.module)
+	return _is_module_active_for_tick(record.module)
 
 
-func _is_module_ready_for_tick(instance: Object) -> bool:
-	return _GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0) >= 3
+func _is_tick_record_ready_for_lifecycle_tick(
+	record: GFArchitectureTickRecord,
+	allowed_instances: Dictionary
+) -> bool:
+	if record == null or not record.is_valid_record():
+		return false
+	if not allowed_instances.has(record.module):
+		return false
+	return _is_module_ready_for_lifecycle_tick(record.module)
+
+
+func _is_module_active_for_tick(instance: Object) -> bool:
+	return (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0)
+		>= _LIFECYCLE_STAGE_ACTIVE
+	)
+
+
+func _is_module_ready_for_lifecycle_tick(instance: Object) -> bool:
+	return (
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_int(_module_lifecycle_stages, instance, 0)
+		>= _LIFECYCLE_STAGE_READY
+	)
+
+
+func _normalize_lifecycle_delta(delta: float) -> float:
+	if not is_finite(delta):
+		return 0.0
+	return clampf(delta, 0.0, _MAX_LIFECYCLE_TICK_DELTA_SECONDS)
 
 
 func _make_tick_record(

--- a/addons/gf/kernel/core/gf_binding.gd
+++ b/addons/gf/kernel/core/gf_binding.gd
@@ -80,7 +80,7 @@ func _init(
 ## [br]
 ## @api framework_internal
 ## [br]
-## @param requesting_architecture: 发起解析的架构。Transient 会优先注入它，Singleton 始终注入拥有该绑定的架构。
+## @param requesting_architecture: 发起解析的架构。Transient 会优先注入它，Singleton 始终注入拥有该绑定的架构；两种生命周期都会固定并复核真实 requester 的准入 generation。
 ## [br]
 ## @param resolution_context: 当前工厂解析上下文，用于跨 Binding 失败链路回滚。
 ## [br]
@@ -102,12 +102,20 @@ func get_instance(requesting_architecture: GFArchitecture = null, resolution_con
 
 			clear_cached_instance()
 			_is_resolving_singleton = true
-			var provided_instance: Object = _provide(_owner_architecture, resolution_context)
+			var provided_instance: Object = _provide(
+				_owner_architecture,
+				requesting_architecture,
+				resolution_context
+			)
 			_is_resolving_singleton = false
 			if provided_instance == null:
 				return null
 			if _resolution_context_has_failed(resolution_context):
-				_release_rejected_factory_instance(provided_instance)
+				_release_rejected_factory_instance(
+					provided_instance,
+					true,
+					_owner_architecture
+				)
 				return null
 
 			_cached_instance = provided_instance
@@ -119,7 +127,11 @@ func get_instance(requesting_architecture: GFArchitecture = null, resolution_con
 			var injection_architecture: GFArchitecture = requesting_architecture
 			if injection_architecture == null:
 				injection_architecture = _owner_architecture
-			return _provide(injection_architecture, resolution_context)
+			return _provide(
+				injection_architecture,
+				requesting_architecture,
+				resolution_context
+			)
 
 		_:
 			_mark_resolution_context_failed(resolution_context)
@@ -139,7 +151,8 @@ func clear_cached_instance() -> void:
 		_release_instance_scope(instance)
 
 
-## 拒绝并释放当前 Singleton 缓存实例。
+## 拒绝并释放当前仍由 Binding 持有的 Singleton 缓存实例。
+## 已由架构关闭流程清空或已经换代的缓存不会再次取得释放权。
 ## [br]
 ## @api framework_internal
 ## [br]
@@ -154,14 +167,20 @@ func reject_cached_instance(instance: Object = null) -> void:
 	if rejected_instance == null:
 		rejected_instance = _cached_instance
 
-	if _cached_instance != null and rejected_instance != null and is_same(_cached_instance, rejected_instance):
-		_cached_instance = null
-		_has_cached_instance = false
-	elif instance == null:
-		_cached_instance = null
-		_has_cached_instance = false
+	if (
+		_cached_instance == null
+		or rejected_instance == null
+		or not is_same(_cached_instance, rejected_instance)
+	):
+		return
+	_cached_instance = null
+	_has_cached_instance = false
 
-	_release_rejected_factory_instance(rejected_instance)
+	_release_rejected_factory_instance(
+		rejected_instance,
+		true,
+		_owner_architecture
+	)
 
 
 ## 释放 Singleton 生命周期缓存实例的框架归属。
@@ -185,7 +204,26 @@ func dispose_cached_instance() -> void:
 
 # --- 私有/辅助方法 ---
 
-func _provide(injection_architecture: GFArchitecture, resolution_context: Dictionary = {}) -> Object:
+func _provide(
+	injection_architecture: GFArchitecture,
+	requesting_architecture: GFArchitecture,
+	resolution_context: Dictionary = {}
+) -> Object:
+	var admitted_requester: GFArchitecture = requesting_architecture
+	if admitted_requester == null:
+		admitted_requester = injection_architecture
+	var owner_lifecycle_generation: int = (
+		_get_admitted_lifecycle_generation(_owner_architecture)
+	)
+	var requester_lifecycle_generation: int = (
+		_get_admitted_lifecycle_generation(admitted_requester)
+	)
+	if (
+		owner_lifecycle_generation < 0
+		or requester_lifecycle_generation < 0
+	):
+		_mark_resolution_context_failed(resolution_context)
+		return null
 	var value: Variant
 	if provider is Callable:
 		var provider_callable: Callable = provider
@@ -201,31 +239,172 @@ func _provide(injection_architecture: GFArchitecture, resolution_context: Dictio
 		return null
 
 	var instance: Object = value
-	if not is_instance_valid(instance):
+	if not _instance_is_live(instance):
 		_mark_resolution_context_failed(resolution_context)
 		push_error("[GFBinding] 绑定来源返回了已失效的 Object 实例。")
+		return null
+	if (
+		_resolution_context_has_failed(resolution_context)
+		or not _is_admission_guard_current(
+			admitted_requester,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation
+		)
+	):
+		_mark_resolution_context_failed(resolution_context)
+		_release_rejected_factory_instance(instance, false)
 		return null
 	if not _instance_matches_key(instance):
 		_mark_resolution_context_failed(resolution_context)
 		push_error("[GFBinding] 绑定来源返回的实例脚本必须继承或等于绑定键。")
+		_release_rejected_factory_instance(instance, false)
 		return null
 
 	if _should_auto_inject:
-		_inject_if_needed(instance, injection_architecture)
+		if not _inject_if_needed(
+			instance,
+			injection_architecture,
+			admitted_requester,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation,
+			resolution_context
+		):
+			_mark_resolution_context_failed(resolution_context)
+			_release_rejected_factory_instance(
+				instance,
+				true,
+				injection_architecture
+			)
+			return null
+	if (
+		not _is_resolution_step_current(
+			instance,
+			admitted_requester,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation,
+			resolution_context
+		)
+	):
+		_mark_resolution_context_failed(resolution_context)
+		_release_rejected_factory_instance(
+			instance,
+			true,
+			injection_architecture
+		)
+		return null
 
 	return instance
 
 
-func _inject_if_needed(instance: Object, architecture: GFArchitecture) -> void:
+func _get_admitted_lifecycle_generation(
+	architecture: GFArchitecture
+) -> int:
+	if (
+		architecture == null
+		or not architecture.is_accepting_runtime_work()
+	):
+		return -1
+	return architecture.get_lifecycle_generation()
+
+
+func _is_admission_guard_current(
+	requesting_architecture: GFArchitecture,
+	owner_lifecycle_generation: int,
+	requester_lifecycle_generation: int
+) -> bool:
+	return (
+		_is_architecture_admission_current(
+			_owner_architecture,
+			owner_lifecycle_generation
+		)
+		and _is_architecture_admission_current(
+			requesting_architecture,
+			requester_lifecycle_generation
+		)
+	)
+
+
+func _is_architecture_admission_current(
+	architecture: GFArchitecture,
+	lifecycle_generation: int
+) -> bool:
+	return (
+		architecture != null
+		and lifecycle_generation >= 0
+		and architecture.get_lifecycle_generation() == lifecycle_generation
+		and architecture.is_accepting_runtime_work()
+	)
+
+
+func _is_resolution_step_current(
+	instance: Object,
+	requesting_architecture: GFArchitecture,
+	owner_lifecycle_generation: int,
+	requester_lifecycle_generation: int,
+	resolution_context: Dictionary
+) -> bool:
+	return (
+		_instance_is_live(instance)
+		and not _resolution_context_has_failed(resolution_context)
+		and _is_admission_guard_current(
+			requesting_architecture,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation
+		)
+	)
+
+
+func _inject_if_needed(
+	instance: Object,
+	architecture: GFArchitecture,
+	requesting_architecture: GFArchitecture,
+	owner_lifecycle_generation: int,
+	requester_lifecycle_generation: int,
+	resolution_context: Dictionary
+) -> bool:
 	if instance == null or architecture == null:
-		return
+		return false
 
 	if instance.has_method("_gf_set_dependency_scope"):
 		instance.call("_gf_set_dependency_scope", architecture)
+		if not _is_resolution_step_current(
+			instance,
+			requesting_architecture,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation,
+			resolution_context
+		):
+			return false
 	if instance.has_method("inject_dependencies"):
 		instance.call("inject_dependencies", architecture)
+		if not _is_resolution_step_current(
+			instance,
+			requesting_architecture,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation,
+			resolution_context
+		):
+			return false
 	if instance.has_method("inject"):
 		instance.call("inject", architecture)
+		if not _is_resolution_step_current(
+			instance,
+			requesting_architecture,
+			owner_lifecycle_generation,
+			requester_lifecycle_generation,
+			resolution_context
+		):
+			return false
+	return true
+
+
+func _instance_is_live(instance: Object) -> bool:
+	if not is_instance_valid(instance):
+		return false
+	if instance is Node:
+		var node: Node = instance
+		return not node.is_queued_for_deletion()
+	return true
 
 
 func _release_instance_scope(instance: Object) -> void:
@@ -234,22 +413,38 @@ func _release_instance_scope(instance: Object) -> void:
 
 	if instance.has_method("release_dependencies"):
 		var _release_dependencies_result: Variant = instance.call("release_dependencies")
+	if not _instance_is_live(instance):
+		return
 	if instance.has_method("_gf_set_dependency_scope"):
 		instance.call("_gf_set_dependency_scope", null)
 	elif instance.has_method("_release_dependency_scope"):
 		instance.call("_release_dependency_scope")
 
 
-func _release_rejected_factory_instance(instance: Object) -> void:
+func _release_rejected_factory_instance(
+	instance: Object,
+	release_injected_scope: bool = true,
+	injection_architecture: GFArchitecture = null
+) -> void:
 	if instance == null or not is_instance_valid(instance):
 		return
 
-	if _owner_architecture != null:
-		_owner_architecture.unregister_owner_events(instance)
-	_release_instance_scope(instance)
+	var injected_scope_architecture: GFArchitecture = injection_architecture
+	if injected_scope_architecture == null:
+		injected_scope_architecture = _owner_architecture
+	if release_injected_scope and injected_scope_architecture != null:
+		injected_scope_architecture.unregister_owner_events(instance)
+	if (
+		_should_dispose_cached_instance
+		and is_instance_valid(instance)
+		and instance.has_method("dispose")
+	):
+		instance.call("dispose")
+	if release_injected_scope and is_instance_valid(instance):
+		_release_instance_scope(instance)
 	if not is_instance_valid(instance):
 		return
-	if instance is Node:
+	if _should_dispose_cached_instance and instance is Node:
 		var rejected_node: Node = instance
 		if rejected_node.get_parent() == null and not rejected_node.is_queued_for_deletion():
 			rejected_node.free()

--- a/addons/gf/kernel/core/gf_kernel_runtime.gd
+++ b/addons/gf/kernel/core/gf_kernel_runtime.gd
@@ -26,10 +26,14 @@ enum LifecycleState {
 	NEW,
 	## 正在推进模块生命周期。
 	INITIALIZING,
-	## 已完成 ready 阶段。
+	## 模块已完成初始化，正在显式激活运行期能力。
+	ACTIVATING,
+	## 已完成第四阶段 activation，并开放运行时准入。
 	READY,
 	## 初始化失败，注册表应保持失败边界。
 	FAILED,
+	## 已停止接纳新工作，正在排空已接纳工作。
+	QUIESCING,
 	## 正在释放运行时。
 	DISPOSING,
 	## 已释放，进入终态。
@@ -81,10 +85,14 @@ func get_state_name() -> String:
 			return "new"
 		LifecycleState.INITIALIZING:
 			return "initializing"
+		LifecycleState.ACTIVATING:
+			return "activating"
 		LifecycleState.READY:
 			return "ready"
 		LifecycleState.FAILED:
 			return "failed"
+		LifecycleState.QUIESCING:
+			return "quiescing"
 		LifecycleState.DISPOSING:
 			return "disposing"
 		LifecycleState.DISPOSED:
@@ -139,6 +147,17 @@ func is_initializing() -> bool:
 	return _state == LifecycleState.INITIALIZING
 
 
+## 检查架构是否正在激活。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/core
+## [br]
+## @return activating 状态返回 true。
+func is_activating() -> bool:
+	return _state == LifecycleState.ACTIVATING
+
+
 ## 检查架构是否已失败。
 ## [br]
 ## @api framework_internal
@@ -148,6 +167,17 @@ func is_initializing() -> bool:
 ## @return failed 状态返回 true。
 func has_failed() -> bool:
 	return _state == LifecycleState.FAILED
+
+
+## 检查架构是否正在静默并排空已接纳工作。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/core
+## [br]
+## @return quiescing 状态返回 true。
+func is_quiescing() -> bool:
+	return _state == LifecycleState.QUIESCING
 
 
 ## 检查架构是否正在释放。
@@ -178,9 +208,14 @@ func is_disposed() -> bool:
 ## [br]
 ## @layer kernel/core
 ## [br]
-## @return initializing 或 ready 状态返回 true。
+## @return initializing、activating、ready 或 quiescing 状态返回 true。
 func is_lifecycle_active() -> bool:
-	return _state == LifecycleState.INITIALIZING or _state == LifecycleState.READY
+	return _state in [
+		LifecycleState.INITIALIZING,
+		LifecycleState.ACTIVATING,
+		LifecycleState.READY,
+		LifecycleState.QUIESCING,
+	]
 
 
 ## 开始一次初始化流程并推进 generation。
@@ -191,26 +226,44 @@ func is_lifecycle_active() -> bool:
 ## [br]
 ## @return 新初始化流程的 generation；正在或已经 dispose 时返回 -1。
 func begin_initialization() -> int:
-	if _state == LifecycleState.DISPOSING or _state == LifecycleState.DISPOSED:
+	if _state != LifecycleState.NEW:
 		return -1
 	_lifecycle_generation += 1
 	_state = LifecycleState.INITIALIZING
 	return _lifecycle_generation
 
 
-## 完成当前初始化流程。
+## 从初始化阶段进入显式激活阶段。
 ## [br]
 ## @api framework_internal
 ## [br]
 ## @layer kernel/core
 ## [br]
-## @param lifecycle_generation: 初始化流程持有的 generation。
+## @param lifecycle_generation: 当前生命周期流程持有的 generation。
 ## [br]
-## @return generation 仍有效且状态可提交时返回 true。
-func finish_initialization(lifecycle_generation: int) -> bool:
+## @return generation 仍有效且正在初始化时返回 true。
+func begin_activation(lifecycle_generation: int) -> bool:
 	if not is_generation_current(lifecycle_generation):
 		return false
 	if _state != LifecycleState.INITIALIZING:
+		return false
+	_state = LifecycleState.ACTIVATING
+	return true
+
+
+## 完成显式激活并进入 ready 状态。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/core
+## [br]
+## @param lifecycle_generation: 当前生命周期流程持有的 generation。
+## [br]
+## @return generation 仍有效且正在激活时返回 true。
+func finish_activation(lifecycle_generation: int) -> bool:
+	if not is_generation_current(lifecycle_generation):
+		return false
+	if _state != LifecycleState.ACTIVATING:
 		return false
 	_state = LifecycleState.READY
 	return true
@@ -228,6 +281,7 @@ func finish_initialization(lifecycle_generation: int) -> bool:
 func fail_initialization(lifecycle_generation: int) -> bool:
 	if (
 		_state == LifecycleState.FAILED
+		or _state == LifecycleState.QUIESCING
 		or _state == LifecycleState.DISPOSING
 		or _state == LifecycleState.DISPOSED
 	):
@@ -254,7 +308,30 @@ func clear_failure() -> bool:
 	return true
 
 
+## 开始静默流程，不推进 generation，也不使活动事务失效。
+##
+## 已接纳 continuation 可在该状态继续提交；新工作应由架构组合层拒绝。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/core
+## [br]
+## @return 本次调用成功进入 quiescing 状态时返回 true。
+func begin_quiesce() -> bool:
+	if (
+		_state == LifecycleState.QUIESCING
+		or _state == LifecycleState.DISPOSING
+		or _state == LifecycleState.DISPOSED
+	):
+		return false
+	_state = LifecycleState.QUIESCING
+	return true
+
+
 ## 开始释放流程并推进 generation。
+##
+## 正常异步关闭会从 quiescing 进入该状态；同步或强制释放也可以从其他非终态
+## 直接进入该状态。
 ## [br]
 ## @api framework_internal
 ## [br]
@@ -276,6 +353,8 @@ func begin_dispose() -> bool:
 ## [br]
 ## @layer kernel/core
 func finish_dispose() -> void:
+	if _state != LifecycleState.DISPOSING:
+		return
 	_state = LifecycleState.DISPOSED
 	_transactions.clear()
 

--- a/addons/gf/kernel/core/gf_node_context.gd
+++ b/addons/gf/kernel/core/gf_node_context.gd
@@ -1,7 +1,9 @@
 ## GFNodeContext: 场景树上的局部架构上下文。
 ##
 ## 可选择继承父级架构，或创建带父级回退的 Scoped 架构。
-## Scoped 架构会在节点退出树时自动 dispose，适合关卡、战斗房间、调试面板等局部模块。
+## Scoped 架构会在节点退出树时使用无法等待的 forced/no-drain dispose fallback，
+## 适合关卡、战斗房间、调试面板等局部模块。可控或数据关键的退出必须先 await
+## owned Architecture 的 shutdown_async()，再移除节点。
 ## [br]
 ## @api public
 ## [br]
@@ -16,9 +18,11 @@ extends Node
 
 # --- 信号 ---
 
-## 当上下文架构完成初始化后发出。
+## 当上下文 Architecture 完成 stage4 activation 并提交 READY 后发出。
 ## [br]
 ## @api public
+## [br]
+## @since 1.9.0
 ## [br]
 ## @param architecture: 当前上下文使用的架构实例。
 signal context_ready(architecture: GFArchitecture)
@@ -891,6 +895,8 @@ func _mark_context_ready(architecture_instance: GFArchitecture) -> void:
 	if _architecture != architecture_instance:
 		return
 	if architecture_instance.has_initialization_failed() or architecture_instance.is_disposed():
+		return
+	if not architecture_instance.is_inited():
 		return
 	if not is_inside_tree():
 		return

--- a/addons/gf/standard/utilities/storage/gf_storage_utility.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_utility.gd
@@ -285,7 +285,7 @@ func tick(_delta: float = 0.0) -> void:
 ## [br]
 ## @param _scope: 当前 Storage 激活阶段的取消作用域。
 ## [br]
-## @return 已成功完成；正在 dispose 时返回失败终态。
+## @return 成功打开 I/O 准入；正在 dispose 或已经进入过 quiesce 时返回失败终态。
 func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
 	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
 	if _is_disposing:

--- a/addons/gf/standard/utilities/storage/gf_storage_utility.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_utility.gd
@@ -218,6 +218,8 @@ var _async_file_locks: Dictionary = {}
 var _next_async_request_id: int = 1
 var _next_async_transaction_id: int = 1
 var _is_disposing: bool = false
+var _io_admission_open: bool = true
+var _quiesce_completion: GFAsyncCompletion = null
 var _migration_steps: Dictionary = {}
 var _path_policy: _StoragePathPolicy
 var _file_ops: _StorageFileOps
@@ -236,6 +238,8 @@ func _init() -> void:
 ## [br]
 ## @api public
 func init() -> void:
+	if not _io_admission_open:
+		return
 	_ensure_storage_helpers()
 	ignore_pause = true
 	var dir_path: String = _get_save_base_path()
@@ -250,6 +254,7 @@ func init() -> void:
 func dispose() -> void:
 	if _is_disposing:
 		return
+	_io_admission_open = false
 	_is_disposing = true
 	_wait_for_async_tasks()
 	_async_tasks.clear()
@@ -259,6 +264,7 @@ func dispose() -> void:
 	last_load_result = null
 	_release_storage_helpers()
 	_is_disposing = false
+	_try_complete_quiesce()
 
 
 ## 驱动异步存档任务完成检查。
@@ -268,6 +274,55 @@ func dispose() -> void:
 ## @param _delta: 本帧时间增量（秒），默认实现不直接使用。
 func tick(_delta: float = 0.0) -> void:
 	_poll_async_tasks()
+	_try_complete_quiesce()
+
+
+## 激活 Storage 的同步与异步 I/O 准入。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前 Storage 激活阶段的取消作用域。
+## [br]
+## @return 已成功完成；正在 dispose 时返回失败终态。
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	if _is_disposing:
+		var _failed: bool = completion.fail("Storage utility is disposing.")
+		return completion
+	if _quiesce_completion != null:
+		var _failed_quiesced: bool = completion.fail(
+			"Storage utility cannot reactivate after quiesce."
+		)
+		return completion
+	_quiesce_completion = null
+	_io_admission_open = true
+	init()
+	var _succeeded: bool = completion.succeed()
+	return completion
+
+
+## 关闭新 I/O 准入，并等待此前接纳的队列、线程和文件锁全部收敛。
+##
+## 已接纳任务继续由 lifecycle tick 推进；强制 dispose 仍会使用同步 join fallback。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param scope: 当前 Storage 静默阶段的取消作用域。
+## [br]
+## @return 队列、任务和锁全部终态后成功的一次性完成源。
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+	_io_admission_open = false
+	if _quiesce_completion != null:
+		return _quiesce_completion
+	_quiesce_completion = GFAsyncCompletion.new()
+	if scope != null:
+		var _bound: bool = _quiesce_completion.bind_cancel_token(scope)
+	_try_complete_quiesce()
+	return _quiesce_completion
 
 
 # --- 公共方法（Resource 存取） ---
@@ -282,6 +337,8 @@ func tick(_delta: float = 0.0) -> void:
 ## [br]
 ## @return Godot 的 `Error` 结果码。
 func save_resource(file_name: String, resource: Resource) -> Error:
+	if not _io_admission_open:
+		return ERR_UNAVAILABLE
 	if not _validate_public_file_name(file_name, "save_resource"):
 		return ERR_INVALID_PARAMETER
 	if resource == null:
@@ -325,6 +382,8 @@ func save_resource(file_name: String, resource: Resource) -> Error:
 ## [br]
 ## 该方法会调用 Godot `ResourceLoader`，默认关闭。调用方必须先启用 `allow_resource_loads`，并通过类型提示 allowlist、扩展名 allowlist 与存储路径策略收窄加载边界。
 func load_resource(file_name: String, type_hint: String = "") -> Resource:
+	if not _io_admission_open:
+		return null
 	if not _validate_public_file_name(file_name, "load_resource"):
 		return null
 	if not allow_resource_loads:
@@ -369,6 +428,8 @@ func load_resource(file_name: String, type_hint: String = "") -> Resource:
 ## [br]
 ## @return Godot 的 `Error` 结果码。
 func ensure_directory(directory_name: String = "") -> Error:
+	if not _io_admission_open:
+		return ERR_UNAVAILABLE
 	if not _validate_public_directory_name(directory_name, "ensure_directory"):
 		return ERR_INVALID_PARAMETER
 	init()
@@ -417,6 +478,8 @@ func list_files(
 	recursive: bool = false,
 	options: Dictionary = {}
 ) -> PackedStringArray:
+	if not _io_admission_open:
+		return PackedStringArray()
 	if not _validate_public_directory_name(directory_name, "list_files"):
 		return PackedStringArray()
 	init()
@@ -453,6 +516,8 @@ func list_files(
 ## [br]
 ## @return Godot 的 `Error` 结果码；文件不存在时返回 `ERR_FILE_NOT_FOUND`。
 func delete_file(file_name: String) -> Error:
+	if not _io_admission_open:
+		return ERR_UNAVAILABLE
 	if not _validate_public_file_name(file_name, "delete_file"):
 		return ERR_INVALID_PARAMETER
 
@@ -493,6 +558,8 @@ func delete_file(file_name: String) -> Error:
 ## [br]
 ## @return Godot 的 `Error` 结果码。
 func save_data(file_name: String, data: Dictionary) -> Error:
+	if not _io_admission_open:
+		return ERR_UNAVAILABLE
 	if not _validate_public_file_name(file_name, "save_data"):
 		return ERR_INVALID_PARAMETER
 
@@ -521,6 +588,8 @@ func save_data(file_name: String, data: Dictionary) -> Error:
 ## [br]
 ## @schema files: Dictionary，键为存储相对文件名，值为要序列化并保存的 Dictionary 载荷。
 func save_data_group(files: Dictionary) -> Error:
+	if not _io_admission_open:
+		return ERR_UNAVAILABLE
 	if files.is_empty():
 		push_error("[GFStorageUtility] save_data_group 失败：files 为空。")
 		return ERR_INVALID_PARAMETER
@@ -573,6 +642,13 @@ func save_data_group(files: Dictionary) -> Error:
 ## [br]
 ## @return 强类型读取结果；调用方必须先检查 ok，再读取 payload。
 func load_data(file_name: String) -> GFStorageReadResult:
+	if not _io_admission_open:
+		last_load_result = _make_load_failure(
+			"Storage I/O admission is closed.",
+			ERR_UNAVAILABLE,
+			GFStorageReadResult.FailureKind.UNAVAILABLE
+		)
+		return last_load_result.duplicate_result()
 	if not _validate_public_file_name(file_name, "load_data"):
 		last_load_result = _make_load_failure(
 			"Storage file name is invalid.",
@@ -730,6 +806,7 @@ func wait_for_async_tasks() -> void:
 			_erase_dictionary_key(_async_file_locks, _get_task_file_key(task))
 			_complete_finished_async_task(task, result_variant)
 		_start_queued_async_tasks()
+	_try_complete_quiesce()
 
 
 ## 使用已注册步骤迁移存档数据。
@@ -879,7 +956,7 @@ func _enqueue_async_save(
 	operation: GFStorageAsyncOperation,
 	operation_name: String
 ) -> Error:
-	if _is_disposing:
+	if _is_disposing or not _io_admission_open:
 		_complete_async_operation(
 			operation,
 			ERR_UNAVAILABLE,
@@ -930,7 +1007,7 @@ func _enqueue_async_payload_save(
 	operation: GFStorageAsyncOperation,
 	operation_name: String
 ) -> Error:
-	if _is_disposing:
+	if _is_disposing or not _io_admission_open:
 		_complete_async_operation(
 			operation,
 			ERR_UNAVAILABLE,
@@ -1028,9 +1105,9 @@ func _enqueue_async_load(
 	operation: GFStorageAsyncOperation,
 	operation_name: String
 ) -> Error:
-	if _is_disposing:
+	if _is_disposing or not _io_admission_open:
 		var unavailable_result: GFStorageReadResult = _make_load_failure(
-			"Storage utility is disposing.",
+			"Storage utility is not accepting new I/O.",
 			ERR_UNAVAILABLE,
 			GFStorageReadResult.FailureKind.UNAVAILABLE
 		)
@@ -1264,6 +1341,18 @@ func _poll_async_tasks() -> void:
 		_erase_dictionary_key(_async_file_locks, _get_task_file_key(task))
 		_complete_finished_async_task(task, result_variant)
 	_start_queued_async_tasks()
+
+
+func _try_complete_quiesce() -> void:
+	if (
+		_quiesce_completion == null
+		or not _quiesce_completion.is_pending()
+		or not _async_tasks.is_empty()
+		or not _async_queue.is_empty()
+		or not _async_file_locks.is_empty()
+	):
+		return
+	var _succeeded: bool = _quiesce_completion.succeed()
 
 
 func _wait_for_async_tasks() -> void:

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "ff54f85352eb56697316340608852f34b28994be98fdf08ec4acb51d15c4a3e4",
-  "class_count": 769,
+  "source_digest": "a74a0759730e2e83f5c5fc10ed6141f194dd6af7f0832fd268ca986aefa4a454",
+  "class_count": 770,
   "package_count": 52,
   "packages": [
     {
@@ -1952,7 +1952,7 @@
       "module": "kernel",
       "package_id": "gf.kernel",
       "path": "addons/gf/kernel/core/gf_architecture.gd",
-      "summary": "GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。 生命周期遵循三阶段初始化协议： 阶段一 (init)       ：所有模块执行自身内部变量初始化。",
+      "summary": "GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。 生命周期遵循四阶段初始化协议： 阶段一 (init)       ：各模块按声明依赖 DAG 执行自身内部变量初始化。",
       "visibility": "public",
       "category": "runtime_service",
       "since": "3.17.0",
@@ -1973,6 +1973,13 @@
         },
         {
           "kind": "signal",
+          "name": "shutdown_finished",
+          "signature": "signal shutdown_finished(result: GFArchitectureShutdownResult)",
+          "summary": "当异步关闭流程或同步强制释放发布类型化终态时发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "signal",
           "name": "project_installers_finished",
           "signature": "signal project_installers_finished",
           "summary": "当项目级 Installer 应用完成或被 dispose() 中断后发出。",
@@ -1987,41 +1994,6 @@
         },
         {
           "kind": "const",
-          "name": "HOOK_GET_REQUIRED_DEPENDENCIES",
-          "signature": "const HOOK_GET_REQUIRED_DEPENDENCIES: StringName = &\"get_required_dependencies\"",
-          "summary": "声明式依赖聚合 Hook 名称。",
-          "visibility": "public"
-        },
-        {
-          "kind": "const",
-          "name": "HOOK_GET_REQUIRED_MODELS",
-          "signature": "const HOOK_GET_REQUIRED_MODELS: StringName = &\"get_required_models\"",
-          "summary": "声明式 Model 依赖 Hook 名称。",
-          "visibility": "public"
-        },
-        {
-          "kind": "const",
-          "name": "HOOK_GET_REQUIRED_SYSTEMS",
-          "signature": "const HOOK_GET_REQUIRED_SYSTEMS: StringName = &\"get_required_systems\"",
-          "summary": "声明式 System 依赖 Hook 名称。",
-          "visibility": "public"
-        },
-        {
-          "kind": "const",
-          "name": "HOOK_GET_REQUIRED_UTILITIES",
-          "signature": "const HOOK_GET_REQUIRED_UTILITIES: StringName = &\"get_required_utilities\"",
-          "summary": "声明式 Utility 依赖 Hook 名称。",
-          "visibility": "public"
-        },
-        {
-          "kind": "const",
-          "name": "HOOK_GET_REQUIRED_FACTORIES",
-          "signature": "const HOOK_GET_REQUIRED_FACTORIES: StringName = &\"get_required_factories\"",
-          "summary": "声明式工厂依赖 Hook 名称。",
-          "visibility": "public"
-        },
-        {
-          "kind": "const",
           "name": "DEFAULT_SNAPSHOT_MODELS_PER_FRAME",
           "signature": "const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8",
           "summary": "分帧快照 API 默认每帧处理的 Model 数量。",
@@ -2031,14 +2003,7 @@
           "kind": "var",
           "name": "module_async_init_timeout_seconds",
           "signature": "var module_async_init_timeout_seconds: float = 0.0",
-          "summary": "单个模块 async_init() 的最长等待时间。小于等于 0 时不启用超时。",
-          "visibility": "public"
-        },
-        {
-          "kind": "var",
-          "name": "module_lifecycle_max_stage_passes",
-          "signature": "var module_lifecycle_max_stage_passes: int = 256",
-          "summary": "单个生命周期阶段最多扫描模块注册表的次数，避免模块在生命周期中无限注册新模块。",
+          "summary": "单个模块 async_init() 的最长等待时间。0 时不启用超时。",
           "visibility": "public"
         },
         {
@@ -2050,9 +2015,16 @@
         },
         {
           "kind": "var",
-          "name": "fail_on_missing_declared_dependencies",
-          "signature": "var fail_on_missing_declared_dependencies: bool = false",
-          "summary": "声明式依赖缺失时是否直接使初始化失败。",
+          "name": "activation_timeout_seconds",
+          "signature": "var activation_timeout_seconds: float = 30.0",
+          "summary": "架构激活阶段的总等待上限（秒）。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "shutdown_timeout_seconds",
+          "signature": "var shutdown_timeout_seconds: float = 10.0",
+          "summary": "架构 quiesce 阶段的总等待上限（秒）。",
           "visibility": "public"
         },
         {
@@ -2073,7 +2045,7 @@
           "kind": "func",
           "name": "is_inited",
           "signature": "func is_inited() -> bool",
-          "summary": "检查架构是否已初始化。",
+          "summary": "检查架构是否已完成四阶段启动并提交 READY。",
           "visibility": "public"
         },
         {
@@ -2087,7 +2059,28 @@
           "kind": "func",
           "name": "is_lifecycle_active",
           "signature": "func is_lifecycle_active() -> bool",
-          "summary": "检查当前架构生命周期是否仍处于可安全继续异步写回的活动状态。",
+          "summary": "检查当前架构生命周期是否仍处于可安全继续已接纳异步写回的活动状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_activating",
+          "signature": "func is_activating() -> bool",
+          "summary": "检查架构是否正在执行第四阶段激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_quiescing",
+          "signature": "func is_quiescing() -> bool",
+          "summary": "检查架构是否已经关闭新工作、正在等待已接纳工作收敛。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_accepting_runtime_work",
+          "signature": "func is_accepting_runtime_work() -> bool",
+          "summary": "检查架构是否仍接纳新的运行时工作。",
           "visibility": "public"
         },
         {
@@ -2123,6 +2116,20 @@
           "name": "is_module_ready",
           "signature": "func is_module_ready(instance: Object) -> bool",
           "summary": "检查指定模块实例是否已经完成 ready 阶段。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_module_active",
+          "signature": "func is_module_active(instance: Object) -> bool",
+          "summary": "检查模块是否已经完成第四阶段激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_last_shutdown_result",
+          "signature": "func get_last_shutdown_result() -> GFArchitectureShutdownResult",
+          "summary": "获取最近一次关闭结果的隔离副本。",
           "visibility": "public"
         },
         {
@@ -2191,15 +2198,22 @@
         {
           "kind": "func",
           "name": "init",
-          "signature": "func init() -> bool",
-          "summary": "初始化架构及所有注册的组件（三阶段）。",
+          "signature": "func init(cancellation_token: GFCancellationToken = null) -> bool",
+          "summary": "初始化架构及所有注册的组件（四阶段）。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "shutdown_async",
+          "signature": "func shutdown_async( cancellation_token: GFCancellationToken = null, timeout_seconds: float = -1.0 ) -> GFArchitectureShutdownResult",
+          "summary": "异步关闭架构。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "dispose",
           "signature": "func dispose() -> void",
-          "summary": "销毁架构及所有注册的组件。",
+          "summary": "强制同步销毁架构及所有注册组件。",
           "visibility": "public"
         },
         {
@@ -2597,21 +2611,21 @@
         {
           "kind": "func",
           "name": "unregister_system",
-          "signature": "func unregister_system(script_cls: Script) -> void",
+          "signature": "func unregister_system(script_cls: Script) -> bool",
           "summary": "注销 System 实例。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "unregister_model",
-          "signature": "func unregister_model(script_cls: Script) -> void",
+          "signature": "func unregister_model(script_cls: Script) -> bool",
           "summary": "注销 Model 实例。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "unregister_utility",
-          "signature": "func unregister_utility(script_cls: Script) -> void",
+          "signature": "func unregister_utility(script_cls: Script) -> bool",
           "summary": "注销 Utility 实例。",
           "visibility": "public"
         },
@@ -2772,7 +2786,7 @@
         {
           "kind": "func",
           "name": "get_dependency_diagnostics",
-          "signature": "func get_dependency_diagnostics(options: Dictionary = {}) -> Dictionary",
+          "signature": "func get_dependency_diagnostics() -> Dictionary",
           "summary": "获取架构中已注册模块的声明式依赖诊断报告。",
           "visibility": "public"
         },
@@ -2789,6 +2803,172 @@
           "signature": "func _on_dispose() -> void",
           "summary": "内部销毁回调，子类可重写。",
           "visibility": "protected"
+        }
+      ]
+    },
+    "GFArchitectureShutdownResult": {
+      "extends": "RefCounted",
+      "module": "kernel",
+      "package_id": "gf.kernel",
+      "path": "addons/gf/kernel/core/gf_architecture_shutdown_result.gd",
+      "summary": "GFArchitectureShutdownResult: 架构关闭流程的不可变终态快照。 结果显式区分正常完成、失败、取消、超时、强制释放和重复释放，并以有界、 JSON-safe 的模块条目保留关闭证据。所有集合在写入和读取边界都会重新复制，",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "enum",
+          "name": "Status",
+          "signature": "enum Status {\n\t## 所有关闭阶段正常完成。\n\tSUCCEEDED,\n\t## 至少一个关闭阶段失败。\n\tFAILED,\n\t## 调用方取消了关闭流程。\n\tCANCELLED,\n\t## 关闭流程超过了时间预算。\n\tTIMED_OUT,\n\t## 框架跳过未完成的静默工作并执行了强制释放。\n\tFORCED,\n\t## 架构在本次请求前已经释放。\n\tALREADY_DISPOSED,\n}",
+          "summary": "架构关闭终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "create",
+          "signature": "static func create( status: Status, started_at_msec: int, completed_at_msec: int, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], duplicate_request_count: int = 0, error_code: Error = OK, error: String = \"\", cancel_reason: String = \"\" ) -> GFArchitectureShutdownResult",
+          "summary": "创建一个规范化的架构关闭结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "succeeded",
+          "signature": "static func succeeded( module_results: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult",
+          "summary": "创建正常完成结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "failed",
+          "signature": "static func failed( error_code: Error, error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult",
+          "summary": "创建失败结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "cancelled",
+          "signature": "static func cancelled( reason: String = \"cancelled\", module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult",
+          "summary": "创建取消结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "timed_out",
+          "signature": "static func timed_out( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult",
+          "summary": "创建超时结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "forced",
+          "signature": "static func forced( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult",
+          "summary": "创建强制释放结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "already_disposed",
+          "signature": "static func already_disposed( started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult",
+          "summary": "创建已释放幂等结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "检查关闭是否以正常或幂等成功结束。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> Status",
+          "summary": "获取关闭终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status_name",
+          "signature": "func get_status_name() -> StringName",
+          "summary": "获取关闭终态名称。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_started_at_msec",
+          "signature": "func get_started_at_msec() -> int",
+          "summary": "获取关闭开始时间。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_completed_at_msec",
+          "signature": "func get_completed_at_msec() -> int",
+          "summary": "获取关闭完成时间。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_duration_msec",
+          "signature": "func get_duration_msec() -> int",
+          "summary": "获取关闭耗时。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_module_results",
+          "signature": "func get_module_results() -> Array[Dictionary]",
+          "summary": "获取已完成模块结果的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_unfinished_modules",
+          "signature": "func get_unfinished_modules() -> Array[Dictionary]",
+          "summary": "获取未完成模块快照的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_duplicate_request_count",
+          "signature": "func get_duplicate_request_count() -> int",
+          "summary": "获取复用同一关闭流程的重复请求数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_code",
+          "signature": "func get_error_code() -> Error",
+          "summary": "获取关闭错误码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error",
+          "signature": "func get_error() -> String",
+          "summary": "获取稳定失败说明。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_cancel_reason",
+          "signature": "func get_cancel_reason() -> String",
+          "summary": "获取取消原因。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_result",
+          "signature": "func duplicate_result() -> GFArchitectureShutdownResult",
+          "summary": "创建隔离结果副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为可报告字典。",
+          "visibility": "public"
         }
       ]
     },
@@ -45226,7 +45406,7 @@
       "module": "kernel",
       "package_id": "gf.kernel",
       "path": "addons/gf/kernel/base/gf_model.gd",
-      "summary": "GFModel: 数据层抽象基类。 负责管理应用数据和业务状态。 子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。",
+      "summary": "GFModel: 数据层抽象基类。 负责管理应用数据和业务状态。 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、",
       "visibility": "public",
       "category": "protocol",
       "since": "3.17.0",
@@ -45235,7 +45415,35 @@
           "kind": "var",
           "name": "lifecycle_priority",
           "signature": "var lifecycle_priority: int = 0",
-          "summary": "生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。",
+          "summary": "生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_models",
+          "signature": "func get_required_models() -> Array[Script]",
+          "summary": "返回此模型声明依赖的 Model 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_systems",
+          "signature": "func get_required_systems() -> Array[Script]",
+          "summary": "返回此模型声明依赖的 System 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_utilities",
+          "signature": "func get_required_utilities() -> Array[Script]",
+          "summary": "返回此模型声明依赖的 Utility 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_factories",
+          "signature": "func get_required_factories() -> Array[Script]",
+          "summary": "返回此模型声明依赖的 Factory 绑定类型。",
           "visibility": "public"
         },
         {
@@ -45257,6 +45465,20 @@
           "name": "ready",
           "signature": "func ready() -> void",
           "summary": "第三阶段初始化。子类可以重写此方法。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_activation",
+          "signature": "func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开始激活模型的运行期能力。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_quiesce",
+          "signature": "func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开始静默模型并排空已经接纳的工作。",
           "visibility": "public"
         },
         {
@@ -50438,7 +50660,7 @@
       "module": "kernel",
       "package_id": "gf.kernel",
       "path": "addons/gf/kernel/core/gf_node_context.gd",
-      "summary": "GFNodeContext: 场景树上的局部架构上下文。 可选择继承父级架构，或创建带父级回退的 Scoped 架构。 Scoped 架构会在节点退出树时自动 dispose，适合关卡、战斗房间、调试面板等局部模块。",
+      "summary": "GFNodeContext: 场景树上的局部架构上下文。 可选择继承父级架构，或创建带父级回退的 Scoped 架构。 Scoped 架构会在节点退出树时使用无法等待的 forced/no-drain dispose fallback，",
       "visibility": "public",
       "category": "runtime_service",
       "since": "3.17.0",
@@ -50447,7 +50669,7 @@
           "kind": "signal",
           "name": "context_ready",
           "signature": "signal context_ready(architecture: GFArchitecture)",
-          "summary": "当上下文架构完成初始化后发出。",
+          "summary": "当上下文 Architecture 完成 stage4 activation 并提交 READY 后发出。",
           "visibility": "public"
         },
         {
@@ -68095,6 +68317,27 @@
         },
         {
           "kind": "func",
+          "name": "get_required_utilities",
+          "signature": "func get_required_utilities() -> Array[Script]",
+          "summary": "声明架构模式下必须显式注册的 Storage 依赖。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_activation",
+          "signature": "func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "激活 Profile 服务；底层 Storage 未配置时失败，不创建业务 profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_quiesce",
+          "signature": "func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "关闭新 profile 工作准入，并等待已接纳 operation、preparation、retry 与 detached 写入收敛。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "tick",
           "signature": "func tick(_delta: float) -> void",
           "summary": "推进到期重试。",
@@ -79696,6 +79939,20 @@
         },
         {
           "kind": "func",
+          "name": "begin_activation",
+          "signature": "func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "激活 Storage 的同步与异步 I/O 准入。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_quiesce",
+          "signature": "func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "关闭新 I/O 准入，并等待此前接纳的队列、线程和文件锁全部收敛。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "save_resource",
           "signature": "func save_resource(file_name: String, resource: Resource) -> Error",
           "summary": "保存一个 `Resource` 文件。",
@@ -80493,7 +80750,7 @@
       "module": "kernel",
       "package_id": "gf.kernel",
       "path": "addons/gf/kernel/base/gf_system.gd",
-      "summary": "GFSystem: 逻辑层抽象基类。 负责实现核心业务逻辑。 子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。",
+      "summary": "GFSystem: 逻辑层抽象基类。 负责实现核心业务逻辑。 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、",
       "visibility": "public",
       "category": "protocol",
       "since": "3.17.0",
@@ -80516,7 +80773,7 @@
           "kind": "var",
           "name": "lifecycle_priority",
           "signature": "var lifecycle_priority: int = 0",
-          "summary": "生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。",
+          "summary": "生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大",
           "visibility": "public"
         },
         {
@@ -80549,6 +80806,34 @@
         },
         {
           "kind": "func",
+          "name": "get_required_models",
+          "signature": "func get_required_models() -> Array[Script]",
+          "summary": "返回此系统声明依赖的 Model 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_systems",
+          "signature": "func get_required_systems() -> Array[Script]",
+          "summary": "返回此系统声明依赖的 System 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_utilities",
+          "signature": "func get_required_utilities() -> Array[Script]",
+          "summary": "返回此系统声明依赖的 Utility 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_factories",
+          "signature": "func get_required_factories() -> Array[Script]",
+          "summary": "返回此系统声明依赖的 Factory 绑定类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "init",
           "signature": "func init() -> void",
           "summary": "第一阶段初始化。子类可以重写此方法。",
@@ -80566,6 +80851,20 @@
           "name": "ready",
           "signature": "func ready() -> void",
           "summary": "第三阶段初始化。子类可以重写此方法。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_activation",
+          "signature": "func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开始激活系统的运行期能力。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_quiesce",
+          "signature": "func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开始静默系统并排空已经接纳的工作。",
           "visibility": "public"
         },
         {
@@ -86757,7 +87056,7 @@
       "module": "kernel",
       "package_id": "gf.kernel",
       "path": "addons/gf/kernel/base/gf_utility.gd",
-      "summary": "GFUtility: 工具组件抽象基类。 提供不依赖其他架构组件的独立工具功能。 子类可以实现 'init'、'async_init'、'ready'、 'dispose' 来管理其生命周期。",
+      "summary": "GFUtility: 工具组件抽象基类。 提供可复用的工具能力；需要其它架构组件时必须通过类型化 Hook 显式声明依赖。 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、",
       "visibility": "public",
       "category": "protocol",
       "since": "3.17.0",
@@ -86780,7 +87079,7 @@
           "kind": "var",
           "name": "lifecycle_priority",
           "signature": "var lifecycle_priority: int = 0",
-          "summary": "生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。",
+          "summary": "生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大",
           "visibility": "public"
         },
         {
@@ -86813,6 +87112,34 @@
         },
         {
           "kind": "func",
+          "name": "get_required_models",
+          "signature": "func get_required_models() -> Array[Script]",
+          "summary": "返回此工具声明依赖的 Model 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_systems",
+          "signature": "func get_required_systems() -> Array[Script]",
+          "summary": "返回此工具声明依赖的 System 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_utilities",
+          "signature": "func get_required_utilities() -> Array[Script]",
+          "summary": "返回此工具声明依赖的 Utility 类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_factories",
+          "signature": "func get_required_factories() -> Array[Script]",
+          "summary": "返回此工具声明依赖的 Factory 绑定类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "init",
           "signature": "func init() -> void",
           "summary": "第一阶段初始化。子类可以重写此方法。",
@@ -86830,6 +87157,20 @@
           "name": "ready",
           "signature": "func ready() -> void",
           "summary": "第三阶段初始化。子类可以重写此方法。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_activation",
+          "signature": "func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开始激活工具的运行期能力。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_quiesce",
+          "signature": "func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开始静默工具并排空已经接纳的工作。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFArchitecture.xml
+++ b/docs/api_catalog/classes/GFArchitecture.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="f8bf63c3d4680c2455f0346de461df6d8ba12ac3e92f5fb518310faceba6d472">
+<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="bbdcae7301e9c4a9d7c57db4bf355175a3cbe9b0614ea9a594a7a2a9ccf6de96">
 	<description>GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。
-生命周期遵循三阶段初始化协议：
-阶段一 (init)       ：所有模块执行自身内部变量初始化。
-阶段二 (async_init) ：所有模块串行执行异步初始化（可使用 await）。
-阶段三 (ready)      ：所有模块均已完成 init，可安全进行跨模块依赖获取。</description>
+生命周期遵循四阶段初始化协议：
+阶段一 (init)       ：各模块按声明依赖 DAG 执行自身内部变量初始化。
+阶段二 (async_init) ：按同一 DAG 串行执行异步准备（可使用 await）。
+阶段三 (ready)      ：当前模块的声明依赖已 ready，可完成同步装配。
+阶段四 (activation) ：按依赖顺序完成异步启动，全部成功后才开放运行时准入。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -27,6 +28,15 @@
 				<tag name="param">reason: 初始化失败原因。</tag>
 			</tags>
 		</member>
+		<member kind="signal" name="shutdown_finished">
+			<signature>signal shutdown_finished(result: GFArchitectureShutdownResult)</signature>
+			<description>当异步关闭流程或同步强制释放发布类型化终态时发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">result: 类型化关闭结果快照。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="signal" name="project_installers_finished">
 			<signature>signal project_installers_finished</signature>
 			<description>当项目级 Installer 应用完成或被 dispose() 中断后发出。</description>
@@ -45,41 +55,6 @@
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
-		<member kind="const" name="HOOK_GET_REQUIRED_DEPENDENCIES">
-			<signature>const HOOK_GET_REQUIRED_DEPENDENCIES: StringName = &amp;"get_required_dependencies"</signature>
-			<description>声明式依赖聚合 Hook 名称。</description>
-			<tags>
-				<tag name="api">public</tag>
-			</tags>
-		</member>
-		<member kind="const" name="HOOK_GET_REQUIRED_MODELS">
-			<signature>const HOOK_GET_REQUIRED_MODELS: StringName = &amp;"get_required_models"</signature>
-			<description>声明式 Model 依赖 Hook 名称。</description>
-			<tags>
-				<tag name="api">public</tag>
-			</tags>
-		</member>
-		<member kind="const" name="HOOK_GET_REQUIRED_SYSTEMS">
-			<signature>const HOOK_GET_REQUIRED_SYSTEMS: StringName = &amp;"get_required_systems"</signature>
-			<description>声明式 System 依赖 Hook 名称。</description>
-			<tags>
-				<tag name="api">public</tag>
-			</tags>
-		</member>
-		<member kind="const" name="HOOK_GET_REQUIRED_UTILITIES">
-			<signature>const HOOK_GET_REQUIRED_UTILITIES: StringName = &amp;"get_required_utilities"</signature>
-			<description>声明式 Utility 依赖 Hook 名称。</description>
-			<tags>
-				<tag name="api">public</tag>
-			</tags>
-		</member>
-		<member kind="const" name="HOOK_GET_REQUIRED_FACTORIES">
-			<signature>const HOOK_GET_REQUIRED_FACTORIES: StringName = &amp;"get_required_factories"</signature>
-			<description>声明式工厂依赖 Hook 名称。</description>
-			<tags>
-				<tag name="api">public</tag>
-			</tags>
-		</member>
 		<member kind="const" name="DEFAULT_SNAPSHOT_MODELS_PER_FRAME">
 			<signature>const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8</signature>
 			<description>分帧快照 API 默认每帧处理的 Model 数量。</description>
@@ -92,17 +67,11 @@
 	<properties>
 		<member kind="property" name="module_async_init_timeout_seconds">
 			<signature>var module_async_init_timeout_seconds: float = 0.0:</signature>
-			<description>单个模块 async_init() 的最长等待时间。小于等于 0 时不启用超时。
+			<description>单个模块 async_init() 的最长等待时间。0 时不启用超时。
 默认关闭；项目可按自身加载预算显式启用。</description>
 			<tags>
 				<tag name="api">public</tag>
-			</tags>
-		</member>
-		<member kind="property" name="module_lifecycle_max_stage_passes">
-			<signature>var module_lifecycle_max_stage_passes: int = 256:</signature>
-			<description>单个生命周期阶段最多扫描模块注册表的次数，避免模块在生命周期中无限注册新模块。</description>
-			<tags>
-				<tag name="api">public</tag>
+				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="strict_dependency_lookup">
@@ -110,16 +79,25 @@
 			<description>严格依赖查询模式。开启后本架构查询不到本地模块时不会回退父级架构。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
-		<member kind="property" name="fail_on_missing_declared_dependencies">
-			<signature>var fail_on_missing_declared_dependencies: bool = false</signature>
-			<description>声明式依赖缺失时是否直接使初始化失败。
-模块可通过 get_required_dependencies() 或 get_required_models/systems/utilities/factories() 声明依赖。
-开启后，init() 会在模块生命周期推进前校验依赖图，缺失依赖会中止本次初始化。</description>
+		<member kind="property" name="activation_timeout_seconds">
+			<signature>var activation_timeout_seconds: float = 30.0:</signature>
+			<description>架构激活阶段的总等待上限（秒）。
+0 时不启用 deadline；默认 30 秒。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="shutdown_timeout_seconds">
+			<signature>var shutdown_timeout_seconds: float = 10.0:</signature>
+			<description>架构 quiesce 阶段的总等待上限（秒）。
+0 时不启用 deadline；默认 10 秒。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="property" name="last_initialization_error">
@@ -141,10 +119,11 @@
 		</member>
 		<member kind="method" name="is_inited">
 			<signature>func is_inited() -&gt; bool:</signature>
-			<description>检查架构是否已初始化。</description>
+			<description>检查架构是否已完成四阶段启动并提交 READY。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">已初始化返回 true，否则返回 false。</tag>
+				<tag name="return">四阶段启动全部完成且 activation 已提交时返回 true，否则返回 false。</tag>
+				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="has_initialization_failed">
@@ -157,10 +136,40 @@
 		</member>
 		<member kind="method" name="is_lifecycle_active">
 			<signature>func is_lifecycle_active() -&gt; bool:</signature>
-			<description>检查当前架构生命周期是否仍处于可安全继续异步写回的活动状态。</description>
+			<description>检查当前架构生命周期是否仍处于可安全继续已接纳异步写回的活动状态。
+QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+is_accepting_runtime_work() 检查。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">正在初始化或已完成初始化，且未被 dispose() 或失败保护中断时返回 true。</tag>
+				<tag name="return">正在初始化、已完成初始化或正在收敛已接纳工作，且未被 dispose() 或失败保护中断时返回 true。</tag>
+				<tag name="since">1.23.2</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_activating">
+			<signature>func is_activating() -&gt; bool:</signature>
+			<description>检查架构是否正在执行第四阶段激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">架构正在执行第四阶段激活时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_quiescing">
+			<signature>func is_quiescing() -&gt; bool:</signature>
+			<description>检查架构是否已经关闭新工作、正在等待已接纳工作收敛。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">架构正在 quiesce 且尚未进入同步释放阶段时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_accepting_runtime_work">
+			<signature>func is_accepting_runtime_work() -&gt; bool:</signature>
+			<description>检查架构是否仍接纳新的运行时工作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">仅在完整激活并处于 READY 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="is_disposed">
@@ -208,6 +217,25 @@
 				<tag name="api">public</tag>
 				<tag name="param">instance: 由当前架构注册的模块实例。</tag>
 				<tag name="return">模块完成 ready 阶段时返回 true。</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_module_active">
+			<signature>func is_module_active(instance: Object) -&gt; bool:</signature>
+			<description>检查模块是否已经完成第四阶段激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">instance: 由当前架构本地注册的模块实例。</tag>
+				<tag name="return">模块属于当前架构且已完成第四阶段激活时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_last_shutdown_result">
+			<signature>func get_last_shutdown_result() -&gt; GFArchitectureShutdownResult:</signature>
+			<description>获取最近一次关闭结果的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未关闭时返回 null。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="fail_initialization">
@@ -284,22 +312,46 @@ DISPOSING / DISPOSED 是不可恢复终态，迟到调用不会改写其状态�
 			</tags>
 		</member>
 		<member kind="method" name="init">
-			<signature>func init() -&gt; bool:</signature>
-			<description>初始化架构及所有注册的组件（三阶段）。
-阶段一：调用所有模块的 init()，用于初始化自身内部变量。
-阶段二：串行 await 所有模块的 async_init()，用于异步资源加载等操作。
-阶段三：调用所有模块的 ready()，此时跨模块依赖获取是安全的。</description>
+			<signature>func init(cancellation_token: GFCancellationToken = null) -&gt; bool:</signature>
+			<description>初始化架构及所有注册的组件（四阶段）。
+阶段一：按声明依赖 DAG 调用模块的 init()，用于初始化自身内部变量。
+阶段二：按同一 DAG 串行 await 模块的 async_init()，用于异步准备。
+阶段三：调用模块的 ready()；当前模块声明的依赖已 ready，未声明依赖无可用保证。
+阶段四：按声明依赖顺序调用 begin_activation()，全部成功后才提交 READY。
+并发调用复用同一初始化事务；首个调用拥有共享流程的取消策略，后续调用的
+token 只取消自身等待，不会中断共享初始化。架构已经 READY 时幂等成功优先于
+调用方 token 的取消状态。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="param">cancellation_token: 可选的初始化取消令牌。</tag>
 				<tag name="return">初始化完成且架构处于 ready 状态时返回 true。</tag>
 				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
-		<member kind="method" name="dispose">
-			<signature>func dispose() -&gt; void:</signature>
-			<description>销毁架构及所有注册的组件。</description>
+		<member kind="method" name="shutdown_async">
+			<signature>func shutdown_async( cancellation_token: GFCancellationToken = null, timeout_seconds: float = -1.0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>异步关闭架构。
+若活动子架构仍持有本架构的外部依赖租约，本方法会在改变任何生命周期
+状态前返回失败；否则新工作准入会不可逆关闭，已接纳工作按激活计划逆序
+quiesce，随后每个模块的同步 dispose/release hook 恰好执行一次。并发调用共享
+同一流程；首个调用拥有共享流程的 cancellation token 与 deadline 策略，后续
+调用在参数校验通过后只等待并复制同一终态结果。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="param">cancellation_token: 可选关闭取消令牌。</tag>
+				<tag name="param">timeout_seconds: cooperative quiesce 与异步等待预算；仅 -1 使用 shutdown_timeout_seconds。最终同步释放不承诺墙钟硬上限。</tag>
+				<tag name="return">类型化关闭结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="dispose">
+			<signature>func dispose() -&gt; void:</signature>
+			<description>强制同步销毁架构及所有注册组件。
+该方法用于 SceneTree 退出等无法等待的终止路径；正常退出应优先 await
+shutdown_async()，以便已接纳工作先收敛。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="tick">
@@ -902,27 +954,33 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 			</tags>
 		</member>
 		<member kind="method" name="unregister_system">
-			<signature>func unregister_system(script_cls: Script) -&gt; void:</signature>
+			<signature>func unregister_system(script_cls: Script) -&gt; bool:</signature>
 			<description>注销 System 实例。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 系统的脚本类。</tag>
+				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
+				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_model">
-			<signature>func unregister_model(script_cls: Script) -&gt; void:</signature>
+			<signature>func unregister_model(script_cls: Script) -&gt; bool:</signature>
 			<description>注销 Model 实例。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 模型的脚本类。</tag>
+				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
+				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_utility">
-			<signature>func unregister_utility(script_cls: Script) -&gt; void:</signature>
+			<signature>func unregister_utility(script_cls: Script) -&gt; bool:</signature>
 			<description>注销 Utility 实例。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 工具的脚本类。</tag>
+				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
+				<tag name="since">5.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_system">
@@ -1023,11 +1081,14 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 		</member>
 		<member kind="method" name="create_instance">
 			<signature>func create_instance(script_cls: Script) -&gt; Object:</signature>
-			<description>通过已注册工厂创建短生命周期对象。</description>
+			<description>通过已注册工厂创建短生命周期对象。
+仅在架构已经提交 READY 且没有热拓扑事务时接纳；其它生命周期状态会在
+调用 provider 前返回 null。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 要创建的脚本类型。</tag>
-				<tag name="return">新对象实例；没有工厂或工厂返回非对象时返回 null。</tag>
+				<tag name="return">新对象实例；运行时未开放、没有工厂或工厂返回非对象时返回 null。</tag>
+				<tag name="since">1.9.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="inject_object">
@@ -1203,14 +1264,12 @@ validate 零写入失败固定为 false。</description>
 			</tags>
 		</member>
 		<member kind="method" name="get_dependency_diagnostics">
-			<signature>func get_dependency_diagnostics(options: Dictionary = {}) -&gt; Dictionary:</signature>
+			<signature>func get_dependency_diagnostics() -&gt; Dictionary:</signature>
 			<description>获取架构中已注册模块的声明式依赖诊断报告。
-模块可选择实现 get_required_dependencies() 或 get_required_models/systems/utilities/factories()。</description>
+模块通过 get_required_models/systems/utilities/factories() 分别声明依赖。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">options: 可选参数，支持 include_parent_lookup 与 include_factories。</tag>
 				<tag name="return">统一诊断报告字典。</tag>
-				<tag name="schema">options: Dictionary with optional bool keys include_parent_lookup and include_factories.</tag>
 				<tag name="schema">return: Dictionary dependency diagnostics report with modules, resolved_dependencies, missing_dependencies, parent-chain cycle issue records, issue counts, and next_action.</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>

--- a/docs/api_catalog/classes/GFArchitecture.xml
+++ b/docs/api_catalog/classes/GFArchitecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="bbdcae7301e9c4a9d7c57db4bf355175a3cbe9b0614ea9a594a7a2a9ccf6de96">
+<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="ffe58eee8a9758a10073a0edd610bb27e453ff53cf67b105870c134027253e69">
 	<description>GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。
 生命周期遵循四阶段初始化协议：
 阶段一 (init)       ：各模块按声明依赖 DAG 执行自身内部变量初始化。
@@ -71,7 +71,7 @@
 默认关闭；项目可按自身加载预算显式启用。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">1.23.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="strict_dependency_lookup">
@@ -79,7 +79,7 @@
 			<description>严格依赖查询模式。开启后本架构查询不到本地模块时不会回退父级架构。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">1.23.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="activation_timeout_seconds">
@@ -123,7 +123,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">四阶段启动全部完成且 activation 已提交时返回 true，否则返回 false。</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="has_initialization_failed">
@@ -960,7 +960,7 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 系统的脚本类。</tag>
 				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_model">
@@ -970,7 +970,7 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 模型的脚本类。</tag>
 				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="unregister_utility">
@@ -980,7 +980,7 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 				<tag name="api">public</tag>
 				<tag name="param">script_cls: 工具的脚本类。</tag>
 				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_system">

--- a/docs/api_catalog/classes/GFArchitectureShutdownResult.xml
+++ b/docs/api_catalog/classes/GFArchitectureShutdownResult.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFArchitectureShutdownResult" path="addons/gf/kernel/core/gf_architecture_shutdown_result.gd" module="kernel" extends="RefCounted" classDigest="36470ff19b27b02a7c557dfcc9a1318bb22ec4a2f78f38b2d8a421cfda4961ba">
+	<description>GFArchitectureShutdownResult: 架构关闭流程的不可变终态快照。
+结果显式区分正常完成、失败、取消、超时、强制释放和重复释放，并以有界、
+JSON-safe 的模块条目保留关闭证据。所有集合在写入和读取边界都会重新复制，
+调用方不能借由返回值修改已提交终态。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="layer">kernel/core</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums>
+		<member kind="enum" name="Status">
+			<signature>enum Status {
+	## 所有关闭阶段正常完成。
+	SUCCEEDED,
+	## 至少一个关闭阶段失败。
+	FAILED,
+	## 调用方取消了关闭流程。
+	CANCELLED,
+	## 关闭流程超过了时间预算。
+	TIMED_OUT,
+	## 框架跳过未完成的静默工作并执行了强制释放。
+	FORCED,
+	## 架构在本次请求前已经释放。
+	ALREADY_DISPOSED,
+}</signature>
+			<description>架构关闭终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="create">
+			<signature>static func create( status: Status, started_at_msec: int, completed_at_msec: int, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], duplicate_request_count: int = 0, error_code: Error = OK, error: String = "", cancel_reason: String = "" ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建一个规范化的架构关闭结果。
+模块条目最多各保留 256 项，并且只保留 kind、script、instance_id、status、
+reason 和 duration_msec 字段。字符串和非负 duration 会被限制到固定预算；
+instance_id 保留 Godot 返回的有符号 int 身份值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">status: `Status` 终态。</tag>
+				<tag name="param">started_at_msec: 单调开始时间；负值归零。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间；早于开始时间时收敛到开始时间。</tag>
+				<tag name="param">module_results: 已进入终态的模块关闭结果。</tag>
+				<tag name="param">unfinished_modules: 强制释放时仍未完成的模块快照。</tag>
+				<tag name="param">duplicate_request_count: 复用同一关闭流程的并发重复请求数量。</tag>
+				<tag name="param">error_code: 关闭错误码；成功终态强制归一为 OK。</tag>
+				<tag name="param">error: 稳定失败说明；最多保留 2048 个字符。</tag>
+				<tag name="param">cancel_reason: 取消原因；仅取消终态保留，最多 1024 个字符。</tag>
+				<tag name="return">新的不可变结果。</tag>
+				<tag name="schema">module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="schema">unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="succeeded">
+			<signature>static func succeeded( module_results: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建正常完成结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">module_results: 已完成的模块关闭结果。</tag>
+				<tag name="param">started_at_msec: 单调开始时间。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间。</tag>
+				<tag name="param">duplicate_request_count: 并发重复请求数量。</tag>
+				<tag name="return">新的成功结果。</tag>
+				<tag name="schema">module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="failed">
+			<signature>static func failed( error_code: Error, error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建失败结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">error_code: 关闭错误码。</tag>
+				<tag name="param">error: 稳定失败说明。</tag>
+				<tag name="param">module_results: 已完成的模块关闭结果。</tag>
+				<tag name="param">unfinished_modules: 尚未完成的模块快照。</tag>
+				<tag name="param">started_at_msec: 单调开始时间。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间。</tag>
+				<tag name="param">duplicate_request_count: 并发重复请求数量。</tag>
+				<tag name="return">新的失败结果。</tag>
+				<tag name="schema">module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="schema">unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="cancelled">
+			<signature>static func cancelled( reason: String = "cancelled", module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建取消结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">reason: 稳定取消原因。</tag>
+				<tag name="param">module_results: 已完成的模块关闭结果。</tag>
+				<tag name="param">unfinished_modules: 尚未完成的模块快照。</tag>
+				<tag name="param">started_at_msec: 单调开始时间。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间。</tag>
+				<tag name="param">duplicate_request_count: 并发重复请求数量。</tag>
+				<tag name="return">新的取消结果。</tag>
+				<tag name="schema">module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="schema">unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="timed_out">
+			<signature>static func timed_out( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建超时结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">error: 稳定超时说明。</tag>
+				<tag name="param">module_results: 已完成的模块关闭结果。</tag>
+				<tag name="param">unfinished_modules: 超时时尚未完成的模块快照。</tag>
+				<tag name="param">started_at_msec: 单调开始时间。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间。</tag>
+				<tag name="param">duplicate_request_count: 并发重复请求数量。</tag>
+				<tag name="return">新的超时结果。</tag>
+				<tag name="schema">module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="schema">unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="forced">
+			<signature>static func forced( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建强制释放结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">error: 强制释放原因。</tag>
+				<tag name="param">module_results: 已完成的模块关闭结果。</tag>
+				<tag name="param">unfinished_modules: 被强制跳过的模块快照。</tag>
+				<tag name="param">started_at_msec: 单调开始时间。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间。</tag>
+				<tag name="param">duplicate_request_count: 并发重复请求数量。</tag>
+				<tag name="return">新的强制释放结果。</tag>
+				<tag name="schema">module_results: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="schema">unfinished_modules: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="already_disposed">
+			<signature>static func already_disposed( started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建已释放幂等结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">started_at_msec: 单调开始时间。</tag>
+				<tag name="param">completed_at_msec: 单调完成时间。</tag>
+				<tag name="param">duplicate_request_count: 并发重复请求数量。</tag>
+				<tag name="return">新的已释放结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>检查关闭是否以正常或幂等成功结束。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正常完成或此前已释放时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; Status:</signature>
+			<description>获取关闭终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`Status` 终态。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status_name">
+			<signature>func get_status_name() -&gt; StringName:</signature>
+			<description>获取关闭终态名称。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">小写稳定状态名称。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_started_at_msec">
+			<signature>func get_started_at_msec() -&gt; int:</signature>
+			<description>获取关闭开始时间。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非负单调毫秒时间。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_completed_at_msec">
+			<signature>func get_completed_at_msec() -&gt; int:</signature>
+			<description>获取关闭完成时间。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">不早于开始时间的单调毫秒时间。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_duration_msec">
+			<signature>func get_duration_msec() -&gt; int:</signature>
+			<description>获取关闭耗时。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非负单调毫秒耗时。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_module_results">
+			<signature>func get_module_results() -&gt; Array[Dictionary]:</signature>
+			<description>获取已完成模块结果的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">最多 256 个规范化模块条目。</tag>
+				<tag name="schema">return: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_unfinished_modules">
+			<signature>func get_unfinished_modules() -&gt; Array[Dictionary]:</signature>
+			<description>获取未完成模块快照的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">最多 256 个规范化模块条目。</tag>
+				<tag name="schema">return: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_duplicate_request_count">
+			<signature>func get_duplicate_request_count() -&gt; int:</signature>
+			<description>获取复用同一关闭流程的重复请求数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非负重复请求数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_code">
+			<signature>func get_error_code() -&gt; Error:</signature>
+			<description>获取关闭错误码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功终态为 OK。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error">
+			<signature>func get_error() -&gt; String:</signature>
+			<description>获取稳定失败说明。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">最多 2048 个字符的失败说明。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_cancel_reason">
+			<signature>func get_cancel_reason() -&gt; String:</signature>
+			<description>获取取消原因。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">最多 1024 个字符的取消原因；非取消终态为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_result">
+			<signature>func duplicate_result() -&gt; GFArchitectureShutdownResult:</signature>
+			<description>创建隔离结果副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新的不可变结果对象。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为可报告字典。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">关闭终态、时间、模块结果和错误证据的隔离快照。</tag>
+				<tag name="schema">return: Dictionary with ok, status, status_name, started_at_msec, completed_at_msec, duration_msec, module_results, unfinished_modules, duplicate_request_count, error_code, error, and cancel_reason.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFModel.xml
+++ b/docs/api_catalog/classes/GFModel.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFModel" path="addons/gf/kernel/base/gf_model.gd" module="kernel" extends="Object" classDigest="82e0d6da1c83673e9da2cd9960eb20c1650c1fa58c3f107e4bed95b279e42b88">
+<class name="GFModel" path="addons/gf/kernel/base/gf_model.gd" module="kernel" extends="Object" classDigest="84c42762ee81393bf1664c448daae9af67ad6486c043472f7ce92d3f276a78cf">
 	<description>GFModel: 数据层抽象基类。
 负责管理应用数据和业务状态。
-子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。
-三阶段初始化约定：
+子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
+'begin_quiesce'、'dispose' 来管理其生命周期。
+四阶段启动与关闭约定：
 - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。
 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。
-- 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。</description>
+- 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。
+- 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。
+- 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。
+- 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">protocol</tag>
@@ -18,14 +22,56 @@
 	<properties>
 		<member kind="property" name="lifecycle_priority">
 			<signature>var lifecycle_priority: int = 0</signature>
-			<description>生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。
-默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。</description>
+			<description>生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大
+越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。
+默认 0 表示同一 frontier 内按稳定注册顺序执行。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">1.31.0</tag>
 			</tags>
 		</member>
 	</properties>
 	<methods>
+		<member kind="method" name="get_required_models">
+			<signature>func get_required_models() -&gt; Array[Script]:</signature>
+			<description>返回此模型声明依赖的 Model 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此模型激活前必须可解析的 Model 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_systems">
+			<signature>func get_required_systems() -&gt; Array[Script]:</signature>
+			<description>返回此模型声明依赖的 System 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此模型激活前必须可解析的 System 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_utilities">
+			<signature>func get_required_utilities() -&gt; Array[Script]:</signature>
+			<description>返回此模型声明依赖的 Utility 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此模型激活前必须可解析的 Utility 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_factories">
+			<signature>func get_required_factories() -&gt; Array[Script]:</signature>
+			<description>返回此模型声明依赖的 Factory 绑定类型。
+Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此模型激活前必须可解析的 Factory 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="init">
 			<signature>func init() -&gt; void:</signature>
 			<description>第一阶段初始化。子类可以重写此方法。
@@ -49,9 +95,35 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 		<member kind="method" name="ready">
 			<signature>func ready() -&gt; void:</signature>
 			<description>第三阶段初始化。子类可以重写此方法。
-约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。</description>
+约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖；
+未声明依赖没有可用性保证。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">5.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_activation">
+			<signature>func begin_activation(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开始激活模型的运行期能力。
+重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。
+基类返回已经成功的完成源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前模型激活阶段的取消作用域。</tag>
+				<tag name="return">当前激活阶段的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_quiesce">
+			<signature>func begin_quiesce(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开始静默模型并排空已经接纳的工作。
+重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。
+基类返回已经成功的完成源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前模型静默阶段的取消作用域。</tag>
+				<tag name="return">当前静默阶段的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="dispose">
@@ -109,10 +181,13 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 		<member kind="method" name="is_lifecycle_active">
 			<signature>func is_lifecycle_active() -&gt; bool:</signature>
 			<description>检查所属架构生命周期是否仍可安全继续异步写回。
-async_init() 或其他 await 之后写入状态前建议检查该值。</description>
+async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。
+QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+GFArchitecture.is_accepting_runtime_work() 检查。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">所属架构仍处于活动生命周期时返回 true。</tag>
+				<tag name="since">3.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="is_ready_in_architecture">

--- a/docs/api_catalog/classes/GFModel.xml
+++ b/docs/api_catalog/classes/GFModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFModel" path="addons/gf/kernel/base/gf_model.gd" module="kernel" extends="Object" classDigest="84c42762ee81393bf1664c448daae9af67ad6486c043472f7ce92d3f276a78cf">
+<class name="GFModel" path="addons/gf/kernel/base/gf_model.gd" module="kernel" extends="Object" classDigest="0eb970028e23640ca44cd1f35041fef441fb3eb5cf18177765e3e4e722a7caac">
 	<description>GFModel: 数据层抽象基类。
 负责管理应用数据和业务状态。
 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
@@ -99,7 +99,7 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 未声明依赖没有可用性保证。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="begin_activation">

--- a/docs/api_catalog/classes/GFNodeContext.xml
+++ b/docs/api_catalog/classes/GFNodeContext.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFNodeContext" path="addons/gf/kernel/core/gf_node_context.gd" module="kernel" extends="Node" classDigest="f9f9fb5055c91a438316256d1e0786afe4df4242e67a0c36238c5efdec2ce926">
+<class name="GFNodeContext" path="addons/gf/kernel/core/gf_node_context.gd" module="kernel" extends="Node" classDigest="63a846aa8095abbb6a0ba3d501a29c1da3f859c5f355ea31a009a6175b2f76f4">
 	<description>GFNodeContext: 场景树上的局部架构上下文。
 可选择继承父级架构，或创建带父级回退的 Scoped 架构。
-Scoped 架构会在节点退出树时自动 dispose，适合关卡、战斗房间、调试面板等局部模块。</description>
+Scoped 架构会在节点退出树时使用无法等待的 forced/no-drain dispose fallback，
+适合关卡、战斗房间、调试面板等局部模块。可控或数据关键的退出必须先 await
+owned Architecture 的 shutdown_async()，再移除节点。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -12,10 +14,11 @@ Scoped 架构会在节点退出树时自动 dispose，适合关卡、战斗房�
 	<signals>
 		<member kind="signal" name="context_ready">
 			<signature>signal context_ready(architecture: GFArchitecture)</signature>
-			<description>当上下文架构完成初始化后发出。</description>
+			<description>当上下文 Architecture 完成 stage4 activation 并提交 READY 后发出。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">architecture: 当前上下文使用的架构实例。</tag>
+				<tag name="since">1.9.0</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="context_failed">

--- a/docs/api_catalog/classes/GFSaveProfileUtility.xml
+++ b/docs/api_catalog/classes/GFSaveProfileUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveProfileUtility" path="addons/gf/extensions/save/profile/gf_save_profile_utility.gd" module="extensions/save" extends="GFUtility" classDigest="0ef1cfaa8cf84b2d61d94bd43431d0b4c483d3626dc12c1e7a91b6802a1e3ec7">
+<class name="GFSaveProfileUtility" path="addons/gf/extensions/save/profile/gf_save_profile_utility.gd" module="extensions/save" extends="GFUtility" classDigest="102beb45467c19d82257d460c6781b7bfa20a2251b7b4bc391961a68eb35b2ff">
 	<description>GFSaveProfileUtility: 多 section 存档的异步协调器。
 每个 profile 只串行推进一个当前 IO；超时后无法取消的写入会 detached 保留路径所有权。
 连续保存通过 generation 合并为最新后续写入；读取在保存屏障后执行，并在主线程完成迁移、校验和 provider 事务化应用。</description>
@@ -126,6 +126,39 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">10.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_utilities">
+			<signature>func get_required_utilities() -&gt; Array[Script]:</signature>
+			<description>声明架构模式下必须显式注册的 Storage 依赖。
+`setup()` 仍可用于 standalone 测试与非 Architecture 所有权场景；进入 Architecture
+生命周期时不会因此绕过 GFStorageUtility 的显式注册要求。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">仅包含 GFStorageUtility 的依赖声明。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_activation">
+			<signature>func begin_activation(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>激活 Profile 服务；底层 Storage 未配置时失败，不创建业务 profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前 Profile 服务激活阶段的取消作用域。</tag>
+				<tag name="return">Storage 可用时成功，否则返回失败终态。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_quiesce">
+			<signature>func begin_quiesce(scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>关闭新 profile 工作准入，并等待已接纳 operation、preparation、retry 与 detached 写入收敛。
+静默期间不会注册业务 profile，也不会取消已接纳工作；这些工作继续由 lifecycle tick
+和底层 Storage 完成回调推进。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">scope: 当前 Profile 服务静默阶段的取消作用域。</tag>
+				<tag name="return">所有已接纳工作进入终态后成功的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="tick">

--- a/docs/api_catalog/classes/GFSaveProfileUtility.xml
+++ b/docs/api_catalog/classes/GFSaveProfileUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveProfileUtility" path="addons/gf/extensions/save/profile/gf_save_profile_utility.gd" module="extensions/save" extends="GFUtility" classDigest="102beb45467c19d82257d460c6781b7bfa20a2251b7b4bc391961a68eb35b2ff">
+<class name="GFSaveProfileUtility" path="addons/gf/extensions/save/profile/gf_save_profile_utility.gd" module="extensions/save" extends="GFUtility" classDigest="db7703edad6d7c9f4265d26058d1f7aaa703e0bffad1fab404d539e06de4851d">
 	<description>GFSaveProfileUtility: 多 section 存档的异步协调器。
 每个 profile 只串行推进一个当前 IO；超时后无法取消的写入会 detached 保留路径所有权。
 连续保存通过 generation 合并为最新后续写入；读取在保存屏障后执行，并在主线程完成迁移、校验和 provider 事务化应用。</description>
@@ -145,7 +145,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">_scope: 当前 Profile 服务激活阶段的取消作用域。</tag>
-				<tag name="return">Storage 可用时成功，否则返回失败终态。</tag>
+				<tag name="return">Storage 可用且实例未 dispose/quiesce 时成功，否则返回失败终态。</tag>
 				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
@@ -185,7 +185,7 @@
 				<tag name="api">public</tag>
 				<tag name="param">storage: 底层事务存储工具。</tag>
 				<tag name="param">clock: 可选单调时钟；为空时保留当前时钟。</tag>
-				<tag name="return">当前 Utility；参数无效、已释放或已有注册 profile 时返回 null。</tag>
+				<tag name="return">当前 Utility；准入关闭、参数无效、已释放、处于不安全回调或已有 profile 时返回 null。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
@@ -207,7 +207,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">profile_id: profile ID。</tag>
-				<tag name="return">profile 存在且没有未完成操作时返回 true。</tag>
+				<tag name="return">准入开放、回调安全且 profile 空闲并无任何待处理工作时返回 true。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFStorageUtility.xml
+++ b/docs/api_catalog/classes/GFStorageUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="6064b17e618783d53c51d21bb3ac2c29ca97d8b129db1768ebc84fb2c290c150">
+<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="475e5da59b0d380b928eb58e6e0f0987059d5c5091068611d62e252d3ef829ca">
 	<description>GFStorageUtility: 基于 `user://` 的轻量存档系统。
 支持槽位存档、元数据分离读取、`Resource` 存取，
 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。
@@ -247,6 +247,27 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">_delta: 本帧时间增量（秒），默认实现不直接使用。</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_activation">
+			<signature>func begin_activation(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>激活 Storage 的同步与异步 I/O 准入。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前 Storage 激活阶段的取消作用域。</tag>
+				<tag name="return">已成功完成；正在 dispose 时返回失败终态。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_quiesce">
+			<signature>func begin_quiesce(scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>关闭新 I/O 准入，并等待此前接纳的队列、线程和文件锁全部收敛。
+已接纳任务继续由 lifecycle tick 推进；强制 dispose 仍会使用同步 join fallback。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">scope: 当前 Storage 静默阶段的取消作用域。</tag>
+				<tag name="return">队列、任务和锁全部终态后成功的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="save_resource">

--- a/docs/api_catalog/classes/GFStorageUtility.xml
+++ b/docs/api_catalog/classes/GFStorageUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="475e5da59b0d380b928eb58e6e0f0987059d5c5091068611d62e252d3ef829ca">
+<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="5ec43970f594a2213d612fdb8a22bff66a7eb291823462a37ee3db86872b3686">
 	<description>GFStorageUtility: 基于 `user://` 的轻量存档系统。
 支持槽位存档、元数据分离读取、`Resource` 存取，
 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。
@@ -255,7 +255,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">_scope: 当前 Storage 激活阶段的取消作用域。</tag>
-				<tag name="return">已成功完成；正在 dispose 时返回失败终态。</tag>
+				<tag name="return">成功打开 I/O 准入；正在 dispose 或已经进入过 quiesce 时返回失败终态。</tag>
 				<tag name="since">unreleased</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFSystem.xml
+++ b/docs/api_catalog/classes/GFSystem.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSystem" path="addons/gf/kernel/base/gf_system.gd" module="kernel" extends="Object" classDigest="6499e2fd9397c38c9292d65889f095e06e8d6691aa74bd38ca9eb79442278a83">
+<class name="GFSystem" path="addons/gf/kernel/base/gf_system.gd" module="kernel" extends="Object" classDigest="02f6650dae2dc182e4c1e836324e60c0446d20510c3f77af1a49035f680e4ac4">
 	<description>GFSystem: 逻辑层抽象基类。
 负责实现核心业务逻辑。
-子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。
-三阶段初始化约定：
+子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
+'begin_quiesce'、'dispose' 来管理其生命周期。
+四阶段启动与关闭约定：
 - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。
 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。
-- 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。</description>
+- 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。
+- 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。
+- 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。
+- 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">protocol</tag>
@@ -37,10 +41,12 @@
 		</member>
 		<member kind="property" name="lifecycle_priority">
 			<signature>var lifecycle_priority: int = 0</signature>
-			<description>生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。
-默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。</description>
+			<description>生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大
+越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。
+默认 0 表示同一 frontier 内按稳定注册顺序执行。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">1.31.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="tick_priority">
@@ -79,6 +85,46 @@
 		</member>
 	</properties>
 	<methods>
+		<member kind="method" name="get_required_models">
+			<signature>func get_required_models() -&gt; Array[Script]:</signature>
+			<description>返回此系统声明依赖的 Model 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此系统激活前必须可解析的 Model 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_systems">
+			<signature>func get_required_systems() -&gt; Array[Script]:</signature>
+			<description>返回此系统声明依赖的 System 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此系统激活前必须可解析的 System 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_utilities">
+			<signature>func get_required_utilities() -&gt; Array[Script]:</signature>
+			<description>返回此系统声明依赖的 Utility 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此系统激活前必须可解析的 Utility 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_factories">
+			<signature>func get_required_factories() -&gt; Array[Script]:</signature>
+			<description>返回此系统声明依赖的 Factory 绑定类型。
+Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此系统激活前必须可解析的 Factory 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="init">
 			<signature>func init() -&gt; void:</signature>
 			<description>第一阶段初始化。子类可以重写此方法。
@@ -102,9 +148,35 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 		<member kind="method" name="ready">
 			<signature>func ready() -&gt; void:</signature>
 			<description>第三阶段初始化。子类可以重写此方法。
-约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。</description>
+约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖；
+未声明依赖没有可用性保证。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">5.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_activation">
+			<signature>func begin_activation(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开始激活系统的运行期能力。
+重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。
+基类返回已经成功的完成源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前系统激活阶段的取消作用域。</tag>
+				<tag name="return">当前激活阶段的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_quiesce">
+			<signature>func begin_quiesce(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开始静默系统并排空已经接纳的工作。
+重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。
+基类返回已经成功的完成源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前系统静默阶段的取消作用域。</tag>
+				<tag name="return">当前静默阶段的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="dispose">
@@ -144,10 +216,13 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 		<member kind="method" name="is_lifecycle_active">
 			<signature>func is_lifecycle_active() -&gt; bool:</signature>
 			<description>检查所属架构生命周期是否仍可安全继续异步写回。
-async_init() 或其他 await 之后写入状态前建议检查该值。</description>
+async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。
+QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+GFArchitecture.is_accepting_runtime_work() 检查。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">所属架构仍处于活动生命周期时返回 true。</tag>
+				<tag name="since">3.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="is_ready_in_architecture">

--- a/docs/api_catalog/classes/GFSystem.xml
+++ b/docs/api_catalog/classes/GFSystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSystem" path="addons/gf/kernel/base/gf_system.gd" module="kernel" extends="Object" classDigest="02f6650dae2dc182e4c1e836324e60c0446d20510c3f77af1a49035f680e4ac4">
+<class name="GFSystem" path="addons/gf/kernel/base/gf_system.gd" module="kernel" extends="Object" classDigest="ecf44bb9e0f65c6471861a9a2ac9868a81f8790bf568766b7907b60532ba19dd">
 	<description>GFSystem: 逻辑层抽象基类。
 负责实现核心业务逻辑。
 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
@@ -152,7 +152,7 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 未声明依赖没有可用性保证。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="begin_activation">

--- a/docs/api_catalog/classes/GFUtility.xml
+++ b/docs/api_catalog/classes/GFUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFUtility" path="addons/gf/kernel/base/gf_utility.gd" module="kernel" extends="Object" classDigest="e34c9b393e90a8449ba7a6651c5f460ded0e661f14181ee3501420d6d17c17ae">
+<class name="GFUtility" path="addons/gf/kernel/base/gf_utility.gd" module="kernel" extends="Object" classDigest="b9fda12508d94957882637de69cf3ef1e2969a435e2f84e49da20c4f93b8ab22">
 	<description>GFUtility: 工具组件抽象基类。
 提供可复用的工具能力；需要其它架构组件时必须通过类型化 Hook 显式声明依赖。
 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
@@ -151,7 +151,7 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 未声明依赖没有可用性保证。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.0.0</tag>
+				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="begin_activation">

--- a/docs/api_catalog/classes/GFUtility.xml
+++ b/docs/api_catalog/classes/GFUtility.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFUtility" path="addons/gf/kernel/base/gf_utility.gd" module="kernel" extends="Object" classDigest="9de17239e27a5f2c76e7c1f417c6c9aa6c57037381078dadf28e70bca9c42201">
+<class name="GFUtility" path="addons/gf/kernel/base/gf_utility.gd" module="kernel" extends="Object" classDigest="e34c9b393e90a8449ba7a6651c5f460ded0e661f14181ee3501420d6d17c17ae">
 	<description>GFUtility: 工具组件抽象基类。
-提供不依赖其他架构组件的独立工具功能。
-子类可以实现 'init'、'async_init'、'ready'、 'dispose' 来管理其生命周期。
-三阶段初始化约定：
+提供可复用的工具能力；需要其它架构组件时必须通过类型化 Hook 显式声明依赖。
+子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、
+'begin_quiesce'、'dispose' 来管理其生命周期。
+四阶段启动与关闭约定：
 - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。
 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。
-- 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。</description>
+- 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。
+- 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。
+- 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。
+- 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">protocol</tag>
@@ -36,10 +40,12 @@
 		</member>
 		<member kind="property" name="lifecycle_priority">
 			<signature>var lifecycle_priority: int = 0</signature>
-			<description>生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。
-默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。</description>
+			<description>生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大
+越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。
+默认 0 表示同一 frontier 内按稳定注册顺序执行。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">1.31.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="tick_priority">
@@ -78,6 +84,46 @@
 		</member>
 	</properties>
 	<methods>
+		<member kind="method" name="get_required_models">
+			<signature>func get_required_models() -&gt; Array[Script]:</signature>
+			<description>返回此工具声明依赖的 Model 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此工具激活前必须可解析的 Model 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_systems">
+			<signature>func get_required_systems() -&gt; Array[Script]:</signature>
+			<description>返回此工具声明依赖的 System 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此工具激活前必须可解析的 System 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_utilities">
+			<signature>func get_required_utilities() -&gt; Array[Script]:</signature>
+			<description>返回此工具声明依赖的 Utility 类型。
+返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此工具激活前必须可解析的 Utility 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_required_factories">
+			<signature>func get_required_factories() -&gt; Array[Script]:</signature>
+			<description>返回此工具声明依赖的 Factory 绑定类型。
+Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">此工具激活前必须可解析的 Factory 脚本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="init">
 			<signature>func init() -&gt; void:</signature>
 			<description>第一阶段初始化。子类可以重写此方法。
@@ -101,9 +147,35 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 		<member kind="method" name="ready">
 			<signature>func ready() -&gt; void:</signature>
 			<description>第三阶段初始化。子类可以重写此方法。
-约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。</description>
+约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖；
+未声明依赖没有可用性保证。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">5.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_activation">
+			<signature>func begin_activation(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开始激活工具的运行期能力。
+重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。
+基类返回已经成功的完成源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前工具激活阶段的取消作用域。</tag>
+				<tag name="return">当前激活阶段的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_quiesce">
+			<signature>func begin_quiesce(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开始静默工具并排空已经接纳的工作。
+重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。
+基类返回已经成功的完成源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前工具静默阶段的取消作用域。</tag>
+				<tag name="return">当前静默阶段的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="dispose">
@@ -125,10 +197,13 @@ Godot 4 支持在 void 函数内部使用 await，框架的 Gf.init() 会串行�
 		<member kind="method" name="is_lifecycle_active">
 			<signature>func is_lifecycle_active() -&gt; bool:</signature>
 			<description>检查所属架构生命周期是否仍可安全继续异步写回。
-async_init() 或其他 await 之后写入状态前建议检查该值。</description>
+async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。
+QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过
+GFArchitecture.is_accepting_runtime_work() 检查。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">所属架构仍处于活动生命周期时返回 true。</tag>
+				<tag name="since">3.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="is_ready_in_architecture">

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="9e39789450c4cbf9fc430ce4d263f028aefa8c493e1a23a8db60025c98455864" classCount="793" methodCount="7151">
-	<module id="kernel" label="Kernel" classCount="73" methodCount="747">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="86e4d52b3f10357105f4007a41f882fa32fe14ad28c23fb6f2d0665d7a5cf33a" classCount="794" methodCount="7201">
+	<module id="kernel" label="Kernel" classCount="74" methodCount="792">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
+		<class name="GFArchitectureShutdownResult" path="classes/GFArchitectureShutdownResult.xml" sourcePath="addons/gf/kernel/core/gf_architecture_shutdown_result.gd" extends="RefCounted" />
 		<class name="GFArtifactWriteTransaction" path="classes/GFArtifactWriteTransaction.xml" sourcePath="addons/gf/kernel/editor/gf_artifact_write_transaction.gd" extends="RefCounted" />
 		<class name="GFAsyncCompletion" path="classes/GFAsyncCompletion.xml" sourcePath="addons/gf/kernel/core/gf_async_completion.gd" extends="RefCounted" />
 		<class name="GFAsyncScope" path="classes/GFAsyncScope.xml" sourcePath="addons/gf/kernel/core/gf_async_scope.gd" extends="GFCancellationToken" />
@@ -75,7 +76,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="443" methodCount="4465">
+	<module id="standard" label="Standard" classCount="443" methodCount="4467">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />
@@ -762,7 +763,7 @@
 		<class name="GFGravityField3D" path="classes/GFGravityField3D.xml" sourcePath="addons/gf/extensions/physics/nodes/gf_gravity_field_3d.gd" extends="Node3D" />
 		<class name="GFGravityProbe3D" path="classes/GFGravityProbe3D.xml" sourcePath="addons/gf/extensions/physics/nodes/gf_gravity_probe_3d.gd" extends="Node3D" />
 	</module>
-	<module id="extensions/save" label="Save" classCount="44" methodCount="322">
+	<module id="extensions/save" label="Save" classCount="44" methodCount="325">
 		<class name="GFNodeAnimationPlayerSerializer" path="classes/GFNodeAnimationPlayerSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_animation_player_serializer.gd" extends="GFNodeSerializer" />
 		<class name="GFNodeAudioStreamPlayerSerializer" path="classes/GFNodeAudioStreamPlayerSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_audio_stream_player_serializer.gd" extends="GFNodeSerializer" />
 		<class name="GFNodeCanvasItemSerializer" path="classes/GFNodeCanvasItemSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_canvas_item_serializer.gd" extends="GFNodeSerializer" />

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="86e4d52b3f10357105f4007a41f882fa32fe14ad28c23fb6f2d0665d7a5cf33a" classCount="794" methodCount="7201">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="55d4090dc63ad9a240ade0c73a8aafd9f194d60f4259e4610c28a6d714102db2" classCount="794" methodCount="7201">
 	<module id="kernel" label="Kernel" classCount="74" methodCount="792">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -24,7 +24,7 @@
 
 ## [未发布]
 
-**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧 Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；框架只提供可验证的通用机制，不内置部署协议、环境业务模型或轮询式音频模拟。
+**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，补充 Save Profile bootstrap、Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；框架只提供可验证的通用机制，不内置项目启动政策、部署协议、环境业务模型或轮询式音频模拟。
 
 ### 🚀 新增特性 (Added)
 
@@ -34,6 +34,9 @@
 - 新增 Headless 服务健康/探针组合配方：组合惰性诊断 Provider、有界会话字段与类型化传输指标，由项目 Adapter 决定 liveness/readiness、传输协议、鉴权和部署政策；Backend 指标补充使用通用执行预算，并对总指标、自定义指标和 ID 长度设置绝对上限。
 - 新增周期环境表现组合配方：组合可注入时钟、项目环境样本、Shader Profile、接口快照与 Binder；周期、天气、天文、时区和持久化策略继续由项目负责。
 - AI Developer Capability / Recipe 知识目录升级到 `1.8.0`，加入两份组合配方的可搜索边界，并让音频能力目录认识类型化播放区间与循环点。
+- `GFModel`、`GFSystem` 与 `GFUtility` 新增 `begin_activation(scope)` / `begin_quiesce(scope)`；`GFArchitecture` 新增 activation/shutdown deadline、激活与 quiescing 状态查询，以及依赖 DAG 驱动的第四阶段 bootstrap。
+- 新增 `GFArchitectureShutdownResult`：类型化区分正常完成、失败、取消、超时、强制释放与幂等重复关闭，并以有界模块条目保存 quiesce 证据；并发 `shutdown_async()` 调用共享同一关闭流程。
+- 新增 Save Profile bootstrap 组合配方：项目 System 声明依赖 `GFSaveProfileUtility`，在 `begin_activation()` 中把 `load_profile()` / `flush_profile()` Operation 桥接到一次性完成源；框架不新增项目存档业务类。
 - `GFArchitecture` 新增 `find_model()`、`find_system()` 与 `find_utility()` 静默可选查询：非严格模式复用普通父链和 alias 规则，严格模式停止本地但不报告 required miss。
 - `GFAsyncKeyedGate` 新增 `try_request_lease()` 与 `STATUS_BUSY`：无法在当前主线程边界立即提交时，不创建 waiter、请求 ID 或 completion，不发请求生命周期信号，也不改变公平游标。
 - 新增 `GFResourceBroker` 与 `GFResourceLease`：为 Asset、Scene 与 BackgroundWork 提供显式共享、无单例的 threaded ResourceLoader admission；不同资源请求使用有界严格 FIFO，同资源身份复用底层请求并保留独立消费者取消，已发起且失去消费者的请求继续 drain 到 Godot 终态。
@@ -55,6 +58,11 @@
 - 新增 tracked-only `codeql_suppression_policy`：禁止 Python 源码中的全部内联 suppression，并拒绝 bracketed legacy、通配、多 query，以及 CodeQL 的路径过滤、查询过滤、自定义配置和自定义查询套件；YAML 约束只匹配真实 mapping key，区分规范注释、URL fragment、说明 scalar 与 block scalar，并通过受控 UTF-8 普通文件读取固定完整父目录链和文件身份。该策略与 GF 凭据门禁的豁免保持完全隔离，并进入 quick、full 与 release。
 - `public_api_boundary` 现在解析 GDScript API 签名，并拒绝 `@api public` / `@api protected` 方法把顶层私有 `*_SCRIPT` 预加载常量暴露为参数或返回类型；framework-internal、private 方法和方法体局部类型保持可用，避免实现细节进入公开契约。
 - API baseline 现在比较公开成员的 `@schema` 契约；已有 free-text schema 的任何文本变化（包括追加、改写、重排或删除）都会 fail-closed 归入 breaking，只有稳定基线此前完全没有 schema、当前首次补充时才归入 compatible，避免 Dictionary 字段迁移绕过 SemVer 主版本门禁。
+- `GFArchitecture.init()` 在模块 Hook 前冻结注册快照并从四类 typed required Hook 编译声明依赖 DAG，按依赖优先顺序执行 `init()`、`async_init()`、`ready()` 和 `begin_activation()`；stage4 全部成功前，命令、查询、事件、普通 tick 与外部运行时准入保持关闭。缺失、stale alias、歧义、非法或循环依赖现在无条件使初始化失败，本地 alias/assignable 解析错误不会回退父级。
+- READY 后的模块注册、替换与注销改为显式拓扑事务：热注册与热替换的新实例只存在于 staged candidate，stage4 成功后才原子发布 registry 与活动计划；注销则先完成目标 quiesce 再提交。事务期间拒绝普通运行时执行，迟到 continuation 和同 Hook 重入不能覆盖更新 topology。Factory 与 alias 拓扑在首次 activation 后冻结。
+- `GFArchitecture.shutdown_async()` 先不可逆关闭新工作准入，再按激活 DAG 严格逆序调用模块 quiesce，并在 deadline、取消或失败后仍执行恰好一次的同步 dispose/release。等待已接纳拓扑事务超时或被取消时，关闭流程按“夺取写权、取消 scope、claim 清理”接管，且不保留长期 tombstone；`unfinished_modules` 同时记录当前 quiesce 失败、取消或超时的模块及其后尚未开始的模块。三个架构生命周期 timeout 属性统一只接受有限 `0..86400`，`0` 禁用 deadline；per-call shutdown timeout 保留 `-1.0` 作为读取属性默认值的唯一负值 sentinel。`dispose()` 明确收敛为 SceneTree 退出等无法等待路径的 forced fallback。
+- `Gf.set_architecture()` 只发布完成 stage4 且接纳运行时工作的 candidate；替换旧全局架构时先等待旧架构 typed shutdown 成功。失败 replacement 会清理未发布 candidate，并以 assignment serial/scope ownership 阻止旧协程晚到写回。
+- `GFNodeContext.context_ready` 只在 owned/inherited Architecture 完成第四阶段后发出；quiescing 架构不可作为可用 Context，节点离树继续使用同步 forced dispose，项目可控关闭应直接等待 owned Architecture 的 `shutdown_async()`。
 - `GFNetworkBackend.get_transport_metrics()` 现在把基础计数与 Adapter 补充阶段隔离；补充 Hook 超过执行预算、未为新增指标消费步骤或突破指标容量时，本次调用失败关闭为基础快照，不把不可控工作带入探针路径。
 - `GFBackgroundWorkUtility` 在接受任务后强持有 `RefCounted` worker/apply callback target，并分别在线程 join 和任务终态释放，避免排队任务依赖调用方局部变量寿命。
 - `GFRenderWarmupUtility` 将清单显式提供的 `entries_per_tick` 在入队时钳制并固定；未覆盖时继续读取当前全局默认值，正常 `tick()` 只消费 FIFO 队首自己的预算，显式 `process_queue()` 继续提供跨清单总预算。
@@ -74,6 +82,8 @@
 - 修复 CodeQL 策略把普通 `LGTM`、步骤说明中的 `paths` / `queries` 和 shell block 行尾反斜杠误判为 suppression/config，以及把 URL fragment 的 `#` 错当注释后漏过禁用默认查询的问题；YAML key lexer 现在同时覆盖 block、flow、quoted、Unicode escape、quoted continuation 与多行显式 key，并在原始输入、线性 Unicode 解码后的原始文本及续行拼接后的逻辑行上累计冒号、引号与标签探测预算。续行改为分块后单次连接，编码或跨行构造的 probe 不能在 normalization 阶段恢复二次复杂度。
 - 修复 Utility 的有界 Bank resolver 用最右子串截断多字符 `fallback_separator`、导致结果偏离 `GFAudioBank.resolve_clip()` 的问题；运行时解析现在保留从左到右、非重叠且忽略空片段的既有分隔语义，同时继续限制标识长度、分隔符长度与最多 16 次回退。
 - 修复异步等待生命周期测试把 1ms 墙钟预算与 deferred free 调度顺序绑定的竞态；测试现在先用 timeout pause 建立等待已挂起的握手，再同步释放 continuation owner，稳定验证失效检查必须先于同轮已到期 timeout 仲裁。
+- 修复仅依赖父级 factory 的活动 child 未保持父链关闭租约，以及 provider/injection 重入关闭架构、嵌套解析失败或待释放对象仍可缓存、交付、重复清理或遗留 child 事件作用域的问题；外部 factory 依赖现在只阻止父链正常关闭而不冻结无关模块拓扑，每次解析固定 owner/requester 的准入与 generation，逐 Hook fail closed，解析栈内拒绝模块拓扑重入，并按缓存释放权与实际注入目标回滚未交付实例。
+- 修复独立 `api-baseline-diff` 无法为受治理的 `X.Y.Z-dev.N` 开发身份选择上一稳定 SemVer 基准、并错误拒绝其目标 major/minor 升级的问题；基准选择、breaking/compatible 判定与 Changelog 门禁现在复用同一稳定 core，未知 prerelease 或 build metadata 继续失败关闭。
 - 修复后台任务只保存 `Callable`、导致短生命周期 `RefCounted` worker 或 apply target 在线程执行前释放的问题；取消、失败和成功路径现在统一清理 callback 所有权。
 - 修复 `GFRenderWarmupUtility.queue_manifest()` 保存但正常帧推进忽略 `entries_per_tick` 的问题，并防止显式零或负清单预算永久停滞。
 - 修复 `GFDiagnosticsUtility` 在 strict architecture 中通过 reporting lookup 探测可选 Console、Log 和工具快照贡献者，导致合法缺失被误报为必需依赖的问题。
@@ -88,6 +98,8 @@
 - 移除 `GFSaveProfileUtility.save_profile(profile_id, metadata, context)` 字典重载；保存调用统一改用一次性 `GFSaveProfileRequest`，不保留隐式复制兼容路径。
 - 移除 `GFSaveProfileResult.STATUS_GATHER_FAILED` / `gather_failed`；Snapshot 创建、协作式推进与 worker payload 预检失败统一使用 `STATUS_PREPARATION_FAILED` / `preparation_failed`，不保留 alias。
 - 移除 `GFSaveSectionProvider.gather_section()`、`_gather_section()`、`GFSaveProfileUtility.STATE_GATHERING` 及读取回滚对保存采集的隐式回退；保存 Provider 必须采用 Snapshot Operation，启用读取的 Provider 必须显式实现 `_capture_section()`。
+- 移除 `GFArchitecture.fail_on_missing_declared_dependencies` 与 `module_lifecycle_max_stage_passes`；声明依赖现在始终是强契约，生命周期计划只编译一个确定性候选 DAG，不保留 warning-only 或初始化期多轮补注册路径。
+- 移除 `GFArchitecture.HOOK_GET_REQUIRED_DEPENDENCIES`、`HOOK_GET_REQUIRED_MODELS`、`HOOK_GET_REQUIRED_SYSTEMS`、`HOOK_GET_REQUIRED_UTILITIES` 与 `HOOK_GET_REQUIRED_FACTORIES`；依赖声明只通过 `GFModel`、`GFSystem`、`GFUtility` 的类型化虚方法表达，不再暴露字符串 Hook 常量。
 
 ### 🔧 API 变动说明 (API Changes)
 
@@ -105,6 +117,11 @@
 - `GFSaveProfileUtility.STATE_PREPARING` 替代 `STATE_GATHERING`，`GFSaveProfileResult.STATUS_PREPARATION_FAILED` 替代 `STATUS_GATHER_FAILED`，并新增 `save_preparation_work_budget_per_tick`、`save_preparation_slice_budget` 与 `save_preparation_time_budget_usec`。
 - `GFSaveProfileResult.get_preparation_duration_msec()`、`get_storage_duration_msec()` 与 `get_preparation_work_units()` 分开暴露阶段诊断；Save 结果的 `get_document()` 固定返回 `null`，只有 load 结果携带文档。
 - `GFStoragePayloadTransfer.take_ownership()`、`release()`、`GFStorageUtility.save_payload_request_async()`、`GFStorageAsyncOperation.reclaim_failed_payload()`、`GFStorageAsyncResult.get_write_failure_kind()` 与 `get_write_validation_report()` 构成新的显式 move / retry 契约。`gf.save` 的 `extension_version` 因此提升到 `6.0.0`。
+- Save 扩展 Installer 现在先确保 `GFStorageUtility` 存在，再装配 Save Graph/Profile；项目 Installer 不再重复拥有 Storage 注册。
+- `GFModel`、`GFSystem`、`GFUtility` 新增 `begin_activation(GFAsyncScope) -> GFAsyncCompletion` 与 `begin_quiesce(GFAsyncScope) -> GFAsyncCompletion`。
+- `GFArchitecture.init(cancellation_token = null)` 保留无参数调用形状并新增显式取消输入；新增 `activation_timeout_seconds`、`shutdown_timeout_seconds`、`is_activating()`、`is_quiescing()`、`is_accepting_runtime_work()`、`is_module_active()`、`shutdown_async()`、`get_last_shutdown_result()` 与 `shutdown_finished`。`module_async_init_timeout_seconds` 与两个新增 timeout 属性统一为有限 `0..86400` 契约，`0` 禁用 deadline；并发 init/shutdown 都由首个调用拥有共享流程策略，后续 init token 只取消自身等待，后续 shutdown 调用只复制同一终态。父级 required module/factory 由 child generation 弱租约保护；模块租约冻结相关父级模块拓扑，任一外部依赖租约都使父级正常关闭以 `ERR_BUSY` 失败。`create_instance()` 现在属于 READY 运行时准入，在 activation、热拓扑事务或 quiesce 期间不会调用 provider。依赖诊断固定复用四类 typed Hook 与真实父级解析语义，不再提供 `include_parent_lookup` / `include_factories` 行为开关。
+- `GFArchitecture.unregister_model()`、`unregister_system()`、`unregister_utility()` 及 classless Autoload facade `Gf.unregister_*()` 均改为必须 `await` 且返回 `bool` 的拓扑事务；旧同步 fire-and-forget 调用不再受支持。
+- 新增公开值对象 `GFArchitectureShutdownResult`；`GFNodeContext.context_ready` 的既有信号形状不变，但成功语义从第三阶段准备完成收紧为第四阶段 activation 已提交。
 
 ### 📘 升级指南 (Migration Guide)
 
@@ -121,6 +138,13 @@
 11. 不再从 Save 的 `GFSaveProfileResult.get_document()` 读取文档；Save 诊断改用 generation、request IDs、准备/Storage 耗时、work units 和校验报告。需要完整文档时只读取 load 结果。
 12. Architecture 项目在 Asset、Scene 或 BackgroundWork Utility 之前注册一个共享 `GFResourceBroker`；独立 Utility 调用 `setup_standalone_resource_broker()`，多个独立消费者则创建同一个 Broker 并分别调用 `set_resource_broker()`。
 13. 将诊断面板中的 `threaded_resource_operations` 读取迁移到 `resource_broker`，并按 active、pending、draining 与 admission 预算字段展示共享状态。
+14. 将过去在 `ready()` 中启动异步运行期工作的模块迁移到 `begin_activation(scope)`，立即返回非空 `GFAsyncCompletion`，并把 callback、Signal 或 Operation 的唯一终态桥接为 succeed/fail/cancel；不要手动 pump Architecture tick。
+15. 为模块补全 `get_required_models()`、`get_required_systems()`、`get_required_utilities()`、`get_required_factories()` 声明并消除本地依赖环；删除聚合依赖 Hook、诊断 include 开关以及对 `fail_on_missing_declared_dependencies` 与 `module_lifecycle_max_stage_passes` 的赋值，把初始化 Hook 中的固定模块注册移回 Installer。修复 stale alias 或用显式 alias 消除本地 assignable 歧义，不能依赖父级结果掩盖错误装配。
+16. 先启动父 Architecture、再初始化 child，并在关闭时反序执行以保证 parent outlive child；父级 required module 只有在父 Architecture 已 READY 且模块 ACTIVE 时才满足。活动 child 的外部模块依赖租约会冻结相关父级模块拓扑，任一外部依赖租约都会使父级正常关闭返回失败；先关闭 child 再重试。不要用同步 `dispose()` 绕过该顺序，除非正在执行无法等待的灾难收敛。正常应用退出、主运行域替换和数据关键的局部 Context 关闭改为 `await architecture.shutdown_async()` 并检查 typed result；只在无法等待的 SceneTree teardown 保留同步 `dispose()`。将三个 lifecycle timeout 属性迁移为有限 `0..86400`，用 `0` 禁用 deadline；per-call shutdown 仅用 `-1.0` 表示读取属性默认值。shutdown deadline 约束 cooperative quiesce 与异步等待，最终同步释放不能强杀 Godot Thread，因此不承诺墙钟硬上限。
+17. READY 后需要改变模块集合时 `await` 对应 register/replace/unregister 事务并检查 `bool`；register/replace 候选在 stage4 成功和原子提交前不可见，失败后不得复用。需要改变 factory 或 alias 拓扑时构建新的 candidate Architecture，不在活动架构上维护兼容分支。
+18. 将 `Gf.unregister_model()`、`Gf.unregister_system()` 与 `Gf.unregister_utility()` 的调用改为 `await` 并检查 `bool`；不要依赖旧的同步注销时序。
+19. 启用 Save 扩展的项目删除项目 Installer 中重复的 `GFStorageUtility` 注册；需要调整参数时取回扩展已安装实例并配置，需要替换实现时显式调用 `replace_utility()`。
+20. 不再在 Installer、`init()`、`ready()` 或 activation 中调用 `create_instance()` 触发工厂副作用；装配期改用 `has_factory()` / `get_required_factories()` 校验，只有 Architecture 提交 READY 且无热拓扑事务后才创建运行时对象。
 
 ### 📁 核心受影响文件 (Affected Files)
 
@@ -131,6 +155,16 @@
 - `addons/gf/standard/utilities/audio/gf_audio_backend_capability.gd`
 - `addons/gf/standard/utilities/audio/gf_audio_clip.gd`
 - `addons/gf/kernel/core/gf_architecture.gd`
+- `addons/gf/kernel/core/gf_binding.gd`
+- `addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd`
+- `addons/gf/kernel/core/gf_architecture_shutdown_result.gd`
+- `addons/gf/kernel/core/gf_kernel_runtime.gd`
+- `addons/gf/kernel/core/gf.gd`
+- `addons/gf/kernel/core/gf_architecture_tick_scheduler.gd`
+- `addons/gf/kernel/core/gf_node_context.gd`
+- `addons/gf/kernel/base/gf_model.gd`
+- `addons/gf/kernel/base/gf_system.gd`
+- `addons/gf/kernel/base/gf_utility.gd`
 - `addons/gf/standard/common/gf_async_keyed_gate.gd`
 - `addons/gf/standard/utilities/debug/gf_diagnostics_utility.gd`
 - `addons/gf/standard/utilities/display/gf_render_warmup_utility.gd`
@@ -146,6 +180,7 @@
 - `addons/gf/standard/utilities/storage/gf_storage_utility.gd`
 - `addons/gf/extensions/save/document/gf_save_section.gd`
 - `addons/gf/extensions/save/profile/gf_save_profile_request.gd`
+- `addons/gf/extensions/save/extension.gd`
 - `addons/gf/extensions/save/profile/gf_save_payload_validation_adapter.gd`
 - `addons/gf/extensions/save/profile/gf_save_profile_operation.gd`
 - `addons/gf/extensions/save/profile/gf_save_section_provider.gd`
@@ -167,6 +202,10 @@
 - `tools/gf_maintenance.py`
 - `docs/zh/editor/tools/ai-developer.md`
 - `docs/zh/extensions/save-graph/save-profile-runtime.md`
+- `docs/zh/kernel/lifecycle/module-lifecycle/init-stages.md`
+- `docs/zh/kernel/lifecycle/module-lifecycle/async-ready.md`
+- `docs/zh/kernel/lifecycle/module-lifecycle/dynamic-registration.md`
+- `docs/zh/kernel/architecture/assembly-diagnostics/dependency-diagnostics.md`
 - `docs/zh/extensions/save-graph/save-profile-adr.md`
 - `docs/zh/extensions/network-turnbased/network-transport/backend-session.md`
 - `docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md`
@@ -175,6 +214,11 @@
 - `docs/zh/standard/utilities/runtime/audio/backend-events.md`
 - `docs/zh/standard/utilities/runtime/settings-ui-scene/shader-parameter-profile.md`
 - `tests/gf_core/extensions/network/test_gf_network_extension.gd`
+- `tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd`
+- `tests/gf_core/kernel/core/test_gf_architecture_lifecycle_transactions.gd`
+- `tests/gf_core/kernel/core/test_gf_architecture_lifecycle_plan.gd`
+- `tests/gf_core/kernel/core/test_gf_assignment_lifecycle.gd`
+- `tests/gf_core/kernel/core/test_gf_node_context_lifecycle.gd`
 - `tests/gf_core/maintenance/test_api_surface_contract_validation.gd`
 - `tests/gf_core/extensions/save/test_gf_save_profile_preparation.gd`
 - `tests/gf_core/extensions/save/test_gf_save_profile_scheduler.gd`

--- a/docs/zh/extensions/installation.md
+++ b/docs/zh/extensions/installation.md
@@ -76,6 +76,6 @@ Domain、Combat 这类业务型内置扩展按外置候选治理：随 GF 包分
 
 `Gf` 会先按依赖优先顺序收集启用扩展的 `installer_paths`，再追加 `gf/project/installers` 中的项目级 Installer。这样内置扩展负责装配自己的抽象模块，项目仍然可以在后面继续注册业务模块或覆盖绑定。
 
-GF 内置扩展中，只有需要参与 `GFArchitecture` 生命周期的服务会进入 `extension.gd`。例如 `save` 注册 `GFSaveGraphUtility`，`combat` 注册 `GFSkillTargetingUtility2D` 和 `GFCombatSystem`，`domain` 注册 `GFLevelUtility` 和 `GFQuestUtility`；纯数据模型、Resource、动作对象和节点桥接不会被扩展安装器自动注册，仍由项目或局部上下文按使用场景装配。
+GF 内置扩展中，只有需要参与 `GFArchitecture` 生命周期的服务或扩展正确工作所必需的标准能力会进入 `extension.gd`。例如 `save` 先确保 `GFStorageUtility` 存在，再注册 `GFSaveGraphUtility`；`combat` 注册 `GFSkillTargetingUtility2D` 和 `GFCombatSystem`，`domain` 注册 `GFLevelUtility` 和 `GFQuestUtility`。纯数据模型、Resource、动作对象和节点桥接不会被扩展安装器自动注册，仍由项目或局部上下文按使用场景装配。
 
-项目 Installer 通常只注册项目自己的 `GFModel`、`GFSystem` 和 `GFUtility`。如果某个内置扩展已启用，不需要再手动注册它的扩展级服务；重复注册会被忽略并提示使用 `replace_*()`。确实需要替换默认实现时，应显式调用 `replace_utility()` 或 `replace_system()`，让覆盖意图和所有权边界清楚可见。
+项目 Installer 通常只注册项目自己的 `GFModel`、`GFSystem` 和 `GFUtility`。如果某个内置扩展已启用，不需要再手动注册它的扩展级服务或必需标准能力；重复注册会被忽略并提示使用 `replace_*()`。需要调整 Save 的 Storage 参数时，应在扩展 Installer 完成后取回已安装实例并配置；确实需要替换实现时，显式调用 `replace_utility()` 或 `replace_system()`，让覆盖意图和所有权边界清楚可见。

--- a/docs/zh/extensions/save-graph/save-profile-runtime.md
+++ b/docs/zh/extensions/save-graph/save-profile-runtime.md
@@ -76,8 +76,14 @@ Snapshot 与读取事务回滚分成两个清晰的一致性边界。
 
 ## 注册 Profile
 
-Save 扩展安装器会注册 `GFSaveProfileUtility`。项目在架构初始化完成后创建并注册
-Profile；同一个 Utility 内的 profile ID 和文件名都必须唯一。
+Save 扩展安装器会先复用架构中已有的 `GFStorageUtility`，或在缺失时注册一个共享
+Storage，再注册 `GFSaveGraphUtility` 与 `GFSaveProfileUtility`。Profile Utility 通过
+类型化依赖声明绑定这份 Storage；安装器路径不需要也不应额外调用 `setup()`。只有
+脱离 Architecture 独立使用 Profile Utility 时，调用方才通过 `setup(storage)` 显式
+交付自有 Storage。项目可以在自己的 Installer 中准备 Profile 定义，再由声明依赖
+该 Utility 的项目 System 在第三阶段 `ready()` 注册；如果 Profile 不参与启动
+bootstrap，也可以在架构 READY 后显式注册。同一个 Utility 内的 profile ID 和
+文件名都必须唯一。
 
 ```gdscript
 var profile := GFSaveProfile.new()
@@ -104,6 +110,85 @@ if not GFVariantData.get_option_bool(registration, "registered"):
 
 `GFSaveMigrationRegistry` 仍是唯一迁移引擎。Profile 不提供字段级兼容回退；文档或
 section 版本落后时必须存在完整迁移链，未来版本始终拒绝读取。
+
+## 与 Architecture Activation 组合
+
+需要在首个运行场景开放前恢复存档或确认既有 generation 已落盘时，由项目
+`GFSystem` 声明 `GFSaveProfileUtility` 为必需依赖，并在
+`begin_activation(scope)` 中把 `load_profile()` 或 `flush_profile()` 的类型化终态
+桥接到 `GFAsyncCompletion`。不要把项目 slot、账号选择或恢复决策写入框架 Utility，
+也不要在 System 中手动轮询 `architecture.tick()`：
+
+```gdscript
+extends GFSystem
+
+const BOOTSTRAP_PROFILE_ID: StringName = &"project.player"
+
+var _save_profiles: GFSaveProfileUtility = null
+var _bootstrap_operation: GFSaveProfileOperation = null
+
+func get_required_utilities() -> Array[Script]:
+	return [GFSaveProfileUtility]
+
+func ready() -> void:
+	var value: Variant = get_utility(GFSaveProfileUtility, true)
+	if value is GFSaveProfileUtility:
+		_save_profiles = value
+	# 在这里注册项目自己的 GFSaveProfile，并检查 registered 报告。
+
+func begin_activation(scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _bound: bool = completion.bind_cancel_token(scope)
+	if not completion.is_pending():
+		return completion
+	if _save_profiles == null:
+		var _failed: bool = completion.fail("Save Profile dependency is unavailable.")
+		return completion
+
+	# 恢复启动状态时等待 load；若职责是确认已排队 generation 落盘，
+	# 则用 flush_profile(BOOTSTRAP_PROFILE_ID) 并复用同一桥接方法。
+	_bootstrap_operation = _save_profiles.load_profile(BOOTSTRAP_PROFILE_ID)
+	_bridge_bootstrap_operation(_bootstrap_operation, completion)
+	return completion
+
+func _bridge_bootstrap_operation(
+	operation: GFSaveProfileOperation,
+	completion: GFAsyncCompletion
+) -> void:
+	if operation == null:
+		var _failed: bool = completion.fail("Save Profile bootstrap returned no operation.")
+		return
+	if operation.is_completed():
+		_finish_bootstrap(operation.get_result(), completion)
+		return
+	var connected: Error = operation.completed.connect(
+		Callable(self, &"_finish_bootstrap").bind(completion),
+		CONNECT_ONE_SHOT
+	)
+	if connected != OK:
+		var _failed_connect: bool = completion.fail("Bootstrap completion is unavailable.")
+
+func _finish_bootstrap(result: GFSaveProfileResult, completion: GFAsyncCompletion) -> void:
+	_bootstrap_operation = null
+	if not completion.is_pending():
+		return
+	if result != null and result.is_successful():
+		var _succeeded: bool = completion.succeed()
+		return
+	var error_message: String = result.get_error() if result != null else "No result."
+	var _failed: bool = completion.fail(error_message)
+```
+
+依赖 DAG 会先激活 `GFStorageUtility`，再激活 `GFSaveProfileUtility`，最后执行项目
+System 的 activation。等待上述 Operation 时，Architecture 只推进当前 System 的
+本地依赖闭包，因此 Profile 与 Storage 的 tick-driven 状态机会继续运行，但命令、
+事件、普通 tick 和其他外部运行时工作仍保持关闭。Operation 失败、scope 取消或超过
+`activation_timeout_seconds` 时，项目 System 必须让 completion 进入非成功终态；
+Architecture 随即拒绝 READY，并由 lifecycle generation 防止迟到回调写回。
+
+`load_profile()` 适合恢复并应用启动状态；`flush_profile()` 只保证调用时捕获的
+generation 或更新 generation 已经持久化，不能替代读取。是否在 load 后安排一次
+save/flush 取决于项目恢复政策，框架不隐式改写文件。
 
 ## 保存、flush 与读取屏障
 

--- a/docs/zh/kernel/architecture/architecture-boundary.md
+++ b/docs/zh/kernel/architecture/architecture-boundary.md
@@ -6,7 +6,9 @@
 
 整个框架的入口是全局 AutoLoad 节点 —— **`Gf`**。它挂载在 Godot 的全局根节点下，负责持有当前 `GFArchitecture`、执行项目级 Installer、代理常用注册/查询接口，并把 `_process` 与 `_physics_process` 转发给架构。
 
-在 `Gf` 背后，真正承载所有业务的对象是 **`GFArchitecture`**。它是一个纯代码容器，负责管理所有 `Model`、`System`、`Utility` 的注册、生命周期调用以及事件总线的派发。主生命周期状态由内部 `GFKernelRuntime` 维护，项目通常只通过 `GFArchitecture.is_inited()`、`init()` 和 `dispose()` 观察或推进状态。`Foundation` 层则作为容器外的纯基础件，被这些运行时模块直接依赖。
+在 `Gf` 背后，真正承载所有业务的对象是 **`GFArchitecture`**。它是一个纯代码容器，负责管理所有 `Model`、`System`、`Utility` 的注册、依赖 DAG、四阶段激活、热模块事务、事件总线和异步关闭。主生命周期状态由内部 `GFKernelRuntime` 维护；项目用 `init()` / `is_accepting_runtime_work()` 观察启动提交，用 `shutdown_async()` 执行可等待的正常关闭，只在 SceneTree 强制退出等无法等待路径使用 `dispose()`。`Foundation` 层则作为容器外的纯基础件，被这些运行时模块直接依赖。
+
+父子 Architecture 是依赖方向，不是隐式生命周期所有权。child 的计划只会为实际命中的父级 required module/factory 建立弱租约：外部模块租约冻结相关父级模块拓扑，所有外部依赖租约都会阻止父级正常关闭，直到 child 初始化失败或先完成关闭。父级 `shutdown_async()` 被阻挡时返回 `ERR_BUSY` 且保持 READY；框架不会级联关闭未知 child。同步 `dispose()` 可以突破租约，只用于进程或 SceneTree 无法等待的强制收敛，不能替代“先 child、后 parent”的正常顺序。
 
 ## 层级依赖边界
 
@@ -22,7 +24,7 @@ addons/gf/kernel   <-  addons/gf/standard   <-  addons/gf/extensions
 
 根插件 `addons/gf/plugin.gd` 是组合入口，可以同时知道 `kernel` 与 `standard`，负责把标准库声明的编辑器增强记录传给 `kernel/editor` 辅助脚本。这个例外不改变内核边界：`addons/gf/kernel/**` 本身仍不能依赖 `addons/gf/standard/**`。
 
-框架内部通过 `GFAutoload` 解析全局 AutoLoad 节点，避免插件首次导入、脚本解析或测试环境里直接引用全局 `Gf` 时出错。`get_architecture_or_null()` 只表示全局架构实例已经存在，不保证它完成 `init()`；需要读取 ready 后模块时，应使用 `get_ready_architecture_or_null()`。项目代码通常继续使用 `Gf.get_model()` 等入口；只有编写框架级工具、编辑器脚本或需要在 AutoLoad 未就绪时安全探测架构，才需要直接使用这些辅助入口。
+框架内部通过 `GFAutoload` 解析全局 AutoLoad 节点，避免插件首次导入、脚本解析或测试环境里直接引用全局 `Gf` 时出错。`get_architecture_or_null()` 只表示全局 identity 仍存在，不保证它完成 activation，也不保证它尚未进入 quiescing；需要消费已开放运行时准入的模块时，应使用 `get_ready_architecture_or_null()`。处于 quiescing、disposing 或 disposed 的架构不能继续执行运行时工作。项目代码通常继续使用 `Gf.get_model()` 等 facade；只有编写框架级工具、编辑器脚本或需要在 AutoLoad 未就绪时安全探测架构，才需要直接使用这些辅助入口。
 
 ```text
 Godot SceneTree

--- a/docs/zh/kernel/architecture/assembly-diagnostics/assembly-context.md
+++ b/docs/zh/kernel/architecture/assembly-diagnostics/assembly-context.md
@@ -4,7 +4,7 @@
 
 **Installer 装配**：继承 `GFInstaller` 并重写 `install(architecture, scope)`。项目自己的启动装配放入 `Project Settings > gf/project/installers`；GF 扩展自己的装配入口放入 `gf_extension.json` 的 `installer_paths`，并由 `gf/extensions/selection_mode` 与显式 `gf/extensions/enabled` 列表共同决定是否启用。
 
-`Gf.init()` 与 `Gf.set_architecture()` 会在三阶段生命周期开始前先执行启用扩展 Installer，再执行项目 Installer，适合集中注册全局 Model、System 和 Utility。
+`Gf.init()` 与 `Gf.set_architecture()` 会先执行启用扩展 Installer，再执行项目 Installer；随后冻结模块注册快照、编译声明依赖 DAG，并推进四阶段生命周期。它适合集中注册全局 Model、System 和 Utility，生命周期 Hook 不能再补写固定拓扑。
 
 默认情况下，配置错误会输出错误并中断初始化。迁移旧项目时可把 `gf/project/fail_on_installer_error` 显式设为 `false` 临时跳过错误 Installer。如果 Installer 可能长期等待外部流程，可用 `gf/project/installer_timeout_seconds` 限制单步等待时间，并在 `await` 后检查 `GFAsyncScope` 是否已取消。
 

--- a/docs/zh/kernel/architecture/assembly-diagnostics/dependency-diagnostics.md
+++ b/docs/zh/kernel/architecture/assembly-diagnostics/dependency-diagnostics.md
@@ -1,8 +1,8 @@
 # 依赖诊断
 
-`GFArchitecture.get_dependency_diagnostics()` 可读取已注册模块的可选依赖声明，并生成统一报告。它适合大型项目、局部 `GFNodeContext` 或插件式装配在初始化前后检查“模块声明需要什么、当前架构是否已经注册”。
+`GFArchitecture.get_dependency_diagnostics()` 可读取已注册模块的声明依赖并生成统一报告。它适合大型项目、局部 `GFNodeContext` 或插件式装配在初始化前预检“模块声明需要什么、当前候选架构能否满足”。
 
-诊断只读，不会自动注册缺失模块，也不会改变 `get_model()`、`get_system()`、`get_utility()` 和工厂创建的现有语义。
+诊断调用本身只读，不会自动注册缺失模块，也不会改变 `get_model()`、`get_system()`、`get_utility()` 和工厂创建的解析语义。依赖声明本身则是强生命周期契约：`GFArchitecture.init()` 会无条件校验，缺失、非法或歧义依赖会让初始化 fail closed，不提供降级为 warning 的运行时开关。
 
 ## 必需查询与可选查询
 
@@ -30,24 +30,38 @@ func get_required_models() -> Array[Script]:
 func get_required_utilities() -> Array[Script]:
 	return [InventoryConfigUtility]
 
-func get_required_dependencies() -> Dictionary:
-	return {
-		"systems": [BattleSystem],
-		"factories": [DealDamageCommand],
-	}
+func get_required_systems() -> Array[Script]:
+	return [BattleSystem]
+
+func get_required_factories() -> Array[Script]:
+	return [DealDamageCommand]
 ```
+
+四个按类别返回 `Array[Script]` 的 Hook 是生命周期计划和依赖诊断的唯一事实源；不存在额外的聚合 Hook 或由诊断参数补充、删减声明类别的兼容路径。Model、System、Utility 声明会用于编译本地生命周期 DAG，并按 exact 注册键、alias、唯一 assignable 与允许的父架构解析；factory 依赖只校验 exact binding availability 与允许的父级，不实例化对象，也不成为 DAG 节点。
+
+本地 stale alias 或多个 assignable 匹配都是解析失败屏障，不会继续回退父架构；只有完整的本地 miss 才能在非严格模式向上查找。父级依赖仅在对应父 Architecture 已提交 READY 时有效；Model、System、Utility 还必须已经 ACTIVE，factory 则要求父级存在 exact binding。父级命中的依赖只记为 external satisfaction，不进入当前架构的本地 DAG；`strict_dependency_lookup` 会禁止所有类别的父级满足。
+
+计划编译成功后、执行计划内模块的初始化与 activation Hook 前，框架会为实际命中的父级 required module/factory 建立弱租约。外部模块租约阻止相关父级改变模块拓扑，所有外部依赖租约都会使父级正常 `shutdown_async()` 在改变状态前以 `ERR_BUSY` 失败，直到 child 初始化失败或先完成关闭。租约不让 parent 接管 child，也不会触发级联关闭；生命周期所有权必须继续与依赖方向一致：先启动父架构，再初始化子架构；先关闭子架构，再关闭父架构。
+
+有效 DAG 决定四阶段的依赖优先顺序，并保存严格逆序的 quiesce/shutdown 顺序。`lifecycle_priority` 只用于多个 DAG-ready 节点的稳定破平，不能覆盖真实依赖边。以下情况会直接拒绝计划：
+
+- 声明的依赖不存在，或 assignable 匹配不唯一。
+- 任一 typed Hook 返回值不是约定的 `Array[Script]` 形状。
+- 本地模块之间存在依赖循环，包括自环。
+- 热注册、替换或注销后的候选拓扑不再满足任一声明。
+
+生命周期计划只编译一次候选快照，再按计划推进；初始化期间不能靠 Hook 动态注册新模块，也不提供可配置的多轮补跑。热注册和热替换都只在 staged candidate 快照中求值，只有 stage4 成功后才原子发布 registry 与活动计划；候选诊断成功本身不会让新实例可见。固定模块应在 Installer 阶段注册，活动架构的有意变化使用热模块事务。
 
 ## 诊断调用
 
 ```gdscript
-var report := architecture.get_dependency_diagnostics({
-	"include_parent_lookup": true,
-	"include_factories": true,
-})
+var report := architecture.get_dependency_diagnostics()
 if not report["ok"]:
 	for issue in report["issues"]:
 		push_warning(issue["message"])
 ```
+
+报告固定按四类 typed Hook 和架构本身的 `strict_dependency_lookup` 生成。调用方不能用 `include_parent_lookup` 或 `include_factories` 改变校验语义；初始化会执行同一份强契约，因此显式诊断主要用于编辑器、启动前报告和测试断言，不是绕过初始化失败的恢复入口。缺失依赖应在装配处修复；真正可选的集成不要写入 required Hook，而应在消费点使用 `find_model()`、`find_system()` 或 `find_utility()`。
 
 ## 绑定图诊断
 
@@ -69,6 +83,6 @@ for issue in bindings["issues"]:
 
 ## 使用边界
 
-依赖声明应保持抽象和稳定，优先声明模块真正需要的接口脚本、基类或别名类型；不要把具体关卡、敌人、UI 页面或临时玩法条件写进通用模块 hook。
+依赖声明应保持抽象和稳定，优先声明模块真正需要的接口脚本、基类或别名类型；不要把具体关卡、敌人、UI 页面或临时玩法条件写进通用模块 Hook。
 
 需要按玩家进度、DLC、服务器配置或场景状态动态判断的内容，应留在项目自己的装配流程或诊断命令里。

--- a/docs/zh/kernel/architecture/index.md
+++ b/docs/zh/kernel/architecture/index.md
@@ -4,12 +4,12 @@ Kernel 是 GF 的运行内核，负责全局入口、架构容器、注册表、
 
 ## 阅读入口
 
-- [核心单例与层级边界](architecture-boundary.md)：`Gf`、`GFArchitecture`、源码依赖方向和 AutoLoad 安全入口。
+- [核心单例与层级边界](architecture-boundary.md)：`Gf`、`GFArchitecture`、四阶段准入、正常关闭、源码依赖方向和 AutoLoad 安全入口。
 - [装配入口与依赖诊断](assembly-diagnostics/index.md)：Installer、`GFNodeContext`、声明式绑定、工厂和依赖诊断。
 - [五层分工与信息流](module-roles-flow/index.md)：Foundation、Model、System、Controller、Utility 的职责和信息流方向。
 - [IDE 类型提示与编辑器访问器](editor-accessors.md)：类型断言、脚本模板、访问器生成和编辑器工具索引。
 - [全局快照与内核基础设施](snapshots-infrastructure.md)：架构快照、脚本类型检查、属性工具和时间提供者协议。
-- [生命周期、装配与依赖](../lifecycle/index.md)：更完整的初始化、局部上下文、工厂、别名和 Controller 接入说明。
+- [生命周期、装配与依赖](../lifecycle/index.md)：依赖 DAG、activation/quiesce、热模块事务、局部上下文和 Controller 接入说明。
 - [消息、事件、命令与查询](../messaging/index.md)：事件系统、命令、查询、规则和命令历史。
 - [场景桥接、Controller 与数据绑定](../scene-controller/index.md)：场景节点、Controller、绑定属性和场景桥接。
 

--- a/docs/zh/kernel/index.md
+++ b/docs/zh/kernel/index.md
@@ -5,7 +5,7 @@ Kernel 是 GF 的运行内核，负责全局入口、架构容器、生命周期
 ## 阅读入口
 
 - [架构容器](architecture/index.md)：`Gf`、`GFArchitecture`、层级边界、装配诊断、五层分工、编辑器访问器和内核基础设施。
-- [生命周期、装配与依赖](lifecycle/index.md)：Installer、三阶段初始化、动态注册、局部上下文、工厂、别名和 Controller 初始化。
+- [生命周期、装配与依赖](lifecycle/index.md)：Installer、依赖 DAG、四阶段激活、异步关闭、热模块事务、局部上下文和 Controller 初始化。
 - [消息、事件、命令与查询](messaging/index.md)：事件系统、命令、查询、规则和命令历史。
 - [场景桥接、Controller 与数据绑定](scene-controller/index.md)：`GFController`、System 更新、绑定属性和局部响应式组合。
 

--- a/docs/zh/kernel/lifecycle/boot-installers/extension-installers.md
+++ b/docs/zh/kernel/lifecycle/boot-installers/extension-installers.md
@@ -6,10 +6,10 @@
 
 扩展 Installer 与项目 Installer 使用同一生命周期钩子签名：`install(architecture, scope)` 和 `install_bindings(binder, scope)`。如果扩展安装器需要等待外部流程，也应在 `await` 后检查 `scope.is_cancel_requested()`，并用 `scope.register_cleanup()` 释放临时资源。
 
-扩展负责装配自己的抽象模块，项目负责装配业务模块或覆盖绑定。GF 内置扩展安装器只注册扩展级生命周期服务，例如 Save 扩展的 `GFSaveGraphUtility`、Combat 扩展的 `GFCombatSystem` 和 `GFSkillTargetingUtility2D`。
+扩展负责装配自身闭包内的抽象模块与必需基础能力，项目负责装配业务模块或覆盖绑定。GF 内置扩展安装器会注册扩展级生命周期服务；当扩展不能在缺少某项标准能力时正确工作，也会声明并安装该能力。例如 Save 扩展会先确保 `GFStorageUtility` 存在，再注册 `GFSaveGraphUtility`；Combat 扩展注册 `GFCombatSystem` 和 `GFSkillTargetingUtility2D`。
 
 纯数据对象、Resource、命令和场景节点仍由项目或局部上下文按需要创建。
 
-项目 Installer 不需要重复注册已启用扩展自动装配的服务。重复注册会被忽略并输出 warning。
+项目 Installer 不需要重复注册已启用扩展自动装配的服务或其必需标准能力。重复注册会被忽略并输出 warning。
 
-如果项目确实要替换某个扩展默认服务，应使用 `replace_utility()` 或 `replace_system()`，而不是再次调用 `register_*()`。
+如果项目需要配置 Save 安装的 Storage，应在扩展 Installer 完成后取回 `GFStorageUtility` 并设置参数；需要替换实现时使用 `replace_utility()`。其他扩展默认服务同样使用 `replace_utility()` 或 `replace_system()`，而不是再次调用 `register_*()`。

--- a/docs/zh/kernel/lifecycle/boot-installers/failure-timeout.md
+++ b/docs/zh/kernel/lifecycle/boot-installers/failure-timeout.md
@@ -15,3 +15,11 @@
 超时不抢占首个 `await` 前的同步代码。Installer 如果需要扫描大量文件、解析大型表格或构建索引，应先拆成能让帧的步骤，再在每段之间检查架构状态；否则这段同步工作仍会阻塞编辑器或启动流程。
 
 架构进入初始化失败状态后，模块、工厂和别名注册入口会拒绝迟到写入，避免超时 coroutine 恢复后污染失败架构。
+
+Installer 全部完成后，声明依赖缺失、歧义或成环也会直接使初始化失败，不提供 warning-only 模式或初始化期多轮补注册。应在 Installer 中补齐固定模块，并用 `get_dependency_diagnostics()` 做启动前诊断。
+
+架构级 `module_async_init_timeout_seconds`、`activation_timeout_seconds` 与 `shutdown_timeout_seconds` 都只接受 `0..86400` 的有限秒数，`0` 禁用对应 deadline。第四阶段 activation 默认使用独立的 30 秒总预算；模块 `begin_activation(scope)` 返回的 `GFAsyncCompletion` 必须在该预算内进入成功终态，取消、超时、失败或空完成源都会阻止 READY 提交并清理本轮模块。它与单个 Installer timeout、单个 `async_init()` timeout 相互独立。
+
+`shutdown_async(token, timeout_seconds)` 的 per-call 参数接受同一区间；默认 `-1.0` 是唯一的负值 sentinel，表示使用 `shutdown_timeout_seconds` 属性。其它负值、非有限值或大于 `86400` 的值会返回失败结果，而不是静默变成无限等待。
+
+关闭等待已经接纳的拓扑事务时也受同一 per-call deadline 与取消令牌约束。触发接管后，框架按“夺取事务写权 → 取消事务 scope → claim 未提交候选的恰好一次清理”的顺序收敛，迟到 continuation 不能发布；若当前模块的 quiesce 失败、取消或超时，该模块本身也会进入 `unfinished_modules`，而不只记录尚未开始 quiesce 的后续模块。

--- a/docs/zh/kernel/lifecycle/boot-installers/index.md
+++ b/docs/zh/kernel/lifecycle/boot-installers/index.md
@@ -1,6 +1,6 @@
 # Kernel 启动注册与 Installer
 
-这一组文档说明全局架构的启动装配流程。项目可以在 boot 脚本中显式注册模块，也可以通过项目 Installer 和扩展 Installer 统一声明依赖。
+这一组文档说明全局架构的启动装配流程。项目可以在 boot 脚本中显式注册模块，也可以通过项目 Installer 和扩展 Installer 完成固定拓扑装配；模块依赖由 lifecycle Hook 声明并编译为 DAG。
 
 ## 阅读入口
 
@@ -11,4 +11,4 @@
 
 ## 使用边界
 
-Installer 只负责注册模块，不应该直接启动玩法流程。启动流程仍建议放在引导场景或专门的 System 中。
+Installer 只负责注册模块，不应该直接启动玩法流程。必须阻止架构过早开放的异步 bootstrap 放在声明依赖的项目 System `begin_activation()` 中；架构 READY 后的场景与玩法流程仍由引导场景或项目状态机负责。

--- a/docs/zh/kernel/lifecycle/boot-installers/manual-boot.md
+++ b/docs/zh/kernel/lifecycle/boot-installers/manual-boot.md
@@ -1,6 +1,6 @@
 # 手动启动注册
 
-在游戏启动之初，通常在根节点的首个场景或 AutoLoad 执行，项目可以手动向 `GFArchitecture` 注册模块。推荐顺序是数据、工具、系统。
+在游戏启动之初，通常在根节点的首个场景或 AutoLoad 执行，项目可以手动向 `GFArchitecture` 注册模块。按 Model、Utility、System 分组能提高可读性，但真正的生命周期顺序来自模块声明依赖 DAG，不由注册顺序隐式表达。
 
 ```gdscript
 # boot.gd
@@ -17,11 +17,12 @@ func _ready():
 	await Gf.register_system(BattleSystem.new())
 	await Gf.register_system(QuestSystem.new())
 
-	# 全部注册完毕后，启动生命周期引擎
-	await Gf.init()
+	# 全部注册完毕后，编译依赖 DAG 并完成四阶段激活。
+	if not await Gf.init():
+		return
 
-	# 启动游戏初始场景
+	# init() 返回成功时，架构才已开放运行时准入。
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
 ```
 
-手动 boot 适合小型项目、原型和希望显式控制启动顺序的工程。项目规模扩大后，可以把装配逻辑迁移到项目级 Installer。
+手动 boot 适合小型项目、原型和希望显式控制装配入口的工程。模块仍应通过 `get_required_*()` 声明依赖；需要在 READY 提交前等待的 bootstrap 放进项目 System 的 `begin_activation()`。项目规模扩大后，可以把装配逻辑迁移到项目级 Installer。

--- a/docs/zh/kernel/lifecycle/boot-installers/project-installers.md
+++ b/docs/zh/kernel/lifecycle/boot-installers/project-installers.md
@@ -55,6 +55,8 @@ Installer 是固定启动拓扑的最后注册边界。依赖 DAG 开始编译�
 
 同一个候选已经处于 pending 时，再次调用 `set_architecture(candidate)` 会立即返回 `false`，但不会取消、dispose 或抢占原 assignment；原调用仍是唯一有权提交该候选的事务。不同候选的更新 assignment 会使旧事务失效。candidate activation、旧架构 shutdown 以及 identity listener 中的重入都遵守同一 serial/scope ownership 规则；每个 `await` 后都会重新验证，迟到 continuation 不能覆盖更新 assignment。成功提交会先清除 pending、解除 scope 跟踪并调用 `scope.complete()`，再发布全局 identity 通知。
 
+这里的原子性只覆盖 facade identity、registry 可见性与事务所有权，不会自动回滚模块直接写入进程级 singleton、全局回调、网络监听等框架外副作用。`begin_activation()` 创建这类副作用时必须同步登记 cleanup，使失败或被替代的 candidate 可以完整撤销；架构替换还必须容忍 candidate activation 与旧架构 shutdown 完成前的短暂外部重叠。
+
 `QUIESCING`、`DISPOSING` 或 `DISPOSED` Architecture 不能作为新 candidate，也不能重新 `init()`。这些状态下，`Gf.has_architecture()` 返回 false，`Gf.create_architecture()` 与依赖它的注册、替换、binder/factory helper 会分别返回 `null` 或 `false`，不会暴露关闭中的旧实例或创建瞬态默认架构。若项目在 assignment 之外直接关闭当前全局 identity，下一次合法创建会先清除 terminal identity；绝不会复活旧实例。
 
 ## 显式关闭

--- a/docs/zh/kernel/lifecycle/boot-installers/project-installers.md
+++ b/docs/zh/kernel/lifecycle/boot-installers/project-installers.md
@@ -33,7 +33,7 @@ func install_bindings(binder: Variant, _scope: GFAsyncScope) -> void:
 
 ## 路径与等待边界
 
-然后在 `Project Settings > gf/project/installers` 中加入安装器脚本资源。编辑器可能保存 `res://`，也可能保存稳定 `uid://`；运行时会把可解析 UID 规范化为真实 `res://` 脚本路径。之后 `await Gf.init()` 会按数组顺序逐个执行 Installer：每个 Installer 先执行 `install(architecture, scope)`，再执行 `install_bindings(binder, scope)`，所有 Installer 完成后才进入 `init()`、`async_init()`、`ready()` 三阶段。
+然后在 `Project Settings > gf/project/installers` 中加入安装器脚本资源。编辑器可能保存 `res://`，也可能保存稳定 `uid://`；运行时会把可解析 UID 规范化为真实 `res://` 脚本路径。之后 `await Gf.init()` 会按数组顺序逐个执行 Installer：每个 Installer 先执行 `install(architecture, scope)`，再执行 `install_bindings(binder, scope)`。所有 Installer 完成后，架构冻结注册快照、编译依赖 DAG，再依次执行 `init()`、`async_init()`、`ready()`、`begin_activation()` 四阶段。
 
 Installer 路径必须最终解析到 `res://` 下的 `.gd` 脚本。空路径、失效 UID、`user://`、绝对文件系统路径、错误元素类型和非脚本资源都会被视为配置错误；默认会中断初始化，迁移期才应临时关闭 `gf/project/fail_on_installer_error`。
 
@@ -41,17 +41,36 @@ Installer 路径必须最终解析到 `res://` 下的 `.gd` 脚本。空路径�
 
 `install()` 和 `install_bindings()` 都可以在内部使用 `await`，但首个 `await` 之前仍运行在主线程。需要等待外部资源、网络或编辑器回调时，可以用 `gf/project/installer_timeout_seconds` 限制单步等待时间；长同步扫描或解析应拆成让帧步骤，避免超时检测被同步段阻塞。
 
+Installer 是固定启动拓扑的最后注册边界。依赖 DAG 开始编译后，生命周期 Hook 内新增、替换或注销模块都会被拒绝；不要依赖初始化阶段的动态补注册或多轮 stage pass。架构 READY 后确实需要改变模块集合时，使用返回类型化成功值的热模块事务。
+
 ## 原子提交与 Gf facade 边界
 
-`await Gf.set_architecture(candidate)` 会先把 `candidate` 作为未提交候选运行 Installer 和三阶段初始化，全部成功后才原子替换当前全局架构。在候选提交点之前，`Gf.has_architecture()`、`Gf.get_architecture()` 和其他 `Gf` facade 入口只观察先前已经提交的架构；若此前没有架构，则仍观察为空。提交点会先完成 assignment scope，再同步发布 identity 通知，最后让外层调用返回 `true`；identity listener 因而可以在外层返回前观察新架构，并把其中发起的 replacement 作为独立后续事务提交。
+`await Gf.set_architecture(candidate)` 会先把 `candidate` 作为未发布候选运行 Installer、依赖计划和四阶段生命周期。只有 `init()` 返回成功、candidate 已提交 READY 且 `is_accepting_runtime_work()` 为 true 时，assignment 才有资格继续；stage4 完成前，所有 `Gf` facade 入口都不会观察到 candidate。
 
 因此，Installer 必须使用 `install(architecture, scope)` 收到的 `architecture` 参数或 `install_bindings(binder, scope)` 收到的 `binder` 注册候选模块。不要在 Installer 中用 `Gf.register_*()`、`Gf.create_binder()` 或 `Gf.get_*()` 隐式访问候选架构；这些入口在替换期间仍属于旧架构。
 
 如果 pending assignment 被更新的 `set_architecture()`、尚无已提交架构时由 `Gf.create_architecture()` 创建的默认架构，或 Gf 退出场景树替代，框架会取消本轮 `scope`、执行已登记的 cleanup，并 dispose 尚未提交的候选架构。每个异步检查点都应检查 `scope.is_cancel_requested()`；即使 Installer 已返回，只要保留的公开 scope 在候选初始化期间被取消或提前 `complete()`，本轮 assignment 也会清除 pending 状态、拒绝提交并释放未提交候选。被替代的调用返回 `false` 后，不要复用该候选，重试时创建新的 `GFArchitecture`。
 
-同一个候选已经处于 pending 时，再次调用 `set_architecture(candidate)` 会立即返回 `false`，但不会取消、dispose 或抢占原 assignment；原调用仍是唯一有权提交该候选的事务。不同候选的更新 assignment 会使旧事务失效。旧架构 `dispose()` 或候选生命周期回调中的重入也遵守同一 serial 规则，只有最后一次有效 assignment 能提交。成功提交会先清除 pending、解除 scope 跟踪并调用 `scope.complete()`，再发布全局 identity 通知；因此 identity listener 发起的 replacement 是一笔独立后续事务，不会倒过来执行已成功 assignment 的取消 cleanup。
+替换已有全局架构时，candidate 保持未发布，框架先 `await old_architecture.shutdown_async()`。旧架构一进入 quiescing 就不再是可接受运行时工作的 facade identity；新工作不会在旧架构 drain 与 candidate 提交之间钻入。只有 typed shutdown result `is_successful()` 时才发布 candidate。旧架构关闭失败、取消、超时或被强制释放时，candidate 会被拒绝并强制清理；旧终态 identity 只在 assignment serial 与 identity 仍匹配时清除，不会用失败 candidate 填补。
 
-`DISPOSING` / `DISPOSED` Architecture 不能作为新 candidate，也不能重新 `init()`。旧架构同步释放回调期间，`Gf.create_architecture()` 与依赖它的注册、替换、binder/factory helper 会分别返回 `null` 或 `false`，不会暴露正在释放的旧实例或创建瞬态默认架构。Gf 退出树期间采用相同的 fail-closed 规则。若项目在事务之外直接 dispose 当前全局 identity，下一次 `create_architecture()` 会先发布该 terminal identity 被清除的通知，再创建全新的默认架构；绝不会复活旧实例。
+同一个候选已经处于 pending 时，再次调用 `set_architecture(candidate)` 会立即返回 `false`，但不会取消、dispose 或抢占原 assignment；原调用仍是唯一有权提交该候选的事务。不同候选的更新 assignment 会使旧事务失效。candidate activation、旧架构 shutdown 以及 identity listener 中的重入都遵守同一 serial/scope ownership 规则；每个 `await` 后都会重新验证，迟到 continuation 不能覆盖更新 assignment。成功提交会先清除 pending、解除 scope 跟踪并调用 `scope.complete()`，再发布全局 identity 通知。
+
+`QUIESCING`、`DISPOSING` 或 `DISPOSED` Architecture 不能作为新 candidate，也不能重新 `init()`。这些状态下，`Gf.has_architecture()` 返回 false，`Gf.create_architecture()` 与依赖它的注册、替换、binder/factory helper 会分别返回 `null` 或 `false`，不会暴露关闭中的旧实例或创建瞬态默认架构。若项目在 assignment 之外直接关闭当前全局 identity，下一次合法创建会先清除 terminal identity；绝不会复活旧实例。
+
+## 显式关闭
+
+应用正常退出、切换主运行域或测试需要保留已接纳异步工作时，应直接等待架构：
+
+```gdscript
+var architecture: GFArchitecture = Gf.get_architecture()
+var shutdown_result: GFArchitectureShutdownResult = (
+	await architecture.shutdown_async()
+)
+if not shutdown_result.is_successful():
+	push_warning(shutdown_result.get_error())
+```
+
+`shutdown_async()` 会关闭新工作准入、按依赖逆序 quiesce，再执行同步释放。`Gf` 自身退出 SceneTree 时无法可靠等待，仍使用同步 `dispose()` 强制兜底；这条路径不承诺 drain，不能替代项目可控的正常关闭。
 
 ## 启动失败诊断
 

--- a/docs/zh/kernel/lifecycle/controllers/ready-context.md
+++ b/docs/zh/kernel/lifecycle/controllers/ready-context.md
@@ -1,6 +1,6 @@
 # Ready 与上下文等待
 
-表现层 Controller 依附于 Godot 原生场景树，继承自 `Node`。它们的初始化仍由 Godot `_ready()` 触发，不属于 `GFModel`、`GFSystem`、`GFUtility` 的三阶段生命周期。
+表现层 Controller 依附于 Godot 原生场景树，继承自 `Node`。它们的初始化仍由 Godot `_ready()` 触发，不属于 `GFModel`、`GFSystem`、`GFUtility` 的四阶段生命周期。
 
 Controller 的 `_ready()` 中通常执行以下操作：
 
@@ -16,7 +16,9 @@ class_name HUDController extends GFController
 @onready var hp_bar: ProgressBar = $HealthBar
 
 func _ready() -> void:
-	var architecture := await wait_for_context_ready()
+	var architecture: GFArchitecture = await wait_for_context_ready()
+	if architecture == null:
+		return
 	var user_model := architecture.get_model(UserModel) as UserModel
 
 	user_model.health.value_changed.connect(_on_health_changed)
@@ -26,4 +28,4 @@ func _on_health_changed(_old_value: Variant, new_val: Variant) -> void:
 	hp_bar.value = new_val
 ```
 
-如果 Controller 依赖局部架构，等待上下文 ready 能避免节点 `_ready()` 早于架构初始化完成时读取到缺失模块。
+如果 Controller 依赖局部架构，等待上下文 ready 能避免节点 `_ready()` 早于架构完成第四阶段时读取到未激活模块。`GFNodeContext.context_ready` 只在 Architecture 已提交 READY 后发出；第三阶段模块 ready 不会提前唤醒 Controller。

--- a/docs/zh/kernel/lifecycle/factories-aliases/aliases.md
+++ b/docs/zh/kernel/lifecycle/factories-aliases/aliases.md
@@ -30,4 +30,11 @@ func _ready() -> void:
 
 `Model`、`System` 与 `Utility` 的注册表遵循同一套规则：重复注册会被忽略并提示使用 `replace_*()`；同一实例不能用多个脚本键重复注册；`unregister_*()` 只注销直接注册键，删除 alias 应使用 `unregister_*_alias()`，且不会释放目标实例；注册表变化后继承匹配缓存会失效。
 
-显式 alias 会校验 `target_cls` 必须继承或等于 `alias_cls`。无关类型会被拒绝，避免 `get_utility(AbstractType)` 返回无法强转的实例。若 alias 指向的目标类型尚未注册，查询会报告错误，并且不会在同一架构内退回另一个可赋值实现；非严格子架构仍可继续回退父架构。项目层应保持注册键、alias 和实际实例类型一致。
+显式 alias 会校验 `target_cls` 必须继承或等于 `alias_cls`。无关类型会被拒绝，避免 `get_utility(AbstractType)` 返回无法强转的实例。
+
+本地解析只有在精确键、alias 和可赋值实例都完全未命中时，非严格架构才可以继续查询父架构。以下两种结果都是父级 fallback barrier：
+
+- alias 已存在但目标注册项缺失；该 stale alias 会报告错误，且不会改找本地可赋值实例或父级实例。
+- 本地存在多个可赋值实例；该歧义会返回 `null`，且不会由父级同类型实例掩盖。
+
+普通 `get_*()`、可选 `find_*()` 查询与声明式依赖计划遵循同一屏障语义。项目层应保持注册键、alias 和实际实例类型一致，并用显式 alias 消除合法的多实现歧义。

--- a/docs/zh/kernel/lifecycle/factories-aliases/factories.md
+++ b/docs/zh/kernel/lifecycle/factories-aliases/factories.md
@@ -16,6 +16,12 @@ command.execute()
 工厂默认是 `GFBindingLifetimes.Lifetime.TRANSIENT`。每次 `create_instance()` 都会调用 provider，并把返回对象注入发起解析的架构。通常 provider 会创建新对象，但框架不会强制校验对象唯一性；如果 provider 自己返回缓存对象，transient 也会返回该对象。
 `register_factory()`、`replace_factory()`、`register_factory_instance()`、`replace_factory_instance()` 和 `unregister_factory()` 都返回 `bool`；重复注册、无效生命周期或 dispose 后写入会返回 `false`。
 
+`create_instance()` 是运行时准入入口，不是装配期探测接口。只有 Architecture 已经完成第四阶段并处于 READY，且没有正在提交的热模块拓扑事务时，框架才会调用 provider；初始化、activation、拓扑事务、quiesce 和 dispose 期间都在 provider 发生任何副作用前返回 `null`。装配期只检查 binding 是否存在时使用 `has_factory()` 或声明 `get_required_factories()`，不要通过试创建验证工厂。
+
+每次解析都会在调用 provider 前固定 binding owner 与真实 requester 的生命周期 generation，并在 provider 返回后以及每个依赖注入 Hook 后复核准入、解析事务和实例存活状态。任一参与架构关闭运行时准入会立即使共享解析上下文失败；此后嵌套 `create_instance()` 会在 factory 查找、缓存读取或 provider 调用前短路。任一 Hook 触发嵌套解析失败、让 Node 进入待释放状态，或尝试在解析栈内重入修改模块拓扑，也会立即停止后续 Hook 并使整条解析失败。框架不会缓存或交付失效结果，只在实际注入目标上清理本次建立的事件与依赖作用域，并始终保留 `register_factory_instance()` 外部实例的所有权。解析回滚只清理 Binding 仍持有的缓存，关闭流程已经取得释放权的 Singleton 不会被二次释放。
+
+Transient 的所有权在它自己的 `create_instance()` 成功返回时转给直接调用者，即使该调用者是另一个 provider。外层解析之后失败不会追溯释放已经交付的 Transient；直接调用者必须接管其成功路径与失败路径清理。若业务需要一组 Transient 在更大范围内原子提交，应使用显式的领域事务或所有权收养协议，不能把普通 `create_instance()` 的返回值假定为隐式 provisional 对象。
+
 `GFBinding` 是架构内部保存 provider、生命周期、singleton 缓存和解析回滚状态的记录类型。项目代码不应直接构造、缓存或修改它；通过上述工厂注册 API 表达所有权，才能让循环检测、失败链回滚和架构释放保持完整。
 
 ## 生命周期策略

--- a/docs/zh/kernel/lifecycle/index.md
+++ b/docs/zh/kernel/lifecycle/index.md
@@ -5,7 +5,7 @@ Kernel 生命周期文档说明 `GFArchitecture` 如何装配 `GFModel`、`GFSys
 ## 阅读入口
 
 - [启动注册与 Installer](boot-installers/index.md)：boot 脚本、项目 Installer、扩展 Installer、失败状态和超时策略。
-- [模块三阶段生命周期](module-lifecycle/index.md)：`init()`、`async_init()`、`ready()`、动态注册和 ready 查询。
+- [模块四阶段生命周期](module-lifecycle/index.md)：依赖 DAG、`init()`、`async_init()`、`ready()`、activation、quiesce 与热模块事务。
 - [场景级局部上下文](node-contexts.md)：`GFNodeContext`、scoped 架构、继承上下文、局部 tick 和上下文等待。
 - [短生命周期工厂与别名](factories-aliases/index.md)：factory、transient/singleton、alias 注册和抽象类型获取。
 - [Controller 初始化](controllers/index.md)：`GFController` 与 Godot 节点 `_ready()`、宿主节点和局部上下文协作。

--- a/docs/zh/kernel/lifecycle/module-lifecycle/async-ready.md
+++ b/docs/zh/kernel/lifecycle/module-lifecycle/async-ready.md
@@ -1,17 +1,39 @@
-# 异步超时与 Ready 查询
+# 异步超时、Activation 与状态查询
 
 `async_init()` 适合等待网络请求、本地 IO 或大批量资源异步加载。项目应避免让开发期资源加载、网络请求或外部回调永久挂起。
 
 ## 异步超时
 
-可通过 `GFArchitecture.module_async_init_timeout_seconds` 设置模块异步初始化超时。超时会取消当前模块收到的 `GFAsyncScope`，让架构进入初始化失败状态，并唤醒等待 `init()` / `GFNodeContext.wait_until_ready()` 的调用方。
+可通过 `GFArchitecture.module_async_init_timeout_seconds` 设置模块异步初始化超时。该属性只接受 `0..86400` 的有限秒数；`0` 明确禁用 deadline，非法赋值会被拒绝并保留原值。超时会取消当前模块收到的 `GFAsyncScope`，让架构进入初始化失败状态，并唤醒等待 `init()` / `GFNodeContext.wait_until_ready()` 的调用方。
 
 Godot coroutine 无法被框架抢占式终止。超时会阻止架构继续推进，并让 `scope.is_cancel_requested()` 返回 true；已经挂起的 `async_init(scope)` 如果之后恢复，模块内部应先检查 scope，再决定是否写回状态。需要注册临时连接、后台请求或外部句柄清理时，使用 `scope.register_cleanup()`。
 
 超时也不会抢占首个 `await` 之前的同步执行段。需要处理大文件、批量资源索引或复杂表格解析时，应先进入可让帧的分段流程，再在每段之间检查生命周期状态；否则一次长同步段仍会卡住主线程，并推迟超时检测。
 
-## Ready 查询
+## Activation deadline
+
+第四阶段使用独立的 `GFArchitecture.activation_timeout_seconds` 总 deadline，默认 30 秒；该属性同样只接受 `0..86400` 的有限秒数，`0` 禁用 deadline。它不是每个模块各自拥有一份完整预算。`begin_activation(scope)` 必须立即返回 `GFAsyncCompletion`，并在异步回调、Signal 或 tick-driven bootstrap 完成时提交一次终态。把 scope 绑定到完成源可以让初始化取消直接传播：
+
+```gdscript
+func begin_activation(scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _bound: bool = completion.bind_cancel_token(scope)
+	_begin_bootstrap(completion)
+	return completion
+```
+
+不要在 `begin_activation()` 返回前自行轮询 `architecture.tick()`，也不要为了等待兄弟服务而阻塞主线程。架构会根据声明依赖的闭包推进必要模块的 lifecycle tick；完成源失败、取消、超时或从 Hook 返回 `null` 时，本轮初始化不会提交 READY。
+
+## Ready、Active 与架构准入
 
 依赖查询默认保持兼容，会返回已注册但仍处于初始化过程中的模块。如果代码必须只消费完成 `ready()` 的模块，可以在 `GFArchitecture`、`Gf`、`GFNodeContext`、`GFController`、`GFCommand`、`GFQuery`、`GFSystem` 或 `GFUtility` 的 `get_model()` / `get_system()` / `get_utility()` 中传入 `require_ready = true`。
 
-本地查询 `get_local_*()` 也支持相同参数。需要判断某个实例是否已经完成 `ready()` 时，可调用 `architecture.is_module_ready(instance)`，模块自身可用 `is_ready_in_architecture()`。
+本地查询 `get_local_*()` 也支持相同参数。需要判断某个实例是否已经完成第三阶段时，可调用 `architecture.is_module_ready(instance)`，模块自身可用 `is_ready_in_architecture()`。
+
+“ready”只表示依赖装配完成，不等同于已经接纳运行时工作。只有第四阶段成功后，`architecture.is_module_active(instance)` 才表示该模块已激活；只有架构整体提交 READY 后，`architecture.is_accepting_runtime_work()` 和 `architecture.is_inited()` 才返回 true。外部启动流程应以架构准入状态为边界，不要在第三阶段通过 ready 查询绕过 activation。
+
+## Shutdown deadline
+
+`GFArchitecture.shutdown_timeout_seconds` 是正常异步关闭的默认总 deadline，也只接受 `0..86400` 的有限秒数，`0` 禁用 deadline。调用 `shutdown_async(token, timeout_seconds)` 时可以传入同一区间的 per-call 覆盖值；默认 sentinel `-1.0` 表示读取 `shutdown_timeout_seconds`，不是另一个 deadline 值。非有限值、其它负值或大于 `86400` 的覆盖值会失败关闭。关闭开始后架构立即进入 quiescing，新命令、查询、事件派发、运行时写入和模块拓扑事务都会被拒绝。
+
+模块的 `begin_quiesce(scope)` 应返回一次性完成源，并只排空关闭前已经接纳的工作。无论关闭成功、失败、取消或超时，架构最终都会同步释放所有模块；调用方应检查 `GFArchitectureShutdownResult`，不能把对象已经 disposed 误当成数据已经正常 drain。

--- a/docs/zh/kernel/lifecycle/module-lifecycle/dynamic-registration.md
+++ b/docs/zh/kernel/lifecycle/module-lifecycle/dynamic-registration.md
@@ -17,6 +17,8 @@ var registered: bool = await architecture.register_system_instance(
 
 事务执行期间普通命令、查询和事件派发被关闭，避免外部运行时观察半提交拓扑。候选 activation 需要 tick-driven 依赖时，框架只临时驱动候选的本地依赖闭包。
 
+原子发布只保证框架管理的 registry 与活动计划不可见，不隔离模块直接写入全局回调、进程级 singleton、网络监听等外部副作用。候选模块必须在 activation scope 中登记对应 cleanup，确保准备失败、事务失效或关闭接管时可以完整撤销；替换模块还应容忍候选 activation 与旧实例 quiesce 之间的短暂外部重叠。
+
 若活动 child 的生命周期计划命中了本架构提供的 required module，child 持有的外部依赖租约会使本架构的模块注册、替换和注销在创建候选前失败。租约只冻结维持已提交 child 计划所需的模块拓扑；仅命中父级 required factory 时不会额外冻结模块拓扑，但仍会阻止父级在 child 之前正常关闭。先关闭相关 child，再重试父级拓扑事务。
 
 ## 替换

--- a/docs/zh/kernel/lifecycle/module-lifecycle/dynamic-registration.md
+++ b/docs/zh/kernel/lifecycle/module-lifecycle/dynamic-registration.md
@@ -1,27 +1,55 @@
-# 初始化后的动态注册
+# 热模块拓扑事务
 
-自 `1.6.0` 起，如果架构已经完成 `Gf.init()`，之后再注册新的 Model、System 或 Utility，框架会为新模块自动补跑完整生命周期：
+架构提交 READY 后，Model、System、Utility 的注册、替换和注销属于显式的热模块拓扑事务。它们不是初始化阶段的动态补注册机制：Installer 必须在 `init()` 前完成基础装配；生命周期计划冻结后，`init()`、`async_init()`、`ready()`、`begin_activation()`、`begin_quiesce()` 和 `dispose()` Hook 内的注册表重入都会被拒绝。
 
-```text
-init() -> async_init() -> ready()
-```
+Factory 和 alias 属于依赖解析拓扑，首次 activation 后保持不可变。需要改变这些绑定时创建并原子替换新的 `GFArchitecture`，不要在活动架构上维护第二套可变解析图。
 
-这适合运行时加载关卡专属系统、DLC 模块、调试工具或临时玩法模块。
+## 注册
 
 ```gdscript
-await Gf.init()
-
-var battle_system := BattleSystem.new()
-await Gf.register_system(battle_system)
-# battle_system 会自动完成三阶段生命周期，随后参与 tick / physics_tick。
+var architecture: GFArchitecture = Gf.get_architecture()
+var registered: bool = await architecture.register_system_instance(
+	RuntimeFeatureSystem.new()
+)
 ```
 
-如果动态模块在 `async_init()` 中等待资源或网络流程，而调用点需要确认它已经完全 ready，可以直接使用底层架构方法并 `await`：
+热注册会用候选模块重新编译完整依赖 DAG，再让候选依次完成 `init()`、`async_init()`、`ready()` 和 `begin_activation()`。新实例始终保留在 staged candidate 中；只有 stage4 成功且原事务仍拥有当前 lifecycle generation 时，框架才原子发布 registry 与活动计划。提交前，普通 `get_*()` / `find_*()` 查询看不到候选；失败候选会被清理，不能视为已归属架构。
+
+事务执行期间普通命令、查询和事件派发被关闭，避免外部运行时观察半提交拓扑。候选 activation 需要 tick-driven 依赖时，框架只临时驱动候选的本地依赖闭包。
+
+若活动 child 的生命周期计划命中了本架构提供的 required module，child 持有的外部依赖租约会使本架构的模块注册、替换和注销在创建候选前失败。租约只冻结维持已提交 child 计划所需的模块拓扑；仅命中父级 required factory 时不会额外冻结模块拓扑，但仍会阻止父级在 child 之前正常关闭。先关闭相关 child，再重试父级拓扑事务。
+
+## 替换
 
 ```gdscript
-await Gf.get_architecture().register_utility_instance(RuntimeConfigProvider.new())
+var replaced: bool = await architecture.replace_utility(
+	RuntimeConfigUtility,
+	replacement
+)
 ```
 
-动态注册和替换采用 prepare / commit / rollback 事务。injection、`init()`、`async_init()` 或 `ready()` 中发生取消、失败、dispose 或同 key 重入时，候选实例不会留在 registry；其 service、event、injection scope 等副作用会一起回滚。替换过程中如果用户回调注册了更新实例，外层旧事务会返回失败，不会覆盖最新结果。
+替换同样先把新实例留在 staged candidate 中，在候选注册快照上编译 DAG，并私下完成四阶段准备。stage4 成功后，框架才按旧计划 quiesce 旧实例并原子发布 registry 与活动计划。准备失败会保留旧实例；旧实例无法 quiesce 时，框架会强制 dispose 整个架构，避免留下“旧服务仍工作、候选却部分可见”的不一致状态。
 
-动态注册仍应遵守依赖边界。长期跨场景服务应在项目 Installer 中注册；关卡专属或临时模块应在卸载时明确注销，或通过场景切换瞬态清理机制处理。注册返回 `false` 时不得把候选视为已归属架构；调用方应释放自己的外部资源或创建新候选重试。
+同 key 重入、lifecycle generation 漂移、并发拓扑事务或 dispose 会使旧事务失效。迟到 continuation 只能清理自己的未提交候选，不能覆盖更新事务的结果。
+
+## 注销
+
+```gdscript
+var removed: bool = await architecture.unregister_system(RuntimeFeatureSystem)
+```
+
+注销先编译“移除目标后”的候选 DAG。仍有本地模块声明依赖目标时，候选计划无效，注销在触碰活动 registry 前失败。计划有效时，框架先 quiesce 目标，再提交新计划并执行同步 dispose/release；quiesce 失败同样使整个架构进入强制释放终态。
+
+传入 alias 会被拒绝，必须使用对应 alias API；但 activation 后 alias 拓扑本身不可变。返回 `false` 时，调用方不得假定变更已提交，也不得复用已经交给失败事务并被清理的候选实例。
+
+`Gf.unregister_model()`、`Gf.unregister_system()` 与 `Gf.unregister_utility()` 是同一异步事务的 Autoload facade，也必须 `await` 并检查返回的 `bool`。它们不再是可忽略终态的同步通知入口。
+
+## 关闭接管
+
+`shutdown_async()` 会先关闭准入，再等待已经接纳的拓扑事务稳定。等待达到 deadline 或被取消时，关闭流程按固定顺序接管：先夺取事务写权，再取消事务 scope，最后 claim 未提交候选的恰好一次清理；迟到 continuation 只能观察终态并 no-op，不能发布 registry 或活动计划。
+
+清理所有权随当前事务描述符收敛，框架不会为已释放实例保留无界、长期存在的 tombstone。关闭结果中的 `unfinished_modules` 同时包含 quiesce 失败、取消或超时的当前模块，以及因此未开始 quiesce 的后续模块。
+
+## 适用边界
+
+长期跨场景服务应由 Installer 在启动图中注册。热模块事务适合真正需要在活动架构中装卸的可选运行时能力；关卡普通表现节点、临时数据和项目流程更适合 `GFNodeContext`、Controller 或项目自己的状态机。不要仅为规避明确启动依赖而把固定模块改成热注册。

--- a/docs/zh/kernel/lifecycle/module-lifecycle/index.md
+++ b/docs/zh/kernel/lifecycle/module-lifecycle/index.md
@@ -1,13 +1,13 @@
-# 模块三阶段生命周期
+# 模块四阶段生命周期
 
-本组页面说明 `GFModel`、`GFSystem` 和 `GFUtility` 在 `Gf.init()` 后经历的三阶段生命周期，以及初始化完成后的动态注册行为。
+本组页面说明 `GFModel`、`GFSystem` 和 `GFUtility` 如何按声明依赖 DAG 完成四阶段初始化、在 READY 后执行热模块拓扑事务，并通过异步 quiesce 安全关闭。
 
 ## 阅读入口
 
-- [三阶段初始化](init-stages.md)：`init()`、`async_init()`、`ready()` 的执行顺序与职责。
-- [异步超时与 Ready 查询](async-ready.md)：异步初始化超时、生命周期有效性和 `require_ready` 查询。
-- [初始化后的动态注册](dynamic-registration.md)：架构 ready 后注册新模块时的自动补跑流程。
+- [四阶段初始化、激活与关闭](init-stages.md)：`init()`、`async_init()`、`ready()`、`begin_activation()` 与 `begin_quiesce()` 的职责。
+- [异步超时、Activation 与状态查询](async-ready.md)：初始化/激活/关闭 deadline、Ready 与 Active 的区别。
+- [热模块拓扑事务](dynamic-registration.md)：READY 后注册、替换、注销的 prepare / commit / rollback 边界。
 
 ## 使用边界
 
-GF 生命周期只覆盖注册进架构的 Model、System 和 Utility。Godot 节点生命周期仍由场景树负责；场景桥接逻辑应放在 `GFController`、`GFNodeContext` 或普通节点中。
+GF 生命周期只覆盖注册进架构的 Model、System 和 Utility。Godot 节点生命周期仍由场景树负责；场景桥接逻辑应放在 `GFController`、`GFNodeContext` 或普通节点中。固定模块必须在生命周期计划冻结前由 Installer 装配，不能在 Hook 中动态补注册。

--- a/docs/zh/kernel/lifecycle/module-lifecycle/init-stages.md
+++ b/docs/zh/kernel/lifecycle/module-lifecycle/init-stages.md
@@ -1,60 +1,106 @@
-# 三阶段初始化
+# 四阶段初始化、激活与关闭
 
-调用 `Gf.init()` 后，框架会遍历所有模块组件，并依次触发 `init()`、`async_init()`、`ready()` 三个阶段。默认保持注册顺序；如果模块设置了 `lifecycle_priority`，同类模块会按数值从高到低初始化，释放时反向处理。
+`GFArchitecture.init()` 会先冻结 Model、Utility、System 注册快照，并从模块声明的依赖编译生命周期 DAG。缺失依赖、歧义解析或本地循环都会在任何模块生命周期阶段 Hook 执行前使初始化失败；不存在“继续多轮扫描，等待某个 Hook 再补注册”的兼容路径。
 
-所有 `GFModel`、`GFSystem` 和 `GFUtility` 基类都提供这三个虚方法供模块重写。架构生命周期只调用这三个基类的强类型虚方法；普通 `Object` 或未继承对应基类的对象不能作为框架模块注册，也不会依靠同名方法参与生命周期。
+有效 DAG 对四个阶段都使用同一份依赖优先顺序。依赖关系先于 `lifecycle_priority`；只有多个已满足依赖的模块同时可执行时，框架才用模块类别、较高的 `lifecycle_priority` 和注册顺序稳定破平。父架构提供的依赖只作为外部满足项，不会变成本地 DAG 节点；父 Architecture 必须已经提交 READY，父级模块还必须处于 ACTIVE。
 
-## 同步初始化
+子架构完成计划编译后、执行计划内模块的 `init()` / `async_init()` / `ready()` / activation Hook 前，会为实际命中的父级 required module/factory 取得弱所有权租约。正常生命周期中，租约使依赖提供者和中间父链在 child 整个活动 generation 内保持可用：模块依赖会阻止相关父级改变模块拓扑，任一外部依赖都会使父级正常 `shutdown_async()` 以 `ERR_BUSY` 失败且不改变生命周期状态。child 初始化失败、正常关闭或强制释放都会幂等释放租约。项目仍应先启动父架构、再初始化子架构，并按相反顺序先关闭 child、最后关闭 parent。
+
+`GFArchitectureLifecyclePlan` 是框架内部用于冻结上述顺序、依赖闭包与有界诊断的计划对象；项目代码不应自行构造、修改或长期持有它。对外诊断由 Architecture 从同一份计划快照投影，避免执行顺序与诊断结果分别扫描后发生漂移。
+
+所有 `GFModel`、`GFSystem` 和 `GFUtility` 基类都提供对应的强类型虚方法。普通 `Object` 或未继承这些基类的对象不能依靠同名方法参与架构生命周期。
+
+| 阶段 | Hook | 主要职责 | 运行时状态 |
+| --- | --- | --- | --- |
+| 1 | `init()` | 初始化模块自己的同步状态 | 未开放 |
+| 2 | `async_init(scope)` | 准备模块自己的异步资源 | 未开放 |
+| 3 | `ready()` | 解析已 ready 的声明依赖并完成装配 | 未开放 |
+| 4 | `begin_activation(scope)` | 启动运行期能力并提交类型化终态 | 全部成功后才开放 |
+
+## 第一阶段：同步初始化
 
 ```gdscript
 func init() -> void:
-	# 同步的初步设置。
+	# 只建立当前模块自己的同步状态。
 ```
 
-`init()` 会首先遍历并调用所有实例。它适合执行没有外部依赖、立即完成的轻量设置，例如绑定初始响应式属性、设置默认数值等。
+`init()` 适合绑定初始响应式属性、设置默认数值和建立本模块内部不变量。不要在这里启动请求、派发事件或依赖偶然的注册顺序读取其他模块。
 
-此时不能保证其他模块已经完成 `init()`，因此不建议在这里频繁跨模块调用。
-
-## 异步等待
+## 第二阶段：异步准备
 
 ```gdscript
 func async_init(scope: GFAsyncScope) -> void:
-	var asset_utility := Gf.get_utility(GFAssetUtility) as GFAssetUtility
-	var load_state := { "done": false, "resource": null }
-	asset_utility.load_async("res://data/tables.json", func(resource: Resource) -> void:
-		load_state.resource = resource
-		load_state.done = true
-	)
-	while not load_state.done:
+	while not _local_preparation_finished:
 		if scope.is_cancel_requested():
 			return
 		await Engine.get_main_loop().process_frame
 ```
 
-`async_init(scope)` 会在所有 `init()` 执行完毕后串行运行。它返回 `void`，但 Godot 4 支持在 `void` 函数内部使用 `await`；框架的 `Gf.init()` 会自动等待每个模块的 `async_init(scope)` 完成，避免模块在异步资源未就绪前进入 `ready()` 或 tick。`scope` 是本轮异步生命周期的协作取消边界，超时、初始化失败或架构释放后会进入取消状态。
+`async_init(scope)` 在所有模块完成第一阶段后按 DAG 顺序串行运行。它仍是主线程 coroutine；首个 `await` 前的同步段不能被框架抢占。长任务应拆成可让帧的有界步骤，并在每个 `await` 或外部回调返回后检查 `scope.is_cancel_requested()`。
 
-`async_init(scope)` 仍是主线程 coroutine。函数开始到首个 `await` 之前是同步执行段，框架无法在这段中主动让帧或触发超时；不要把大批量扫描、重型解析或阻塞 IO 放在首个 `await` 之前。长任务应拆成可让帧的步骤，并在每个 `await` 或外部回调返回后检查 `scope.is_cancel_requested()`。
+这一阶段用于准备当前模块自己的资源，不是启动依赖型运行时流程的入口。需要访问已经 ready 的兄弟服务、等待该服务由 tick 推进的操作，并阻止架构过早对外可用时，应使用第四阶段。
 
-## 就绪完成
+## 第三阶段：装配完成
 
 ```gdscript
 func ready() -> void:
-	register_simple_event(&"GAME_STARTED", GFEventListener.from_method(self, &"_on_game_started", 1))
+	var value: Variant = get_utility(ProjectConfigUtility, true)
+	if value is ProjectConfigUtility:
+		_config = value
 ```
 
-`ready()` 会在所有模块的 `async_init()` 结束后触发。此时整个架构已经完成挂载，模块可以安全获取其他 Model、System 或 Utility，并注册事件监听。
+`ready()` 执行时，当前模块的本地声明依赖已经按 DAG 顺序完成第三阶段，可以安全缓存 Model、System 或 Utility。`ready()` 仍是同步装配 Hook；此时 `is_module_ready()` 可以为 true，但架构尚未提交 READY，命令、查询、事件派发、普通 tick 和模块自己的新工作准入都不应开始。
 
-## 释放引用
+## 第四阶段：显式激活
 
 ```gdscript
+func begin_activation(scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	var _bound: bool = completion.bind_cancel_token(scope)
+	if not _start_runtime_admission():
+		var _failed: bool = completion.fail("Runtime admission could not start.")
+		return completion
+	var _succeeded: bool = completion.succeed()
+	return completion
+```
+
+`begin_activation(scope)` 必须立即返回非空 `GFAsyncCompletion`，再以 `succeed()`、`fail()` 或 `cancel()` 恰好提交一次终态。框架按 DAG 顺序等待每个完成源；等待某个模块时，只驱动该模块及其本地传递依赖闭包的生命周期 tick，使 Storage、Save Profile 等已经 ready 的 tick-driven 服务可以推进 bootstrap，而不会提前开放整个运行时。
+
+全部模块激活成功后，架构才提交 READY；此后 `is_inited()`、`is_accepting_runtime_work()` 和 `architecture.is_module_active(instance)` 才表示运行时可用。激活取消、超时、空完成源或失败终态都会 fail closed：架构不提交 READY，取消本轮作用域并清理模块，迟到回调无权恢复旧 generation。
+
+并发 `init()` 调用共享同一初始化事务。首个调用拥有共享 cancellation token 与 timeout 策略；后续调用的 token 只取消自身等待，不能终止其它调用正在等待的 activation。架构一旦提交 READY，之后的幂等 `init()` 固定成功，即使该调用携带已经取消的 token，也不会把稳定终态重新解释为失败。
+
+## 正常关闭与强制释放
+
+正常、可等待的退出路径使用：
+
+```gdscript
+var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+if not result.is_successful():
+	push_warning(result.get_error())
+```
+
+`shutdown_async()` 会先确认没有仍依赖本架构的活动 child；命中外部依赖租约时返回 `ERR_BUSY`，且不关闭准入或改变生命周期状态。检查通过后，它首先不可逆地关闭新运行时工作准入，再按激活 DAG 的严格逆序调用 `begin_quiesce(scope)`。模块应停止接纳新工作，并让此前已经接纳的操作在完成源进入终态前收敛。框架在等待期间继续只驱动当前模块的依赖闭包；取消、超时或模块失败会写入类型化结果，其中 `unfinished_modules` 包含当前 quiesce 失败、取消或超时的模块，以及因此未开始 quiesce 的后续模块。最终仍会执行每个模块恰好一次的同步 `dispose()` 和 `release_dependencies()`。
+
+如果关闭开始时已有被接纳的拓扑事务，框架会先等待事务稳定；deadline 或取消触发接管时，顺序固定为夺取事务写权、取消事务 scope、claim 未提交候选的恰好一次清理。迟到 continuation 不能再写回；清理状态随事务描述符收敛，不为已释放实例保留长期 tombstone。
+
+并发 `shutdown_async()` 调用共享同一关闭流程：每个调用都会先独立校验参数，首个被接纳的调用拥有共享 cancellation token 与 deadline 策略，后续调用只等待并取得同一终态结果的隔离副本。调用方不能用重复调用缩短、延长或替换已开始流程的策略。
+
+`dispose()` 则是 SceneTree 退出等无法等待场景的同步强制兜底：它会取消活动作用域并立即释放，也不会被 child 租约阻挡。调用方必须把这视为打破父子 outlive 契约的灾难收敛路径。强制释放、中断 activation 或无法进入正常 quiesce 时，类型化关闭结果会在清理前快照所有已经进入任一生命周期阶段的模块与未提交拓扑候选，并把它们记录到 `unfinished_modules`；它提供审计证据，但不承诺排空已接纳工作。
+
+```gdscript
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+	_close_runtime_admission()
+	return _drain_accepted_work(scope)
+
+
 func dispose() -> void:
-	_stop_runtime_work()
+	_release_owned_runtime_state()
+
 
 func release_dependencies() -> void:
 	_cached_utility = null
 	super.release_dependencies()
 ```
 
-架构注销模块或整体 `dispose()` 时，会先调用模块的 `dispose()`，再调用 `release_dependencies()`。`dispose()` 负责停止模块自身工作、断开业务监听和释放本模块拥有的对象；`release_dependencies()` 只负责清空模块缓存的外部 Model/System/Utility 引用，并释放框架注入作用域。
-
-GF 不会自动扫描并清空模块的任意成员变量。需要释放哪些引用由模块自己声明，避免在错误生命周期点破坏模块自己的 dispose 逻辑。
+GF 不会扫描并清空模块的任意成员变量。`dispose()` 负责本模块拥有的终止性清理；`release_dependencies()` 只负责清空外部模块引用和框架注入作用域。

--- a/docs/zh/kernel/lifecycle/node-contexts.md
+++ b/docs/zh/kernel/lifecycle/node-contexts.md
@@ -50,17 +50,18 @@ func install_bindings(binder: Variant, _scope: GFAsyncScope) -> void:
 `SCOPED` 上下文会：
 
 1. 创建新的 `GFArchitecture`。
-2. 将最近的父级上下文或全局 `Gf` 架构作为父级依赖来源。
-3. 在 `auto_init == true` 时自动初始化局部模块。
-4. 在节点退出树时自动 `dispose()` 局部模块。
+2. 将最近且已提交 READY 的父级上下文或全局 `Gf` 架构作为父级依赖来源。
+3. 在 `auto_init == true` 时编译局部依赖 DAG 并完成四阶段初始化。
+4. 只在第四阶段成功、局部架构提交 READY 后发出 `context_ready`。
+5. 在节点退出树时同步强制 `dispose()` 局部模块。
 
-如果把 `auto_init` 设为 `false`，Context 仍会创建局部架构并执行 `install()` / `install_bindings()`，但不会自动进入三阶段生命周期。需要在合适的业务时机调用 `await context.initialize_context()`；该方法会等待安装完成、统一触发初始化，并在成功或失败时沿用 `context_ready` / `context_failed` 语义。
+如果把 `auto_init` 设为 `false`，Context 仍会创建局部架构并执行 `install()` / `install_bindings()`，但不会自动进入四阶段生命周期。需要在合适的业务时机调用 `await context.initialize_context()`；该方法会等待安装完成、统一触发初始化，并在 stage4 成功或任一阶段失败时沿用 `context_ready` / `context_failed` 语义。第三阶段 `ready()` 完成但 activation 仍在等待时，Context 继续保持未 ready，子树不能提前取得运行时准入。
 
-`install()` 与 `install_bindings()` 收到的 `GFAsyncScope` 是该局部上下文安装过程的取消边界。`SCOPED` 节点退出树、父级架构失败、scope 自取消或上下文失败时，框架会取消 scope 并执行登记的清理回调；安装逻辑中每次 `await` 后都应检查 `scope.is_cancel_requested()`，避免已离树的上下文继续写入外部副作用。每次入树拥有独立 generation，旧协程迟到完成不能修改新一轮安装；Context 的 READY 与 FAILED 互斥，首次失败原因保持稳定。Context 会固定本轮选择的父级 Architecture identity，并在父级首次 READY 后固定其 lifecycle generation；install await、局部初始化和 Context READY 期间，父级被替换、失败、dispose 或跨 generation 重试都会让当前 Context fail closed。Scoped Context 一旦进入 FAILED，会立即 dispose 自己拥有的架构并停止 tick，但不会接管父级的释放；若 owned Architecture 在 READY 后被外部 dispose，Context 也会撤销 READY 并进入 FAILED。Inherited Context 不拥有共享架构，因此失败时同样不会替父级执行 dispose。
+`install()` 与 `install_bindings()` 收到的 `GFAsyncScope` 是该局部上下文安装过程的取消边界。`SCOPED` 节点退出树、父级架构失败、scope 自取消或上下文失败时，框架会取消 scope 并执行登记的清理回调；安装逻辑中每次 `await` 后都应检查 `scope.is_cancel_requested()`，避免已离树的上下文继续写入外部副作用。每次入树拥有独立 generation，旧协程迟到完成不能修改新一轮安装；Context 的 READY 与 FAILED 互斥，首次失败原因保持稳定。Context 会固定本轮选择的父级 Architecture identity，并在父级首次 READY 后固定其 lifecycle generation；父级声明依赖只有在父 Architecture 已 READY、对应模块已 ACTIVE 时才能满足。install await、局部初始化和 Context READY 期间，父级被替换、失败、dispose 或跨 generation 重试都会让当前 Context fail closed。Scoped Context 一旦进入 FAILED，会立即 dispose 自己拥有的架构并停止 tick，但不会接管父级的释放；若 owned Architecture 在 READY 后被外部 dispose，Context 也会撤销 READY 并进入 FAILED。Inherited Context 不拥有共享架构，因此失败时同样不会替父级执行 dispose。
 
 如果把 `process_scoped_ticks` 设为 `false`，该 Context 只负责创建和生命周期管理，不再驱动局部架构的 `tick()` / `physics_tick()`。这种模式适合由外部调度器统一驱动局部架构；否则局部 `GFSystem.tick()` 和 `GFUtility.tick()` 不会自动执行。
 
-如果只想让某个节点树分支复用父级上下文，可以把 `scope_mode` 设为 `INHERITED`。继承模式不会创建或释放局部架构，但会在继承到的架构 ready 后发出同样的 `context_ready` 信号；如果父级架构稍后才初始化完成，上下文会等待后再发出信号。继承来源在本轮入树期间不会热迁移：全局或最近父 Context 改成另一 Architecture 时，当前 Inherited Context 会失败，调用方应让对应场景分支退出并重新进入以建立新 generation。等待、安装和 READY 期间若继承架构或 Scoped 架构的父级失败、`dispose()` 或生命周期 generation 漂移，Context 会立即进入 `FAILED` 并发出 `context_failed`；即使 `context_wait_timeout_seconds <= 0`，也不会对不可恢复的生命周期终态永久逐帧等待。`FAILED` 是当前 Context generation 的终态：即使共享 Architecture 随后以同一 identity 重试并重新 READY，该 Context 子树中的 `GFController` 仍不会恢复事件绑定，也不会通过架构、模块、命令、查询或事件代理访问它；无 Context 的全局 Controller 不受此限制，可随全局 Architecture 重试正常恢复。
+如果只想让某个节点树分支复用父级上下文，可以把 `scope_mode` 设为 `INHERITED`。继承模式不会创建或释放局部架构，但只会在继承架构完成 activation 并提交 READY 后发出同样的 `context_ready` 信号；如果父级架构稍后才初始化完成，上下文会等待后再发出信号。继承来源在本轮入树期间不会热迁移：全局或最近父 Context 改成另一 Architecture 时，当前 Inherited Context 会失败，调用方应让对应场景分支退出并重新进入以建立新 generation。等待、安装和 READY 期间若继承架构或 Scoped 架构的父级初始化失败、进入 quiescing/dispose 或 lifecycle generation 漂移，Context 会立即进入 `FAILED` 并发出 `context_failed`；即使 `context_wait_timeout_seconds <= 0`，也不会对不可恢复的生命周期终态永久逐帧等待。`FAILED` 是当前 Context generation 的终态：即使共享 Architecture 随后以同一 identity 重试并重新 READY，该 Context 子树中的 `GFController` 仍不会恢复事件绑定，也不会通过架构、模块、命令、查询或事件代理访问它；无 Context 的全局 Controller 不受此限制，可随全局 Architecture 重试正常恢复。
 
 局部上下文中的 `GFController` 无需额外传参，会自动沿父节点查找最近的 `GFNodeContext`。注册到局部上下文的 `GFSystem` / `GFModel` / `GFUtility` 也会在注册时获得当前架构引用，因此基类提供的 `get_model()`、`get_system()`、`get_utility()` 会优先使用局部架构，并在本地未命中时回退父架构。
 
@@ -80,3 +81,19 @@ func _ready() -> void:
 ```
 
 普通节点也可以直接等待 `GFNodeContext.wait_until_ready()`，它会在当前上下文架构及本轮固定父级都保持有效时返回可用的 `GFArchitecture`；如果上下文或父级架构失败、等待目标已经 dispose、父级 identity 被替换或 generation 漂移，则返回 `null` 并发出 `context_failed`。`context_ready` 是同步信号；如果 listener 在回调中 dispose 架构、替换父级 identity 或让 Context 离树，`initialize_context()` / `wait_until_ready()` 会在返回前重新验证当前 generation，不会把回调已经失效的架构返回给等待方。`GFArchitecture.is_disposed()` 可用于项目自己的等待器辨认这一不可恢复终态。
+
+## 正常关闭与离树兜底
+
+`GFNodeContext` 不增加第二个架构关闭入口。项目能控制关闭时机，并且局部 Storage、Save Profile 或后台任务需要 drain，应先取得 owned architecture，直接等待 `shutdown_async()`，确认 typed result 后再让 Context 离树：
+
+```gdscript
+var local_architecture: GFArchitecture = context.get_architecture()
+var result: GFArchitectureShutdownResult = (
+	await local_architecture.shutdown_async()
+)
+if not result.is_successful():
+	push_warning(result.get_error())
+context.queue_free()
+```
+
+父级 Architecture 必须 outlive scoped child：先等待并释放所有 child，再关闭提供依赖的 parent。节点 `_exit_tree()` 无法可靠 `await`，因此始终调用同步 `dispose()` 作为 forced fallback。它保证模块最终释放且重复调用幂等，但不保证已接纳异步操作正常完成；数据关键路径不能把 `queue_free()` 当作 flush。

--- a/docs/zh/kernel/scene-controller/updates-and-controllers/controller-updates.md
+++ b/docs/zh/kernel/scene-controller/updates-and-controllers/controller-updates.md
@@ -32,7 +32,7 @@ Controller 可以按普通 Godot 节点习惯读取输入、驱动局部动画�
 
 Controller 的事件 helper 维护“期望绑定”而不是一次性的信号连接。节点退出树时会从当前架构注销实际监听，但再次入树后会自动恢复；同一 `SceneTree` 内 reparent 到另一个 `GFNodeContext`，或全局 `Gf` 原子提交 replacement Architecture 时，会在相应生命周期操作返回前同步迁移监听并清理旧 owner 注册。同一架构内追加或删除 type、assignable、simple 绑定也会按 desired-set revision 立即重建，不会等到下一帧。对象池 acquire 如果暂时找不到架构，会保留期望绑定，并在正式的全局架构提交通知到达时恢复；Controller 不再为此永久逐帧扫描父链。
 
-Controller 还会观察当前 Architecture 的初始化终态。初始化失败会清空实际 owner 注册并保留 desired set；同一个全局 Architecture 随后重试成功时，即使 identity 没有变化，也会在 `initialization_finished` 后强制恢复监听。已失败、正在 dispose 或已经 dispose 的最近 Context 不会让 `get_architecture()`、`get_architecture_or_null()` 或事件绑定静默越过局部边界回退到全局架构。
+Controller 还会观察当前 Architecture 的初始化终态。初始化失败会清空实际 owner 注册并保留 desired set；同一个全局 Architecture 随后重试成功时，即使 identity 没有变化，也会在 `initialization_finished` 后强制恢复监听。已失败、正在 quiesce、正在 dispose 或已经 dispose 的最近 Context 不会让 `get_architecture()`、`get_architecture_or_null()` 或事件绑定静默越过局部边界回退到全局架构。
 
 实例级 `send_command()` 会保留最近 `GFNodeContext` 的依赖作用域。只有明确要绕过局部架构并发送到全局容器时，才直接调用 `Gf.send_command()`。
 

--- a/docs/zh/kernel/scene-controller/updates-and-controllers/priority-time.md
+++ b/docs/zh/kernel/scene-controller/updates-and-controllers/priority-time.md
@@ -15,13 +15,13 @@ input_system.tick_priority = 100
 var battle_system := BattleSystem.new()
 battle_system.tick_priority = 0
 
-Gf.register_system(input_system)
-Gf.register_system(battle_system)
+assert(await Gf.register_system(input_system))
+assert(await Gf.register_system(battle_system))
 ```
 
 未重写 `tick()` / `physics_tick()` 且未显式启用对应标记的 System 不会进入缓存。这能减少空模板调用，同时让诊断快照中的 `has_tick` / `has_physics_tick` 更接近真实热路径。
 
-生命周期也支持同样的显式优先级：`lifecycle_priority` 越大，`init()` / `async_init()` / `ready()` 越早执行，`dispose()` 越晚释放。它只解决框架模块之间的初始化和释放顺序，不应替代项目自己的流程状态机或命令队列。
+生命周期顺序首先由声明依赖 DAG 决定。`lifecycle_priority` 只在多个依赖已经满足的节点之间破平：数值越大，`init()`、`async_init()`、`ready()` 和 `begin_activation()` 越早执行；正常关闭按同一计划严格逆序执行 `begin_quiesce()`，随后同步释放。优先级不能覆盖依赖边，也不应替代项目自己的流程状态机或命令队列。
 
 ## 时间缩放
 

--- a/docs/zh/overview/best-practices/events-lifecycle.md
+++ b/docs/zh/overview/best-practices/events-lifecycle.md
@@ -14,8 +14,12 @@
 
 ## 生命周期
 
-`init()`、`async_init()` 和 `ready()` 中都应保持防御式依赖读取。模块初始化顺序不应依赖偶然的注册顺序。
+固定模块应由 Installer 在生命周期计划冻结前完成注册。模块用 `get_required_models()`、`get_required_systems()` 和 `get_required_utilities()` 声明真实依赖；架构据此编译 DAG，而不是依赖偶然的注册顺序或在初始化 Hook 中补注册。
 
-需要跨模块检查时，优先使用依赖声明和 `GFArchitecture.get_dependency_diagnostics()`。诊断只报告缺失依赖，不自动注册模块。
+`init()` 只建立本模块同步状态，`async_init()` 准备本模块异步资源，`ready()` 装配已 ready 的依赖，`begin_activation()` 才启动需要阻止架构过早开放的运行时流程。第三阶段完成不代表运行时可用；外部代码应等待 `is_accepting_runtime_work()` 或 `GFNodeContext.context_ready`。
 
-异步初始化不要无限等待外部流程。Installer 或模块需要等待外部资源时，应有项目层超时和失败策略。
+依赖诊断只读，不会自动注册模块；声明缺失、歧义或成环会让初始化 fail closed。真正可选的集成用 `find_*()`，不要把 required 声明写成“有就用”的探测。
+
+异步初始化和 activation 不要无限等待外部流程。Installer、模块准备和 bootstrap 都应使用 `GFAsyncScope`、一次性完成源以及显式 timeout/cancellation；每个异步恢复点重新检查 scope 或 lifecycle generation。
+
+正常退出优先 `await architecture.shutdown_async()`：架构先关闭新工作准入，再按依赖逆序 quiesce 已接纳工作。同步 `dispose()` 只用于 SceneTree 退出等无法等待的 forced fallback，不能替代存档 flush 或后台任务 drain。

--- a/docs/zh/overview/best-practices/index.md
+++ b/docs/zh/overview/best-practices/index.md
@@ -5,7 +5,7 @@
 ## 阅读入口
 
 - [模块边界](module-boundaries.md)：依赖读取、Model、System 和 Controller 的职责边界。
-- [事件与生命周期](events-lifecycle.md)：事件使用条件、监听 owner、三阶段初始化和依赖诊断。
+- [事件与生命周期](events-lifecycle.md)：事件使用条件、监听 owner、四阶段激活、依赖 DAG 和正常关闭。
 - [放置、Godot 边界与测试](placement-godot-testing.md)：新增能力归属、Godot 引擎语义边界和测试优先级。
 
 ## 总原则

--- a/docs/zh/overview/index.md
+++ b/docs/zh/overview/index.md
@@ -12,7 +12,7 @@
 ## 下一步
 
 - 想理解容器和分层边界：读 [Kernel 架构容器](../kernel/index.md)。
-- 想理解 Installer、三阶段初始化和局部架构：读 [生命周期、装配与依赖](../kernel/lifecycle/index.md)。
+- 想理解 Installer、依赖 DAG、四阶段激活、异步关闭和局部架构：读 [生命周期、装配与依赖](../kernel/lifecycle/index.md)。
 - 想写事件、命令和查询：读 [消息、事件、命令与查询](../kernel/messaging/index.md)。
 - 想把场景节点、UI 和输入接入 GF：读 [场景桥接、Controller 与数据绑定](../kernel/scene-controller/index.md)。
 - 想查具体类、属性、信号和方法签名：读 [API Reference](../reference/api/index.md)。

--- a/docs/zh/overview/quickstart/minimal-installer.md
+++ b/docs/zh/overview/quickstart/minimal-installer.md
@@ -28,8 +28,8 @@ func _ready() -> void:
 这个例子表达的是最小流程：
 
 1. 注册 `GFModel`、`GFUtility` 和 `GFSystem`。
-2. 调用 `await Gf.init()` 进入生命周期。
-3. 从架构取回模块时使用 `as Type` 保留补全和显式失败处理。
+2. 调用 `await Gf.init()` 编译声明依赖 DAG，并完成 `init()`、`async_init()`、`ready()`、`begin_activation()` 四阶段。
+3. 只在返回成功、架构开放运行时准入后取回模块；使用 `as Type` 保留补全和显式失败处理。
 
 真实项目通常不会把所有注册写在某个场景 `_ready()` 里，而是使用 Installer。
 
@@ -65,6 +65,6 @@ func install(architecture: GFArchitecture, scope: GFAsyncScope) -> void:
 		return
 ```
 
-然后把安装器脚本加入 `Project Settings > gf/project/installers`。编辑器可保存 `res://` 或稳定 `uid://` 引用；GF 会在启动时解析并严格校验。调用 `await Gf.init()` 时，GF 会先运行启用扩展的 Installer，再运行项目 Installer，最后进入模块生命周期。初始化返回 `false` 时必须停止后续查询，并读取 `Gf.get_architecture().last_initialization_error`。
+然后把安装器脚本加入 `Project Settings > gf/project/installers`。编辑器可保存 `res://` 或稳定 `uid://` 引用；GF 会在启动时解析并严格校验。调用 `await Gf.init()` 时，GF 会先运行启用扩展的 Installer，再运行项目 Installer，随后冻结拓扑、编译依赖 DAG 并完成四阶段生命周期。初始化返回 `false` 时必须停止后续查询，并读取 `Gf.get_architecture().last_initialization_error`。
 
-Installer 只负责注册模块，不应该直接启动关卡、打开 UI 或执行玩法流程。启动流程更适合放在引导场景或专门的 `GFSystem` 中。
+Installer 只负责注册模块，不应该直接启动关卡、打开 UI 或执行玩法流程。必须在 READY 前完成的异步 bootstrap 放在声明依赖的项目 `GFSystem.begin_activation()`；架构 READY 后的关卡、UI 与玩法流程更适合由引导场景或项目状态机驱动。

--- a/docs/zh/reference/api/classes/GFArchitecture.md
+++ b/docs/zh/reference/api/classes/GFArchitecture.md
@@ -235,7 +235,7 @@ const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8
 ### `module_async_init_timeout_seconds`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`1.23.0`
 
 ```gdscript
 var module_async_init_timeout_seconds: float = 0.0:
@@ -248,7 +248,7 @@ var module_async_init_timeout_seconds: float = 0.0:
 ### `strict_dependency_lookup`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`1.23.0`
 
 ```gdscript
 var strict_dependency_lookup: bool = false
@@ -319,7 +319,7 @@ func _init(parent_architecture: GFArchitecture = null) -> void:
 ### `is_inited`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func is_inited() -> bool:
@@ -1888,7 +1888,7 @@ func register_utility_instance_as(instance: Object, alias_cls: Script) -> bool:
 ### `unregister_system`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func unregister_system(script_cls: Script) -> bool:
@@ -1909,7 +1909,7 @@ func unregister_system(script_cls: Script) -> bool:
 ### `unregister_model`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func unregister_model(script_cls: Script) -> bool:
@@ -1930,7 +1930,7 @@ func unregister_model(script_cls: Script) -> bool:
 ### `unregister_utility`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func unregister_utility(script_cls: Script) -> bool:

--- a/docs/zh/reference/api/classes/GFArchitecture.md
+++ b/docs/zh/reference/api/classes/GFArchitecture.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`3.17.0`
 
-管理 Model、System 和 Utility 的注册与生命周期的容器。 生命周期遵循三阶段初始化协议： 阶段一 (init)       ：所有模块执行自身内部变量初始化。 阶段二 (async_init) ：所有模块串行执行异步初始化（可使用 await）。 阶段三 (ready)      ：所有模块均已完成 init，可安全进行跨模块依赖获取。
+管理 Model、System 和 Utility 的注册与生命周期的容器。 生命周期遵循四阶段初始化协议： 阶段一 (init)       ：各模块按声明依赖 DAG 执行自身内部变量初始化。 阶段二 (async_init) ：按同一 DAG 串行执行异步准备（可使用 await）。 阶段三 (ready)      ：当前模块的声明依赖已 ready，可完成同步装配。 阶段四 (activation) ：按依赖顺序完成异步启动，全部成功后才开放运行时准入。
 
 ## 成员概览
 
@@ -17,28 +17,29 @@
 |---|---|---|
 | 信号 | [`initialization_finished`](#member-gfarchitecture-signals-initialization_finished) | `signal initialization_finished` |
 | 信号 | [`initialization_failed`](#member-gfarchitecture-signals-initialization_failed) | `signal initialization_failed(reason: String)` |
+| 信号 | [`shutdown_finished`](#member-gfarchitecture-signals-shutdown_finished) | `signal shutdown_finished(result: GFArchitectureShutdownResult)` |
 | 信号 | [`project_installers_finished`](#member-gfarchitecture-signals-project_installers_finished) | `signal project_installers_finished` |
 | 常量 | [`SERVICE_COMMAND_HISTORY_STORE`](#member-gfarchitecture-constants-service_command_history_store) | `const SERVICE_COMMAND_HISTORY_STORE: StringName = &"gf.kernel.command_history_store"` |
-| 常量 | [`HOOK_GET_REQUIRED_DEPENDENCIES`](#member-gfarchitecture-constants-hook_get_required_dependencies) | `const HOOK_GET_REQUIRED_DEPENDENCIES: StringName = &"get_required_dependencies"` |
-| 常量 | [`HOOK_GET_REQUIRED_MODELS`](#member-gfarchitecture-constants-hook_get_required_models) | `const HOOK_GET_REQUIRED_MODELS: StringName = &"get_required_models"` |
-| 常量 | [`HOOK_GET_REQUIRED_SYSTEMS`](#member-gfarchitecture-constants-hook_get_required_systems) | `const HOOK_GET_REQUIRED_SYSTEMS: StringName = &"get_required_systems"` |
-| 常量 | [`HOOK_GET_REQUIRED_UTILITIES`](#member-gfarchitecture-constants-hook_get_required_utilities) | `const HOOK_GET_REQUIRED_UTILITIES: StringName = &"get_required_utilities"` |
-| 常量 | [`HOOK_GET_REQUIRED_FACTORIES`](#member-gfarchitecture-constants-hook_get_required_factories) | `const HOOK_GET_REQUIRED_FACTORIES: StringName = &"get_required_factories"` |
 | 常量 | [`DEFAULT_SNAPSHOT_MODELS_PER_FRAME`](#member-gfarchitecture-constants-default_snapshot_models_per_frame) | `const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8` |
 | 属性 | [`module_async_init_timeout_seconds`](#member-gfarchitecture-properties-module_async_init_timeout_seconds) | `var module_async_init_timeout_seconds: float = 0.0:` |
-| 属性 | [`module_lifecycle_max_stage_passes`](#member-gfarchitecture-properties-module_lifecycle_max_stage_passes) | `var module_lifecycle_max_stage_passes: int = 256:` |
 | 属性 | [`strict_dependency_lookup`](#member-gfarchitecture-properties-strict_dependency_lookup) | `var strict_dependency_lookup: bool = false` |
-| 属性 | [`fail_on_missing_declared_dependencies`](#member-gfarchitecture-properties-fail_on_missing_declared_dependencies) | `var fail_on_missing_declared_dependencies: bool = false` |
+| 属性 | [`activation_timeout_seconds`](#member-gfarchitecture-properties-activation_timeout_seconds) | `var activation_timeout_seconds: float = 30.0:` |
+| 属性 | [`shutdown_timeout_seconds`](#member-gfarchitecture-properties-shutdown_timeout_seconds) | `var shutdown_timeout_seconds: float = 10.0:` |
 | 属性 | [`last_initialization_error`](#member-gfarchitecture-properties-last_initialization_error) | `var last_initialization_error: String = ""` |
 | 方法 | [`_init`](#member-gfarchitecture-methods-_init) | `func _init(parent_architecture: GFArchitecture = null) -> void:` |
 | 方法 | [`is_inited`](#member-gfarchitecture-methods-is_inited) | `func is_inited() -> bool:` |
 | 方法 | [`has_initialization_failed`](#member-gfarchitecture-methods-has_initialization_failed) | `func has_initialization_failed() -> bool:` |
 | 方法 | [`is_lifecycle_active`](#member-gfarchitecture-methods-is_lifecycle_active) | `func is_lifecycle_active() -> bool:` |
+| 方法 | [`is_activating`](#member-gfarchitecture-methods-is_activating) | `func is_activating() -> bool:` |
+| 方法 | [`is_quiescing`](#member-gfarchitecture-methods-is_quiescing) | `func is_quiescing() -> bool:` |
+| 方法 | [`is_accepting_runtime_work`](#member-gfarchitecture-methods-is_accepting_runtime_work) | `func is_accepting_runtime_work() -> bool:` |
 | 方法 | [`is_disposed`](#member-gfarchitecture-methods-is_disposed) | `func is_disposed() -> bool:` |
 | 方法 | [`is_disposing`](#member-gfarchitecture-methods-is_disposing) | `func is_disposing() -> bool:` |
 | 方法 | [`get_lifecycle_generation`](#member-gfarchitecture-methods-get_lifecycle_generation) | `func get_lifecycle_generation() -> int:` |
 | 方法 | [`is_lifecycle_generation_active`](#member-gfarchitecture-methods-is_lifecycle_generation_active) | `func is_lifecycle_generation_active(lifecycle_generation: int) -> bool:` |
 | 方法 | [`is_module_ready`](#member-gfarchitecture-methods-is_module_ready) | `func is_module_ready(instance: Object) -> bool:` |
+| 方法 | [`is_module_active`](#member-gfarchitecture-methods-is_module_active) | `func is_module_active(instance: Object) -> bool:` |
+| 方法 | [`get_last_shutdown_result`](#member-gfarchitecture-methods-get_last_shutdown_result) | `func get_last_shutdown_result() -> GFArchitectureShutdownResult:` |
 | 方法 | [`fail_initialization`](#member-gfarchitecture-methods-fail_initialization) | `func fail_initialization(reason: String) -> void:` |
 | 方法 | [`get_parent_architecture`](#member-gfarchitecture-methods-get_parent_architecture) | `func get_parent_architecture() -> GFArchitecture:` |
 | 方法 | [`set_parent_architecture`](#member-gfarchitecture-methods-set_parent_architecture) | `func set_parent_architecture(parent_architecture: GFArchitecture) -> void:` |
@@ -48,7 +49,8 @@
 | 方法 | [`mark_project_installers_applied`](#member-gfarchitecture-methods-mark_project_installers_applied) | `func mark_project_installers_applied() -> void:` |
 | 方法 | [`finish_project_installers`](#member-gfarchitecture-methods-finish_project_installers) | `func finish_project_installers() -> void:` |
 | 方法 | [`create_binder`](#member-gfarchitecture-methods-create_binder) | `func create_binder() -> GFBinder:` |
-| 方法 | [`init`](#member-gfarchitecture-methods-init) | `func init() -> bool:` |
+| 方法 | [`init`](#member-gfarchitecture-methods-init) | `func init(cancellation_token: GFCancellationToken = null) -> bool:` |
+| 方法 | [`shutdown_async`](#member-gfarchitecture-methods-shutdown_async) | `func shutdown_async( cancellation_token: GFCancellationToken = null, timeout_seconds: float = -1.0 ) -> GFArchitectureShutdownResult:` |
 | 方法 | [`dispose`](#member-gfarchitecture-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`tick`](#member-gfarchitecture-methods-tick) | `func tick(delta: float) -> void:` |
 | 方法 | [`physics_tick`](#member-gfarchitecture-methods-physics_tick) | `func physics_tick(delta: float) -> void:` |
@@ -106,9 +108,9 @@
 | 方法 | [`register_system_instance_as`](#member-gfarchitecture-methods-register_system_instance_as) | `func register_system_instance_as(instance: Object, alias_cls: Script) -> bool:` |
 | 方法 | [`register_model_instance_as`](#member-gfarchitecture-methods-register_model_instance_as) | `func register_model_instance_as(instance: Object, alias_cls: Script) -> bool:` |
 | 方法 | [`register_utility_instance_as`](#member-gfarchitecture-methods-register_utility_instance_as) | `func register_utility_instance_as(instance: Object, alias_cls: Script) -> bool:` |
-| 方法 | [`unregister_system`](#member-gfarchitecture-methods-unregister_system) | `func unregister_system(script_cls: Script) -> void:` |
-| 方法 | [`unregister_model`](#member-gfarchitecture-methods-unregister_model) | `func unregister_model(script_cls: Script) -> void:` |
-| 方法 | [`unregister_utility`](#member-gfarchitecture-methods-unregister_utility) | `func unregister_utility(script_cls: Script) -> void:` |
+| 方法 | [`unregister_system`](#member-gfarchitecture-methods-unregister_system) | `func unregister_system(script_cls: Script) -> bool:` |
+| 方法 | [`unregister_model`](#member-gfarchitecture-methods-unregister_model) | `func unregister_model(script_cls: Script) -> bool:` |
+| 方法 | [`unregister_utility`](#member-gfarchitecture-methods-unregister_utility) | `func unregister_utility(script_cls: Script) -> bool:` |
 | 方法 | [`get_system`](#member-gfarchitecture-methods-get_system) | `func get_system(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_model`](#member-gfarchitecture-methods-get_model) | `func get_model(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_utility`](#member-gfarchitecture-methods-get_utility) | `func get_utility(script_cls: Script, require_ready: bool = false) -> Object:` |
@@ -131,7 +133,7 @@
 | 方法 | [`restore_global_snapshot_async`](#member-gfarchitecture-methods-restore_global_snapshot_async) | `func restore_global_snapshot_async( data: Dictionary, command_builder: Callable = Callable(), options: Dictionary = {} ) -> Dictionary:` |
 | 方法 | [`get_debug_lifecycle_state`](#member-gfarchitecture-methods-get_debug_lifecycle_state) | `func get_debug_lifecycle_state() -> Dictionary:` |
 | 方法 | [`get_binding_diagnostics`](#member-gfarchitecture-methods-get_binding_diagnostics) | `func get_binding_diagnostics(options: Dictionary = {}) -> Dictionary:` |
-| 方法 | [`get_dependency_diagnostics`](#member-gfarchitecture-methods-get_dependency_diagnostics) | `func get_dependency_diagnostics(options: Dictionary = {}) -> Dictionary:` |
+| 方法 | [`get_dependency_diagnostics`](#member-gfarchitecture-methods-get_dependency_diagnostics) | `func get_dependency_diagnostics() -> Dictionary:` |
 | 方法 | [`_on_init`](#member-gfarchitecture-methods-_on_init) | `func _on_init() -> void:` |
 | 方法 | [`_on_dispose`](#member-gfarchitecture-methods-_on_dispose) | `func _on_dispose() -> void:` |
 
@@ -167,6 +169,25 @@ signal initialization_failed(reason: String)
 |---|---|
 | `reason` | 初始化失败原因。 |
 
+<a id="member-gfarchitecture-signals-shutdown_finished"></a>
+
+### `shutdown_finished`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal shutdown_finished(result: GFArchitectureShutdownResult)
+```
+
+当异步关闭流程或同步强制释放发布类型化终态时发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `result` | 类型化关闭结果快照。 |
+
 <a id="member-gfarchitecture-signals-project_installers_finished"></a>
 
 ### `project_installers_finished`
@@ -194,66 +215,6 @@ const SERVICE_COMMAND_HISTORY_STORE: StringName = &"gf.kernel.command_history_st
 
 命令历史服务 capability key。
 
-<a id="member-gfarchitecture-constants-hook_get_required_dependencies"></a>
-
-### `HOOK_GET_REQUIRED_DEPENDENCIES`
-
-- API：`public`
-
-```gdscript
-const HOOK_GET_REQUIRED_DEPENDENCIES: StringName = &"get_required_dependencies"
-```
-
-声明式依赖聚合 Hook 名称。
-
-<a id="member-gfarchitecture-constants-hook_get_required_models"></a>
-
-### `HOOK_GET_REQUIRED_MODELS`
-
-- API：`public`
-
-```gdscript
-const HOOK_GET_REQUIRED_MODELS: StringName = &"get_required_models"
-```
-
-声明式 Model 依赖 Hook 名称。
-
-<a id="member-gfarchitecture-constants-hook_get_required_systems"></a>
-
-### `HOOK_GET_REQUIRED_SYSTEMS`
-
-- API：`public`
-
-```gdscript
-const HOOK_GET_REQUIRED_SYSTEMS: StringName = &"get_required_systems"
-```
-
-声明式 System 依赖 Hook 名称。
-
-<a id="member-gfarchitecture-constants-hook_get_required_utilities"></a>
-
-### `HOOK_GET_REQUIRED_UTILITIES`
-
-- API：`public`
-
-```gdscript
-const HOOK_GET_REQUIRED_UTILITIES: StringName = &"get_required_utilities"
-```
-
-声明式 Utility 依赖 Hook 名称。
-
-<a id="member-gfarchitecture-constants-hook_get_required_factories"></a>
-
-### `HOOK_GET_REQUIRED_FACTORIES`
-
-- API：`public`
-
-```gdscript
-const HOOK_GET_REQUIRED_FACTORIES: StringName = &"get_required_factories"
-```
-
-声明式工厂依赖 Hook 名称。
-
 <a id="member-gfarchitecture-constants-default_snapshot_models_per_frame"></a>
 
 ### `DEFAULT_SNAPSHOT_MODELS_PER_FRAME`
@@ -274,30 +235,20 @@ const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8
 ### `module_async_init_timeout_seconds`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
 var module_async_init_timeout_seconds: float = 0.0:
 ```
 
-单个模块 async_init() 的最长等待时间。小于等于 0 时不启用超时。 默认关闭；项目可按自身加载预算显式启用。
-
-<a id="member-gfarchitecture-properties-module_lifecycle_max_stage_passes"></a>
-
-### `module_lifecycle_max_stage_passes`
-
-- API：`public`
-
-```gdscript
-var module_lifecycle_max_stage_passes: int = 256:
-```
-
-单个生命周期阶段最多扫描模块注册表的次数，避免模块在生命周期中无限注册新模块。
+单个模块 async_init() 的最长等待时间。0 时不启用超时。 默认关闭；项目可按自身加载预算显式启用。
 
 <a id="member-gfarchitecture-properties-strict_dependency_lookup"></a>
 
 ### `strict_dependency_lookup`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
 var strict_dependency_lookup: bool = false
@@ -305,18 +256,31 @@ var strict_dependency_lookup: bool = false
 
 严格依赖查询模式。开启后本架构查询不到本地模块时不会回退父级架构。
 
-<a id="member-gfarchitecture-properties-fail_on_missing_declared_dependencies"></a>
+<a id="member-gfarchitecture-properties-activation_timeout_seconds"></a>
 
-### `fail_on_missing_declared_dependencies`
+### `activation_timeout_seconds`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`unreleased`
 
 ```gdscript
-var fail_on_missing_declared_dependencies: bool = false
+var activation_timeout_seconds: float = 30.0:
 ```
 
-声明式依赖缺失时是否直接使初始化失败。 模块可通过 get_required_dependencies() 或 get_required_models/systems/utilities/factories() 声明依赖。 开启后，init() 会在模块生命周期推进前校验依赖图，缺失依赖会中止本次初始化。
+架构激活阶段的总等待上限（秒）。 0 时不启用 deadline；默认 30 秒。
+
+<a id="member-gfarchitecture-properties-shutdown_timeout_seconds"></a>
+
+### `shutdown_timeout_seconds`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var shutdown_timeout_seconds: float = 10.0:
+```
+
+架构 quiesce 阶段的总等待上限（秒）。 0 时不启用 deadline；默认 10 秒。
 
 <a id="member-gfarchitecture-properties-last_initialization_error"></a>
 
@@ -355,14 +319,15 @@ func _init(parent_architecture: GFArchitecture = null) -> void:
 ### `is_inited`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
 func is_inited() -> bool:
 ```
 
-检查架构是否已初始化。
+检查架构是否已完成四阶段启动并提交 READY。
 
-返回：已初始化返回 true，否则返回 false。
+返回：四阶段启动全部完成且 activation 已提交时返回 true，否则返回 false。
 
 <a id="member-gfarchitecture-methods-has_initialization_failed"></a>
 
@@ -383,14 +348,60 @@ func has_initialization_failed() -> bool:
 ### `is_lifecycle_active`
 
 - API：`public`
+- 首次版本：`1.23.2`
 
 ```gdscript
 func is_lifecycle_active() -> bool:
 ```
 
-检查当前架构生命周期是否仍处于可安全继续异步写回的活动状态。
+检查当前架构生命周期是否仍处于可安全继续已接纳异步写回的活动状态。 QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过 is_accepting_runtime_work() 检查。
 
-返回：正在初始化或已完成初始化，且未被 dispose() 或失败保护中断时返回 true。
+返回：正在初始化、已完成初始化或正在收敛已接纳工作，且未被 dispose() 或失败保护中断时返回 true。
+
+<a id="member-gfarchitecture-methods-is_activating"></a>
+
+### `is_activating`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_activating() -> bool:
+```
+
+检查架构是否正在执行第四阶段激活。
+
+返回：架构正在执行第四阶段激活时返回 true。
+
+<a id="member-gfarchitecture-methods-is_quiescing"></a>
+
+### `is_quiescing`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_quiescing() -> bool:
+```
+
+检查架构是否已经关闭新工作、正在等待已接纳工作收敛。
+
+返回：架构正在 quiesce 且尚未进入同步释放阶段时返回 true。
+
+<a id="member-gfarchitecture-methods-is_accepting_runtime_work"></a>
+
+### `is_accepting_runtime_work`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_accepting_runtime_work() -> bool:
+```
+
+检查架构是否仍接纳新的运行时工作。
+
+返回：仅在完整激活并处于 READY 时返回 true。
 
 <a id="member-gfarchitecture-methods-is_disposed"></a>
 
@@ -477,6 +488,42 @@ func is_module_ready(instance: Object) -> bool:
 | `instance` | 由当前架构注册的模块实例。 |
 
 返回：模块完成 ready 阶段时返回 true。
+
+<a id="member-gfarchitecture-methods-is_module_active"></a>
+
+### `is_module_active`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_module_active(instance: Object) -> bool:
+```
+
+检查模块是否已经完成第四阶段激活。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `instance` | 由当前架构本地注册的模块实例。 |
+
+返回：模块属于当前架构且已完成第四阶段激活时返回 true。
+
+<a id="member-gfarchitecture-methods-get_last_shutdown_result"></a>
+
+### `get_last_shutdown_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_last_shutdown_result() -> GFArchitectureShutdownResult:
+```
+
+获取最近一次关闭结果的隔离副本。
+
+返回：尚未关闭时返回 null。
 
 <a id="member-gfarchitecture-methods-fail_initialization"></a>
 
@@ -621,24 +668,53 @@ func create_binder() -> GFBinder:
 - 首次版本：`5.0.0`
 
 ```gdscript
-func init() -> bool:
+func init(cancellation_token: GFCancellationToken = null) -> bool:
 ```
 
-初始化架构及所有注册的组件（三阶段）。 阶段一：调用所有模块的 init()，用于初始化自身内部变量。 阶段二：串行 await 所有模块的 async_init()，用于异步资源加载等操作。 阶段三：调用所有模块的 ready()，此时跨模块依赖获取是安全的。
+初始化架构及所有注册的组件（四阶段）。 阶段一：按声明依赖 DAG 调用模块的 init()，用于初始化自身内部变量。 阶段二：按同一 DAG 串行 await 模块的 async_init()，用于异步准备。 阶段三：调用模块的 ready()；当前模块声明的依赖已 ready，未声明依赖无可用保证。 阶段四：按声明依赖顺序调用 begin_activation()，全部成功后才提交 READY。 并发调用复用同一初始化事务；首个调用拥有共享流程的取消策略，后续调用的 token 只取消自身等待，不会中断共享初始化。架构已经 READY 时幂等成功优先于 调用方 token 的取消状态。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `cancellation_token` | 可选的初始化取消令牌。 |
 
 返回：初始化完成且架构处于 ready 状态时返回 true。
+
+<a id="member-gfarchitecture-methods-shutdown_async"></a>
+
+### `shutdown_async`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func shutdown_async( cancellation_token: GFCancellationToken = null, timeout_seconds: float = -1.0 ) -> GFArchitectureShutdownResult:
+```
+
+异步关闭架构。 若活动子架构仍持有本架构的外部依赖租约，本方法会在改变任何生命周期 状态前返回失败；否则新工作准入会不可逆关闭，已接纳工作按激活计划逆序 quiesce，随后每个模块的同步 dispose/release hook 恰好执行一次。并发调用共享 同一流程；首个调用拥有共享流程的 cancellation token 与 deadline 策略，后续 调用在参数校验通过后只等待并复制同一终态结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `cancellation_token` | 可选关闭取消令牌。 |
+| `timeout_seconds` | cooperative quiesce 与异步等待预算；仅 -1 使用 shutdown_timeout_seconds。最终同步释放不承诺墙钟硬上限。 |
+
+返回：类型化关闭结果。
 
 <a id="member-gfarchitecture-methods-dispose"></a>
 
 ### `dispose`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func dispose() -> void:
 ```
 
-销毁架构及所有注册的组件。
+强制同步销毁架构及所有注册组件。 该方法用于 SceneTree 退出等无法等待的终止路径；正常退出应优先 await shutdown_async()，以便已接纳工作先收敛。
 
 <a id="member-gfarchitecture-methods-tick"></a>
 
@@ -1812,9 +1888,10 @@ func register_utility_instance_as(instance: Object, alias_cls: Script) -> bool:
 ### `unregister_system`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
-func unregister_system(script_cls: Script) -> void:
+func unregister_system(script_cls: Script) -> bool:
 ```
 
 注销 System 实例。
@@ -1825,14 +1902,17 @@ func unregister_system(script_cls: Script) -> void:
 |---|---|
 | `script_cls` | 系统的脚本类。 |
 
+返回：模块完成 quiesce 并从活动拓扑移除时返回 true。
+
 <a id="member-gfarchitecture-methods-unregister_model"></a>
 
 ### `unregister_model`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
-func unregister_model(script_cls: Script) -> void:
+func unregister_model(script_cls: Script) -> bool:
 ```
 
 注销 Model 实例。
@@ -1843,14 +1923,17 @@ func unregister_model(script_cls: Script) -> void:
 |---|---|
 | `script_cls` | 模型的脚本类。 |
 
+返回：模块完成 quiesce 并从活动拓扑移除时返回 true。
+
 <a id="member-gfarchitecture-methods-unregister_utility"></a>
 
 ### `unregister_utility`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
-func unregister_utility(script_cls: Script) -> void:
+func unregister_utility(script_cls: Script) -> bool:
 ```
 
 注销 Utility 实例。
@@ -1860,6 +1943,8 @@ func unregister_utility(script_cls: Script) -> void:
 | 名称 | 说明 |
 |---|---|
 | `script_cls` | 工具的脚本类。 |
+
+返回：模块完成 quiesce 并从活动拓扑移除时返回 true。
 
 <a id="member-gfarchitecture-methods-get_system"></a>
 
@@ -2058,12 +2143,13 @@ func get_local_utility(script_cls: Script, require_ready: bool = false) -> Objec
 ### `create_instance`
 
 - API：`public`
+- 首次版本：`1.9.0`
 
 ```gdscript
 func create_instance(script_cls: Script) -> Object:
 ```
 
-通过已注册工厂创建短生命周期对象。
+通过已注册工厂创建短生命周期对象。 仅在架构已经提交 READY 且没有热拓扑事务时接纳；其它生命周期状态会在 调用 provider 前返回 null。
 
 参数：
 
@@ -2071,7 +2157,7 @@ func create_instance(script_cls: Script) -> Object:
 |---|---|
 | `script_cls` | 要创建的脚本类型。 |
 
-返回：新对象实例；没有工厂或工厂返回非对象时返回 null。
+返回：新对象实例；运行时未开放、没有工厂或工厂返回非对象时返回 null。
 
 <a id="member-gfarchitecture-methods-inject_object"></a>
 
@@ -2361,22 +2447,15 @@ func get_binding_diagnostics(options: Dictionary = {}) -> Dictionary:
 - 首次版本：`7.0.0`
 
 ```gdscript
-func get_dependency_diagnostics(options: Dictionary = {}) -> Dictionary:
+func get_dependency_diagnostics() -> Dictionary:
 ```
 
-获取架构中已注册模块的声明式依赖诊断报告。 模块可选择实现 get_required_dependencies() 或 get_required_models/systems/utilities/factories()。
-
-参数：
-
-| 名称 | 说明 |
-|---|---|
-| `options` | 可选参数，支持 include_parent_lookup 与 include_factories。 |
+获取架构中已注册模块的声明式依赖诊断报告。 模块通过 get_required_models/systems/utilities/factories() 分别声明依赖。
 
 返回：统一诊断报告字典。
 
 结构：
 
-- `options`: Dictionary with optional bool keys include_parent_lookup and include_factories.
 - `return`: Dictionary dependency diagnostics report with modules, resolved_dependencies, missing_dependencies, parent-chain cycle issue records, issue counts, and next_action.
 
 <a id="member-gfarchitecture-methods-_on_init"></a>

--- a/docs/zh/reference/api/classes/GFArchitectureShutdownResult.md
+++ b/docs/zh/reference/api/classes/GFArchitectureShutdownResult.md
@@ -1,0 +1,501 @@
+# GFArchitectureShutdownResult
+
+[API Reference](../index.md) / [Kernel](../kernel.md) / [类索引](index.md)
+
+- 路径：`addons/gf/kernel/core/gf_architecture_shutdown_result.gd`
+- 模块：`Kernel`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+架构关闭流程的不可变终态快照。 结果显式区分正常完成、失败、取消、超时、强制释放和重复释放，并以有界、 JSON-safe 的模块条目保留关闭证据。所有集合在写入和读取边界都会重新复制， 调用方不能借由返回值修改已提交终态。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 枚举 | [`Status`](#member-gfarchitectureshutdownresult-enums-status) | `enum Status` |
+| 方法 | [`create`](#member-gfarchitectureshutdownresult-methods-create) | `static func create( status: Status, started_at_msec: int, completed_at_msec: int, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], duplicate_request_count: int = 0, error_code: Error = OK, error: String = "", cancel_reason: String = "" ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`succeeded`](#member-gfarchitectureshutdownresult-methods-succeeded) | `static func succeeded( module_results: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`failed`](#member-gfarchitectureshutdownresult-methods-failed) | `static func failed( error_code: Error, error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`cancelled`](#member-gfarchitectureshutdownresult-methods-cancelled) | `static func cancelled( reason: String = "cancelled", module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`timed_out`](#member-gfarchitectureshutdownresult-methods-timed_out) | `static func timed_out( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`forced`](#member-gfarchitectureshutdownresult-methods-forced) | `static func forced( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`already_disposed`](#member-gfarchitectureshutdownresult-methods-already_disposed) | `static func already_disposed( started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:` |
+| 方法 | [`is_successful`](#member-gfarchitectureshutdownresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`get_status`](#member-gfarchitectureshutdownresult-methods-get_status) | `func get_status() -> Status:` |
+| 方法 | [`get_status_name`](#member-gfarchitectureshutdownresult-methods-get_status_name) | `func get_status_name() -> StringName:` |
+| 方法 | [`get_started_at_msec`](#member-gfarchitectureshutdownresult-methods-get_started_at_msec) | `func get_started_at_msec() -> int:` |
+| 方法 | [`get_completed_at_msec`](#member-gfarchitectureshutdownresult-methods-get_completed_at_msec) | `func get_completed_at_msec() -> int:` |
+| 方法 | [`get_duration_msec`](#member-gfarchitectureshutdownresult-methods-get_duration_msec) | `func get_duration_msec() -> int:` |
+| 方法 | [`get_module_results`](#member-gfarchitectureshutdownresult-methods-get_module_results) | `func get_module_results() -> Array[Dictionary]:` |
+| 方法 | [`get_unfinished_modules`](#member-gfarchitectureshutdownresult-methods-get_unfinished_modules) | `func get_unfinished_modules() -> Array[Dictionary]:` |
+| 方法 | [`get_duplicate_request_count`](#member-gfarchitectureshutdownresult-methods-get_duplicate_request_count) | `func get_duplicate_request_count() -> int:` |
+| 方法 | [`get_error_code`](#member-gfarchitectureshutdownresult-methods-get_error_code) | `func get_error_code() -> Error:` |
+| 方法 | [`get_error`](#member-gfarchitectureshutdownresult-methods-get_error) | `func get_error() -> String:` |
+| 方法 | [`get_cancel_reason`](#member-gfarchitectureshutdownresult-methods-get_cancel_reason) | `func get_cancel_reason() -> String:` |
+| 方法 | [`duplicate_result`](#member-gfarchitectureshutdownresult-methods-duplicate_result) | `func duplicate_result() -> GFArchitectureShutdownResult:` |
+| 方法 | [`to_dict`](#member-gfarchitectureshutdownresult-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 枚举
+
+<a id="member-gfarchitectureshutdownresult-enums-status"></a>
+
+### `Status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum Status {
+	## 所有关闭阶段正常完成。
+	SUCCEEDED,
+	## 至少一个关闭阶段失败。
+	FAILED,
+	## 调用方取消了关闭流程。
+	CANCELLED,
+	## 关闭流程超过了时间预算。
+	TIMED_OUT,
+	## 框架跳过未完成的静默工作并执行了强制释放。
+	FORCED,
+	## 架构在本次请求前已经释放。
+	ALREADY_DISPOSED,
+}
+```
+
+架构关闭终态。
+
+## 方法
+
+<a id="member-gfarchitectureshutdownresult-methods-create"></a>
+
+### `create`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func create( status: Status, started_at_msec: int, completed_at_msec: int, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], duplicate_request_count: int = 0, error_code: Error = OK, error: String = "", cancel_reason: String = "" ) -> GFArchitectureShutdownResult:
+```
+
+创建一个规范化的架构关闭结果。 模块条目最多各保留 256 项，并且只保留 kind、script、instance_id、status、 reason 和 duration_msec 字段。字符串和非负 duration 会被限制到固定预算； instance_id 保留 Godot 返回的有符号 int 身份值。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `status` | `Status` 终态。 |
+| `started_at_msec` | 单调开始时间；负值归零。 |
+| `completed_at_msec` | 单调完成时间；早于开始时间时收敛到开始时间。 |
+| `module_results` | 已进入终态的模块关闭结果。 |
+| `unfinished_modules` | 强制释放时仍未完成的模块快照。 |
+| `duplicate_request_count` | 复用同一关闭流程的并发重复请求数量。 |
+| `error_code` | 关闭错误码；成功终态强制归一为 OK。 |
+| `error` | 稳定失败说明；最多保留 2048 个字符。 |
+| `cancel_reason` | 取消原因；仅取消终态保留，最多 1024 个字符。 |
+
+返回：新的不可变结果。
+
+结构：
+
+- `module_results`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+- `unfinished_modules`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-succeeded"></a>
+
+### `succeeded`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func succeeded( module_results: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:
+```
+
+创建正常完成结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `module_results` | 已完成的模块关闭结果。 |
+| `started_at_msec` | 单调开始时间。 |
+| `completed_at_msec` | 单调完成时间。 |
+| `duplicate_request_count` | 并发重复请求数量。 |
+
+返回：新的成功结果。
+
+结构：
+
+- `module_results`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-failed"></a>
+
+### `failed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func failed( error_code: Error, error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:
+```
+
+创建失败结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `error_code` | 关闭错误码。 |
+| `error` | 稳定失败说明。 |
+| `module_results` | 已完成的模块关闭结果。 |
+| `unfinished_modules` | 尚未完成的模块快照。 |
+| `started_at_msec` | 单调开始时间。 |
+| `completed_at_msec` | 单调完成时间。 |
+| `duplicate_request_count` | 并发重复请求数量。 |
+
+返回：新的失败结果。
+
+结构：
+
+- `module_results`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+- `unfinished_modules`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-cancelled"></a>
+
+### `cancelled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func cancelled( reason: String = "cancelled", module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:
+```
+
+创建取消结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `reason` | 稳定取消原因。 |
+| `module_results` | 已完成的模块关闭结果。 |
+| `unfinished_modules` | 尚未完成的模块快照。 |
+| `started_at_msec` | 单调开始时间。 |
+| `completed_at_msec` | 单调完成时间。 |
+| `duplicate_request_count` | 并发重复请求数量。 |
+
+返回：新的取消结果。
+
+结构：
+
+- `module_results`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+- `unfinished_modules`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-timed_out"></a>
+
+### `timed_out`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func timed_out( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:
+```
+
+创建超时结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `error` | 稳定超时说明。 |
+| `module_results` | 已完成的模块关闭结果。 |
+| `unfinished_modules` | 超时时尚未完成的模块快照。 |
+| `started_at_msec` | 单调开始时间。 |
+| `completed_at_msec` | 单调完成时间。 |
+| `duplicate_request_count` | 并发重复请求数量。 |
+
+返回：新的超时结果。
+
+结构：
+
+- `module_results`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+- `unfinished_modules`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-forced"></a>
+
+### `forced`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func forced( error: String, module_results: Array[Dictionary] = [], unfinished_modules: Array[Dictionary] = [], started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:
+```
+
+创建强制释放结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `error` | 强制释放原因。 |
+| `module_results` | 已完成的模块关闭结果。 |
+| `unfinished_modules` | 被强制跳过的模块快照。 |
+| `started_at_msec` | 单调开始时间。 |
+| `completed_at_msec` | 单调完成时间。 |
+| `duplicate_request_count` | 并发重复请求数量。 |
+
+返回：新的强制释放结果。
+
+结构：
+
+- `module_results`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+- `unfinished_modules`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-already_disposed"></a>
+
+### `already_disposed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func already_disposed( started_at_msec: int = 0, completed_at_msec: int = 0, duplicate_request_count: int = 0 ) -> GFArchitectureShutdownResult:
+```
+
+创建已释放幂等结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `started_at_msec` | 单调开始时间。 |
+| `completed_at_msec` | 单调完成时间。 |
+| `duplicate_request_count` | 并发重复请求数量。 |
+
+返回：新的已释放结果。
+
+<a id="member-gfarchitectureshutdownresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+检查关闭是否以正常或幂等成功结束。
+
+返回：正常完成或此前已释放时返回 true。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> Status:
+```
+
+获取关闭终态。
+
+返回：`Status` 终态。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_status_name"></a>
+
+### `get_status_name`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status_name() -> StringName:
+```
+
+获取关闭终态名称。
+
+返回：小写稳定状态名称。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_started_at_msec"></a>
+
+### `get_started_at_msec`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_started_at_msec() -> int:
+```
+
+获取关闭开始时间。
+
+返回：非负单调毫秒时间。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_completed_at_msec"></a>
+
+### `get_completed_at_msec`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_completed_at_msec() -> int:
+```
+
+获取关闭完成时间。
+
+返回：不早于开始时间的单调毫秒时间。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_duration_msec"></a>
+
+### `get_duration_msec`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_duration_msec() -> int:
+```
+
+获取关闭耗时。
+
+返回：非负单调毫秒耗时。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_module_results"></a>
+
+### `get_module_results`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_module_results() -> Array[Dictionary]:
+```
+
+获取已完成模块结果的隔离副本。
+
+返回：最多 256 个规范化模块条目。
+
+结构：
+
+- `return`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-get_unfinished_modules"></a>
+
+### `get_unfinished_modules`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_unfinished_modules() -> Array[Dictionary]:
+```
+
+获取未完成模块快照的隔离副本。
+
+返回：最多 256 个规范化模块条目。
+
+结构：
+
+- `return`: Array of Dictionaries with kind, script, instance_id, status, reason, and duration_msec.
+
+<a id="member-gfarchitectureshutdownresult-methods-get_duplicate_request_count"></a>
+
+### `get_duplicate_request_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_duplicate_request_count() -> int:
+```
+
+获取复用同一关闭流程的重复请求数量。
+
+返回：非负重复请求数量。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_error_code"></a>
+
+### `get_error_code`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_code() -> Error:
+```
+
+获取关闭错误码。
+
+返回：成功终态为 OK。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_error"></a>
+
+### `get_error`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error() -> String:
+```
+
+获取稳定失败说明。
+
+返回：最多 2048 个字符的失败说明。
+
+<a id="member-gfarchitectureshutdownresult-methods-get_cancel_reason"></a>
+
+### `get_cancel_reason`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_cancel_reason() -> String:
+```
+
+获取取消原因。
+
+返回：最多 1024 个字符的取消原因；非取消终态为空。
+
+<a id="member-gfarchitectureshutdownresult-methods-duplicate_result"></a>
+
+### `duplicate_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_result() -> GFArchitectureShutdownResult:
+```
+
+创建隔离结果副本。
+
+返回：新的不可变结果对象。
+
+<a id="member-gfarchitectureshutdownresult-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为可报告字典。
+
+返回：关闭终态、时间、模块结果和错误证据的隔离快照。
+
+结构：
+
+- `return`: Dictionary with ok, status, status_name, started_at_msec, completed_at_msec, duration_msec, module_results, unfinished_modules, duplicate_request_count, error_code, error, and cancel_reason.

--- a/docs/zh/reference/api/classes/GFModel.md
+++ b/docs/zh/reference/api/classes/GFModel.md
@@ -9,16 +9,22 @@
 - 类别：协议与扩展点 (`protocol`)
 - 首次版本：`3.17.0`
 
-数据层抽象基类。 负责管理应用数据和业务状态。 子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。 三阶段初始化约定： - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。 - 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。
+数据层抽象基类。 负责管理应用数据和业务状态。 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、 'begin_quiesce'、'dispose' 来管理其生命周期。 四阶段启动与关闭约定： - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。 - 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。 - 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。 - 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。 - 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。
 
 ## 成员概览
 
 | 类型 | 名称 | 签名 |
 |---|---|---|
 | 属性 | [`lifecycle_priority`](#member-gfmodel-properties-lifecycle_priority) | `var lifecycle_priority: int = 0` |
+| 方法 | [`get_required_models`](#member-gfmodel-methods-get_required_models) | `func get_required_models() -> Array[Script]:` |
+| 方法 | [`get_required_systems`](#member-gfmodel-methods-get_required_systems) | `func get_required_systems() -> Array[Script]:` |
+| 方法 | [`get_required_utilities`](#member-gfmodel-methods-get_required_utilities) | `func get_required_utilities() -> Array[Script]:` |
+| 方法 | [`get_required_factories`](#member-gfmodel-methods-get_required_factories) | `func get_required_factories() -> Array[Script]:` |
 | 方法 | [`init`](#member-gfmodel-methods-init) | `func init() -> void:` |
 | 方法 | [`async_init`](#member-gfmodel-methods-async_init) | `func async_init(_scope: GFAsyncScope) -> void:` |
 | 方法 | [`ready`](#member-gfmodel-methods-ready) | `func ready() -> void:` |
+| 方法 | [`begin_activation`](#member-gfmodel-methods-begin_activation) | `func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`begin_quiesce`](#member-gfmodel-methods-begin_quiesce) | `func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
 | 方法 | [`dispose`](#member-gfmodel-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`release_dependencies`](#member-gfmodel-methods-release_dependencies) | `func release_dependencies() -> void:` |
 | 方法 | [`get_save_key`](#member-gfmodel-methods-get_save_key) | `func get_save_key() -> StringName:` |
@@ -37,14 +43,75 @@
 ### `lifecycle_priority`
 
 - API：`public`
+- 首次版本：`1.31.0`
 
 ```gdscript
 var lifecycle_priority: int = 0
 ```
 
-生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。 默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。
+生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大 越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。 默认 0 表示同一 frontier 内按稳定注册顺序执行。
 
 ## 方法
+
+<a id="member-gfmodel-methods-get_required_models"></a>
+
+### `get_required_models`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_models() -> Array[Script]:
+```
+
+返回此模型声明依赖的 Model 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此模型激活前必须可解析的 Model 脚本。
+
+<a id="member-gfmodel-methods-get_required_systems"></a>
+
+### `get_required_systems`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_systems() -> Array[Script]:
+```
+
+返回此模型声明依赖的 System 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此模型激活前必须可解析的 System 脚本。
+
+<a id="member-gfmodel-methods-get_required_utilities"></a>
+
+### `get_required_utilities`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_utilities() -> Array[Script]:
+```
+
+返回此模型声明依赖的 Utility 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此模型激活前必须可解析的 Utility 脚本。
+
+<a id="member-gfmodel-methods-get_required_factories"></a>
+
+### `get_required_factories`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_factories() -> Array[Script]:
+```
+
+返回此模型声明依赖的 Factory 绑定类型。 Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。
+
+返回：此模型激活前必须可解析的 Factory 脚本。
 
 <a id="member-gfmodel-methods-init"></a>
 
@@ -82,12 +149,55 @@ func async_init(_scope: GFAsyncScope) -> void:
 ### `ready`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
 func ready() -> void:
 ```
 
-第三阶段初始化。子类可以重写此方法。 约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。
+第三阶段初始化。子类可以重写此方法。 约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖； 未声明依赖没有可用性保证。
+
+<a id="member-gfmodel-methods-begin_activation"></a>
+
+### `begin_activation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开始激活模型的运行期能力。 重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。 基类返回已经成功的完成源。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前模型激活阶段的取消作用域。 |
+
+返回：当前激活阶段的一次性完成源。
+
+<a id="member-gfmodel-methods-begin_quiesce"></a>
+
+### `begin_quiesce`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开始静默模型并排空已经接纳的工作。 重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。 基类返回已经成功的完成源。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前模型静默阶段的取消作用域。 |
+
+返回：当前静默阶段的一次性完成源。
 
 <a id="member-gfmodel-methods-dispose"></a>
 
@@ -174,12 +284,13 @@ func from_dict(_data: Dictionary) -> void:
 ### `is_lifecycle_active`
 
 - API：`public`
+- 首次版本：`3.0.0`
 
 ```gdscript
 func is_lifecycle_active() -> bool:
 ```
 
-检查所属架构生命周期是否仍可安全继续异步写回。 async_init() 或其他 await 之后写入状态前建议检查该值。
+检查所属架构生命周期是否仍可安全继续异步写回。 async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。 QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过 GFArchitecture.is_accepting_runtime_work() 检查。
 
 返回：所属架构仍处于活动生命周期时返回 true。
 

--- a/docs/zh/reference/api/classes/GFModel.md
+++ b/docs/zh/reference/api/classes/GFModel.md
@@ -149,7 +149,7 @@ func async_init(_scope: GFAsyncScope) -> void:
 ### `ready`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func ready() -> void:

--- a/docs/zh/reference/api/classes/GFNodeContext.md
+++ b/docs/zh/reference/api/classes/GFNodeContext.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`3.17.0`
 
-场景树上的局部架构上下文。 可选择继承父级架构，或创建带父级回退的 Scoped 架构。 Scoped 架构会在节点退出树时自动 dispose，适合关卡、战斗房间、调试面板等局部模块。
+场景树上的局部架构上下文。 可选择继承父级架构，或创建带父级回退的 Scoped 架构。 Scoped 架构会在节点退出树时使用无法等待的 forced/no-drain dispose fallback， 适合关卡、战斗房间、调试面板等局部模块。可控或数据关键的退出必须先 await owned Architecture 的 shutdown_async()，再移除节点。
 
 ## 成员概览
 
@@ -49,12 +49,13 @@
 ### `context_ready`
 
 - API：`public`
+- 首次版本：`1.9.0`
 
 ```gdscript
 signal context_ready(architecture: GFArchitecture)
 ```
 
-当上下文架构完成初始化后发出。
+当上下文 Architecture 完成 stage4 activation 并提交 READY 后发出。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFSaveProfileUtility.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileUtility.md
@@ -267,7 +267,7 @@ func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
 |---|---|
 | `_scope` | 当前 Profile 服务激活阶段的取消作用域。 |
 
-返回：Storage 可用时成功，否则返回失败终态。
+返回：Storage 可用且实例未 dispose/quiesce 时成功，否则返回失败终态。
 
 <a id="member-gfsaveprofileutility-methods-begin_quiesce"></a>
 
@@ -342,7 +342,7 @@ func setup(storage: GFStorageUtility, clock: GFClock = null) -> GFSaveProfileUti
 | `storage` | 底层事务存储工具。 |
 | `clock` | 可选单调时钟；为空时保留当前时钟。 |
 
-返回：当前 Utility；参数无效、已释放或已有注册 profile 时返回 null。
+返回：当前 Utility；准入关闭、参数无效、已释放、处于不安全回调或已有 profile 时返回 null。
 
 <a id="member-gfsaveprofileutility-methods-register_profile"></a>
 
@@ -389,7 +389,7 @@ func unregister_profile(profile_id: StringName) -> bool:
 |---|---|
 | `profile_id` | profile ID。 |
 
-返回：profile 存在且没有未完成操作时返回 true。
+返回：准入开放、回调安全且 profile 空闲并无任何待处理工作时返回 true。
 
 <a id="member-gfsaveprofileutility-methods-save_profile"></a>
 

--- a/docs/zh/reference/api/classes/GFSaveProfileUtility.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileUtility.md
@@ -28,6 +28,9 @@
 | 属性 | [`save_preparation_slice_budget`](#member-gfsaveprofileutility-properties-save_preparation_slice_budget) | `var save_preparation_slice_budget: int = 8:` |
 | 属性 | [`save_preparation_time_budget_usec`](#member-gfsaveprofileutility-properties-save_preparation_time_budget_usec) | `var save_preparation_time_budget_usec: int = 2000:` |
 | 方法 | [`ready`](#member-gfsaveprofileutility-methods-ready) | `func ready() -> void:` |
+| 方法 | [`get_required_utilities`](#member-gfsaveprofileutility-methods-get_required_utilities) | `func get_required_utilities() -> Array[Script]:` |
+| 方法 | [`begin_activation`](#member-gfsaveprofileutility-methods-begin_activation) | `func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`begin_quiesce`](#member-gfsaveprofileutility-methods-begin_quiesce) | `func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:` |
 | 方法 | [`tick`](#member-gfsaveprofileutility-methods-tick) | `func tick(_delta: float) -> void:` |
 | 方法 | [`dispose`](#member-gfsaveprofileutility-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`setup`](#member-gfsaveprofileutility-methods-setup) | `func setup(storage: GFStorageUtility, clock: GFClock = null) -> GFSaveProfileUtility:` |
@@ -229,6 +232,63 @@ func ready() -> void:
 ```
 
 在架构 ready 阶段采用已注册的 Storage 和 Time 服务。 `setup()` 显式注入的依赖不会被覆盖。
+
+<a id="member-gfsaveprofileutility-methods-get_required_utilities"></a>
+
+### `get_required_utilities`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_utilities() -> Array[Script]:
+```
+
+声明架构模式下必须显式注册的 Storage 依赖。 `setup()` 仍可用于 standalone 测试与非 Architecture 所有权场景；进入 Architecture 生命周期时不会因此绕过 GFStorageUtility 的显式注册要求。
+
+返回：仅包含 GFStorageUtility 的依赖声明。
+
+<a id="member-gfsaveprofileutility-methods-begin_activation"></a>
+
+### `begin_activation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+激活 Profile 服务；底层 Storage 未配置时失败，不创建业务 profile。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前 Profile 服务激活阶段的取消作用域。 |
+
+返回：Storage 可用时成功，否则返回失败终态。
+
+<a id="member-gfsaveprofileutility-methods-begin_quiesce"></a>
+
+### `begin_quiesce`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+关闭新 profile 工作准入，并等待已接纳 operation、preparation、retry 与 detached 写入收敛。 静默期间不会注册业务 profile，也不会取消已接纳工作；这些工作继续由 lifecycle tick 和底层 Storage 完成回调推进。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `scope` | 当前 Profile 服务静默阶段的取消作用域。 |
+
+返回：所有已接纳工作进入终态后成功的一次性完成源。
 
 <a id="member-gfsaveprofileutility-methods-tick"></a>
 

--- a/docs/zh/reference/api/classes/GFStorageUtility.md
+++ b/docs/zh/reference/api/classes/GFStorageUtility.md
@@ -504,7 +504,7 @@ func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
 |---|---|
 | `_scope` | 当前 Storage 激活阶段的取消作用域。 |
 
-返回：已成功完成；正在 dispose 时返回失败终态。
+返回：成功打开 I/O 准入；正在 dispose 或已经进入过 quiesce 时返回失败终态。
 
 <a id="member-gfstorageutility-methods-begin_quiesce"></a>
 

--- a/docs/zh/reference/api/classes/GFStorageUtility.md
+++ b/docs/zh/reference/api/classes/GFStorageUtility.md
@@ -45,6 +45,8 @@
 | 方法 | [`init`](#member-gfstorageutility-methods-init) | `func init() -> void:` |
 | 方法 | [`dispose`](#member-gfstorageutility-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`tick`](#member-gfstorageutility-methods-tick) | `func tick(_delta: float = 0.0) -> void:` |
+| 方法 | [`begin_activation`](#member-gfstorageutility-methods-begin_activation) | `func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`begin_quiesce`](#member-gfstorageutility-methods-begin_quiesce) | `func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:` |
 | 方法 | [`save_resource`](#member-gfstorageutility-methods-save_resource) | `func save_resource(file_name: String, resource: Resource) -> Error:` |
 | 方法 | [`load_resource`](#member-gfstorageutility-methods-load_resource) | `func load_resource(file_name: String, type_hint: String = "") -> Resource:` |
 | 方法 | [`ensure_directory`](#member-gfstorageutility-methods-ensure_directory) | `func ensure_directory(directory_name: String = "") -> Error:` |
@@ -482,6 +484,48 @@ func tick(_delta: float = 0.0) -> void:
 | 名称 | 说明 |
 |---|---|
 | `_delta` | 本帧时间增量（秒），默认实现不直接使用。 |
+
+<a id="member-gfstorageutility-methods-begin_activation"></a>
+
+### `begin_activation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+激活 Storage 的同步与异步 I/O 准入。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前 Storage 激活阶段的取消作用域。 |
+
+返回：已成功完成；正在 dispose 时返回失败终态。
+
+<a id="member-gfstorageutility-methods-begin_quiesce"></a>
+
+### `begin_quiesce`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+关闭新 I/O 准入，并等待此前接纳的队列、线程和文件锁全部收敛。 已接纳任务继续由 lifecycle tick 推进；强制 dispose 仍会使用同步 join fallback。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `scope` | 当前 Storage 静默阶段的取消作用域。 |
+
+返回：队列、任务和锁全部终态后成功的一次性完成源。
 
 <a id="member-gfstorageutility-methods-save_resource"></a>
 

--- a/docs/zh/reference/api/classes/GFSystem.md
+++ b/docs/zh/reference/api/classes/GFSystem.md
@@ -238,7 +238,7 @@ func async_init(_scope: GFAsyncScope) -> void:
 ### `ready`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func ready() -> void:

--- a/docs/zh/reference/api/classes/GFSystem.md
+++ b/docs/zh/reference/api/classes/GFSystem.md
@@ -9,7 +9,7 @@
 - 类别：协议与扩展点 (`protocol`)
 - 首次版本：`3.17.0`
 
-逻辑层抽象基类。 负责实现核心业务逻辑。 子类可以实现 'init'、'async_init'、'ready'、'dispose' 来管理其生命周期。 三阶段初始化约定： - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。 - 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。
+逻辑层抽象基类。 负责实现核心业务逻辑。 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、 'begin_quiesce'、'dispose' 来管理其生命周期。 四阶段启动与关闭约定： - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。 - 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。 - 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。 - 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。 - 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。
 
 ## 成员概览
 
@@ -22,9 +22,15 @@
 | 属性 | [`physics_tick_priority`](#member-gfsystem-properties-physics_tick_priority) | `var physics_tick_priority: int = 0:` |
 | 属性 | [`tick_enabled`](#member-gfsystem-properties-tick_enabled) | `var tick_enabled: bool = false:` |
 | 属性 | [`physics_tick_enabled`](#member-gfsystem-properties-physics_tick_enabled) | `var physics_tick_enabled: bool = false:` |
+| 方法 | [`get_required_models`](#member-gfsystem-methods-get_required_models) | `func get_required_models() -> Array[Script]:` |
+| 方法 | [`get_required_systems`](#member-gfsystem-methods-get_required_systems) | `func get_required_systems() -> Array[Script]:` |
+| 方法 | [`get_required_utilities`](#member-gfsystem-methods-get_required_utilities) | `func get_required_utilities() -> Array[Script]:` |
+| 方法 | [`get_required_factories`](#member-gfsystem-methods-get_required_factories) | `func get_required_factories() -> Array[Script]:` |
 | 方法 | [`init`](#member-gfsystem-methods-init) | `func init() -> void:` |
 | 方法 | [`async_init`](#member-gfsystem-methods-async_init) | `func async_init(_scope: GFAsyncScope) -> void:` |
 | 方法 | [`ready`](#member-gfsystem-methods-ready) | `func ready() -> void:` |
+| 方法 | [`begin_activation`](#member-gfsystem-methods-begin_activation) | `func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`begin_quiesce`](#member-gfsystem-methods-begin_quiesce) | `func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
 | 方法 | [`dispose`](#member-gfsystem-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`release_dependencies`](#member-gfsystem-methods-release_dependencies) | `func release_dependencies() -> void:` |
 | 方法 | [`tick`](#member-gfsystem-methods-tick) | `func tick(_delta: float) -> void:` |
@@ -76,12 +82,13 @@ var ignore_time_scale: bool = false:
 ### `lifecycle_priority`
 
 - API：`public`
+- 首次版本：`1.31.0`
 
 ```gdscript
 var lifecycle_priority: int = 0
 ```
 
-生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。 默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。
+生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大 越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。 默认 0 表示同一 frontier 内按稳定注册顺序执行。
 
 <a id="member-gfsystem-properties-tick_priority"></a>
 
@@ -135,6 +142,66 @@ var physics_tick_enabled: bool = false:
 
 ## 方法
 
+<a id="member-gfsystem-methods-get_required_models"></a>
+
+### `get_required_models`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_models() -> Array[Script]:
+```
+
+返回此系统声明依赖的 Model 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此系统激活前必须可解析的 Model 脚本。
+
+<a id="member-gfsystem-methods-get_required_systems"></a>
+
+### `get_required_systems`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_systems() -> Array[Script]:
+```
+
+返回此系统声明依赖的 System 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此系统激活前必须可解析的 System 脚本。
+
+<a id="member-gfsystem-methods-get_required_utilities"></a>
+
+### `get_required_utilities`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_utilities() -> Array[Script]:
+```
+
+返回此系统声明依赖的 Utility 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此系统激活前必须可解析的 Utility 脚本。
+
+<a id="member-gfsystem-methods-get_required_factories"></a>
+
+### `get_required_factories`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_factories() -> Array[Script]:
+```
+
+返回此系统声明依赖的 Factory 绑定类型。 Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。
+
+返回：此系统激活前必须可解析的 Factory 脚本。
+
 <a id="member-gfsystem-methods-init"></a>
 
 ### `init`
@@ -171,12 +238,55 @@ func async_init(_scope: GFAsyncScope) -> void:
 ### `ready`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
 func ready() -> void:
 ```
 
-第三阶段初始化。子类可以重写此方法。 约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。
+第三阶段初始化。子类可以重写此方法。 约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖； 未声明依赖没有可用性保证。
+
+<a id="member-gfsystem-methods-begin_activation"></a>
+
+### `begin_activation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开始激活系统的运行期能力。 重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。 基类返回已经成功的完成源。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前系统激活阶段的取消作用域。 |
+
+返回：当前激活阶段的一次性完成源。
+
+<a id="member-gfsystem-methods-begin_quiesce"></a>
+
+### `begin_quiesce`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开始静默系统并排空已经接纳的工作。 重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。 基类返回已经成功的完成源。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前系统静默阶段的取消作用域。 |
+
+返回：当前静默阶段的一次性完成源。
 
 <a id="member-gfsystem-methods-dispose"></a>
 
@@ -244,12 +354,13 @@ func physics_tick(_delta: float) -> void:
 ### `is_lifecycle_active`
 
 - API：`public`
+- 首次版本：`3.0.0`
 
 ```gdscript
 func is_lifecycle_active() -> bool:
 ```
 
-检查所属架构生命周期是否仍可安全继续异步写回。 async_init() 或其他 await 之后写入状态前建议检查该值。
+检查所属架构生命周期是否仍可安全继续异步写回。 async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。 QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过 GFArchitecture.is_accepting_runtime_work() 检查。
 
 返回：所属架构仍处于活动生命周期时返回 true。
 

--- a/docs/zh/reference/api/classes/GFUtility.md
+++ b/docs/zh/reference/api/classes/GFUtility.md
@@ -236,7 +236,7 @@ func async_init(_scope: GFAsyncScope) -> void:
 ### `ready`
 
 - API：`public`
-- 首次版本：`5.0.0`
+- 首次版本：`11.0.0`
 
 ```gdscript
 func ready() -> void:

--- a/docs/zh/reference/api/classes/GFUtility.md
+++ b/docs/zh/reference/api/classes/GFUtility.md
@@ -9,7 +9,7 @@
 - 类别：协议与扩展点 (`protocol`)
 - 首次版本：`3.17.0`
 
-工具组件抽象基类。 提供不依赖其他架构组件的独立工具功能。 子类可以实现 'init'、'async_init'、'ready'、 'dispose' 来管理其生命周期。 三阶段初始化约定： - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。 - 'ready'      阶段：架构内所有模块均已完成 'init'，可安全跨模块获取依赖。
+工具组件抽象基类。 提供可复用的工具能力；需要其它架构组件时必须通过类型化 Hook 显式声明依赖。 子类可以实现 'init'、'async_init'、'ready'、'begin_activation'、 'begin_quiesce'、'dispose' 来管理其生命周期。 四阶段启动与关闭约定： - 'init'       阶段：只允许初始化自身内部变量，禁止跨模块获取依赖。 - 'async_init' 阶段：可使用 await，用于异步资源加载等操作。 - 'ready'      阶段：当前模块声明的依赖已按 DAG 完成 ready，可完成同步装配。 - 'begin_activation' 阶段：显式启动运行期能力，并返回一次性完成源。 - 'begin_quiesce' 阶段：停止接纳新工作并排空已接纳工作。 - 'dispose'    阶段：按激活顺序的严格逆序同步释放资源。
 
 ## 成员概览
 
@@ -22,9 +22,15 @@
 | 属性 | [`physics_tick_priority`](#member-gfutility-properties-physics_tick_priority) | `var physics_tick_priority: int = 0:` |
 | 属性 | [`tick_enabled`](#member-gfutility-properties-tick_enabled) | `var tick_enabled: bool = false:` |
 | 属性 | [`physics_tick_enabled`](#member-gfutility-properties-physics_tick_enabled) | `var physics_tick_enabled: bool = false:` |
+| 方法 | [`get_required_models`](#member-gfutility-methods-get_required_models) | `func get_required_models() -> Array[Script]:` |
+| 方法 | [`get_required_systems`](#member-gfutility-methods-get_required_systems) | `func get_required_systems() -> Array[Script]:` |
+| 方法 | [`get_required_utilities`](#member-gfutility-methods-get_required_utilities) | `func get_required_utilities() -> Array[Script]:` |
+| 方法 | [`get_required_factories`](#member-gfutility-methods-get_required_factories) | `func get_required_factories() -> Array[Script]:` |
 | 方法 | [`init`](#member-gfutility-methods-init) | `func init() -> void:` |
 | 方法 | [`async_init`](#member-gfutility-methods-async_init) | `func async_init(_scope: GFAsyncScope) -> void:` |
 | 方法 | [`ready`](#member-gfutility-methods-ready) | `func ready() -> void:` |
+| 方法 | [`begin_activation`](#member-gfutility-methods-begin_activation) | `func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`begin_quiesce`](#member-gfutility-methods-begin_quiesce) | `func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
 | 方法 | [`dispose`](#member-gfutility-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`release_dependencies`](#member-gfutility-methods-release_dependencies) | `func release_dependencies() -> void:` |
 | 方法 | [`is_lifecycle_active`](#member-gfutility-methods-is_lifecycle_active) | `func is_lifecycle_active() -> bool:` |
@@ -74,12 +80,13 @@ var ignore_time_scale: bool = false:
 ### `lifecycle_priority`
 
 - API：`public`
+- 首次版本：`1.31.0`
 
 ```gdscript
 var lifecycle_priority: int = 0
 ```
 
-生命周期优先级。数值越大越早执行 init/async_init/ready，dispose 时越晚释放。 默认 0 表示同优先级下按注册顺序执行；只有存在明确依赖顺序时才建议设置。
+生命周期优先级。声明依赖 DAG 始终优先；仅在同一 ready frontier 内，数值越大 越早执行 init/async_init/ready/activation，关闭时越晚 quiesce 与释放。 默认 0 表示同一 frontier 内按稳定注册顺序执行。
 
 <a id="member-gfutility-properties-tick_priority"></a>
 
@@ -133,6 +140,66 @@ var physics_tick_enabled: bool = false:
 
 ## 方法
 
+<a id="member-gfutility-methods-get_required_models"></a>
+
+### `get_required_models`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_models() -> Array[Script]:
+```
+
+返回此工具声明依赖的 Model 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此工具激活前必须可解析的 Model 脚本。
+
+<a id="member-gfutility-methods-get_required_systems"></a>
+
+### `get_required_systems`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_systems() -> Array[Script]:
+```
+
+返回此工具声明依赖的 System 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此工具激活前必须可解析的 System 脚本。
+
+<a id="member-gfutility-methods-get_required_utilities"></a>
+
+### `get_required_utilities`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_utilities() -> Array[Script]:
+```
+
+返回此工具声明依赖的 Utility 类型。 返回值必须保持纯函数语义，并在同一模块拓扑事务内保持稳定。
+
+返回：此工具激活前必须可解析的 Utility 脚本。
+
+<a id="member-gfutility-methods-get_required_factories"></a>
+
+### `get_required_factories`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_factories() -> Array[Script]:
+```
+
+返回此工具声明依赖的 Factory 绑定类型。 Factory 依赖只校验绑定可用性，不参与模块生命周期 DAG。
+
+返回：此工具激活前必须可解析的 Factory 脚本。
+
 <a id="member-gfutility-methods-init"></a>
 
 ### `init`
@@ -169,12 +236,55 @@ func async_init(_scope: GFAsyncScope) -> void:
 ### `ready`
 
 - API：`public`
+- 首次版本：`5.0.0`
 
 ```gdscript
 func ready() -> void:
 ```
 
-第三阶段初始化。子类可以重写此方法。 约束：此时所有模块已完成 'init'，可安全跨模块获取依赖。
+第三阶段初始化。子类可以重写此方法。 约束：当前模块声明的依赖已按 DAG 完成 ready，可安全获取并缓存这些依赖； 未声明依赖没有可用性保证。
+
+<a id="member-gfutility-methods-begin_activation"></a>
+
+### `begin_activation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开始激活工具的运行期能力。 重写实现应立即返回非空完成源，并在激活成功、失败或取消时只提交一次终态。 基类返回已经成功的完成源。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前工具激活阶段的取消作用域。 |
+
+返回：当前激活阶段的一次性完成源。
+
+<a id="member-gfutility-methods-begin_quiesce"></a>
+
+### `begin_quiesce`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开始静默工具并排空已经接纳的工作。 重写实现不得在该阶段接纳新工作，也不得提前释放仍被已接纳工作使用的状态。 基类返回已经成功的完成源。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前工具静默阶段的取消作用域。 |
+
+返回：当前静默阶段的一次性完成源。
 
 <a id="member-gfutility-methods-dispose"></a>
 
@@ -206,12 +316,13 @@ func release_dependencies() -> void:
 ### `is_lifecycle_active`
 
 - API：`public`
+- 首次版本：`3.0.0`
 
 ```gdscript
 func is_lifecycle_active() -> bool:
 ```
 
-检查所属架构生命周期是否仍可安全继续异步写回。 async_init() 或其他 await 之后写入状态前建议检查该值。
+检查所属架构生命周期是否仍可安全继续异步写回。 async_init() 或其他 await 之后提交已接纳工作的结果前建议检查该值。 QUIESCING 期间该值仍可为 true；它不代表允许接纳新工作，新请求还必须通过 GFArchitecture.is_accepting_runtime_work() 检查。
 
 返回：所属架构仍处于活动生命周期时返回 true。
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -6,8 +6,8 @@
 
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
-| Kernel | 73 | 1046 | [Kernel](#module-kernel) |
-| Standard | 443 | 7066 | [Standard](#module-standard) |
+| Kernel | 74 | 1088 | [Kernel](#module-kernel) |
+| Standard | 443 | 7068 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -23,7 +23,7 @@
 | Interaction | 6 | 82 | [Interaction](#module-extensions-interaction) |
 | Network | 38 | 602 | [Network](#module-extensions-network) |
 | Physics | 4 | 50 | [Physics](#module-extensions-physics) |
-| Save | 44 | 507 | [Save](#module-extensions-save) |
+| Save | 44 | 510 | [Save](#module-extensions-save) |
 | Turn Based | 4 | 49 | [Turn Based](#module-extensions-turn_based) |
 | Tool Packages | 17 | 135 | [Tool Packages](#module-tools) |
 
@@ -35,7 +35,7 @@
 
 | 类 | 类别 | 继承 | 成员 | 源文件 |
 |---|---|---|---:|---|
-| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 119 | `addons/gf/kernel/core/gf_architecture.gd` |
+| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 121 | `addons/gf/kernel/core/gf_architecture.gd` |
 | [`GFDependencyGraphTools`](GFDependencyGraphTools.md#gfdependencygraphtools) | 运行时服务 (`runtime_service`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_dependency_graph_tools.gd` |
 | [`GFExtensionCatalog`](GFExtensionCatalog.md#gfextensioncatalog) | 运行时服务 (`runtime_service`) | `RefCounted` | 5 | `addons/gf/kernel/extension/gf_extension_catalog.gd` |
 | [`GFExtensionManifestDiscovery`](GFExtensionManifestDiscovery.md#gfextensionmanifestdiscovery) | 运行时服务 (`runtime_service`) | `RefCounted` | 2 | `addons/gf/kernel/extension/gf_extension_manifest_discovery.gd` |
@@ -59,15 +59,15 @@
 | [`GFController`](GFController.md#gfcontroller) | 协议与扩展点 (`protocol`) | `Node` | 24 | `addons/gf/kernel/base/gf_controller.gd` |
 | [`GFExtensionToolContribution`](GFExtensionToolContribution.md#gfextensiontoolcontribution) | 协议与扩展点 (`protocol`) | `RefCounted` | 4 | `addons/gf/kernel/extension/gf_extension_tool_contribution.gd` |
 | [`GFInstaller`](GFInstaller.md#gfinstaller) | 协议与扩展点 (`protocol`) | `RefCounted` | 2 | `addons/gf/kernel/core/gf_installer.gd` |
-| [`GFModel`](GFModel.md#gfmodel) | 协议与扩展点 (`protocol`) | `Object` | 14 | `addons/gf/kernel/base/gf_model.gd` |
+| [`GFModel`](GFModel.md#gfmodel) | 协议与扩展点 (`protocol`) | `Object` | 20 | `addons/gf/kernel/base/gf_model.gd` |
 | [`GFPayload`](GFPayload.md#gfpayload) | 协议与扩展点 (`protocol`) | `RefCounted` | 4 | `addons/gf/kernel/base/gf_payload.gd` |
 | [`GFQuery`](GFQuery.md#gfquery) | 协议与扩展点 (`protocol`) | `Object` | 5 | `addons/gf/kernel/base/gf_query.gd` |
 | [`GFReactiveEffect`](GFReactiveEffect.md#gfreactiveeffect) | 协议与扩展点 (`protocol`) | `RefCounted` | 9 | `addons/gf/kernel/core/gf_reactive_effect.gd` |
 | [`GFReadOnlyBindableProperty`](GFReadOnlyBindableProperty.md#gfreadonlybindableproperty) | 协议与扩展点 (`protocol`) | `GFBindableProperty` | 10 | `addons/gf/kernel/core/gf_read_only_bindable_property.gd` |
 | [`GFRule`](GFRule.md#gfrule) | 协议与扩展点 (`protocol`) | `Resource` | 2 | `addons/gf/kernel/base/gf_rule.gd` |
-| [`GFSystem`](GFSystem.md#gfsystem) | 协议与扩展点 (`protocol`) | `Object` | 27 | `addons/gf/kernel/base/gf_system.gd` |
+| [`GFSystem`](GFSystem.md#gfsystem) | 协议与扩展点 (`protocol`) | `Object` | 33 | `addons/gf/kernel/base/gf_system.gd` |
 | [`GFTimeProvider`](GFTimeProvider.md#gftimeprovider) | 协议与扩展点 (`protocol`) | `GFUtility` | 10 | `addons/gf/kernel/base/gf_time_provider.gd` |
-| [`GFUtility`](GFUtility.md#gfutility) | 协议与扩展点 (`protocol`) | `Object` | 25 | `addons/gf/kernel/base/gf_utility.gd` |
+| [`GFUtility`](GFUtility.md#gfutility) | 协议与扩展点 (`protocol`) | `Object` | 31 | `addons/gf/kernel/base/gf_utility.gd` |
 | [`GFExtensionManifest`](GFExtensionManifest.md#gfextensionmanifest) | 资源定义 (`resource_definition`) | `RefCounted` | 33 | `addons/gf/kernel/extension/gf_extension_manifest.gd` |
 | [`GFExtensionPreset`](GFExtensionPreset.md#gfextensionpreset) | 资源定义 (`resource_definition`) | `RefCounted` | 12 | `addons/gf/kernel/extension/gf_extension_preset.gd` |
 | [`GFAsyncCompletion`](GFAsyncCompletion.md#gfasynccompletion) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 20 | `addons/gf/kernel/core/gf_async_completion.gd` |
@@ -79,6 +79,7 @@
 | [`GFSubscriptionToken`](GFSubscriptionToken.md#gfsubscriptiontoken) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 4 | `addons/gf/kernel/core/gf_subscription_token.gd` |
 | [`GFThumbnailRenderTask`](GFThumbnailRenderTask.md#gfthumbnailrendertask) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 23 | `addons/gf/kernel/editor/gf_thumbnail_render_task.gd` |
 | [`GFWeakMethodInvocation`](GFWeakMethodInvocation.md#gfweakmethodinvocation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 6 | `addons/gf/kernel/core/gf_weak_method_invocation.gd` |
+| [`GFArchitectureShutdownResult`](GFArchitectureShutdownResult.md#gfarchitectureshutdownresult) | 值对象 (`value_object`) | `RefCounted` | 22 | `addons/gf/kernel/core/gf_architecture_shutdown_result.gd` |
 | [`GFBindingLifetimes`](GFBindingLifetimes.md#gfbindinglifetimes) | 值对象 (`value_object`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_binding_lifetimes.gd` |
 | [`GFEventListener`](GFEventListener.md#gfeventlistener) | 事件契约 (`event_contract`) | `RefCounted` | 10 | `addons/gf/kernel/core/gf_event_listener.gd` |
 | [`GFAccessGenerator`](GFAccessGenerator.md#gfaccessgenerator) | 编辑器 API (`editor_api`) | `RefCounted` | 13 | `addons/gf/kernel/editor/gf_access_generator.gd` |
@@ -266,7 +267,7 @@
 | [`GFSteeringMath`](GFSteeringMath.md#gfsteeringmath) | 运行时服务 (`runtime_service`) | `RefCounted` | 16 | `addons/gf/standard/foundation/math/gf_steering_math.gd` |
 | [`GFStorageFailoverBackend`](GFStorageFailoverBackend.md#gfstoragefailoverbackend) | 运行时服务 (`runtime_service`) | `GFStorageBackend` | 16 | `addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd` |
 | [`GFStorageSyncUtility`](GFStorageSyncUtility.md#gfstoragesyncutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 11 | `addons/gf/standard/utilities/storage/gf_storage_sync_utility.gd` |
-| [`GFStorageUtility`](GFStorageUtility.md#gfstorageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 51 | `addons/gf/standard/utilities/storage/gf_storage_utility.gd` |
+| [`GFStorageUtility`](GFStorageUtility.md#gfstorageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 53 | `addons/gf/standard/utilities/storage/gf_storage_utility.gd` |
 | [`GFSupportReportUtility`](GFSupportReportUtility.md#gfsupportreportutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 32 | `addons/gf/standard/utilities/debug/gf_support_report_utility.gd` |
 | [`GFSupportReportWorkflow`](GFSupportReportWorkflow.md#gfsupportreportworkflow) | 运行时服务 (`runtime_service`) | `GFUtility` | 23 | `addons/gf/standard/utilities/debug/gf_support_report_workflow.gd` |
 | [`GFSurfaceScatterSampler3D`](GFSurfaceScatterSampler3D.md#gfsurfacescattersampler3d) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/foundation/math/gf_surface_scatter_sampler_3d.gd` |
@@ -885,7 +886,7 @@
 | [`GFNodeSerializerRegistry`](GFNodeSerializerRegistry.md#gfnodeserializerregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/extensions/save/serializers/gf_node_serializer_registry.gd` |
 | [`GFSaveGraphUtility`](GFSaveGraphUtility.md#gfsavegraphutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 30 | `addons/gf/extensions/save/graph/gf_save_graph_utility.gd` |
 | [`GFSaveMigrationRegistry`](GFSaveMigrationRegistry.md#gfsavemigrationregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/extensions/save/document/gf_save_migration_registry.gd` |
-| [`GFSaveProfileUtility`](GFSaveProfileUtility.md#gfsaveprofileutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 23 | `addons/gf/extensions/save/profile/gf_save_profile_utility.gd` |
+| [`GFSaveProfileUtility`](GFSaveProfileUtility.md#gfsaveprofileutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 26 | `addons/gf/extensions/save/profile/gf_save_profile_utility.gd` |
 | [`GFSaveSlotStorageAdapter`](GFSaveSlotStorageAdapter.md#gfsaveslotstorageadapter) | 运行时服务 (`runtime_service`) | `Resource` | 16 | `addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd` |
 | [`GFSaveSlotSyncBridge`](GFSaveSlotSyncBridge.md#gfsaveslotsyncbridge) | 运行时服务 (`runtime_service`) | `RefCounted` | 6 | `addons/gf/extensions/save/slots/gf_save_slot_sync_bridge.gd` |
 | [`GFNodeSerializer`](GFNodeSerializer.md#gfnodeserializer) | 协议与扩展点 (`protocol`) | `Resource` | 15 | `addons/gf/extensions/save/serializers/gf_node_serializer.gd` |

--- a/docs/zh/reference/api/extensions-save.md
+++ b/docs/zh/reference/api/extensions-save.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 6 | 89 | 63 |
+| [运行时服务](#category-runtime_service) | 6 | 92 | 66 |
 | [协议与扩展点](#category-protocol) | 10 | 114 | 69 |
 | [资源定义](#category-resource_definition) | 13 | 92 | 58 |
 | [运行时句柄](#category-runtime_handle) | 4 | 41 | 28 |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,16 +5,16 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`793`
-- 公开成员：`11624`
-- 公开方法：`7151`
+- 公开类：`794`
+- 公开成员：`11671`
+- 公开方法：`7201`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
-| Kernel | 73 | 1046 | 747 | [kernel.md](kernel.md) |
-| Standard | 443 | 7066 | 4465 | [standard.md](standard.md) |
+| Kernel | 74 | 1088 | 792 | [kernel.md](kernel.md) |
+| Standard | 443 | 7068 | 4467 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |
@@ -30,7 +30,7 @@
 | Interaction | 6 | 82 | 29 | [extensions-interaction.md](extensions-interaction.md) |
 | Network | 38 | 602 | 323 | [extensions-network.md](extensions-network.md) |
 | Physics | 4 | 50 | 23 | [extensions-physics.md](extensions-physics.md) |
-| Save | 44 | 507 | 322 | [extensions-save.md](extensions-save.md) |
+| Save | 44 | 510 | 325 | [extensions-save.md](extensions-save.md) |
 | Turn Based | 4 | 49 | 24 | [extensions-turn-based.md](extensions-turn-based.md) |
 | Tool Packages | 17 | 135 | 86 | [tools.md](tools.md) |
 

--- a/docs/zh/reference/api/kernel.md
+++ b/docs/zh/reference/api/kernel.md
@@ -6,11 +6,11 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 14 | 298 | 232 |
-| [协议与扩展点](#category-protocol) | 19 | 195 | 170 |
+| [运行时服务](#category-runtime_service) | 14 | 300 | 238 |
+| [协议与扩展点](#category-protocol) | 19 | 213 | 188 |
 | [资源定义](#category-resource_definition) | 2 | 45 | 15 |
 | [运行时句柄](#category-runtime_handle) | 9 | 86 | 70 |
-| [值对象](#category-value_object) | 1 | 1 | 0 |
+| [值对象](#category-value_object) | 2 | 23 | 21 |
 | [事件契约](#category-event_contract) | 1 | 10 | 10 |
 | [编辑器 API](#category-editor_api) | 26 | 389 | 242 |
 | [工具 API](#category-tool_api) | 1 | 22 | 8 |
@@ -95,6 +95,7 @@
 
 | 类 | 继承 | 源文件 |
 |---|---|---|
+| [`GFArchitectureShutdownResult`](classes/GFArchitectureShutdownResult.md#gfarchitectureshutdownresult) | `RefCounted` | `addons/gf/kernel/core/gf_architecture_shutdown_result.gd` |
 | [`GFBindingLifetimes`](classes/GFBindingLifetimes.md#gfbindinglifetimes) | `RefCounted` | `addons/gf/kernel/core/gf_binding_lifetimes.gd` |
 
 <a id="category-event_contract"></a>

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 188 | 3399 | 2289 |
+| [运行时服务](#category-runtime_service) | 188 | 3401 | 2291 |
 | [协议与扩展点](#category-protocol) | 24 | 338 | 267 |
 | [资源定义](#category-resource_definition) | 120 | 1538 | 792 |
 | [运行时句柄](#category-runtime_handle) | 47 | 821 | 521 |

--- a/tests/gf_core/extensions/combat/test_gf_combat_extension.gd
+++ b/tests/gf_core/extensions/combat/test_gf_combat_extension.gd
@@ -1121,7 +1121,10 @@ func test_tick_skips_entity_removed_by_earlier_entity_callback() -> void:
 func test_combat_event_dispatching() -> void:
 	# 初始化架构以支持事件总线
 	var arch: GFArchitecture = GFArchitecture.new()
-	await Gf.set_architecture(arch)
+	assert_true(
+		await Gf.set_architecture(arch),
+		"Combat 事件测试必须先完成全局 Architecture activation。"
+	)
 	
 	var system: GFCombatSystem = GFCombatSystem.new()
 	var entity: MockEntity = MockEntity.new()
@@ -1169,11 +1172,21 @@ func test_combat_event_dispatching() -> void:
 
 func test_combat_events_use_injected_scoped_architecture() -> void:
 	var parent_arch: GFArchitecture = GFArchitecture.new()
-	await Gf.set_architecture(parent_arch)
+	assert_true(
+		await Gf.set_architecture(parent_arch),
+		"父 Architecture 必须先完成 activation。"
+	)
 
 	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
 	var system: GFCombatSystem = GFCombatSystem.new()
-	await child_arch.register_system_instance(system)
+	assert_true(
+		await child_arch.register_system_instance(system),
+		"Scoped CombatSystem 应在 activation 前注册成功。"
+	)
+	assert_true(
+		await child_arch.init(),
+		"子 Architecture 必须完成 activation 后才能派发 Combat 事件。"
+	)
 
 	var parent_events: Dictionary = { "applied": 0 }
 	var child_events: Dictionary = { "applied": 0 }

--- a/tests/gf_core/extensions/domain/test_gf_quest_utility.gd
+++ b/tests/gf_core/extensions/domain/test_gf_quest_utility.gd
@@ -307,7 +307,7 @@ func test_dispose_unregisters_simple_event_listener() -> void:
 
 	var arch: GFArchitecture = Gf.get_architecture()
 	var quest_script: Script = _quest.get_script()
-	arch.unregister_utility(quest_script)
+	assert_true(await arch.unregister_utility(quest_script))
 
 	assert_true(_quest.disposed_called, "注销 Utility 时应执行 dispose。")
 	Gf.send_simple_event(&"enemy_died", 1)

--- a/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
@@ -297,6 +297,58 @@ func test_save_requests_coalesce_to_latest_generation_without_parallel_writes() 
 	assert_eq(_storage.max_active_io_count, 1, "任意时刻只允许一个底层 IO。")
 
 
+func test_activation_declares_and_requires_storage_without_bootstrapping_profiles() -> void:
+	var dependencies: Array[Script] = _utility.get_required_utilities()
+	assert_eq(dependencies, [GFStorageUtility])
+	var standalone: GFSaveProfileUtility = GFSaveProfileUtility.new()
+	var failed: GFAsyncCompletion = standalone.begin_activation(GFAsyncScope.new())
+	assert_true(failed.is_completed())
+	assert_false(failed.is_successful())
+	assert_true(standalone.get_profile_state_snapshot(&"implicit").is_empty())
+	standalone.dispose()
+
+	var activated: GFAsyncCompletion = _utility.begin_activation(GFAsyncScope.new())
+	assert_true(activated.is_successful(), "standalone setup 注入 Storage 后应允许激活。")
+
+
+func test_quiesce_rejects_new_admission_but_drains_accepted_profile_work() -> void:
+	var provider: MemorySectionProvider = _make_provider(&"state", 17)
+	var profile: GFSaveProfile = _make_profile(&"test.quiesce", provider)
+	assert_true(_register(profile))
+	var accepted: GFSaveProfileOperation = _utility.save_profile(profile.profile_id)
+	_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_count(), 1)
+
+	var completion: GFAsyncCompletion = _utility.begin_quiesce(GFAsyncScope.new())
+	assert_false(completion.is_completed())
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{"document": 1},
+		{"context": 2},
+		{"result": 3}
+	)
+	var rejected_save: GFSaveProfileOperation = _utility.save_profile(
+		profile.profile_id,
+		request
+	)
+	var rejected_load: GFSaveProfileOperation = _utility.load_profile(profile.profile_id)
+	var rejected_flush: GFSaveProfileOperation = _utility.flush_profile(profile.profile_id)
+	assert_eq(rejected_save.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_eq(rejected_load.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_eq(rejected_flush.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_false(request.claim_for_framework().is_empty(), "准入拒绝不得消费 save request 所有权。")
+	assert_false(_utility.unregister_profile(profile.profile_id))
+	var registration: Dictionary = _utility.register_profile(
+		_make_profile(&"test.quiesce.new", _make_provider(&"new", 1))
+	)
+	assert_true(_report_contains_issue(registration, &"utility_quiescing"))
+
+	_storage.complete_save(OK)
+
+	assert_true(accepted.is_completed())
+	assert_true(accepted.get_result().is_successful())
+	assert_true(completion.is_successful(), "已接纳 operation 和底层写入收敛后 quiesce 应成功。")
+
+
 func test_flush_waits_for_latest_generation_visible_at_call_time() -> void:
 	var provider: MemorySectionProvider = _make_provider(&"state", 1)
 	assert_true(_register(_make_profile(&"test.flush", provider)))

--- a/tests/gf_core/kernel/base/test_gf_architecture_snapshot_transactions.gd
+++ b/tests/gf_core/kernel/base/test_gf_architecture_snapshot_transactions.gd
@@ -259,7 +259,7 @@ func test_async_global_capture_fails_when_frozen_registry_changes_between_frames
 		[architecture, pending_result]
 	)
 
-	architecture.unregister_model(AsyncCaptureModelPeer)
+	assert_true(await architecture.unregister_model(AsyncCaptureModelPeer))
 	assert_true(
 		await _wait_for_result(pending_result),
 		"分帧捕获应在有界帧数内结束。"

--- a/tests/gf_core/kernel/base/test_gf_module_lifecycle_contracts.gd
+++ b/tests/gf_core/kernel/base/test_gf_module_lifecycle_contracts.gd
@@ -1,0 +1,122 @@
+# GF 模块基类激活与静默协议回归测试。
+extends GutTest
+
+
+# --- 常量 ---
+
+const GF_MODEL_SCRIPT = preload("res://addons/gf/kernel/base/gf_model.gd")
+const GF_SYSTEM_SCRIPT = preload("res://addons/gf/kernel/base/gf_system.gd")
+const GF_UTILITY_SCRIPT = preload("res://addons/gf/kernel/base/gf_utility.gd")
+
+
+# --- 测试用例 ---
+
+func test_base_modules_expose_isolated_typed_dependency_declarations() -> void:
+	var model: GF_MODEL_SCRIPT = GF_MODEL_SCRIPT.new()
+	var system_instance: GF_SYSTEM_SCRIPT = GF_SYSTEM_SCRIPT.new()
+	var utility: GF_UTILITY_SCRIPT = GF_UTILITY_SCRIPT.new()
+
+	_assert_empty_dependency_contract(model)
+	_assert_empty_dependency_contract(system_instance)
+	_assert_empty_dependency_contract(utility)
+
+
+func test_model_base_lifecycle_completions_are_already_succeeded() -> void:
+	var model: GF_MODEL_SCRIPT = GF_MODEL_SCRIPT.new()
+
+	var activation: GFAsyncCompletion = _call_completion(
+		model,
+		&"begin_activation"
+	)
+	var quiesce: GFAsyncCompletion = _call_completion(
+		model,
+		&"begin_quiesce"
+	)
+
+	assert_not_null(activation)
+	assert_not_null(quiesce)
+	assert_not_same(activation, quiesce)
+	assert_true(activation.is_completed())
+	assert_true(activation.is_successful())
+	assert_true(quiesce.is_completed())
+	assert_true(quiesce.is_successful())
+
+
+func test_system_base_lifecycle_completions_are_already_succeeded() -> void:
+	var system_instance: GF_SYSTEM_SCRIPT = GF_SYSTEM_SCRIPT.new()
+
+	var activation: GFAsyncCompletion = _call_completion(
+		system_instance,
+		&"begin_activation"
+	)
+	var quiesce: GFAsyncCompletion = _call_completion(
+		system_instance,
+		&"begin_quiesce"
+	)
+
+	assert_not_null(activation)
+	assert_not_null(quiesce)
+	assert_not_same(activation, quiesce)
+	assert_true(activation.is_completed())
+	assert_true(activation.is_successful())
+	assert_true(quiesce.is_completed())
+	assert_true(quiesce.is_successful())
+
+
+func test_utility_base_lifecycle_completions_are_already_succeeded() -> void:
+	var utility: GF_UTILITY_SCRIPT = GF_UTILITY_SCRIPT.new()
+
+	var activation: GFAsyncCompletion = _call_completion(
+		utility,
+		&"begin_activation"
+	)
+	var quiesce: GFAsyncCompletion = _call_completion(
+		utility,
+		&"begin_quiesce"
+	)
+
+	assert_not_null(activation)
+	assert_not_null(quiesce)
+	assert_not_same(activation, quiesce)
+	assert_true(activation.is_completed())
+	assert_true(activation.is_successful())
+	assert_true(quiesce.is_completed())
+	assert_true(quiesce.is_successful())
+
+
+# --- 辅助方法 ---
+
+func _assert_empty_dependency_contract(module_instance: Object) -> void:
+	var hooks: Array[StringName] = [
+		&"get_required_models",
+		&"get_required_systems",
+		&"get_required_utilities",
+		&"get_required_factories",
+	]
+	for hook: StringName in hooks:
+		var declaration: Variant = module_instance.call(hook)
+		assert_true(declaration is Array)
+		if declaration is Array:
+			var dependencies: Array = declaration
+			assert_true(dependencies.is_typed())
+			assert_true(dependencies.is_empty())
+			dependencies.append(GF_MODEL_SCRIPT)
+			var fresh_declaration: Variant = module_instance.call(hook)
+			assert_true(fresh_declaration is Array)
+			if fresh_declaration is Array:
+				var fresh_dependencies: Array = fresh_declaration
+				assert_true(
+					fresh_dependencies.is_empty(),
+					"基类每次必须返回新的依赖声明容器。"
+				)
+
+
+func _call_completion(
+	module_instance: Object,
+	hook: StringName
+) -> GFAsyncCompletion:
+	var result: Variant = module_instance.call(hook, GFAsyncScope.new())
+	if result is GFAsyncCompletion:
+		var completion: GFAsyncCompletion = result
+		return completion
+	return null

--- a/tests/gf_core/kernel/base/test_gf_module_lifecycle_contracts.gd.uid
+++ b/tests/gf_core/kernel/base/test_gf_module_lifecycle_contracts.gd.uid
@@ -1,0 +1,1 @@
+uid://ojyh3krw2q8r

--- a/tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd
@@ -1,0 +1,1724 @@
+## 验证 GFArchitecture 第四阶段激活与异步关闭边界。
+extends GutTest
+
+
+# --- 测试用模块 ---
+
+class TickBootstrapUtility extends GFUtility:
+	var lifecycle_log: Array[String] = []
+	var activation_completion: GFAsyncCompletion = null
+	var tick_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(shared_log: Array[String]) -> void:
+		lifecycle_log = shared_log
+		tick_enabled = true
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		lifecycle_log.append("provider_activation")
+		activation_completion = GFAsyncCompletion.new()
+		return activation_completion
+
+	func tick(_delta: float) -> void:
+		tick_count += 1
+		if tick_count >= 2 and activation_completion != null:
+			var _succeeded: bool = activation_completion.succeed()
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		lifecycle_log.append("provider_quiesce")
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class DependentBootstrapSystem extends GFSystem:
+	var lifecycle_log: Array[String] = []
+	var dispose_count: int = 0
+
+	func _init(shared_log: Array[String]) -> void:
+		lifecycle_log = shared_log
+
+	func get_required_utilities() -> Array[Script]:
+		return [TickBootstrapUtility]
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var provider: Object = get_utility(TickBootstrapUtility)
+		lifecycle_log.append(
+			"consumer_activation_ready"
+			if provider is TickBootstrapUtility
+			else "consumer_activation_missing"
+		)
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		lifecycle_log.append("consumer_quiesce")
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class FailingActivationUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _failed: bool = completion.fail("activation fixture failure")
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class PendingActivationUtility extends GFUtility:
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		return GFAsyncCompletion.new()
+
+
+class StableShutdownUtility extends GFUtility:
+	var activation_count: int = 0
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class AwaitedHotRegisterUtility extends GFUtility:
+	var activation_completion: GFAsyncCompletion = null
+	var activation_count: int = 0
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		activation_completion = GFAsyncCompletion.new()
+		return activation_completion
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+	func complete_activation() -> bool:
+		return (
+			activation_completion != null
+			and activation_completion.succeed()
+		)
+
+
+class AwaitedHotReplaceUtility extends GFUtility:
+	var block_activation: bool = false
+	var activation_completion: GFAsyncCompletion = null
+	var activation_count: int = 0
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(p_block_activation: bool) -> void:
+		block_activation = p_block_activation
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		activation_completion = GFAsyncCompletion.new()
+		if not block_activation:
+			var _succeeded: bool = activation_completion.succeed()
+		return activation_completion
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+	func complete_activation() -> bool:
+		return (
+			activation_completion != null
+			and activation_completion.succeed()
+		)
+
+
+class FailDuringHotActivationUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var architecture: GFArchitecture = _get_architecture_or_null()
+		if architecture != null:
+			architecture.fail_initialization(
+				"[test] fail during synchronous hot activation"
+			)
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class CancelDuringQuiesceUtility extends GFUtility:
+	var cancellation_source: GFCancellationSource = null
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(source: GFCancellationSource) -> void:
+		cancellation_source = source
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var _cancelled: bool = cancellation_source.cancel(
+			&"cancel_during_synchronous_quiesce"
+		)
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class DeadlineCrossingQuiesceUtility extends GFUtility:
+	var block_msec: int = 0
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(p_block_msec: int) -> void:
+		block_msec = p_block_msec
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var release_at_msec: int = Time.get_ticks_msec() + block_msec
+		while Time.get_ticks_msec() < release_at_msec:
+			pass
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class AwaitedHotUnregisterUtility extends GFUtility:
+	var quiesce_completion: GFAsyncCompletion = null
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		quiesce_completion = GFAsyncCompletion.new()
+		return quiesce_completion
+
+	func complete_quiesce() -> bool:
+		return (
+			quiesce_completion != null
+			and quiesce_completion.succeed()
+		)
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class CancelAfterAsyncInitUtility extends GFUtility:
+	var cancellation_source: GFCancellationSource = null
+	var ready_count: int = 0
+	var activation_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(source: GFCancellationSource) -> void:
+		cancellation_source = source
+
+	func async_init(_scope: GFAsyncScope) -> void:
+		var _cancelled: bool = cancellation_source.cancel(
+			&"cancel_after_async_init"
+		)
+
+	func ready() -> void:
+		ready_count += 1
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class CancelAfterActivationSuccessUtility extends GFUtility:
+	var cancellation_source: GFCancellationSource = null
+	var activation_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(source: GFCancellationSource) -> void:
+		cancellation_source = source
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		var _cancelled: bool = cancellation_source.cancel(
+			&"cancel_before_ready_commit"
+		)
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class ReversePlanDependencyUtility extends GFUtility:
+	var dispose_log: Array[String] = []
+	var dispose_count: int = 0
+
+	func _init(shared_log: Array[String]) -> void:
+		dispose_log = shared_log
+
+	func dispose() -> void:
+		dispose_count += 1
+		dispose_log.append("dependency")
+
+
+class ReversePlanConsumerUtility extends GFUtility:
+	var dispose_log: Array[String] = []
+	var dispose_count: int = 0
+
+	func _init(shared_log: Array[String]) -> void:
+		dispose_log = shared_log
+
+	func get_required_utilities() -> Array[Script]:
+		return [ReversePlanDependencyUtility]
+
+	func dispose() -> void:
+		dispose_count += 1
+		dispose_log.append("consumer")
+
+
+class ReversePlanFailingUtility extends GFUtility:
+	var dispose_log: Array[String] = []
+	var dispose_count: int = 0
+
+	func _init(shared_log: Array[String]) -> void:
+		dispose_log = shared_log
+
+	func get_required_utilities() -> Array[Script]:
+		return [ReversePlanConsumerUtility]
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _failed: bool = completion.fail("reverse cleanup fixture failure")
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+		dispose_log.append("failing")
+
+
+class ReadyFailureDisposeProbeUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class CapturedPendingActivationUtility extends GFUtility:
+	var activation_completion: GFAsyncCompletion = null
+	var activation_count: int = 0
+	var dispose_count: int = 0
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		activation_completion = GFAsyncCompletion.new()
+		return activation_completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+	func complete_activation() -> bool:
+		return (
+			activation_completion != null
+			and activation_completion.succeed()
+		)
+
+
+class TickDrivenQuiesceUtility extends GFUtility:
+	var quiesce_completion: GFAsyncCompletion = null
+	var quiesce_started: bool = false
+	var quiesce_tick_count: int = 0
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func _init() -> void:
+		tick_enabled = true
+
+	func tick(_delta: float) -> void:
+		if not quiesce_started:
+			return
+		quiesce_tick_count += 1
+		if quiesce_tick_count >= 2 and quiesce_completion != null:
+			var _succeeded: bool = quiesce_completion.succeed()
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		quiesce_started = true
+		quiesce_completion = GFAsyncCompletion.new()
+		return quiesce_completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class FailingQuiesceUtility extends GFUtility:
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _failed: bool = completion.fail("typed quiesce fixture failure")
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class PendingDependentQuiesceUtility extends GFUtility:
+	var quiesce_completion: GFAsyncCompletion = null
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func get_required_utilities() -> Array[Script]:
+		return [StableShutdownUtility]
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		quiesce_completion = GFAsyncCompletion.new()
+		return quiesce_completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+	func complete_quiesce() -> bool:
+		return (
+			quiesce_completion != null
+			and quiesce_completion.succeed()
+		)
+
+
+class ReentrantShutdownDisposeUtility extends GFUtility:
+	var owner_architecture: GFArchitecture = null
+	var dispose_count: int = 0
+	var reentrant_request_count: int = 0
+	var reentrant_done: bool = false
+	var reentrant_result: GFArchitectureShutdownResult = null
+
+	func _init(architecture: GFArchitecture) -> void:
+		owner_architecture = architecture
+
+	func dispose() -> void:
+		dispose_count += 1
+		if owner_architecture == null:
+			return
+		reentrant_request_count += 1
+		@warning_ignore("missing_await")
+		_capture_reentrant_shutdown(owner_architecture)
+
+	func _capture_reentrant_shutdown(architecture: GFArchitecture) -> void:
+		reentrant_result = await architecture.shutdown_async()
+		reentrant_done = true
+
+
+class ReentrantFailureCleanupUtility extends GFUtility:
+	var owner_architecture: GFArchitecture = null
+	var dispose_count: int = 0
+
+	func _init(architecture: GFArchitecture) -> void:
+		owner_architecture = architecture
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _failed: bool = completion.fail(
+			"reentrant failure cleanup fixture"
+		)
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+		if owner_architecture != null:
+			owner_architecture.dispose()
+
+
+class NestedCleanupSiblingUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class SecondIndependentUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class RuntimeFactoryProduct extends RefCounted:
+	pass
+
+
+# --- 测试 ---
+
+func test_activation_waits_for_dependency_tick_before_ready_commit() -> void:
+	var lifecycle_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var consumer: DependentBootstrapSystem = DependentBootstrapSystem.new(
+		lifecycle_log
+	)
+	var provider: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+
+	assert_true(await architecture.register_system_instance(consumer))
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(await architecture.init())
+	assert_true(architecture.is_inited())
+	assert_true(architecture.is_module_active(provider))
+	assert_true(architecture.is_module_active(consumer))
+	assert_gte(provider.tick_count, 2)
+	assert_eq(
+		lifecycle_log,
+		["provider_activation", "consumer_activation_ready"],
+		"依赖必须先激活，且只允许依赖闭包 tick 推进 bootstrap。"
+	)
+
+	var shutdown_result: GFArchitectureShutdownResult = (
+		await architecture.shutdown_async()
+	)
+	assert_true(shutdown_result.is_successful())
+	assert_eq(
+		lifecycle_log,
+		[
+			"provider_activation",
+			"consumer_activation_ready",
+			"consumer_quiesce",
+			"provider_quiesce",
+		],
+		"quiesce 必须严格逆转已提交的激活顺序。"
+	)
+	assert_eq(consumer.dispose_count, 1)
+	assert_eq(provider.dispose_count, 1)
+
+
+func test_activation_failure_never_opens_runtime_admission() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: FailingActivationUtility = FailingActivationUtility.new()
+	assert_true(await architecture.register_utility_instance(utility))
+
+	assert_false(await architecture.init())
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_false(architecture.is_module_active(utility))
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] activation 失败")
+	architecture.dispose()
+
+
+func test_failed_initialization_requires_an_explicit_retry_call() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: FailingActivationUtility = FailingActivationUtility.new()
+	assert_true(await architecture.register_utility_instance(utility))
+
+	assert_false(await architecture.init())
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] activation 失败")
+
+	assert_true(await architecture.init())
+	assert_true(architecture.is_inited())
+	assert_true(architecture.is_accepting_runtime_work())
+	assert_eq(utility.dispose_count, 1, "失败模块不得被隐式重新登记或重复释放。")
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+
+
+func test_pre_cancelled_initialization_fails_closed() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var source: GFCancellationSource = GFCancellationSource.new()
+	assert_true(source.cancel(&"test_cancel"))
+
+	assert_false(await architecture.init(source.get_token()))
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_push_error("[GFArchitecture] 初始化已取消")
+	architecture.dispose()
+	source.dispose()
+
+
+func test_pending_activation_without_scene_tree_fails_instead_of_busy_spin() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.activation_timeout_seconds = 0.01
+	var utility: PendingActivationUtility = PendingActivationUtility.new()
+	assert_true(await architecture.register_utility_instance(utility))
+
+	assert_false(await architecture.init())
+	assert_true(architecture.has_initialization_failed())
+	assert_push_error("[GFArchitecture] activation 失败")
+	architecture.dispose()
+
+
+func test_pending_activation_external_cancellation_rejects_late_success() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var source: GFCancellationSource = GFCancellationSource.new()
+	var utility: CapturedPendingActivationUtility = (
+		CapturedPendingActivationUtility.new()
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+	var init_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+
+	@warning_ignore("missing_await")
+	_await_init(architecture, source.get_token(), init_state)
+	await get_tree().process_frame
+	assert_eq(utility.activation_count, 1)
+	assert_not_null(utility.activation_completion)
+	assert_true(source.cancel(&"cancel_pending_activation"))
+	await _wait_until_states_done([init_state])
+
+	assert_false(GFVariantData.get_option_bool(init_state, "result"))
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_inited())
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_true(utility.activation_completion.is_cancelled())
+	assert_eq(
+		utility.activation_completion.get_cancel_reason(),
+		&"cancel_pending_activation"
+	)
+	assert_false(utility.complete_activation(), "取消终态不得接受迟到 activation 成功。")
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] activation 已取消")
+
+	architecture.dispose()
+	assert_eq(utility.dispose_count, 1)
+	source.dispose()
+
+
+func test_concurrent_init_waiter_can_cancel_without_aborting_shared_activation() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: CapturedPendingActivationUtility = (
+		CapturedPendingActivationUtility.new()
+	)
+	var primary_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	var waiter_state: Dictionary = {
+		"done": false,
+		"result": true,
+	}
+	var waiter_source: GFCancellationSource = GFCancellationSource.new()
+	assert_true(await architecture.register_utility_instance(utility))
+
+	@warning_ignore("missing_await")
+	_await_init(architecture, null, primary_state)
+	await get_tree().process_frame
+	assert_true(architecture.is_activating())
+
+	@warning_ignore("missing_await")
+	_await_init(architecture, waiter_source.get_token(), waiter_state)
+	await get_tree().process_frame
+	assert_true(waiter_source.cancel(&"cancel_joined_init_wait"))
+	await _wait_until_states_done([waiter_state])
+
+	assert_false(GFVariantData.get_option_bool(waiter_state, "result"))
+	assert_false(GFVariantData.get_option_bool(primary_state, "done"))
+	assert_true(architecture.is_activating(), "waiter 取消不得劫持共享初始化事务。")
+	assert_false(utility.activation_completion.is_cancelled())
+
+	assert_true(utility.complete_activation())
+	await _wait_until_states_done([primary_state])
+	assert_true(GFVariantData.get_option_bool(primary_state, "result"))
+	assert_true(architecture.is_inited())
+
+	var already_cancelled: GFCancellationSource = GFCancellationSource.new()
+	assert_true(already_cancelled.cancel(&"ready_idempotent_call"))
+	assert_true(
+		await architecture.init(already_cancelled.get_token()),
+		"架构已经 READY 时，幂等成功应优先于调用方取消状态。"
+	)
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+	waiter_source.dispose()
+	already_cancelled.dispose()
+
+
+func test_pending_activation_deadline_rejects_late_success() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.activation_timeout_seconds = 0.001
+	var utility: CapturedPendingActivationUtility = (
+		CapturedPendingActivationUtility.new()
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+
+	assert_false(await architecture.init())
+
+	assert_eq(utility.activation_count, 1)
+	assert_not_null(utility.activation_completion)
+	assert_true(utility.activation_completion.is_cancelled())
+	assert_eq(
+		utility.activation_completion.get_cancel_reason(),
+		&"lifecycle_timeout"
+	)
+	assert_false(utility.complete_activation(), "超时终态不得接受迟到 activation 成功。")
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_inited())
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] activation 失败")
+
+	architecture.dispose()
+	assert_eq(utility.dispose_count, 1)
+
+
+func test_forced_dispose_runs_module_cleanup_exactly_once() -> void:
+	var lifecycle_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var provider: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(await architecture.init())
+
+	architecture.dispose()
+	architecture.dispose()
+
+	assert_eq(provider.dispose_count, 1)
+	assert_true(architecture.is_disposed())
+	var result: GFArchitectureShutdownResult = architecture.get_last_shutdown_result()
+	assert_not_null(result)
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.FORCED)
+	var unfinished_modules: Array[Dictionary] = result.get_unfinished_modules()
+	assert_eq(unfinished_modules.size(), 1)
+	assert_eq(
+		GFVariantData.get_option_int(unfinished_modules[0], "instance_id"),
+		provider.get_instance_id()
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(unfinished_modules[0], "status"),
+		&"skipped"
+	)
+
+
+func test_shutdown_interrupting_activation_reports_forced_unfinished_module() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: CapturedPendingActivationUtility = (
+		CapturedPendingActivationUtility.new()
+	)
+	var init_state: Dictionary = {
+		"done": false,
+		"result": true,
+	}
+	assert_true(await architecture.register_utility_instance(utility))
+	@warning_ignore("missing_await")
+	_await_init(architecture, null, init_state)
+	await get_tree().process_frame
+	assert_true(architecture.is_activating())
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	await _wait_until_states_done([init_state])
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.FORCED)
+	assert_false(GFVariantData.get_option_bool(init_state, "result"))
+	assert_eq(utility.dispose_count, 1)
+	var unfinished_modules: Array[Dictionary] = result.get_unfinished_modules()
+	assert_eq(unfinished_modules.size(), 1)
+	assert_eq(
+		GFVariantData.get_option_int(unfinished_modules[0], "instance_id"),
+		utility.get_instance_id()
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(unfinished_modules[0], "status"),
+		&"skipped"
+	)
+
+
+func test_direct_dispose_hook_reentrant_shutdown_publishes_one_terminal_result() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: ReentrantShutdownDisposeUtility = (
+		ReentrantShutdownDisposeUtility.new(architecture)
+	)
+	var signal_state: Dictionary = {
+		"count": 0,
+		"status": -1,
+	}
+	var shutdown_callback: Callable = Callable(
+		self,
+		&"_record_shutdown_finished"
+	).bind(signal_state)
+	var connect_error: Error = architecture.shutdown_finished.connect(
+		shutdown_callback
+	) as Error
+	assert_eq(connect_error, OK)
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	architecture.dispose()
+	await get_tree().process_frame
+
+	assert_true(architecture.is_disposed())
+	assert_eq(utility.dispose_count, 1)
+	assert_eq(utility.reentrant_request_count, 1)
+	assert_true(utility.reentrant_done)
+	assert_not_null(utility.reentrant_result)
+	if utility.reentrant_result != null:
+		assert_eq(
+			utility.reentrant_result.get_status(),
+			GFArchitectureShutdownResult.Status.FORCED
+		)
+		assert_eq(utility.reentrant_result.get_duplicate_request_count(), 1)
+	assert_eq(GFVariantData.get_option_int(signal_state, "count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(signal_state, "status"),
+		GFArchitectureShutdownResult.Status.FORCED
+	)
+	var last_result: GFArchitectureShutdownResult = (
+		architecture.get_last_shutdown_result()
+	)
+	assert_not_null(last_result)
+	assert_eq(last_result.get_duplicate_request_count(), 1)
+
+
+func test_failure_cleanup_reentrant_dispose_releases_each_module_once() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var sibling: NestedCleanupSiblingUtility = NestedCleanupSiblingUtility.new()
+	var failing: ReentrantFailureCleanupUtility = (
+		ReentrantFailureCleanupUtility.new(architecture)
+	)
+	assert_true(await architecture.register_utility_instance(sibling))
+	assert_true(await architecture.register_utility_instance(failing))
+
+	assert_false(await architecture.init())
+
+	assert_true(architecture.is_disposed())
+	assert_eq(failing.dispose_count, 1)
+	assert_eq(sibling.dispose_count, 1)
+	var result: GFArchitectureShutdownResult = architecture.get_last_shutdown_result()
+	assert_not_null(result)
+	if result != null:
+		assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.FORCED)
+	assert_push_error("[GFArchitecture] activation 失败")
+
+	architecture.dispose()
+	assert_eq(failing.dispose_count, 1)
+	assert_eq(sibling.dispose_count, 1)
+
+
+func test_hot_register_runs_full_activation_transaction() -> void:
+	var lifecycle_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await architecture.init())
+	var provider: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(architecture.is_module_active(provider))
+	assert_gte(provider.tick_count, 2)
+	assert_eq(lifecycle_log, ["provider_activation"])
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+	assert_eq(provider.dispose_count, 1)
+
+
+func test_factory_creation_is_rejected_while_hot_topology_is_pending() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var invocation_state: Dictionary = {"count": 0}
+	var factory: Callable = func() -> Object:
+		invocation_state["count"] = (
+			GFVariantData.get_option_int(invocation_state, "count") + 1
+		)
+		return RuntimeFactoryProduct.new()
+	assert_true(architecture.register_factory(RuntimeFactoryProduct, factory))
+	assert_true(await architecture.init())
+	var candidate: AwaitedHotRegisterUtility = (
+		AwaitedHotRegisterUtility.new()
+	)
+	var topology_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+
+	@warning_ignore("missing_await")
+	_await_hot_register(architecture, candidate, topology_state)
+	await get_tree().process_frame
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_null(architecture.create_instance(RuntimeFactoryProduct))
+	assert_eq(GFVariantData.get_option_int(invocation_state, "count"), 0)
+	assert_push_error("模块拓扑事务尚未完成")
+
+	assert_true(candidate.complete_activation())
+	await _wait_until_states_done([topology_state])
+	assert_true(GFVariantData.get_option_bool(topology_state, "result"))
+	assert_not_null(architecture.create_instance(RuntimeFactoryProduct))
+	assert_eq(GFVariantData.get_option_int(invocation_state, "count"), 1)
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+
+
+func test_factory_creation_is_rejected_after_quiesce_closes_admission() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var invocation_state: Dictionary = {"count": 0}
+	var factory: Callable = func() -> Object:
+		invocation_state["count"] = (
+			GFVariantData.get_option_int(invocation_state, "count") + 1
+		)
+		return RuntimeFactoryProduct.new()
+	var provider: StableShutdownUtility = StableShutdownUtility.new()
+	var quiesce_gate: PendingDependentQuiesceUtility = (
+		PendingDependentQuiesceUtility.new()
+	)
+	assert_true(architecture.register_factory(RuntimeFactoryProduct, factory))
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(await architecture.register_utility_instance(quiesce_gate))
+	assert_true(await architecture.init())
+	var shutdown_state: Dictionary = {
+		"done": false,
+		"result": null,
+	}
+
+	@warning_ignore("missing_await")
+	_await_shutdown(architecture, null, 1.0, shutdown_state)
+	await get_tree().process_frame
+	assert_true(architecture.is_quiescing())
+	assert_null(architecture.create_instance(RuntimeFactoryProduct))
+	assert_eq(GFVariantData.get_option_int(invocation_state, "count"), 0)
+	assert_push_error("架构正在 quiesce")
+
+	assert_true(quiesce_gate.complete_quiesce())
+	await _wait_until_states_done([shutdown_state])
+	var result: GFArchitectureShutdownResult = (
+		_shutdown_result_from_state(shutdown_state)
+	)
+	assert_not_null(result)
+	assert_true(result.is_successful())
+
+
+func test_synchronous_hot_activation_failure_does_not_restore_plan_or_double_dispose() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var stable: StableShutdownUtility = StableShutdownUtility.new()
+	assert_true(await architecture.register_utility_instance(stable))
+	assert_true(await architecture.init())
+	var candidate: FailDuringHotActivationUtility = (
+		FailDuringHotActivationUtility.new()
+	)
+
+	assert_false(await architecture.register_utility_instance(candidate))
+	assert_true(architecture.has_initialization_failed())
+	assert_eq(stable.dispose_count, 1)
+	assert_eq(candidate.dispose_count, 1)
+	var dependency_report: Dictionary = architecture.get_dependency_diagnostics()
+	assert_eq(
+		GFVariantData.get_option_int(dependency_report, "module_count"),
+		0,
+		"同步成功 completion 不得在 fail_initialization 后恢复陈旧 lifecycle plan。"
+	)
+	assert_push_error("[test] fail during synchronous hot activation")
+	assert_push_error("[GFArchitecture] 热模块 activation 失败")
+
+	architecture.dispose()
+	architecture.dispose()
+	assert_eq(stable.dispose_count, 1, "失败清理后的旧计划模块不得再次 dispose。")
+	assert_eq(candidate.dispose_count, 1, "失败清理后的热注册候选不得再次 dispose。")
+
+
+func test_hot_replace_activates_candidate_before_old_quiesce_and_commit() -> void:
+	var lifecycle_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+	var replacement: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+
+	assert_true(
+		await architecture.replace_utility(
+			TickBootstrapUtility,
+			replacement
+		)
+	)
+	assert_eq(
+		architecture.get_utility(TickBootstrapUtility, true),
+		replacement
+	)
+	assert_true(architecture.is_module_active(replacement))
+	assert_false(architecture.is_module_active(previous))
+	assert_eq(previous.dispose_count, 1)
+	assert_eq(
+		lifecycle_log,
+		[
+			"provider_activation",
+			"provider_activation",
+			"provider_quiesce",
+		],
+		"候选 activation 成功后，旧实例必须先 quiesce 再提交替换。"
+	)
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+	assert_eq(previous.dispose_count, 1)
+	assert_eq(replacement.dispose_count, 1)
+
+
+func test_hot_unregister_rejects_removing_live_dependency() -> void:
+	var lifecycle_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var provider: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+	var consumer: DependentBootstrapSystem = DependentBootstrapSystem.new(
+		lifecycle_log
+	)
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(await architecture.register_system_instance(consumer))
+	assert_true(await architecture.init())
+
+	assert_false(
+		await architecture.unregister_utility(TickBootstrapUtility),
+		"仍被活动模块声明依赖的 provider 不得从候选 DAG 移除。"
+	)
+	assert_eq(
+		architecture.get_utility(TickBootstrapUtility, true),
+		provider
+	)
+	assert_push_error("[GFArchitecture] hot unregister 失败")
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+
+
+func test_hot_unregister_quiesces_and_removes_independent_module() -> void:
+	var lifecycle_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var provider: TickBootstrapUtility = TickBootstrapUtility.new(lifecycle_log)
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(await architecture.init())
+
+	assert_true(await architecture.unregister_utility(TickBootstrapUtility))
+	assert_null(architecture.get_utility(TickBootstrapUtility))
+	assert_eq(provider.dispose_count, 1)
+	assert_eq(
+		lifecycle_log,
+		["provider_activation", "provider_quiesce"]
+	)
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+	assert_eq(provider.dispose_count, 1)
+
+
+func test_hot_unregister_uses_stable_identity_not_registry_ordinal() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var first: StableShutdownUtility = StableShutdownUtility.new()
+	var second: SecondIndependentUtility = SecondIndependentUtility.new()
+	assert_true(await architecture.register_utility_instance(first))
+	assert_true(await architecture.register_utility_instance(second))
+	assert_true(await architecture.init())
+
+	assert_true(
+		await architecture.unregister_utility(StableShutdownUtility),
+		"删除同类注册表的首项不得让后续独立模块因 ordinal 改变被误判依赖漂移。"
+	)
+
+	assert_eq(first.dispose_count, 1)
+	assert_same(
+		architecture.get_local_utility(
+			SecondIndependentUtility,
+			true
+		),
+		second
+	)
+	assert_true(architecture.is_module_active(second))
+	assert_eq(second.dispose_count, 0)
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+	assert_true(result.is_successful())
+	assert_eq(second.dispose_count, 1)
+
+
+func test_shutdown_waits_for_accepted_hot_register_before_quiescing_final_plan() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var stable: StableShutdownUtility = StableShutdownUtility.new()
+	assert_true(await architecture.register_utility_instance(stable))
+	assert_true(await architecture.init())
+
+	var candidate: AwaitedHotRegisterUtility = AwaitedHotRegisterUtility.new()
+	var register_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	@warning_ignore("missing_await")
+	_await_hot_register(architecture, candidate, register_state)
+	await get_tree().process_frame
+	assert_eq(candidate.activation_count, 1)
+
+	var shutdown_state: Dictionary = {
+		"done": false,
+		"result": null,
+	}
+	@warning_ignore("missing_await")
+	_await_shutdown(architecture, null, 0.5, shutdown_state)
+	await get_tree().process_frame
+
+	assert_false(architecture.is_accepting_runtime_work(), "shutdown 开始后必须先关闭新工作准入。")
+	assert_false(
+		GFVariantData.get_option_bool(shutdown_state, "done"),
+		"已接纳 hot register 未稳定前 shutdown 不得提前完成。"
+	)
+	assert_eq(stable.quiesce_count, 0, "topology 稳定前不得 quiesce 旧计划模块。")
+	assert_eq(candidate.quiesce_count, 0, "topology 稳定前不得 quiesce 注册候选。")
+
+	assert_true(candidate.complete_activation())
+	await _wait_until_states_done([register_state, shutdown_state])
+
+	assert_true(GFVariantData.get_option_bool(register_state, "result"))
+	var result: GFArchitectureShutdownResult = _shutdown_result_from_state(
+		shutdown_state
+	)
+	assert_not_null(result)
+	assert_true(result.is_successful())
+	assert_eq(stable.quiesce_count, 1, "最终计划中的旧模块只应 quiesce 一次。")
+	assert_eq(candidate.quiesce_count, 1, "最终计划中的注册候选只应 quiesce 一次。")
+	assert_eq(stable.dispose_count, 1)
+	assert_eq(candidate.dispose_count, 1)
+
+
+func test_shutdown_waits_for_accepted_hot_replace_before_quiescing_final_plan() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: AwaitedHotReplaceUtility = AwaitedHotReplaceUtility.new(false)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+
+	var replacement: AwaitedHotReplaceUtility = AwaitedHotReplaceUtility.new(true)
+	var replace_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	@warning_ignore("missing_await")
+	_await_hot_replace(architecture, replacement, replace_state)
+	await get_tree().process_frame
+	assert_eq(replacement.activation_count, 1)
+
+	var shutdown_state: Dictionary = {
+		"done": false,
+		"result": null,
+	}
+	@warning_ignore("missing_await")
+	_await_shutdown(architecture, null, 0.5, shutdown_state)
+	await get_tree().process_frame
+
+	assert_false(architecture.is_accepting_runtime_work(), "shutdown 开始后必须先关闭新工作准入。")
+	assert_false(
+		GFVariantData.get_option_bool(shutdown_state, "done"),
+		"已接纳 hot replace 未稳定前 shutdown 不得提前完成。"
+	)
+	assert_eq(previous.quiesce_count, 0, "候选 activation 未完成前不得 quiesce 旧实例。")
+	assert_eq(replacement.quiesce_count, 0, "topology 稳定前不得 quiesce 替换候选。")
+
+	assert_true(replacement.complete_activation())
+	await _wait_until_states_done([replace_state, shutdown_state])
+
+	assert_true(GFVariantData.get_option_bool(replace_state, "result"))
+	var result: GFArchitectureShutdownResult = _shutdown_result_from_state(
+		shutdown_state
+	)
+	assert_not_null(result)
+	assert_true(result.is_successful())
+	assert_eq(previous.quiesce_count, 1, "旧实例只应由已接纳 replace 事务 quiesce 一次。")
+	assert_eq(replacement.quiesce_count, 1, "最终计划中的替换实例只应由 shutdown quiesce 一次。")
+	assert_eq(previous.dispose_count, 1)
+	assert_eq(replacement.dispose_count, 1)
+
+
+func test_topology_wait_timeout_forces_cleanup_without_late_commit_or_double_dispose() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: AwaitedHotReplaceUtility = AwaitedHotReplaceUtility.new(false)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+
+	var replacement: AwaitedHotReplaceUtility = AwaitedHotReplaceUtility.new(true)
+	var replace_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	@warning_ignore("missing_await")
+	_await_hot_replace(architecture, replacement, replace_state)
+	await get_tree().process_frame
+	assert_eq(replacement.activation_count, 1)
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		null,
+		0.001
+	)
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.TIMED_OUT)
+	assert_true(architecture.is_disposed())
+	assert_eq(previous.dispose_count, 1, "shutdown 返回时旧实例必须已经 exactly-once 释放。")
+	assert_eq(
+		replacement.dispose_count,
+		1,
+		"shutdown 超时结果返回下一行，未提交替换候选必须已经清理。"
+	)
+
+	await _wait_until_states_done([replace_state])
+	assert_false(GFVariantData.get_option_bool(replace_state, "result"))
+	assert_eq(previous.dispose_count, 1, "强制释放旧实例必须 exactly-once。")
+	assert_eq(replacement.dispose_count, 1, "未提交替换候选也必须 exactly-once 清理。")
+
+	assert_false(replacement.complete_activation(), "超时取消后的 activation completion 不得迟到成功。")
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_eq(previous.dispose_count, 1, "迟到恢复不得重复释放旧实例。")
+	assert_eq(replacement.dispose_count, 1, "迟到恢复不得重复释放替换候选。")
+	assert_true(architecture.is_disposed(), "迟到恢复不得重新提交 topology。")
+	assert_push_error("[GFArchitecture] 热模块 activation 失败")
+
+
+func test_topology_wait_cancel_cleans_pending_replacement_before_return() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: AwaitedHotReplaceUtility = AwaitedHotReplaceUtility.new(false)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+
+	var replacement: AwaitedHotReplaceUtility = AwaitedHotReplaceUtility.new(true)
+	var replace_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	@warning_ignore("missing_await")
+	_await_hot_replace(architecture, replacement, replace_state)
+	await get_tree().process_frame
+	assert_eq(replacement.activation_count, 1)
+
+	var source: GFCancellationSource = GFCancellationSource.new()
+	@warning_ignore("missing_await")
+	_cancel_on_next_frame(source, &"cancel_pending_hot_replacement")
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		source.get_token(),
+		0.5
+	)
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.CANCELLED)
+	assert_eq(result.get_cancel_reason(), "cancel_pending_hot_replacement")
+	assert_true(architecture.is_disposed())
+	assert_eq(previous.dispose_count, 1, "shutdown 返回时旧实例必须已经 exactly-once 释放。")
+	assert_eq(
+		replacement.dispose_count,
+		1,
+		"shutdown 取消结果返回下一行，未提交替换候选必须已经清理。"
+	)
+
+	await _wait_until_states_done([replace_state])
+	assert_false(GFVariantData.get_option_bool(replace_state, "result"))
+	assert_false(replacement.complete_activation(), "取消后的 activation completion 不得迟到成功。")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(previous.dispose_count, 1)
+	assert_eq(replacement.dispose_count, 1, "迟到 continuation 不得重复清理替换候选。")
+	assert_push_error("[GFArchitecture] 热模块 activation 失败")
+	source.dispose()
+
+
+func test_concurrent_shutdown_is_single_flight_and_first_caller_owns_policy() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: AwaitedHotUnregisterUtility = AwaitedHotUnregisterUtility.new()
+	var signal_state: Dictionary = {
+		"count": 0,
+		"status": -1,
+	}
+	var shutdown_callback: Callable = Callable(
+		self,
+		&"_record_shutdown_finished"
+	).bind(signal_state)
+	var connect_error: Error = architecture.shutdown_finished.connect(
+		shutdown_callback
+	) as Error
+	assert_eq(connect_error, OK)
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	var first_state: Dictionary = {
+		"done": false,
+		"result": null,
+	}
+	@warning_ignore("missing_await")
+	_await_shutdown(architecture, null, 0.5, first_state)
+	await get_tree().process_frame
+	assert_eq(utility.quiesce_count, 1)
+
+	var duplicate_source: GFCancellationSource = GFCancellationSource.new()
+	assert_true(duplicate_source.cancel(&"duplicate_policy_must_not_win"))
+	var second_state: Dictionary = {
+		"done": false,
+		"result": null,
+	}
+	@warning_ignore("missing_await")
+	_await_shutdown(
+		architecture,
+		duplicate_source.get_token(),
+		0.001,
+		second_state
+	)
+	await get_tree().process_frame
+	assert_false(GFVariantData.get_option_bool(first_state, "done"))
+	assert_false(GFVariantData.get_option_bool(second_state, "done"))
+	assert_eq(utility.quiesce_count, 1, "重复 shutdown 不得再次调用 quiesce hook。")
+
+	assert_true(utility.complete_quiesce())
+	await _wait_until_states_done([first_state, second_state])
+
+	var first_result: GFArchitectureShutdownResult = (
+		_shutdown_result_from_state(first_state)
+	)
+	var second_result: GFArchitectureShutdownResult = (
+		_shutdown_result_from_state(second_state)
+	)
+	assert_not_null(first_result)
+	assert_not_null(second_result)
+	assert_true(first_result.is_successful())
+	assert_true(second_result.is_successful())
+	assert_eq(first_result.get_duplicate_request_count(), 1)
+	assert_eq(second_result.get_duplicate_request_count(), 1)
+	assert_eq(
+		first_result.get_started_at_msec(),
+		second_result.get_started_at_msec()
+	)
+	assert_eq(
+		first_result.get_completed_at_msec(),
+		second_result.get_completed_at_msec()
+	)
+	assert_eq(first_result.get_module_results(), second_result.get_module_results())
+	assert_eq(utility.quiesce_count, 1)
+	assert_eq(utility.dispose_count, 1)
+	assert_eq(GFVariantData.get_option_int(signal_state, "count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(signal_state, "status"),
+		GFArchitectureShutdownResult.Status.SUCCEEDED
+	)
+	duplicate_source.dispose()
+
+
+func test_shutdown_quiesce_can_complete_from_lifecycle_tick() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: TickDrivenQuiesceUtility = TickDrivenQuiesceUtility.new()
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		null,
+		0.5
+	)
+
+	assert_true(result.is_successful())
+	assert_eq(utility.quiesce_count, 1)
+	assert_gte(utility.quiesce_tick_count, 2)
+	assert_true(utility.quiesce_completion.is_successful())
+	assert_eq(utility.dispose_count, 1)
+	var module_results: Array[Dictionary] = result.get_module_results()
+	assert_eq(module_results.size(), 1)
+	assert_eq(
+		GFVariantData.get_option_string_name(module_results[0], "status"),
+		&"succeeded"
+	)
+
+
+func test_failed_quiesce_returns_typed_module_evidence() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: FailingQuiesceUtility = FailingQuiesceUtility.new()
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async()
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.FAILED)
+	assert_eq(result.get_error_code(), FAILED)
+	assert_eq(utility.quiesce_count, 1)
+	assert_eq(utility.dispose_count, 1)
+	var module_results: Array[Dictionary] = result.get_module_results()
+	var unfinished_modules: Array[Dictionary] = result.get_unfinished_modules()
+	assert_eq(module_results.size(), 1)
+	assert_eq(unfinished_modules.size(), 1)
+	var module_entry: Dictionary = module_results[0]
+	var unfinished_entry: Dictionary = unfinished_modules[0]
+	assert_eq(
+		GFVariantData.get_option_string_name(module_entry, "kind"),
+		&"utility"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(module_entry, "instance_id"),
+		utility.get_instance_id()
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(module_entry, "status"),
+		&"failed"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(module_entry, "reason"),
+		"typed quiesce fixture failure"
+	)
+	assert_eq(unfinished_entry, module_entry)
+
+
+func test_timed_out_quiesce_reports_current_and_skipped_modules() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var provider: StableShutdownUtility = StableShutdownUtility.new()
+	var timed_out_utility: PendingDependentQuiesceUtility = (
+		PendingDependentQuiesceUtility.new()
+	)
+	assert_true(await architecture.register_utility_instance(provider))
+	assert_true(await architecture.register_utility_instance(timed_out_utility))
+	assert_true(await architecture.init())
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		null,
+		0.5
+	)
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.TIMED_OUT)
+	assert_eq(result.get_error_code(), ERR_TIMEOUT)
+	assert_eq(timed_out_utility.quiesce_count, 1)
+	assert_eq(provider.quiesce_count, 0, "deadline 后不得开始后续 provider quiesce。")
+	assert_not_null(timed_out_utility.quiesce_completion)
+	if timed_out_utility.quiesce_completion != null:
+		assert_true(timed_out_utility.quiesce_completion.is_cancelled())
+	assert_false(timed_out_utility.complete_quiesce(), "超时 completion 不得接受迟到成功。")
+	var module_results: Array[Dictionary] = result.get_module_results()
+	var unfinished_modules: Array[Dictionary] = result.get_unfinished_modules()
+	assert_eq(module_results.size(), 1)
+	assert_eq(unfinished_modules.size(), 2)
+	assert_eq(
+		GFVariantData.get_option_int(module_results[0], "instance_id"),
+		timed_out_utility.get_instance_id()
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(module_results[0], "status"),
+		&"timed_out"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(unfinished_modules[0], "status"),
+		&"timed_out"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(unfinished_modules[1], "instance_id"),
+		provider.get_instance_id()
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(unfinished_modules[1], "status"),
+		&"skipped"
+	)
+	assert_eq(timed_out_utility.dispose_count, 1)
+	assert_eq(provider.dispose_count, 1)
+
+
+func test_pre_cancelled_shutdown_returns_cancelled_for_empty_plan() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await architecture.init())
+	var source: GFCancellationSource = GFCancellationSource.new()
+	assert_true(source.cancel(&"pre_cancelled_empty_shutdown"))
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		source.get_token()
+	)
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.CANCELLED)
+	assert_eq(result.get_cancel_reason(), "pre_cancelled_empty_shutdown")
+	assert_true(architecture.is_disposed())
+	source.dispose()
+
+
+func test_synchronous_quiesce_cancellation_wins_over_successful_completion() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var source: GFCancellationSource = GFCancellationSource.new()
+	var utility: CancelDuringQuiesceUtility = CancelDuringQuiesceUtility.new(
+		source
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		source.get_token(),
+		0.5
+	)
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.CANCELLED)
+	assert_eq(result.get_cancel_reason(), "cancel_during_synchronous_quiesce")
+	assert_eq(utility.quiesce_count, 1)
+	assert_eq(utility.dispose_count, 1)
+	assert_true(architecture.is_disposed())
+	source.dispose()
+
+
+func test_synchronous_quiesce_crossing_deadline_returns_timed_out() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: DeadlineCrossingQuiesceUtility = (
+		DeadlineCrossingQuiesceUtility.new(40)
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		null,
+		0.01
+	)
+
+	assert_eq(result.get_status(), GFArchitectureShutdownResult.Status.TIMED_OUT)
+	assert_eq(utility.quiesce_count, 1)
+	assert_eq(utility.dispose_count, 1)
+	assert_true(architecture.is_disposed())
+
+
+func test_empty_final_plan_rechecks_deadline_after_topology_stabilizes() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: AwaitedHotUnregisterUtility = AwaitedHotUnregisterUtility.new()
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	@warning_ignore("missing_await")
+	_complete_quiesce_after_blocking_frame(utility, 40)
+	var unregister_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	@warning_ignore("missing_await")
+	_await_hot_unregister(architecture, unregister_state)
+	var result: GFArchitectureShutdownResult = await architecture.shutdown_async(
+		null,
+		0.01
+	)
+
+	assert_true(GFVariantData.get_option_bool(unregister_state, "done"))
+	assert_true(GFVariantData.get_option_bool(unregister_state, "result"))
+	assert_eq(
+		result.get_status(),
+		GFArchitectureShutdownResult.Status.TIMED_OUT,
+		"topology 在 deadline 后稳定为空计划时，shutdown 不得错误报告成功。"
+	)
+	assert_eq(utility.quiesce_count, 1)
+	assert_eq(utility.dispose_count, 1)
+	assert_true(architecture.is_disposed())
+
+
+func test_init_rechecks_cancellation_after_async_init_before_ready() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var source: GFCancellationSource = GFCancellationSource.new()
+	var utility: CancelAfterAsyncInitUtility = CancelAfterAsyncInitUtility.new(
+		source
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+
+	assert_false(await architecture.init(source.get_token()))
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_inited())
+	assert_eq(utility.ready_count, 0, "async_init await 后必须先复检取消，再进入 ready。")
+	assert_eq(utility.activation_count, 0)
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] 初始化已取消")
+
+	architecture.dispose()
+	assert_eq(utility.dispose_count, 1)
+	source.dispose()
+
+
+func test_init_rechecks_cancellation_before_final_ready_commit() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var source: GFCancellationSource = GFCancellationSource.new()
+	var utility: CancelAfterActivationSuccessUtility = (
+		CancelAfterActivationSuccessUtility.new(source)
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+
+	assert_false(await architecture.init(source.get_token()))
+	assert_eq(utility.activation_count, 1)
+	assert_true(architecture.has_initialization_failed())
+	assert_false(architecture.is_inited(), "最后一个 activation 成功后仍须复检取消，禁止提交 READY。")
+	assert_false(architecture.is_accepting_runtime_work())
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] activation 已取消")
+
+	architecture.dispose()
+	assert_eq(utility.dispose_count, 1)
+	source.dispose()
+
+
+func test_activation_failure_cleans_plan_in_strict_reverse_order_exactly_once() -> void:
+	var dispose_log: Array[String] = []
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var dependency: ReversePlanDependencyUtility = (
+		ReversePlanDependencyUtility.new(dispose_log)
+	)
+	var consumer: ReversePlanConsumerUtility = (
+		ReversePlanConsumerUtility.new(dispose_log)
+	)
+	var failing: ReversePlanFailingUtility = (
+		ReversePlanFailingUtility.new(dispose_log)
+	)
+
+	assert_true(await architecture.register_utility_instance(failing))
+	assert_true(await architecture.register_utility_instance(consumer))
+	assert_true(await architecture.register_utility_instance(dependency))
+
+	assert_false(await architecture.init())
+	assert_eq(
+		dispose_log,
+		["failing", "consumer", "dependency"],
+		"activation 失败必须严格逆转编译计划，不能退化为注册表遍历顺序。"
+	)
+	assert_eq(failing.dispose_count, 1)
+	assert_eq(consumer.dispose_count, 1)
+	assert_eq(dependency.dispose_count, 1)
+	assert_push_error("[GFArchitecture] activation 失败")
+
+	architecture.dispose()
+	assert_eq(failing.dispose_count, 1)
+	assert_eq(consumer.dispose_count, 1)
+	assert_eq(dependency.dispose_count, 1)
+
+
+func test_ready_failure_then_dispose_does_not_release_module_twice() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var utility: ReadyFailureDisposeProbeUtility = (
+		ReadyFailureDisposeProbeUtility.new()
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	architecture.fail_initialization("[test] ready failure")
+	assert_true(architecture.has_initialization_failed())
+	assert_eq(utility.dispose_count, 1, "READY 后首次 fail_initialization 应只释放一次。")
+	assert_push_error("[test] ready failure")
+
+	architecture.dispose()
+	architecture.dispose()
+	assert_true(architecture.is_disposed())
+	assert_eq(utility.dispose_count, 1, "fail_initialization 后 dispose 不得重复释放模块。")
+
+
+func _await_init(
+	architecture: GFArchitecture,
+	cancellation_token: GFCancellationToken,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.init(cancellation_token)
+	state["done"] = true
+
+
+func _await_hot_register(
+	architecture: GFArchitecture,
+	candidate: AwaitedHotRegisterUtility,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.register_utility_instance(candidate)
+	state["done"] = true
+
+
+func _await_hot_replace(
+	architecture: GFArchitecture,
+	replacement: AwaitedHotReplaceUtility,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.replace_utility(
+		AwaitedHotReplaceUtility,
+		replacement
+	)
+	state["done"] = true
+
+
+func _await_hot_unregister(
+	architecture: GFArchitecture,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.unregister_utility(
+		AwaitedHotUnregisterUtility
+	)
+	state["done"] = true
+
+
+func _await_shutdown(
+	architecture: GFArchitecture,
+	cancellation_token: GFCancellationToken,
+	timeout_seconds: float,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.shutdown_async(
+		cancellation_token,
+		timeout_seconds
+	)
+	state["done"] = true
+
+
+func _cancel_on_next_frame(
+	source: GFCancellationSource,
+	reason: StringName
+) -> void:
+	await get_tree().process_frame
+	var _cancelled: bool = source.cancel(reason)
+
+
+func _complete_quiesce_after_blocking_frame(
+	utility: AwaitedHotUnregisterUtility,
+	block_msec: int
+) -> void:
+	await get_tree().process_frame
+	var release_at_msec: int = Time.get_ticks_msec() + block_msec
+	while Time.get_ticks_msec() < release_at_msec:
+		pass
+	var _completed: bool = utility.complete_quiesce()
+
+
+func _wait_until_states_done(states: Array[Dictionary]) -> void:
+	for _frame: int in range(30):
+		var all_done: bool = true
+		for state: Dictionary in states:
+			if not GFVariantData.get_option_bool(state, "done"):
+				all_done = false
+				break
+		if all_done:
+			return
+		await get_tree().process_frame
+
+
+func _shutdown_result_from_state(
+	state: Dictionary
+) -> GFArchitectureShutdownResult:
+	var value: Variant = state.get("result")
+	if value is GFArchitectureShutdownResult:
+		return value
+	return null
+
+
+func _record_shutdown_finished(
+	result: GFArchitectureShutdownResult,
+	state: Dictionary
+) -> void:
+	state["count"] = GFVariantData.get_option_int(state, "count") + 1
+	state["status"] = result.get_status()

--- a/tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd
@@ -491,6 +491,66 @@ class RuntimeFactoryProduct extends RefCounted:
 
 # --- 测试 ---
 
+func test_lifecycle_timeout_properties_accept_only_finite_closed_range() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var property_names: Array[StringName] = [
+		&"module_async_init_timeout_seconds",
+		&"activation_timeout_seconds",
+		&"shutdown_timeout_seconds",
+	]
+	var invalid_values: Array[float] = [NAN, INF, -INF, -0.001, 86_400.001]
+	for property_name: StringName in property_names:
+		architecture.set(property_name, 0.0)
+		assert_eq(_get_lifecycle_timeout_property(architecture, property_name), 0.0, "0 应是合法的无 deadline 边界。")
+		architecture.set(property_name, 86_400.0)
+		assert_eq(_get_lifecycle_timeout_property(architecture, property_name), 86_400.0, "86400 应是合法上界。")
+		for invalid_value: float in invalid_values:
+			architecture.set(property_name, invalid_value)
+			assert_eq(
+				_get_lifecycle_timeout_property(architecture, property_name),
+				86_400.0,
+				"无效 timeout 不得覆盖最近一次合法值：%s" % property_name
+			)
+	assert_push_error_count(15, "三个 timeout 属性应分别拒绝五种非有限或越界输入。")
+	architecture.dispose()
+
+
+func test_shutdown_timeout_override_validates_before_state_change() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	for invalid_value: float in [NAN, INF, -INF, -2.0, 86_400.001]:
+		var invalid_result: GFArchitectureShutdownResult = (
+			await architecture.shutdown_async(null, invalid_value)
+		)
+		assert_eq(
+			invalid_result.get_status(),
+			GFArchitectureShutdownResult.Status.FAILED,
+			"无效 override 应返回 FAILED typed 结果。"
+		)
+		assert_eq(invalid_result.get_error_code(), ERR_INVALID_PARAMETER)
+		assert_false(architecture.is_disposed(), "参数错误不得改变生命周期状态。")
+
+	assert_true(await architecture.init())
+	var upper_bound_result: GFArchitectureShutdownResult = (
+		await architecture.shutdown_async(null, 86_400.0)
+	)
+	assert_true(upper_bound_result.is_successful(), "86400 override 应被正常接受。")
+	var disposed_result: GFArchitectureShutdownResult = (
+		await architecture.shutdown_async(null, 0.0)
+	)
+	assert_eq(
+		disposed_result.get_status(),
+		GFArchitectureShutdownResult.Status.ALREADY_DISPOSED,
+		"合法 override 下的重复关闭应返回 ALREADY_DISPOSED。"
+	)
+
+	var zero_timeout_architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await zero_timeout_architecture.init())
+	var zero_timeout_result: GFArchitectureShutdownResult = (
+		await zero_timeout_architecture.shutdown_async(null, 0.0)
+	)
+	assert_true(zero_timeout_result.is_successful(), "0 override 应作为合法无 deadline 值。")
+
+
 func test_activation_waits_for_dependency_tick_before_ready_commit() -> void:
 	var lifecycle_log: Array[String] = []
 	var architecture: GFArchitecture = GFArchitecture.new()
@@ -1621,6 +1681,22 @@ func test_ready_failure_then_dispose_does_not_release_module_twice() -> void:
 	architecture.dispose()
 	assert_true(architecture.is_disposed())
 	assert_eq(utility.dispose_count, 1, "fail_initialization 后 dispose 不得重复释放模块。")
+
+
+func _get_lifecycle_timeout_property(
+	architecture: GFArchitecture,
+	property_name: StringName
+) -> float:
+	match property_name:
+		&"module_async_init_timeout_seconds":
+			return architecture.module_async_init_timeout_seconds
+		&"activation_timeout_seconds":
+			return architecture.activation_timeout_seconds
+		&"shutdown_timeout_seconds":
+			return architecture.shutdown_timeout_seconds
+		_:
+			fail_test("未知的生命周期 timeout 属性：%s" % property_name)
+			return -1.0
 
 
 func _await_init(

--- a/tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd.uid
+++ b/tests/gf_core/kernel/core/test_gf_architecture_activation_shutdown.gd.uid
@@ -1,0 +1,1 @@
+uid://dvu2sde7c10ui

--- a/tests/gf_core/kernel/core/test_gf_architecture_dependency_diagnostics.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_dependency_diagnostics.gd
@@ -5,12 +5,15 @@ extends GutTest
 const GF_VARIANT_ACCESS = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
 
 
-func test_dependency_diagnostics_reports_registered_dependencies_as_ok() -> void:
+func test_dependency_diagnostics_reads_only_four_typed_hooks() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
+	var factory_provider: CountingFactoryProvider = CountingFactoryProvider.new()
 	await arch.register_model_instance(DiagnosticModel.new())
 	await arch.register_utility_instance(DiagnosticUtility.new())
-	var _registered_factory: bool = arch.register_factory(DiagnosticFactoryObject, func() -> DiagnosticFactoryObject:
-		return DiagnosticFactoryObject.new()
+	await arch.register_system_instance(DiagnosticDependencySystem.new())
+	var _registered_factory: bool = arch.register_factory(
+		DiagnosticFactoryObject,
+		Callable(factory_provider, "create")
 	)
 	await arch.register_system_instance(CompleteDiagnosticSystem.new())
 
@@ -18,7 +21,8 @@ func test_dependency_diagnostics_reports_registered_dependencies_as_ok() -> void
 
 	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "所有声明依赖已注册时诊断应通过。")
 	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "missing_dependencies").size(), 0, "不应报告缺失依赖。")
-	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "resolved_dependencies").size(), 3, "应报告已解析的声明依赖。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "resolved_dependencies").size(), 4, "四类 typed hook 都应成为唯一声明来源。")
+	assert_eq(factory_provider.call_count, 0, "Factory 依赖诊断只能校验 binding，不得实例化对象。")
 	arch.dispose()
 
 
@@ -39,6 +43,7 @@ func test_dependency_diagnostics_can_resolve_parent_dependencies() -> void:
 	var parent_arch: GFArchitecture = GFArchitecture.new()
 	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
 	await parent_arch.register_model_instance(DiagnosticModel.new())
+	assert_true(await parent_arch.init())
 	await child_arch.register_system_instance(MissingModelSystem.new())
 
 	var report: Dictionary = child_arch.get_dependency_diagnostics()
@@ -51,44 +56,158 @@ func test_dependency_diagnostics_can_resolve_parent_dependencies() -> void:
 	parent_arch.dispose()
 
 
-func test_dependency_diagnostics_can_disable_parent_lookup() -> void:
+func test_dependency_diagnostics_rejects_dependency_from_parent_that_is_not_ready() -> void:
 	var parent_arch: GFArchitecture = GFArchitecture.new()
 	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
 	await parent_arch.register_model_instance(DiagnosticModel.new())
 	await child_arch.register_system_instance(MissingModelSystem.new())
 
-	var report: Dictionary = child_arch.get_dependency_diagnostics({ "include_parent_lookup": false })
+	var report: Dictionary = child_arch.get_dependency_diagnostics()
 
-	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "关闭父级查找后，本地缺失依赖应报告错误。")
-	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "missing_dependencies").size(), 1, "应报告本地缺失依赖。")
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "未 READY 父架构不能满足子架构依赖。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "missing_dependencies").size(), 1, "未 READY parent 依赖应保持缺失。")
 	child_arch.dispose()
 	parent_arch.dispose()
 
 
-func test_dependency_diagnostics_warns_about_invalid_hook_values() -> void:
+func test_dependency_diagnostics_treats_corrupt_registry_entries_as_hard_errors() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
-	await arch.register_system_instance(InvalidDiagnosticSystem.new())
+	var invalid_item: InvalidHookItemDiagnosticObject = (
+		InvalidHookItemDiagnosticObject.new()
+	)
+	var invalid_return: InvalidHookReturnDiagnosticObject = (
+		InvalidHookReturnDiagnosticObject.new()
+	)
+	arch._system_registry.instances[InvalidHookItemDiagnosticObject] = (
+		invalid_item
+	)
+	arch._system_registry.instances[InvalidHookReturnDiagnosticObject] = (
+		invalid_return
+	)
 
 	var report: Dictionary = arch.get_dependency_diagnostics()
 	var issue_counts_by_kind: Dictionary = GF_VARIANT_ACCESS.get_option_dictionary(report, "issue_counts_by_kind")
 
-	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "无缺失依赖时，非法声明项只应产生警告。")
-	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "healthy"), "非法声明项应让报告不健康。")
-	assert_eq(GF_VARIANT_ACCESS.get_option_int(issue_counts_by_kind, "invalid_dependency_type"), 1, "应报告非 Script 依赖声明。")
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "损坏的注册表条目必须 hard fail。")
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "healthy"), "损坏的注册表条目应让报告不健康。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "error_count"), 2, "两个损坏条目都应计入 error。")
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_int(
+			issue_counts_by_kind,
+			"invalid_registration_instance"
+		),
+		2,
+		"非 GFSystem 实例应在强类型注册表边界被拒绝。"
+	)
 	arch.dispose()
 
 
-func test_dependency_diagnostics_reads_dictionary_hook() -> void:
+func test_stale_local_alias_blocks_ready_parent_fallback_without_output_side_effects() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	await parent_arch.register_utility_instance(DiagnosticUtility.new())
+	assert_true(await parent_arch.init())
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+	await child_arch.register_system_instance(UtilityDependentSystem.new())
+	child_arch._utility_registry.aliases[DiagnosticUtility] = (
+		MissingDiagnosticUtility
+	)
+
+	var report: Dictionary = child_arch.get_dependency_diagnostics()
+	var issue_counts: Dictionary = GF_VARIANT_ACCESS.get_option_dictionary(
+		report,
+		"issue_counts_by_kind"
+	)
+
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "本地 stale alias 必须阻断 READY parent fallback。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(issue_counts, "stale_alias_dependency"), 1)
+	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "resolved_dependencies").size(), 0)
+	child_arch.dispose()
+	parent_arch.dispose()
+
+
+func test_multiple_local_assignable_matches_block_ready_parent_fallback_without_output_side_effects() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	await parent_arch.register_utility_instance(DiagnosticUtility.new())
+	assert_true(await parent_arch.init())
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+	await child_arch.register_utility_instance(DiagnosticUtilityAlias.new())
+	await child_arch.register_utility_instance(SecondDiagnosticUtilityAlias.new())
+	await child_arch.register_system_instance(UtilityDependentSystem.new())
+
+	var report: Dictionary = child_arch.get_dependency_diagnostics()
+	var issue_counts: Dictionary = GF_VARIANT_ACCESS.get_option_dictionary(
+		report,
+		"issue_counts_by_kind"
+	)
+
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "多个本地 assignable 匹配必须阻断 parent fallback。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(issue_counts, "ambiguous_dependency"), 1)
+	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "resolved_dependencies").size(), 0)
+	child_arch.dispose()
+	parent_arch.dispose()
+
+
+func test_factory_dependency_requires_exact_binding_without_instantiation() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
-	await arch.register_model_instance(DiagnosticModel.new())
-	await arch.register_utility_instance(DiagnosticUtility.new())
-	await arch.register_system_instance(DictionaryDiagnosticSystem.new())
+	var derived_provider: CountingDerivedFactoryProvider = (
+		CountingDerivedFactoryProvider.new()
+	)
+	var exact_provider: CountingFactoryProvider = CountingFactoryProvider.new()
+	assert_true(
+		arch.register_factory(
+			DerivedDiagnosticFactoryObject,
+			Callable(derived_provider, "create")
+		)
+	)
+	await arch.register_system_instance(FactoryDependentSystem.new())
 
-	var report: Dictionary = arch.get_dependency_diagnostics()
+	var missing_report: Dictionary = arch.get_dependency_diagnostics()
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(missing_report, "ok"), "可赋值 Factory binding 不得冒充 exact binding。")
+	assert_eq(derived_provider.call_count, 0)
 
-	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "ok"), "字典式依赖声明应能被解析。")
-	assert_eq(GF_VARIANT_ACCESS.get_option_array(report, "resolved_dependencies").size(), 2, "字典式声明应汇总 Model 和 Utility。")
+	assert_true(
+		arch.register_factory(
+			DiagnosticFactoryObject,
+			Callable(exact_provider, "create")
+		)
+	)
+	var resolved_report: Dictionary = arch.get_dependency_diagnostics()
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(resolved_report, "ok"), "exact Factory binding 应满足声明。")
+	assert_eq(derived_provider.call_count, 0)
+	assert_eq(exact_provider.call_count, 0, "Factory 诊断不得调用 exact provider。")
 	arch.dispose()
+
+
+func test_parent_factory_dependency_requires_ready_owner_without_instantiation() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	var provider: CountingFactoryProvider = CountingFactoryProvider.new()
+	assert_true(
+		parent_arch.register_factory(
+			DiagnosticFactoryObject,
+			Callable(provider, "create")
+		)
+	)
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+	await child_arch.register_system_instance(FactoryDependentSystem.new())
+
+	var unavailable_report: Dictionary = child_arch.get_dependency_diagnostics()
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(unavailable_report, "ok"), "未 READY parent 的 Factory binding 不可用。")
+	assert_eq(provider.call_count, 0)
+
+	assert_true(await parent_arch.init())
+	var available_report: Dictionary = child_arch.get_dependency_diagnostics()
+	var resolved: Array = GF_VARIANT_ACCESS.get_option_array(
+		available_report,
+		"resolved_dependencies"
+	)
+	var first_dependency: Dictionary = GF_VARIANT_ACCESS.as_dictionary(
+		resolved[0]
+	)
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(available_report, "ok"), "READY parent 的 exact Factory binding 应满足声明。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_string(first_dependency, "scope"), "parent")
+	assert_eq(provider.call_count, 0, "父级 Factory availability 校验不得实例化对象。")
+	child_arch.dispose()
+	parent_arch.dispose()
 
 
 func test_binding_diagnostics_reports_registries_aliases_factories_and_parent_chain() -> void:
@@ -146,7 +265,39 @@ class DiagnosticUtilityAlias extends DiagnosticUtility:
 	pass
 
 
+class SecondDiagnosticUtilityAlias extends DiagnosticUtility:
+	pass
+
+
+class MissingDiagnosticUtility extends DiagnosticUtility:
+	pass
+
+
 class DiagnosticFactoryObject extends RefCounted:
+	pass
+
+
+class DerivedDiagnosticFactoryObject extends DiagnosticFactoryObject:
+	pass
+
+
+class CountingFactoryProvider extends RefCounted:
+	var call_count: int = 0
+
+	func create() -> DiagnosticFactoryObject:
+		call_count += 1
+		return DiagnosticFactoryObject.new()
+
+
+class CountingDerivedFactoryProvider extends RefCounted:
+	var call_count: int = 0
+
+	func create() -> DerivedDiagnosticFactoryObject:
+		call_count += 1
+		return DerivedDiagnosticFactoryObject.new()
+
+
+class DiagnosticDependencySystem extends GFSystem:
 	pass
 
 
@@ -154,6 +305,10 @@ class CompleteDiagnosticSystem extends GFSystem:
 	func get_required_models() -> Array[Script]:
 		var models: Array[Script] = [DiagnosticModel]
 		return models
+
+	func get_required_systems() -> Array[Script]:
+		var systems: Array[Script] = [DiagnosticDependencySystem]
+		return systems
 
 	func get_required_utilities() -> Array[Script]:
 		var utilities: Array[Script] = [DiagnosticUtility]
@@ -170,14 +325,25 @@ class MissingModelSystem extends GFSystem:
 		return models
 
 
-class DictionaryDiagnosticSystem extends GFSystem:
-	func get_required_dependencies() -> Dictionary:
-		return {
-			"models": [DiagnosticModel],
-			"utilities": [DiagnosticUtility],
-		}
+class UtilityDependentSystem extends GFSystem:
+	func get_required_utilities() -> Array[Script]:
+		var utilities: Array[Script] = [DiagnosticUtility]
+		return utilities
 
 
-class InvalidDiagnosticSystem extends GFSystem:
+class FactoryDependentSystem extends GFSystem:
+	func get_required_factories() -> Array[Script]:
+		var factories: Array[Script] = [DiagnosticFactoryObject]
+		return factories
+
+
+class InvalidHookItemDiagnosticObject extends RefCounted:
 	func get_required_models() -> Array:
 		return ["not a script"]
+
+
+class InvalidHookReturnDiagnosticObject extends RefCounted:
+	func get_required_models() -> Variant:
+		return {
+			"models": [DiagnosticModel],
+		}

--- a/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_plan.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_plan.gd
@@ -1,0 +1,697 @@
+## 测试 GFArchitectureLifecyclePlan 的确定性 DAG 与关闭快照。
+extends GutTest
+
+
+const GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = preload(
+	"res://addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd"
+)
+
+
+func test_independent_modules_use_kind_priority_and_registration_ordinal() -> void:
+	var first_model: PlanModel = PlanModel.new()
+	var second_model: SecondPlanModel = SecondPlanModel.new()
+	var utility: PlanUtility = PlanUtility.new()
+	var system: PlanSystem = PlanSystem.new()
+	first_model.lifecycle_priority = 2
+	second_model.lifecycle_priority = 2
+	utility.lifecycle_priority = 100
+	system.lifecycle_priority = 200
+	var models: Dictionary = {
+		PlanModel: first_model,
+		SecondPlanModel: second_model,
+	}
+	var utilities: Dictionary = {PlanUtility: utility}
+	var systems: Dictionary = {PlanSystem: system}
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+
+	assert_true(plan.compile(models, utilities, systems))
+	assert_eq(
+		plan.get_activation_order(),
+		[first_model, second_model, utility, system],
+		"无依赖节点应按 kind、priority、注册 ordinal 稳定排序。"
+	)
+
+
+func test_dependencies_override_ready_queue_tie_breakers() -> void:
+	var model: ModelDependingOnSystem = ModelDependingOnSystem.new()
+	var system: PlanSystem = PlanSystem.new()
+	model.required_systems = [PlanSystem]
+	model.lifecycle_priority = 100
+	system.lifecycle_priority = -100
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+
+	assert_true(
+		plan.compile(
+			{ModelDependingOnSystem: model},
+			{},
+			{PlanSystem: system}
+		)
+	)
+	assert_eq(plan.get_activation_order(), [system, model], "依赖必须先于声明者激活。")
+
+
+func test_unique_assignable_local_dependency_is_a_dag_edge() -> void:
+	var model: DerivedPlanModel = DerivedPlanModel.new()
+	var system: SystemDependingOnBaseModel = SystemDependingOnBaseModel.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+
+	assert_true(
+		plan.compile(
+			{DerivedPlanModel: model},
+			{},
+			{SystemDependingOnBaseModel: system}
+		)
+	)
+	assert_eq(plan.get_activation_order(), [model, system])
+	assert_eq(plan.get_external_dependency_count(), 0)
+
+
+func test_authoritative_resolver_can_satisfy_parent_dependency_as_external() -> void:
+	var parent_model: PlanModel = PlanModel.new()
+	var system: SystemDependingOnPlanModel = SystemDependingOnPlanModel.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	var resolvers: Dictionary = {
+		&"models": func(required_script: Script) -> Dictionary:
+			if required_script != PlanModel:
+				return { "status": &"missing" }
+			return {
+				"status": &"external",
+				"scope": &"parent",
+				"architecture_depth": 1,
+				"instance": parent_model,
+			}
+	}
+
+	assert_true(plan.compile({}, {}, {SystemDependingOnPlanModel: system}, resolvers))
+	assert_eq(plan.get_activation_order(), [system])
+	assert_eq(plan.get_external_dependency_count(), 1)
+	assert_true(plan.get_dependency_closure(system).has(system))
+	assert_false(plan.get_dependency_closure(system).has(parent_model))
+
+
+func test_missing_dependency_fails_closed_with_typed_diagnostic() -> void:
+	var system: SystemDependingOnPlanModel = SystemDependingOnPlanModel.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+
+	assert_false(plan.compile({}, {}, {SystemDependingOnPlanModel: system}))
+	assert_false(plan.is_valid())
+	assert_true(plan.get_activation_order().is_empty())
+	assert_true(plan.get_shutdown_order().is_empty())
+	assert_eq(_diagnostic_codes(plan), [&"missing_dependency"])
+
+
+func test_defensive_capture_rejects_invalid_return_and_entry() -> void:
+	var provider: InvalidDependencyProvider = InvalidDependencyProvider.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	var node: Dictionary = _make_capture_node(provider)
+	var declarations: Dictionary = _make_dependency_declarations()
+
+	var _invalid_return_capture: Variant = plan.call(
+		&"_capture_dependency_hook",
+		node,
+		declarations,
+		&"models",
+		&"get_required_models"
+	)
+	var _invalid_entry_capture: Variant = plan.call(
+		&"_capture_dependency_hook",
+		node,
+		declarations,
+		&"systems",
+		&"get_required_systems"
+	)
+
+	var codes: Array[StringName] = _diagnostic_codes(plan)
+	assert_has(codes, &"invalid_dependency_hook_return")
+	assert_has(codes, &"invalid_dependency_type")
+
+
+func test_cycle_fails_closed_with_stable_cycle_members() -> void:
+	var first: FirstCycleSystem = FirstCycleSystem.new()
+	var second: SecondCycleSystem = SecondCycleSystem.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+
+	assert_false(
+		plan.compile(
+			{},
+			{},
+			{
+				FirstCycleSystem: first,
+				SecondCycleSystem: second,
+			}
+		)
+	)
+	var diagnostics: Array[Dictionary] = plan.get_diagnostics()
+	assert_eq(diagnostics.size(), 1)
+	assert_eq(
+		_get_dictionary_string_name(diagnostics[0], "code"),
+		&"dependency_cycle"
+	)
+	assert_eq(
+		_get_dictionary_int(diagnostics[0], "cycle_member_count"),
+		2
+	)
+	var cycle_members_variant: Variant = diagnostics[0].get("cycle_members")
+	assert_true(cycle_members_variant is Array)
+	var cycle_members: Array = cycle_members_variant
+	assert_eq(cycle_members.size(), 2)
+
+
+func test_shutdown_order_is_exact_reverse_compile_snapshot_and_defensive() -> void:
+	var model: PlanModel = PlanModel.new()
+	var utility: UtilityDependingOnPlanModel = UtilityDependingOnPlanModel.new()
+	var system: SystemDependingOnUtility = SystemDependingOnUtility.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+
+	assert_true(
+		plan.compile(
+			{PlanModel: model},
+			{UtilityDependingOnPlanModel: utility},
+			{SystemDependingOnUtility: system}
+		)
+	)
+	var activation: Array[Object] = plan.get_activation_order()
+	var shutdown: Array[Object] = plan.get_shutdown_order()
+	assert_eq(activation, [model, utility, system])
+	assert_eq(shutdown, [system, utility, model])
+	activation.clear()
+	shutdown.clear()
+	assert_eq(plan.get_activation_order(), [model, utility, system])
+	assert_eq(plan.get_shutdown_order(), [system, utility, model])
+
+
+func test_dependency_closure_is_transitive_local_new_and_can_exclude_self() -> void:
+	var model: PlanModel = PlanModel.new()
+	var utility: UtilityDependingOnPlanModel = UtilityDependingOnPlanModel.new()
+	var system: SystemDependingOnUtility = SystemDependingOnUtility.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	assert_true(
+		plan.compile(
+			{PlanModel: model},
+			{UtilityDependingOnPlanModel: utility},
+			{SystemDependingOnUtility: system}
+		)
+	)
+
+	var closure: Dictionary = plan.get_dependency_closure(system, false)
+	assert_eq(closure.size(), 2)
+	assert_true(closure.has(model))
+	assert_true(closure.has(utility))
+	assert_false(closure.has(system))
+	closure.clear()
+	assert_eq(plan.get_dependency_closure(system, false).size(), 2, "每次必须返回新 Dictionary。")
+	assert_true(plan.get_dependency_closure(PlanSystem.new()).is_empty())
+
+
+func test_compile_captures_each_typed_hook_once_and_returns_defensive_snapshot() -> void:
+	var model: PlanModel = PlanModel.new()
+	var utility: PlanUtility = PlanUtility.new()
+	var provider_system: PlanSystem = PlanSystem.new()
+	var dependent: CountingDependenciesSystem = CountingDependenciesSystem.new()
+	var factory_resolver_calls: CallCounter = CallCounter.new()
+	var resolvers: Dictionary = {
+		&"factories": func(required_script: Script) -> Dictionary:
+			factory_resolver_calls.value += 1
+			return {
+				"status": (
+					&"local"
+					if required_script == PlanFactoryProduct
+					else &"missing"
+				),
+				"resolution_kind": &"exact",
+			}
+	}
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = (
+		GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	)
+
+	assert_true(
+		plan.compile(
+			{PlanModel: model},
+			{PlanUtility: utility},
+			{
+				PlanSystem: provider_system,
+				CountingDependenciesSystem: dependent,
+			},
+			resolvers
+		)
+	)
+	assert_eq(
+		dependent.get_hook_call_counts(),
+		{
+			"models": 1,
+			"utilities": 1,
+			"systems": 1,
+			"factories": 1,
+		},
+		"一次 compile 对每个模块的四类声明都只能捕获一次。"
+	)
+	assert_eq(factory_resolver_calls.value, 1)
+	assert_eq(
+		plan.get_activation_order(),
+		[model, utility, provider_system, dependent]
+	)
+	var closure: Dictionary = plan.get_dependency_closure(dependent)
+	assert_eq(closure.size(), 4, "Factory availability 不能成为本地 DAG 节点。")
+
+	var snapshot: Array[Dictionary] = plan.get_dependency_snapshot()
+	var dependent_snapshot: Dictionary = _find_module_snapshot(
+		snapshot,
+		dependent
+	)
+	var declarations: Dictionary = dependent_snapshot.get(
+		"dependencies",
+		{}
+	)
+	var factory_dependencies: Array = declarations.get("factories", [])
+	assert_eq(factory_dependencies, [PlanFactoryProduct])
+	factory_dependencies.clear()
+	snapshot.clear()
+
+	var fresh_snapshot: Dictionary = _find_module_snapshot(
+		plan.get_dependency_snapshot(),
+		dependent
+	)
+	var fresh_declarations: Dictionary = fresh_snapshot.get(
+		"dependencies",
+		{}
+	)
+	var fresh_factory_dependencies: Array = fresh_declarations.get(
+		"factories",
+		[]
+	)
+	assert_eq(
+		fresh_factory_dependencies,
+		[PlanFactoryProduct],
+		"调用方不得修改 plan 内部 dependency snapshot。"
+	)
+
+	var records: Array[Dictionary] = plan.get_dependency_records()
+	assert_eq(_records_for_module(records, dependent).size(), 4)
+	var factory_record: Dictionary = _find_dependency_record(
+		records,
+		dependent,
+		&"factories"
+	)
+	assert_eq(
+		_get_dictionary_string_name(factory_record, "status"),
+		&"local"
+	)
+	assert_true(_get_dictionary_bool(factory_record, "resolved"))
+	assert_null(_get_dictionary_object(factory_record, "resolved_instance"))
+	records.clear()
+	assert_eq(plan.get_dependency_records().size(), 4)
+
+
+func test_factory_dependency_is_required_but_never_becomes_a_dag_edge() -> void:
+	var dependent: FactoryDependentSystem = FactoryDependentSystem.new()
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = (
+		GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	)
+
+	assert_false(
+		plan.compile(
+			{},
+			{},
+			{FactoryDependentSystem: dependent}
+		)
+	)
+	assert_eq(_diagnostic_codes(plan), [&"missing_dependency"])
+	var missing_record: Dictionary = plan.get_dependency_records()[0]
+	assert_eq(
+		_get_dictionary_string_name(missing_record, "dependency_kind"),
+		&"factories"
+	)
+	assert_eq(
+		_get_dictionary_string_name(missing_record, "status"),
+		&"missing"
+	)
+
+	var resolver_calls: CallCounter = CallCounter.new()
+	var resolvers: Dictionary = {
+		&"factories": func(required_script: Script) -> Dictionary:
+			resolver_calls.value += 1
+			return {
+				"status": (
+					&"external"
+					if required_script == PlanFactoryProduct
+					else &"missing"
+				),
+				"scope": &"parent",
+				"architecture_depth": 1,
+			}
+	}
+	assert_true(
+		plan.compile(
+			{},
+			{},
+			{FactoryDependentSystem: dependent},
+			resolvers
+		)
+	)
+	assert_eq(resolver_calls.value, 1)
+	assert_eq(plan.get_activation_order(), [dependent])
+	assert_eq(plan.get_dependency_closure(dependent).size(), 1)
+	assert_eq(plan.get_external_dependency_count(), 1)
+
+
+func test_structured_resolver_failure_statuses_are_preserved() -> void:
+	var expected_codes: Dictionary = {
+		&"stale_alias": &"stale_alias_dependency",
+		&"ambiguous": &"ambiguous_dependency",
+		&"parent_cycle": &"parent_dependency_cycle",
+	}
+	for status_variant: Variant in expected_codes.keys():
+		var status: StringName = status_variant
+		var dependent: SystemDependingOnPlanModel = (
+			SystemDependingOnPlanModel.new()
+		)
+		var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = (
+			GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+		)
+		var resolvers: Dictionary = {
+			&"models": func(_required_script: Script) -> Dictionary:
+				return {
+					"status": status,
+					"scope": status,
+					"parent_chain_cycle_detected": (
+						status == &"parent_cycle"
+					),
+					"cycle_architecture": "fixture-parent",
+					"cycle_depth": 2,
+					"cycle_start_depth": 0,
+				}
+		}
+
+		assert_false(
+			plan.compile(
+				{},
+				{},
+				{SystemDependingOnPlanModel: dependent},
+				resolvers
+			)
+		)
+		assert_eq(
+			_diagnostic_codes(plan),
+			[_get_dictionary_string_name(expected_codes, status)]
+		)
+		var record: Dictionary = plan.get_dependency_records()[0]
+		assert_eq(
+			_get_dictionary_string_name(record, "status"),
+			status
+		)
+		assert_false(
+			_get_dictionary_bool(record, "resolved", true)
+		)
+
+
+func test_invalid_structured_resolver_result_fails_closed() -> void:
+	var dependent: SystemDependingOnPlanModel = (
+		SystemDependingOnPlanModel.new()
+	)
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = (
+		GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	)
+	var resolvers: Dictionary = {
+		&"models": func(_required_script: Script) -> Variant:
+			return "not a resolution"
+	}
+
+	assert_false(
+		plan.compile(
+			{},
+			{},
+			{SystemDependingOnPlanModel: dependent},
+			resolvers
+		)
+	)
+	assert_eq(
+		_diagnostic_codes(plan),
+		[&"invalid_dependency_resolution"]
+	)
+	assert_eq(
+		_get_dictionary_string_name(
+			plan.get_dependency_records()[0],
+			"status"
+		),
+		&"invalid"
+	)
+
+
+func test_diagnostics_are_bounded_and_report_truncation() -> void:
+	var provider: ManyInvalidDependenciesProvider = (
+		ManyInvalidDependenciesProvider.new()
+	)
+	var plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT = GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT.new()
+	var _capture_result: Variant = plan.call(
+		&"_capture_dependency_hook",
+		_make_capture_node(provider),
+		_make_dependency_declarations(),
+		&"models",
+		&"get_required_models"
+	)
+
+	assert_eq(
+		plan.get_diagnostics().size(),
+		64
+	)
+	assert_true(plan.were_diagnostics_truncated())
+
+
+# --- 辅助方法 ---
+
+func _diagnostic_codes(
+	plan: GF_ARCHITECTURE_LIFECYCLE_PLAN_SCRIPT
+) -> Array[StringName]:
+	var result: Array[StringName] = []
+	for diagnostic: Dictionary in plan.get_diagnostics():
+		result.append(_get_dictionary_string_name(diagnostic, "code"))
+	return result
+
+
+func _get_dictionary_string_name(
+	source: Dictionary,
+	key: Variant,
+	default_value: StringName = &""
+) -> StringName:
+	var value: Variant = source.get(key)
+	if value is StringName:
+		var string_name_value: StringName = value
+		return string_name_value
+	if value is String:
+		var string_value: String = value
+		return StringName(string_value)
+	return default_value
+
+
+func _get_dictionary_int(
+	source: Dictionary,
+	key: Variant,
+	default_value: int = 0
+) -> int:
+	var value: Variant = source.get(key)
+	if value is int:
+		var int_value: int = value
+		return int_value
+	return default_value
+
+
+func _get_dictionary_bool(
+	source: Dictionary,
+	key: Variant,
+	default_value: bool = false
+) -> bool:
+	var value: Variant = source.get(key)
+	if value is bool:
+		var bool_value: bool = value
+		return bool_value
+	return default_value
+
+
+func _get_dictionary_object(source: Dictionary, key: Variant) -> Object:
+	var value: Variant = source.get(key)
+	if value is Object:
+		var object_value: Object = value
+		return object_value
+	return null
+
+
+func _make_capture_node(provider: Object) -> Dictionary:
+	return {
+		"instance": provider,
+		"kind": &"System",
+		"module_key": "hostile-provider",
+	}
+
+
+func _make_dependency_declarations() -> Dictionary:
+	return {
+		&"models": [],
+		&"utilities": [],
+		&"systems": [],
+		&"factories": [],
+	}
+
+
+func _find_module_snapshot(
+	snapshot: Array[Dictionary],
+	module_instance: Object
+) -> Dictionary:
+	for entry: Dictionary in snapshot:
+		if entry.get("module_instance") == module_instance:
+			return entry
+	return {}
+
+
+func _records_for_module(
+	records: Array[Dictionary],
+	module_instance: Object
+) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for record: Dictionary in records:
+		if record.get("module_instance") == module_instance:
+			result.append(record)
+	return result
+
+
+func _find_dependency_record(
+	records: Array[Dictionary],
+	module_instance: Object,
+	dependency_kind: StringName
+) -> Dictionary:
+	for record: Dictionary in records:
+		if (
+			record.get("module_instance") == module_instance
+			and record.get("dependency_kind") == dependency_kind
+		):
+			return record
+	return {}
+
+
+# --- 辅助类型 ---
+
+class PlanModel extends GFModel:
+	pass
+
+
+class SecondPlanModel extends GFModel:
+	pass
+
+
+class BasePlanModel extends GFModel:
+	pass
+
+
+class DerivedPlanModel extends BasePlanModel:
+	pass
+
+
+class PlanUtility extends GFUtility:
+	pass
+
+
+class PlanSystem extends GFSystem:
+	pass
+
+
+class PlanFactoryProduct extends RefCounted:
+	pass
+
+
+class CallCounter extends RefCounted:
+	var value: int = 0
+
+
+class CountingDependenciesSystem extends GFSystem:
+	var model_hook_calls: int = 0
+	var utility_hook_calls: int = 0
+	var system_hook_calls: int = 0
+	var factory_hook_calls: int = 0
+
+	func get_required_models() -> Array[Script]:
+		model_hook_calls += 1
+		return [PlanModel]
+
+	func get_required_utilities() -> Array[Script]:
+		utility_hook_calls += 1
+		return [PlanUtility]
+
+	func get_required_systems() -> Array[Script]:
+		system_hook_calls += 1
+		return [PlanSystem]
+
+	func get_required_factories() -> Array[Script]:
+		factory_hook_calls += 1
+		return [PlanFactoryProduct]
+
+	func get_hook_call_counts() -> Dictionary:
+		return {
+			"models": model_hook_calls,
+			"utilities": utility_hook_calls,
+			"systems": system_hook_calls,
+			"factories": factory_hook_calls,
+		}
+
+
+class FactoryDependentSystem extends GFSystem:
+	func get_required_factories() -> Array[Script]:
+		return [PlanFactoryProduct]
+
+
+class ModelDependingOnSystem extends GFModel:
+	var required_systems: Array[Script] = []
+
+	func get_required_systems() -> Array[Script]:
+		return required_systems
+
+
+class SystemDependingOnBaseModel extends GFSystem:
+	func get_required_models() -> Array[Script]:
+		var dependencies: Array[Script] = [BasePlanModel]
+		return dependencies
+
+
+class SystemDependingOnPlanModel extends GFSystem:
+	func get_required_models() -> Array[Script]:
+		var dependencies: Array[Script] = [PlanModel]
+		return dependencies
+
+
+class UtilityDependingOnPlanModel extends GFUtility:
+	func get_required_models() -> Array[Script]:
+		var dependencies: Array[Script] = [PlanModel]
+		return dependencies
+
+
+class SystemDependingOnUtility extends GFSystem:
+	func get_required_utilities() -> Array[Script]:
+		var dependencies: Array[Script] = [UtilityDependingOnPlanModel]
+		return dependencies
+
+
+class InvalidDependencyProvider extends RefCounted:
+	func get_required_models() -> Variant:
+		return "invalid"
+
+	func get_required_systems() -> Array:
+		return [42]
+
+
+class FirstCycleSystem extends GFSystem:
+	func get_required_systems() -> Array[Script]:
+		var dependencies: Array[Script] = [SecondCycleSystem]
+		return dependencies
+
+
+class SecondCycleSystem extends GFSystem:
+	func get_required_systems() -> Array[Script]:
+		var dependencies: Array[Script] = [FirstCycleSystem]
+		return dependencies
+
+
+class ManyInvalidDependenciesProvider extends RefCounted:
+	func get_required_models() -> Array:
+		var result: Array = []
+		for index: int in range(69):
+			result.append(index)
+		return result

--- a/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_plan.gd.uid
+++ b/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://c4gflifecycleplantest

--- a/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_transactions.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_transactions.gd
@@ -6,6 +6,7 @@ extends GutTest
 
 const REPLACEMENT_EVENT_ID: StringName = &"gf.test.replacement.rollback"
 const REPLACEMENT_SERVICE_KEY: StringName = &"gf.test.replacement.service"
+const STAGED_SERVICE_KEY: StringName = &"gf.test.topology.staged_service"
 
 
 # --- 测试用例 ---
@@ -40,7 +41,19 @@ func test_registration_does_not_commit_after_injection_disposes_architecture() -
 	assert_false(registered, "注入回调 dispose 架构后，外层注册不得继续提交。")
 	assert_true(registered_utilities.is_empty(), "已 dispose 的架构不得被重入注册重新写入模块。")
 	assert_true(disposing_utility.dependencies_released, "未提交模块的注入作用域必须被释放。")
-	assert_push_error_count(1, "被重入失效的注册事务应报告一次明确错误。")
+	assert_eq(disposing_utility.init_count, 0, "依赖注入使事务失效后不得继续 init Hook。")
+	assert_eq(disposing_utility.async_init_count, 0, "依赖注入使事务失效后不得继续 async_init Hook。")
+	assert_eq(disposing_utility.ready_count, 0, "依赖注入使事务失效后不得继续 ready Hook。")
+	assert_eq(disposing_utility.activation_count, 0, "依赖注入使事务失效后不得继续 activation Hook。")
+	assert_eq(disposing_utility.dispose_count, 1, "未提交候选必须且只应释放一次。")
+	assert_eq(
+		GFVariantData.get_option_int(
+			architecture.get_dependency_diagnostics(),
+			"module_count"
+		),
+		0,
+		"dispose 重入后不得复活 lifecycle plan。"
+	)
 
 
 func test_preinitialization_replacement_does_not_commit_after_injection_disposes_architecture() -> void:
@@ -84,6 +97,349 @@ func test_hot_registration_rolls_back_when_async_init_cancels() -> void:
 	architecture.dispose()
 
 
+func test_hot_registration_is_invisible_until_activation_commits() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await architecture.init(), "测试架构应先进入 READY。")
+	var candidate: PendingHotRegistrationUtility = (
+		PendingHotRegistrationUtility.new()
+	)
+	var register_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+
+	@warning_ignore("missing_await")
+	_await_pending_hot_register(architecture, candidate, register_state)
+	await get_tree().process_frame
+
+	assert_eq(candidate.activation_count, 1, "测试候选应停在 activation pending。")
+	assert_false(
+		architecture.is_accepting_runtime_work(),
+		"热注册事务未稳定时必须关闭普通运行时工作准入。"
+	)
+	assert_false(
+		GFVariantData.get_option_bool(register_state, "done"),
+		"activation pending 时外层热注册不得提前完成。"
+	)
+	assert_null(
+		architecture.get_local_utility(PendingHotRegistrationUtility),
+		"staged 候选在 activation 完成前不得进入本地注册表。"
+	)
+	assert_null(
+		architecture.get_utility(PendingHotRegistrationUtility),
+		"普通依赖查询也不得观察到尚未提交的 staged 候选。"
+	)
+	var lifecycle_tick_count: int = candidate.tick_count
+	architecture.tick(0.1)
+	assert_eq(
+		candidate.tick_count,
+		lifecycle_tick_count,
+		"pending 候选只能由 lifecycle tick 推进，普通 tick 不得重复驱动。"
+	)
+
+	assert_true(candidate.complete_activation())
+	await _wait_for_transaction_state(register_state)
+
+	assert_true(GFVariantData.get_option_bool(register_state, "done"))
+	assert_true(GFVariantData.get_option_bool(register_state, "result"))
+	assert_true(
+		architecture.is_accepting_runtime_work(),
+		"热注册提交后应恢复普通运行时工作准入。"
+	)
+	assert_same(
+		architecture.get_local_utility(PendingHotRegistrationUtility),
+		candidate,
+		"activation 成功后本地查询应原子切换到已提交候选。"
+	)
+	assert_same(
+		architecture.get_utility(PendingHotRegistrationUtility),
+		candidate,
+		"activation 成功后普通查询应与本地注册表看到同一实例。"
+	)
+	architecture.dispose()
+	assert_eq(candidate.dispose_count, 1)
+
+
+func test_pending_hot_replace_closes_acceptance_and_regular_tick_does_not_double_drive() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: PendingHotRegistrationUtility = (
+		PendingHotRegistrationUtility.new(false)
+	)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+	var replacement: PendingHotRegistrationUtility = (
+		PendingHotRegistrationUtility.new(true)
+	)
+	var replace_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+
+	@warning_ignore("missing_await")
+	_await_pending_hot_replace(architecture, replacement, replace_state)
+	await get_tree().process_frame
+
+	assert_false(
+		architecture.is_accepting_runtime_work(),
+		"热替换事务未稳定时必须关闭普通运行时工作准入。"
+	)
+	assert_false(GFVariantData.get_option_bool(replace_state, "done"))
+	assert_same(
+		architecture.get_local_utility(PendingHotRegistrationUtility),
+		previous,
+		"替换提交前注册表必须继续公开旧实例。"
+	)
+	var previous_tick_count: int = previous.tick_count
+	var replacement_tick_count: int = replacement.tick_count
+	architecture.tick(0.1)
+	assert_eq(previous.tick_count, previous_tick_count)
+	assert_eq(
+		replacement.tick_count,
+		replacement_tick_count,
+		"普通 tick 不得重复驱动 staged replacement。"
+	)
+
+	assert_true(replacement.complete_activation())
+	await _wait_for_transaction_state(replace_state)
+
+	assert_true(GFVariantData.get_option_bool(replace_state, "result"))
+	assert_true(architecture.is_accepting_runtime_work())
+	assert_same(
+		architecture.get_local_utility(PendingHotRegistrationUtility),
+		replacement,
+		"替换成功后注册表应原子切换到新实例。"
+	)
+	assert_eq(previous.dispose_count, 1)
+	architecture.dispose()
+	assert_eq(replacement.dispose_count, 1)
+
+
+func test_hot_register_stages_service_until_atomic_commit() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await architecture.init())
+	var candidate: StagedServiceProviderUtility = (
+		StagedServiceProviderUtility.new(true, false)
+	)
+	var register_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+
+	@warning_ignore("missing_await")
+	_await_staged_service_register(architecture, candidate, register_state)
+	await get_tree().process_frame
+
+	assert_true(candidate.service_registered, "候选应已写入事务内 service intent。")
+	assert_null(
+		architecture.get_service(STAGED_SERVICE_KEY),
+		"候选提交前不得公开 staged service provider。"
+	)
+	assert_false(architecture.is_accepting_runtime_work())
+
+	assert_true(candidate.complete_activation())
+	await _wait_for_transaction_state(register_state)
+
+	assert_true(GFVariantData.get_option_bool(register_state, "result"))
+	assert_same(
+		architecture.get_service(STAGED_SERVICE_KEY),
+		candidate,
+		"候选与 service provider 必须在同一提交点原子可见。"
+	)
+	architecture.dispose()
+	assert_eq(candidate.dispose_count, 1)
+
+
+func test_hot_replace_switches_service_provider_only_at_commit() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: StagedServiceProviderUtility = (
+		StagedServiceProviderUtility.new(false, false)
+	)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+	assert_same(architecture.get_service(STAGED_SERVICE_KEY), previous)
+	var replacement: StagedServiceProviderUtility = (
+		StagedServiceProviderUtility.new(true, false)
+	)
+	var replace_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+
+	@warning_ignore("missing_await")
+	_await_staged_service_replace(architecture, replacement, replace_state)
+	await get_tree().process_frame
+
+	assert_true(replacement.service_registered)
+	assert_same(
+		architecture.get_service(STAGED_SERVICE_KEY),
+		previous,
+		"替换候选 pending 时 service 查询必须继续返回旧 provider。"
+	)
+	assert_false(GFVariantData.get_option_bool(replace_state, "done"))
+
+	assert_true(replacement.complete_activation())
+	await _wait_for_transaction_state(replace_state)
+
+	assert_true(GFVariantData.get_option_bool(replace_state, "result"))
+	assert_same(
+		architecture.get_service(STAGED_SERVICE_KEY),
+		replacement,
+		"替换提交后 service 查询必须原子切换到新 provider。"
+	)
+	assert_eq(previous.dispose_count, 1)
+	architecture.dispose()
+	assert_eq(replacement.dispose_count, 1)
+
+
+func test_failed_hot_replace_preserves_previous_service_provider() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: StagedServiceProviderUtility = (
+		StagedServiceProviderUtility.new(false, false)
+	)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+	var rejected: StagedServiceProviderUtility = (
+		StagedServiceProviderUtility.new(false, true)
+	)
+
+	assert_false(
+		await architecture.replace_utility(
+			StagedServiceProviderUtility,
+			rejected
+		)
+	)
+
+	assert_same(
+		architecture.get_service(STAGED_SERVICE_KEY),
+		previous,
+		"替换失败必须保留旧 service provider。"
+	)
+	assert_same(
+		architecture.get_local_utility(StagedServiceProviderUtility),
+		previous,
+		"替换失败必须保留旧 Utility。"
+	)
+	assert_eq(previous.dispose_count, 0)
+	assert_eq(rejected.dispose_count, 1)
+	assert_push_error("[GFArchitecture] 热模块 activation 失败")
+	architecture.dispose()
+	assert_eq(previous.dispose_count, 1)
+
+
+func test_hot_replace_rejects_provider_identity_drift_for_active_consumer() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	var consumer: StableDependencyConsumerSystem = (
+		StableDependencyConsumerSystem.new()
+	)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.register_system_instance(consumer))
+	assert_true(await architecture.init())
+	var replacement: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+
+	assert_false(
+		await architecture.replace_utility(
+			StableDependencyProviderUtility,
+			replacement
+		),
+		"活动 Consumer 的已解析 provider 身份不得被热替换漂移。"
+	)
+
+	assert_same(
+		architecture.get_local_utility(
+			StableDependencyProviderUtility
+		),
+		previous
+	)
+	assert_eq(previous.dispose_count, 0, "拒绝替换时旧 provider 应继续活动。")
+	assert_eq(replacement.dispose_count, 1, "拒绝的 replacement 应且只应清理一次。")
+	assert_push_error(
+		"[GFArchitecture] hot replace 失败：既有活动模块的声明或解析目标发生漂移"
+	)
+	architecture.dispose()
+	assert_eq(previous.dispose_count, 1)
+
+
+func test_hot_unregister_rejects_alternate_fallback_resolution_drift() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var exact_provider: FallbackProviderUtility = (
+		FallbackProviderUtility.new()
+	)
+	var alternate_provider: AlternateFallbackProviderUtility = (
+		AlternateFallbackProviderUtility.new()
+	)
+	var consumer: FallbackConsumerSystem = FallbackConsumerSystem.new()
+	assert_true(await architecture.register_utility_instance(exact_provider))
+	assert_true(
+		await architecture.register_utility_instance(alternate_provider)
+	)
+	assert_true(await architecture.register_system_instance(consumer))
+	assert_true(await architecture.init())
+
+	assert_false(
+		await architecture.unregister_utility(FallbackProviderUtility),
+		"移除 exact provider 导致 assignable fallback 漂移时必须拒绝。"
+	)
+
+	assert_same(
+		architecture.get_local_utility(FallbackProviderUtility),
+		exact_provider
+	)
+	assert_same(
+		architecture.get_local_utility(
+			AlternateFallbackProviderUtility
+		),
+		alternate_provider
+	)
+	assert_eq(exact_provider.dispose_count, 0)
+	assert_push_error(
+		"[GFArchitecture] hot unregister 失败：既有活动模块的声明或解析目标发生漂移"
+	)
+	architecture.dispose()
+	assert_eq(exact_provider.dispose_count, 1)
+	assert_eq(alternate_provider.dispose_count, 1)
+
+
+func test_unrelated_hot_register_rejects_existing_dependency_hook_drift() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var primary: DriftPrimaryProviderUtility = (
+		DriftPrimaryProviderUtility.new()
+	)
+	var alternate: DriftAlternateProviderUtility = (
+		DriftAlternateProviderUtility.new()
+	)
+	var consumer: DriftingDependencyConsumerSystem = (
+		DriftingDependencyConsumerSystem.new()
+	)
+	assert_true(await architecture.register_utility_instance(primary))
+	assert_true(await architecture.register_utility_instance(alternate))
+	assert_true(await architecture.register_system_instance(consumer))
+	assert_true(await architecture.init())
+	consumer.use_alternate = true
+	var unrelated: UnrelatedHotUtility = UnrelatedHotUtility.new()
+
+	assert_false(
+		await architecture.register_utility_instance(unrelated),
+		"无关热注册也不得接受既有 required Hook 的声明漂移。"
+	)
+
+	assert_null(architecture.get_local_utility(UnrelatedHotUtility))
+	assert_eq(unrelated.inject_count, 0, "计划稳定性失败后不得继续准备无关候选。")
+	assert_eq(unrelated.dispose_count, 1)
+	assert_same(
+		architecture.get_local_utility(DriftPrimaryProviderUtility),
+		primary
+	)
+	assert_push_error(
+		"[GFArchitecture] hot register 失败：既有活动模块的声明或解析目标发生漂移"
+	)
+	architecture.dispose()
+
+
 func test_failed_replacement_rolls_back_owned_events_and_services() -> void:
 	var architecture: GFArchitecture = GFArchitecture.new()
 	var old_utility: ReplacementSideEffectUtility = ReplacementSideEffectUtility.new(false)
@@ -115,7 +471,7 @@ func test_failed_replacement_rolls_back_owned_events_and_services() -> void:
 	architecture.dispose()
 
 
-func test_hot_replacement_ready_reentry_cannot_commit_removed_candidate() -> void:
+func test_hot_replacement_ready_reentry_cannot_supersede_outer_transaction() -> void:
 	var architecture: GFArchitecture = GFArchitecture.new()
 	var previous_utility: ReadyReentrantReplacementUtility = ReadyReentrantReplacementUtility.new(false)
 	var replacement_utility: ReadyReentrantReplacementUtility = ReadyReentrantReplacementUtility.new(true)
@@ -130,18 +486,248 @@ func test_hot_replacement_ready_reentry_cannot_commit_removed_candidate() -> voi
 		replacement_utility
 	)
 
-	assert_false(replaced, "replacement ready 回调移除 candidate 后，外层替换不得报告成功。")
-	assert_null(
+	assert_true(replaced, "replacement ready 回调中的重入注销应被拒绝，外层事务应正常提交。")
+	assert_same(
 		architecture.get_local_utility(ReadyReentrantReplacementUtility),
-		"ready 中较新的 unregister 应拥有最终注册表状态。"
+		replacement_utility,
+		"重入注销不得越过外层拓扑事务移除 replacement。"
 	)
-	assert_false(
+	assert_true(
 		architecture.is_module_ready(replacement_utility),
-		"已被重入移除并释放的 candidate 不得残留 ready stage。"
+		"成功提交的 replacement 应保留 ready stage。"
 	)
-	assert_eq(replacement_utility.dispose_count, 1, "重入移除的 candidate 应只释放一次。")
+	assert_eq(replacement_utility.dispose_count, 0, "活动 replacement 在架构释放前不得被释放。")
 	assert_eq(previous_utility.dispose_count, 1, "被 supersede 的旧实例应只释放一次。")
+	assert_push_error(
+		"[GFArchitecture] unregister_utility 失败：另一项模块拓扑事务尚未完成。"
+	)
 	architecture.dispose()
+	assert_eq(replacement_utility.dispose_count, 1, "架构释放时 replacement 应且只应释放一次。")
+
+
+func test_hot_replace_fails_closed_when_detached_dispose_fails_architecture() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: DetachedDisposeReentryUtility = (
+		DetachedDisposeReentryUtility.new(
+			DetachedDisposeReentryUtility.Reentry.FAIL_INITIALIZATION
+		)
+	)
+	var replacement: DetachedDisposeReentryUtility = (
+		DetachedDisposeReentryUtility.new()
+	)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+
+	var replaced: bool = await architecture.replace_utility(
+		DetachedDisposeReentryUtility,
+		replacement
+	)
+	var dependency_report: Dictionary = (
+		architecture.get_dependency_diagnostics()
+	)
+
+	assert_false(
+		replaced,
+		"detached previous.dispose() 使生命周期失败后，replace 不得报告成功。"
+	)
+	assert_true(architecture.has_initialization_failed())
+	assert_null(
+		architecture.get_local_utility(DetachedDisposeReentryUtility),
+		"失败清理后不得把 replacement 或 previous 复活进注册表。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(dependency_report, "module_count"),
+		0,
+		"失败清理后不得恢复候选或旧 lifecycle plan。"
+	)
+	assert_eq(previous.dispose_count, 1)
+	assert_eq(replacement.dispose_count, 1)
+	assert_push_error("[test] detached previous dispose failure")
+
+	architecture.dispose()
+	architecture.dispose()
+	assert_eq(previous.dispose_count, 1, "终态清理不得重复释放 previous。")
+	assert_eq(replacement.dispose_count, 1, "终态清理不得重复释放 replacement。")
+
+
+func test_hot_unregister_fails_closed_when_detached_dispose_disposes_architecture() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var previous: DetachedDisposeReentryUtility = (
+		DetachedDisposeReentryUtility.new(
+			DetachedDisposeReentryUtility.Reentry.DISPOSE_ARCHITECTURE
+		)
+	)
+	assert_true(await architecture.register_utility_instance(previous))
+	assert_true(await architecture.init())
+
+	var unregistered_value: Variant = await architecture.call(
+		&"unregister_utility",
+		DetachedDisposeReentryUtility
+	)
+	var unregistered: bool = GFVariantData.to_bool(unregistered_value)
+	var dependency_report: Dictionary = (
+		architecture.get_dependency_diagnostics()
+	)
+
+	assert_false(
+		unregistered,
+		"detached previous.dispose() 进入 DISPOSED 后，unregister 不得报告成功。"
+	)
+	assert_true(architecture.is_disposed())
+	assert_null(
+		architecture.get_local_utility(DetachedDisposeReentryUtility),
+		"dispose 重入后不得把已 detached 实例复活进注册表。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(dependency_report, "module_count"),
+		0,
+		"dispose 重入后不得恢复 unregister 前的 lifecycle plan。"
+	)
+	assert_eq(previous.dispose_count, 1)
+
+	architecture.dispose()
+	architecture.dispose()
+	assert_eq(previous.dispose_count, 1, "重复终态调用不得再次释放 previous。")
+
+
+func test_hot_candidate_ready_failure_stops_activation_and_clears_plan() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var stable: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	assert_true(await architecture.register_utility_instance(stable))
+	assert_true(await architecture.init())
+	var candidate: ReadyInvalidatingUtility = ReadyInvalidatingUtility.new()
+
+	assert_false(await architecture.register_utility_instance(candidate))
+
+	assert_true(architecture.has_initialization_failed())
+	assert_eq(candidate.inject_count, 1)
+	assert_eq(candidate.init_count, 1)
+	assert_eq(candidate.async_init_count, 1)
+	assert_eq(candidate.ready_count, 1)
+	assert_eq(
+		candidate.activation_count,
+		0,
+		"ready Hook 使事务失败后不得继续 activation Hook。"
+	)
+	assert_eq(candidate.dispose_count, 1)
+	assert_eq(stable.dispose_count, 1)
+	assert_eq(
+		GFVariantData.get_option_int(
+			architecture.get_dependency_diagnostics(),
+			"module_count"
+		),
+		0,
+		"ready Hook 失败后不得复活候选或旧 lifecycle plan。"
+	)
+	assert_push_error("[test] fail during hot candidate ready")
+	architecture.dispose()
+	assert_eq(candidate.dispose_count, 1)
+	assert_eq(stable.dispose_count, 1)
+
+
+func test_plan_hook_dispose_stops_remaining_hooks_and_candidate_pipeline() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await architecture.init())
+	var candidate: PlanHookInvalidatingUtility = (
+		PlanHookInvalidatingUtility.new(
+			architecture,
+			PlanHookInvalidatingUtility.Invalidation.DISPOSE
+		)
+	)
+
+	assert_false(await architecture.register_utility_instance(candidate))
+
+	assert_true(architecture.is_disposed())
+	_assert_plan_hook_invalidation_stopped(candidate)
+	assert_eq(
+		GFVariantData.get_option_int(
+			architecture.get_dependency_diagnostics(),
+			"module_count"
+		),
+		0,
+		"plan Hook dispose 后不得复活 lifecycle plan。"
+	)
+	architecture.dispose()
+	assert_eq(candidate.dispose_count, 1)
+
+
+func test_plan_hook_failure_stops_remaining_hooks_and_candidate_pipeline() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(await architecture.init())
+	var candidate: PlanHookInvalidatingUtility = (
+		PlanHookInvalidatingUtility.new(
+			architecture,
+			PlanHookInvalidatingUtility.Invalidation.FAIL
+		)
+	)
+
+	assert_false(await architecture.register_utility_instance(candidate))
+
+	assert_true(architecture.has_initialization_failed())
+	_assert_plan_hook_invalidation_stopped(candidate)
+	assert_eq(
+		GFVariantData.get_option_int(
+			architecture.get_dependency_diagnostics(),
+			"module_count"
+		),
+		0,
+		"plan Hook failure 后不得复活 lifecycle plan。"
+	)
+	assert_push_error("[test] fail during lifecycle plan hook")
+	architecture.dispose()
+	assert_eq(candidate.dispose_count, 1)
+
+
+func test_synchronous_hot_activation_crossing_frozen_deadline_fails() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.activation_timeout_seconds = 0.001
+	assert_true(await architecture.init())
+	var candidate: DeadlineCrossingActivationUtility = (
+		DeadlineCrossingActivationUtility.new(25)
+	)
+
+	assert_false(await architecture.register_utility_instance(candidate))
+
+	assert_true(architecture.is_inited(), "局部 activation 超时不应破坏既有 READY 架构。")
+	assert_true(architecture.is_accepting_runtime_work())
+	assert_null(
+		architecture.get_local_utility(
+			DeadlineCrossingActivationUtility
+		)
+	)
+	assert_eq(candidate.activation_count, 1)
+	assert_eq(candidate.dispose_count, 1)
+	assert_push_error("[GFArchitecture] 热模块 activation 失败")
+	architecture.dispose()
+	assert_eq(candidate.dispose_count, 1)
+
+
+func test_synchronous_hot_quiesce_crossing_frozen_deadline_fails_closed() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.shutdown_timeout_seconds = 0.001
+	var utility: DeadlineCrossingTopologyQuiesceUtility = (
+		DeadlineCrossingTopologyQuiesceUtility.new(25)
+	)
+	assert_true(await architecture.register_utility_instance(utility))
+	assert_true(await architecture.init())
+
+	assert_false(
+		await architecture.unregister_utility(
+			DeadlineCrossingTopologyQuiesceUtility
+		)
+	)
+
+	assert_true(
+		architecture.is_disposed(),
+		"已接纳的 topology quiesce 超时必须 fail-closed 释放架构。"
+	)
+	assert_eq(utility.quiesce_count, 1)
+	assert_eq(utility.dispose_count, 1)
+	assert_push_error("[GFArchitecture] 模块拓扑事务 quiesce 失败")
+	architecture.dispose()
+	assert_eq(utility.dispose_count, 1)
 
 
 func test_initialization_failure_resets_applied_project_installers() -> void:
@@ -310,6 +896,1096 @@ func test_dispose_cleanup_reentry_does_not_retain_terminal_async_scope() -> void
 		)
 
 
+func test_parent_external_dependency_lease_blocks_topology_until_child_shutdown() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	assert_true(await parent.register_utility_instance(provider))
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(
+		await child.register_system_instance(
+			StableDependencyConsumerSystem.new()
+		)
+	)
+	assert_true(await child.init())
+	var rejected_replacement: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+
+	var blocked_parent_shutdown: GFArchitectureShutdownResult = (
+		await parent.shutdown_async()
+	)
+	assert_eq(
+		blocked_parent_shutdown.get_status(),
+		GFArchitectureShutdownResult.Status.FAILED
+	)
+	assert_eq(blocked_parent_shutdown.get_error_code(), ERR_BUSY)
+	assert_true(
+		parent.is_inited(),
+		"被 child 外部依赖租约拒绝的正常关闭必须保留父架构 READY。"
+	)
+	assert_true(parent.is_accepting_runtime_work())
+	assert_false(parent.is_quiescing())
+	assert_false(parent.is_disposed())
+	assert_false(
+		await parent.replace_utility(
+			StableDependencyProviderUtility,
+			rejected_replacement
+		),
+		"活动 child 的父级外部依赖租约必须拒绝 provider replace。"
+	)
+	assert_false(
+		await parent.unregister_utility(
+			StableDependencyProviderUtility
+		),
+		"活动 child 的父级外部依赖租约必须拒绝 provider unregister。"
+	)
+	assert_same(
+		parent.get_local_utility(StableDependencyProviderUtility),
+		provider
+	)
+	assert_eq(provider.dispose_count, 0)
+	assert_push_error("活动子架构仍持有父级外部模块依赖租约")
+	assert_push_error("活动子架构仍持有父级外部模块依赖租约")
+
+	var child_shutdown: GFArchitectureShutdownResult = (
+		await child.shutdown_async()
+	)
+	assert_true(child_shutdown.is_successful())
+	assert_true(
+		await parent.unregister_utility(
+			StableDependencyProviderUtility
+		),
+		"child 完成关闭并释放租约后，父级拓扑事务应恢复可用。"
+	)
+	assert_eq(provider.dispose_count, 1)
+	parent.dispose()
+
+
+func test_parent_factory_dependency_lease_blocks_shutdown_without_freezing_module_topology() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider_state: Dictionary = {"call_count": 0}
+	var factory: Callable = func() -> Object:
+		provider_state["call_count"] = (
+			GFVariantData.get_option_int(
+				provider_state,
+				"call_count"
+			)
+			+ 1
+		)
+		return FactoryLeaseProduct.new()
+	assert_true(
+		parent.register_factory(
+			FactoryLeaseProduct,
+			factory
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(
+		await child.register_system_instance(
+			FactoryLeaseConsumerSystem.new()
+		)
+	)
+	assert_true(await child.init())
+
+	var product: Object = child.create_instance(FactoryLeaseProduct)
+	assert_not_null(product)
+	assert_eq(
+		GFVariantData.get_option_int(provider_state, "call_count"),
+		1
+	)
+	var unrelated_utility: UnrelatedHotUtility = UnrelatedHotUtility.new()
+	assert_true(
+		await parent.register_utility_instance(unrelated_utility),
+		"仅依赖父级 factory 的 child 不应冻结无关模块拓扑。"
+	)
+	assert_same(
+		parent.get_local_utility(UnrelatedHotUtility),
+		unrelated_utility
+	)
+
+	var blocked_parent_shutdown: GFArchitectureShutdownResult = (
+		await parent.shutdown_async()
+	)
+	assert_eq(
+		blocked_parent_shutdown.get_status(),
+		GFArchitectureShutdownResult.Status.FAILED
+	)
+	assert_eq(blocked_parent_shutdown.get_error_code(), ERR_BUSY)
+	assert_true(parent.is_accepting_runtime_work())
+
+	var child_shutdown: GFArchitectureShutdownResult = (
+		await child.shutdown_async()
+	)
+	assert_true(child_shutdown.is_successful())
+	var parent_shutdown: GFArchitectureShutdownResult = (
+		await parent.shutdown_async()
+	)
+	assert_true(parent_shutdown.is_successful())
+	assert_eq(unrelated_utility.dispose_count, 1)
+
+
+func test_mixed_parent_dependency_lease_preserves_module_topology_scope() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	var factory: Callable = func() -> Object:
+		return FactoryLeaseProduct.new()
+	assert_true(await parent.register_utility_instance(provider))
+	assert_true(parent.register_factory(FactoryLeaseProduct, factory))
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(
+		await child.register_system_instance(
+			MixedExternalDependencyConsumerSystem.new()
+		)
+	)
+	assert_true(await child.init())
+
+	assert_false(
+		await parent.register_utility_instance(UnrelatedHotUtility.new()),
+		"同 owner 的 factory lease 不得把 module lease 的拓扑 scope 降级。"
+	)
+	assert_push_error("活动子架构仍持有父级外部模块依赖租约")
+	var blocked_shutdown: GFArchitectureShutdownResult = (
+		await parent.shutdown_async()
+	)
+	assert_eq(blocked_shutdown.get_error_code(), ERR_BUSY)
+
+	var child_shutdown: GFArchitectureShutdownResult = (
+		await child.shutdown_async()
+	)
+	assert_true(child_shutdown.is_successful())
+	var parent_shutdown: GFArchitectureShutdownResult = (
+		await parent.shutdown_async()
+	)
+	assert_true(parent_shutdown.is_successful())
+
+
+func test_forced_parent_dispose_prevents_child_from_invoking_parent_factory() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider_state: Dictionary = {"call_count": 0}
+	var dispose_probe: FactoryInvocationDuringDisposeUtility = (
+		FactoryInvocationDuringDisposeUtility.new()
+	)
+	var factory: Callable = func() -> Object:
+		provider_state["call_count"] = (
+			GFVariantData.get_option_int(
+				provider_state,
+				"call_count"
+			)
+			+ 1
+		)
+		return FactoryLeaseProduct.new()
+	assert_true(await parent.register_utility_instance(dispose_probe))
+	assert_true(
+		parent.register_factory(
+			FactoryLeaseProduct,
+			factory
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(
+		await child.register_system_instance(
+			FactoryLeaseConsumerSystem.new()
+		)
+	)
+	assert_true(await child.init())
+	dispose_probe.child_architecture = child
+	dispose_probe.requested_script = FactoryLeaseProduct
+
+	parent.dispose()
+
+	assert_null(
+		dispose_probe.factory_result,
+		"强制释放父级期间，child 不得调用正在关闭 owner 的 factory provider。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(provider_state, "call_count"),
+		0
+	)
+	assert_push_error("工厂所属架构未开放运行时准入")
+	child.dispose()
+
+
+func test_owner_denial_releases_unreturned_transient_fallback() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var dispose_probe: FactoryInvocationDuringDisposeUtility = (
+		FactoryInvocationDuringDisposeUtility.new()
+	)
+	var parent_factory: Callable = func() -> Object:
+		return FactoryLeaseProduct.new()
+	assert_true(await parent.register_utility_instance(dispose_probe))
+	assert_true(
+		parent.register_factory(
+			FactoryLeaseProduct,
+			parent_factory
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	var transient_factory: TransientFallbackAfterOwnerDeniedFactory = (
+		TransientFallbackAfterOwnerDeniedFactory.new(child)
+	)
+	assert_true(
+		child.register_factory(
+			TransientFallbackProduct,
+			Callable(transient_factory, &"create")
+		)
+	)
+	assert_true(
+		await child.register_system_instance(
+			FactoryLeaseConsumerSystem.new()
+		)
+	)
+	assert_true(await child.init())
+	dispose_probe.child_architecture = child
+	dispose_probe.requested_script = TransientFallbackProduct
+
+	parent.dispose()
+
+	assert_true(
+		transient_factory.nested_result_was_null,
+		"父级 owner 拒绝后，嵌套 factory 请求应返回 null。"
+	)
+	assert_null(
+		dispose_probe.factory_result,
+		"共享解析上下文失败后，外层 transient fallback 不得交付。"
+	)
+	assert_not_null(transient_factory.rejected_instance_ref)
+	if transient_factory.rejected_instance_ref != null:
+		var rejected_instance_value: Variant = (
+			transient_factory.rejected_instance_ref.get_ref()
+		)
+		assert_true(
+			rejected_instance_value == null,
+			"未交付的 transient Node 必须释放，不能形成 orphan。"
+		)
+	assert_push_error("工厂所属架构未开放运行时准入")
+	child.dispose()
+
+
+func test_parent_external_dependency_lease_closes_activation_race_and_forced_dispose_releases() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	assert_true(await parent.register_utility_instance(provider))
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	var consumer: ExternalLeaseActivationConsumerSystem = (
+		ExternalLeaseActivationConsumerSystem.new(
+			ExternalLeaseActivationConsumerSystem.ActivationMode.PENDING
+		)
+	)
+	assert_true(await child.register_system_instance(consumer))
+	var init_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	@warning_ignore("missing_await")
+	_await_architecture_init(child, init_state)
+	await get_tree().process_frame
+	assert_not_null(
+		consumer.activation_completion,
+		"测试 child 应停在 pending activation。"
+	)
+
+	assert_false(
+		await parent.unregister_utility(
+			StableDependencyProviderUtility
+		),
+		"child activation pending 期间父级 provider 也必须受租约保护。"
+	)
+	assert_eq(provider.dispose_count, 0)
+	assert_push_error("活动子架构仍持有父级外部模块依赖租约")
+
+	child.dispose()
+	child.dispose()
+	await _wait_for_transaction_state(init_state)
+	assert_true(GFVariantData.get_option_bool(init_state, "done"))
+	assert_false(GFVariantData.get_option_bool(init_state, "result"))
+	assert_true(
+		await parent.unregister_utility(
+			StableDependencyProviderUtility
+		),
+		"forced dispose 必须幂等释放 child 的外部依赖租约。"
+	)
+	assert_eq(provider.dispose_count, 1)
+	parent.dispose()
+
+
+func test_failed_child_activation_releases_parent_external_dependency_lease() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	assert_true(await parent.register_utility_instance(provider))
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	var consumer: ExternalLeaseActivationConsumerSystem = (
+		ExternalLeaseActivationConsumerSystem.new(
+			ExternalLeaseActivationConsumerSystem.ActivationMode.FAIL
+		)
+	)
+	assert_true(await child.register_system_instance(consumer))
+
+	assert_false(await child.init())
+	assert_true(child.has_initialization_failed())
+	assert_push_error("[GFArchitecture] activation 失败")
+	assert_true(
+		await parent.unregister_utility(
+			StableDependencyProviderUtility
+		),
+		"child 初始化失败清理必须释放父级外部依赖租约。"
+	)
+	assert_eq(provider.dispose_count, 1)
+	child.dispose()
+	parent.dispose()
+
+
+func test_factory_rejects_owned_result_when_provider_disposes_owner() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var factory: DisposeOwnerDuringProvideFactory = (
+		DisposeOwnerDuringProvideFactory.new(architecture, state)
+	)
+	assert_true(
+		architecture.register_factory(
+			FactoryLifecycleGuardProduct,
+			Callable(factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	assert_true(await architecture.init())
+
+	var result: Object = architecture.create_instance(
+		FactoryLifecycleGuardProduct
+	)
+
+	assert_null(
+		result,
+		"provider 关闭 owner 后返回的实例不得缓存或交付。"
+	)
+	assert_true(architecture.is_disposed())
+	assert_eq(
+		GFVariantData.get_option_int(state, "dispose_count"),
+		1,
+		"框架拥有的未交付实例必须且只 dispose 一次。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(state, "release_count"),
+		0,
+		"provider 后准入失效发生在注入前，不得伪造注入作用域释放。"
+	)
+	var instance_ref_value: Variant = state.get("instance_ref")
+	assert_true(instance_ref_value is WeakRef)
+	if instance_ref_value is WeakRef:
+		var instance_ref: WeakRef = instance_ref_value
+		var released_instance_value: Variant = instance_ref.get_ref()
+		assert_true(
+			released_instance_value == null,
+			"框架拥有的未交付 Node 必须立即释放。"
+		)
+
+
+func test_parent_singleton_factory_rejects_result_when_provider_disposes_requester() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+		"nested_result_was_null": false,
+	}
+	var late_state: Dictionary = {
+		"provider_count": 0,
+		"inject_count": 0,
+	}
+	var factory: DisposeRequesterDuringProvideFactory = (
+		DisposeRequesterDuringProvideFactory.new(
+			parent,
+			state
+		)
+	)
+	assert_true(
+		parent.register_factory(
+			FactoryLifecycleGuardProduct,
+			Callable(factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	var late_factory: LateTransientFactory = (
+		LateTransientFactory.new(late_state)
+	)
+	assert_true(
+		parent.register_factory(
+			LateTransientProduct,
+			Callable(late_factory, &"create")
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(await child.init())
+	factory.requester_architecture = child
+
+	var result: Object = child.create_instance(
+		FactoryLifecycleGuardProduct
+	)
+
+	assert_null(
+		result,
+		"父级 Singleton provider 关闭真实 requester 后不得缓存或交付结果。"
+	)
+	assert_true(child.is_disposed())
+	assert_true(parent.is_accepting_runtime_work())
+	assert_eq(GFVariantData.get_option_int(state, "dispose_count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(state, "release_count"),
+		0,
+		"requester 在 provider 内失效发生于注入前。"
+	)
+	assert_true(
+		GFVariantData.get_option_bool(state, "nested_result_was_null"),
+		"requester 关闭必须立即使共享解析上下文失败。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(late_state, "provider_count"),
+		0,
+		"共享上下文失败后不得执行同一 provider 内的迟到 factory。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(late_state, "inject_count"),
+		0
+	)
+	var instance_ref_value: Variant = state.get("instance_ref")
+	assert_true(instance_ref_value is WeakRef)
+	if instance_ref_value is WeakRef:
+		var instance_ref: WeakRef = instance_ref_value
+		var released_instance_value: Variant = instance_ref.get_ref()
+		assert_true(released_instance_value == null)
+	parent.dispose()
+
+
+func test_parent_provider_owner_disposal_blocks_late_child_factory() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var outer_state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+		"nested_result_was_null": false,
+	}
+	var late_state: Dictionary = {
+		"provider_count": 0,
+		"inject_count": 0,
+	}
+	var factory: DisposeOwnerThenRequesterFactory = (
+		DisposeOwnerThenRequesterFactory.new(
+			parent,
+			outer_state
+		)
+	)
+	assert_true(
+		parent.register_factory(
+			FactoryLifecycleGuardProduct,
+			Callable(factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	var late_factory: LateTransientFactory = (
+		LateTransientFactory.new(late_state)
+	)
+	assert_true(
+		child.register_factory(
+			LateTransientProduct,
+			Callable(late_factory, &"create")
+		)
+	)
+	assert_true(await child.init())
+	factory.requester_architecture = child
+
+	var result: Object = child.create_instance(
+		FactoryLifecycleGuardProduct
+	)
+
+	assert_null(result)
+	assert_true(parent.is_disposed())
+	assert_true(child.is_accepting_runtime_work())
+	assert_true(
+		GFVariantData.get_option_bool(
+			outer_state,
+			"nested_result_was_null"
+		)
+	)
+	assert_eq(
+		GFVariantData.get_option_int(late_state, "provider_count"),
+		0,
+		"owner 关闭必须通过共享上下文阻止 child 的迟到 provider。"
+	)
+	assert_eq(GFVariantData.get_option_int(late_state, "inject_count"), 0)
+	assert_eq(
+		GFVariantData.get_option_int(outer_state, "dispose_count"),
+		1
+	)
+	assert_eq(
+		GFVariantData.get_option_int(outer_state, "release_count"),
+		0
+	)
+	child.dispose()
+
+
+func test_parent_factory_rejects_owned_result_when_injection_disposes_requester() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"inject_count": 0,
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var factory: InjectionDisposesRequesterFactory = (
+		InjectionDisposesRequesterFactory.new(state)
+	)
+	assert_true(
+		parent.register_factory(
+			FactoryRequesterGuardProduct,
+			Callable(factory, &"create")
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(await child.init())
+
+	var result: Object = child.create_instance(
+		FactoryRequesterGuardProduct
+	)
+
+	assert_null(
+		result,
+		"注入期间关闭 requester 后，父级 factory 结果不得交付。"
+	)
+	assert_true(child.is_disposed())
+	assert_true(parent.is_accepting_runtime_work())
+	assert_eq(GFVariantData.get_option_int(state, "inject_count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(state, "dispose_count"),
+		1,
+		"框架拥有的拒绝结果必须且只 dispose 一次。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(state, "release_count"),
+		1,
+		"已开始的 requester 注入作用域必须且只释放一次。"
+	)
+	var instance_ref_value: Variant = state.get("instance_ref")
+	assert_true(instance_ref_value is WeakRef)
+	if instance_ref_value is WeakRef:
+		var instance_ref: WeakRef = instance_ref_value
+		var released_instance_value: Variant = instance_ref.get_ref()
+		assert_true(
+			released_instance_value == null,
+			"拒绝的 transient Node 不得形成 orphan。"
+		)
+	parent.dispose()
+
+
+func test_parent_factory_instance_keeps_external_ownership_after_requester_disposal() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"inject_count": 0,
+		"second_hook_count": 0,
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var external_instance: ExternalRequesterGuardProduct = (
+		ExternalRequesterGuardProduct.new(state)
+	)
+	assert_true(
+		parent.register_factory_instance(
+			ExternalRequesterGuardProduct,
+			external_instance
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(await child.init())
+	external_instance.requester_architecture = child
+
+	var result: Object = child.create_instance(
+		ExternalRequesterGuardProduct
+	)
+
+	assert_null(
+		result,
+		"外部 Singleton 实例在注入期间关闭 requester 后不得交付。"
+	)
+	assert_true(child.is_disposed())
+	assert_true(parent.is_accepting_runtime_work())
+	assert_true(is_instance_valid(external_instance))
+	assert_same(external_instance.injected_architecture, parent)
+	assert_eq(GFVariantData.get_option_int(state, "inject_count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(state, "second_hook_count"),
+		0,
+		"requester generation 失效后不得继续调用后续 inject Hook。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(state, "dispose_count"),
+		0,
+		"register_factory_instance 的外部实例归属不得被框架夺取。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(state, "release_count"),
+		1,
+		"框架仍需释放已经建立的 owner 注入作用域。"
+	)
+	assert_true(is_instance_valid(external_instance))
+	assert_eq(GFVariantData.get_option_int(state, "dispose_count"), 0)
+	assert_eq(GFVariantData.get_option_int(state, "release_count"), 1)
+	child.dispose()
+	parent.dispose()
+	assert_true(
+		is_instance_valid(external_instance),
+		"父级释放 factory binding 后仍不得夺取外部实例所有权。"
+	)
+	assert_eq(GFVariantData.get_option_int(state, "dispose_count"), 0)
+	assert_eq(
+		GFVariantData.get_option_int(state, "release_count"),
+		1,
+		"父级释放不得重复释放已经关闭的外部实例注入作用域。"
+	)
+	external_instance.free()
+
+
+func test_factory_rejects_queued_instance_before_later_injection_hooks() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"inject_count": 0,
+		"second_hook_count": 0,
+		"dispose_count": 0,
+	}
+	var factory: QueueFreeingInjectionFactory = (
+		QueueFreeingInjectionFactory.new(state)
+	)
+	assert_true(
+		architecture.register_factory(
+			QueueFreeingInjectionProduct,
+			Callable(factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	assert_true(await architecture.init())
+
+	var result: Object = architecture.create_instance(
+		QueueFreeingInjectionProduct
+	)
+
+	assert_null(result, "已 queue_free 的注入结果不得缓存或交付。")
+	assert_eq(GFVariantData.get_option_int(state, "inject_count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(state, "second_hook_count"),
+		0,
+		"实例进入 queued 状态后不得继续调用后续 inject Hook。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(state, "dispose_count"),
+		1,
+		"框架拥有的 queued 拒绝结果仍应 exactly-once dispose。"
+	)
+	await get_tree().process_frame
+	var instance_ref_value: Variant = state.get("instance_ref")
+	assert_true(instance_ref_value is WeakRef)
+	if instance_ref_value is WeakRef:
+		var instance_ref: WeakRef = instance_ref_value
+		var released_instance_value: Variant = instance_ref.get_ref()
+		assert_true(released_instance_value == null)
+	architecture.dispose()
+
+
+func test_nested_singleton_rollback_does_not_double_clean_after_owner_disposal() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var outer_state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var nested_state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var nested_factory: NestedLifecycleGuardFactory = (
+		NestedLifecycleGuardFactory.new(nested_state)
+	)
+	var outer_factory: DisposeOwnerAfterNestedSingletonFactory = (
+		DisposeOwnerAfterNestedSingletonFactory.new(
+			architecture,
+			outer_state
+		)
+	)
+	assert_true(
+		architecture.register_factory(
+			FactoryLifecycleGuardProduct,
+			Callable(outer_factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	assert_true(
+		architecture.register_factory(
+			NestedLifecycleGuardProduct,
+			Callable(nested_factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	assert_true(await architecture.init())
+
+	var result: Object = architecture.create_instance(
+		FactoryLifecycleGuardProduct
+	)
+
+	assert_null(result)
+	assert_true(architecture.is_disposed())
+	assert_eq(
+		GFVariantData.get_option_int(outer_state, "dispose_count"),
+		1
+	)
+	assert_eq(
+		GFVariantData.get_option_int(outer_state, "release_count"),
+		0
+	)
+	assert_eq(
+		GFVariantData.get_option_int(nested_state, "dispose_count"),
+		1,
+		"owner dispose 与 resolution rollback 不得重复 dispose 已清理 Singleton。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(nested_state, "release_count"),
+		1,
+		"owner dispose 与 resolution rollback 不得重复释放注入作用域。"
+	)
+
+
+func test_parent_transient_rejection_cleans_actual_child_event_scope() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"registered_listener_count": 0,
+		"second_hook_count": 0,
+		"dispose_count": 0,
+		"release_count": 0,
+		"scope_bind_count": 0,
+		"scope_clear_count": 0,
+	}
+	var factory: ChildEventFailureFactory = (
+		ChildEventFailureFactory.new(state)
+	)
+	assert_true(
+		parent.register_factory(
+			ChildEventFailureProduct,
+			Callable(factory, &"create")
+		)
+	)
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	assert_true(await child.init())
+
+	var result: Object = child.create_instance(
+		ChildEventFailureProduct
+	)
+
+	assert_null(result)
+	assert_eq(
+		GFVariantData.get_option_int(state, "registered_listener_count"),
+		1,
+		"fixture 应先在实际注入的 child 注册 owner event。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(state, "second_hook_count"),
+		0,
+		"嵌套解析失败后不得继续调用后续 inject Hook。"
+	)
+	assert_eq(GFVariantData.get_option_int(state, "dispose_count"), 1)
+	assert_eq(GFVariantData.get_option_int(state, "release_count"), 1)
+	assert_eq(GFVariantData.get_option_int(state, "scope_bind_count"), 1)
+	assert_eq(
+		GFVariantData.get_option_int(state, "scope_clear_count"),
+		0,
+		"release_dependencies 进入 queued 状态后不得继续调用 scope clear Hook。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(
+			child.get_event_debug_stats(),
+			"listener_count"
+		),
+		0,
+		"父级 transient 拒绝结果必须清理实际 child 注入作用域。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(
+			parent.get_event_debug_stats(),
+			"listener_count"
+		),
+		0
+	)
+	await get_tree().process_frame
+	var instance_ref_value: Variant = state.get("instance_ref")
+	assert_true(instance_ref_value is WeakRef)
+	if instance_ref_value is WeakRef:
+		var instance_ref: WeakRef = instance_ref_value
+		var released_instance_value: Variant = instance_ref.get_ref()
+		assert_true(released_instance_value == null)
+	assert_push_error("create_instance 失败：未注册工厂")
+	child.dispose()
+	parent.dispose()
+
+
+func test_factory_resolution_rejects_reentrant_topology_mutation() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+		"mutation_result": true,
+		"nested_result_was_null": false,
+	}
+	var late_state: Dictionary = {
+		"provider_count": 0,
+		"inject_count": 0,
+	}
+	var cached_state: Dictionary = {
+		"provider_count": 0,
+	}
+	var factory: ReentrantTopologyFactory = (
+		ReentrantTopologyFactory.new(architecture, state)
+	)
+	assert_true(
+		architecture.register_factory(
+			FactoryLifecycleGuardProduct,
+			Callable(factory, &"create")
+		)
+	)
+	var late_factory: LateTransientFactory = (
+		LateTransientFactory.new(late_state)
+	)
+	assert_true(
+		architecture.register_factory(
+			LateTransientProduct,
+			Callable(late_factory, &"create")
+		)
+	)
+	var cached_factory: CachedResolutionGuardFactory = (
+		CachedResolutionGuardFactory.new(cached_state)
+	)
+	assert_true(
+		architecture.register_factory(
+			CachedResolutionGuardProduct,
+			Callable(cached_factory, &"create"),
+			GFBindingLifetimes.Lifetime.SINGLETON
+		)
+	)
+	assert_true(await architecture.init())
+	assert_not_null(
+		architecture.create_instance(CachedResolutionGuardProduct)
+	)
+
+	var result: Object = architecture.create_instance(
+		FactoryLifecycleGuardProduct
+	)
+
+	assert_null(
+		result,
+		"provider 内拒绝的拓扑重入必须使整条 factory 解析失败。"
+	)
+	assert_false(
+		GFVariantData.get_option_bool(state, "mutation_result", true)
+	)
+	assert_false(architecture.has_factory(ReentrantTopologyProduct))
+	assert_true(
+		GFVariantData.get_option_bool(state, "nested_result_was_null")
+	)
+	assert_eq(
+		GFVariantData.get_option_int(late_state, "provider_count"),
+		0,
+		"解析上下文失败后不得继续执行其它 provider。"
+	)
+	assert_eq(GFVariantData.get_option_int(late_state, "inject_count"), 0)
+	assert_true(
+		GFVariantData.get_option_bool(state, "cached_result_was_null"),
+		"失败上下文不得交付已经存在的 Singleton cache。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(cached_state, "provider_count"),
+		1,
+		"失败上下文不得重新进入或重新创建 cached Singleton。"
+	)
+	assert_eq(GFVariantData.get_option_int(state, "dispose_count"), 1)
+	assert_eq(GFVariantData.get_option_int(state, "release_count"), 0)
+	var instance_ref_value: Variant = state.get("instance_ref")
+	assert_true(instance_ref_value is WeakRef)
+	if instance_ref_value is WeakRef:
+		var instance_ref: WeakRef = instance_ref_value
+		var released_instance_value: Variant = instance_ref.get_ref()
+		assert_true(released_instance_value == null)
+	assert_push_error("工厂解析期间禁止重入修改模块拓扑")
+	architecture.dispose()
+
+
+func test_successful_nested_transient_transfer_is_not_retroactively_rolled_back() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var outer_state: Dictionary = {
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var transient_state: Dictionary = {
+		"provider_count": 0,
+		"inject_count": 0,
+		"dispose_count": 0,
+		"release_count": 0,
+	}
+	var transient_factory: TransferredTransientFactory = (
+		TransferredTransientFactory.new(transient_state)
+	)
+	var outer_factory: FailureAfterTransientTransferFactory = (
+		FailureAfterTransientTransferFactory.new(
+			architecture,
+			outer_state
+		)
+	)
+	assert_true(
+		architecture.register_factory(
+			TransferredTransientProduct,
+			Callable(transient_factory, &"create")
+		)
+	)
+	assert_true(
+		architecture.register_factory(
+			FactoryLifecycleGuardProduct,
+			Callable(outer_factory, &"create")
+		)
+	)
+	assert_true(await architecture.init())
+
+	var result: Object = architecture.create_instance(
+		FactoryLifecycleGuardProduct
+	)
+
+	assert_null(result)
+	assert_not_null(outer_factory.transferred_instance)
+	assert_true(
+		is_instance_valid(outer_factory.transferred_instance),
+		"成功返回给直接调用者的 transient 已完成所有权转移。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(transient_state, "provider_count"),
+		1
+	)
+	assert_eq(
+		GFVariantData.get_option_int(transient_state, "inject_count"),
+		1
+	)
+	assert_eq(
+		GFVariantData.get_option_int(transient_state, "dispose_count"),
+		0,
+		"外层解析后续失败不得追溯夺回已交付 transient 的所有权。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(transient_state, "release_count"),
+		0
+	)
+	assert_eq(GFVariantData.get_option_int(outer_state, "dispose_count"), 1)
+	assert_push_error("工厂解析期间禁止重入修改模块拓扑")
+	outer_factory.transferred_instance.free()
+	outer_factory.transferred_instance = null
+	architecture.dispose()
+
+
+# --- 辅助方法 ---
+
+func _await_architecture_init(
+	architecture: GFArchitecture,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.init()
+	state["done"] = true
+
+
+func _await_pending_hot_register(
+	architecture: GFArchitecture,
+	candidate: PendingHotRegistrationUtility,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.register_utility_instance(candidate)
+	state["done"] = true
+
+
+func _await_pending_hot_replace(
+	architecture: GFArchitecture,
+	candidate: PendingHotRegistrationUtility,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.replace_utility(
+		PendingHotRegistrationUtility,
+		candidate
+	)
+	state["done"] = true
+
+
+func _await_staged_service_register(
+	architecture: GFArchitecture,
+	candidate: StagedServiceProviderUtility,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.register_utility_instance(candidate)
+	state["done"] = true
+
+
+func _await_staged_service_replace(
+	architecture: GFArchitecture,
+	candidate: StagedServiceProviderUtility,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.replace_utility(
+		StagedServiceProviderUtility,
+		candidate
+	)
+	state["done"] = true
+
+
+func _wait_for_transaction_state(state: Dictionary) -> void:
+	for _frame: int in range(30):
+		if GFVariantData.get_option_bool(state, "done"):
+			return
+		await get_tree().process_frame
+
+
+func _assert_plan_hook_invalidation_stopped(
+	candidate: PlanHookInvalidatingUtility
+) -> void:
+	assert_eq(candidate.model_hook_count, 1)
+	assert_eq(
+		candidate.system_hook_count,
+		0,
+		"首个 dependency Hook 使事务失效后不得继续 system Hook。"
+	)
+	assert_eq(
+		candidate.utility_hook_count,
+		0,
+		"首个 dependency Hook 使事务失效后不得继续 utility Hook。"
+	)
+	assert_eq(
+		candidate.factory_hook_count,
+		0,
+		"首个 dependency Hook 使事务失效后不得继续 factory Hook。"
+	)
+	assert_eq(candidate.inject_count, 0)
+	assert_eq(candidate.init_count, 0)
+	assert_eq(candidate.async_init_count, 0)
+	assert_eq(candidate.ready_count, 0)
+	assert_eq(candidate.activation_count, 0)
+	assert_eq(candidate.dispose_count, 1)
+
+
 # --- 内部类 ---
 
 class CancellingAsyncUtility extends GFUtility:
@@ -322,12 +1998,691 @@ class CancellingAsyncUtility extends GFUtility:
 		disposed = true
 
 
+class PendingHotRegistrationUtility extends GFUtility:
+	var block_activation: bool = true
+	var activation_completion: GFAsyncCompletion = null
+	var activation_count: int = 0
+	var tick_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(should_block_activation: bool = true) -> void:
+		block_activation = should_block_activation
+		tick_enabled = true
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		activation_completion = GFAsyncCompletion.new()
+		if not block_activation:
+			var _succeeded: bool = activation_completion.succeed()
+		return activation_completion
+
+	func tick(_delta: float) -> void:
+		tick_count += 1
+
+	func complete_activation() -> bool:
+		return (
+			activation_completion != null
+			and activation_completion.succeed()
+		)
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class StagedServiceProviderUtility extends GFUtility:
+	var block_activation: bool = false
+	var fail_activation: bool = false
+	var activation_completion: GFAsyncCompletion = null
+	var service_registered: bool = false
+	var dispose_count: int = 0
+
+	func _init(
+		should_block_activation: bool,
+		should_fail_activation: bool
+	) -> void:
+		block_activation = should_block_activation
+		fail_activation = should_fail_activation
+
+	func init() -> void:
+		var architecture: GFArchitecture = _get_architecture()
+		service_registered = architecture.register_service(
+			STAGED_SERVICE_KEY,
+			self
+		)
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_completion = GFAsyncCompletion.new()
+		if fail_activation:
+			var _failed: bool = activation_completion.fail(
+				"[test] staged service activation rejected"
+			)
+		elif not block_activation:
+			var _succeeded: bool = activation_completion.succeed()
+		return activation_completion
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func complete_activation() -> bool:
+		return (
+			activation_completion != null
+			and activation_completion.succeed()
+		)
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class StableDependencyProviderUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class StableDependencyConsumerSystem extends GFSystem:
+	func get_required_utilities() -> Array[Script]:
+		return [StableDependencyProviderUtility]
+
+
+class FactoryLeaseProduct extends RefCounted:
+	pass
+
+
+class FactoryLeaseConsumerSystem extends GFSystem:
+	func get_required_factories() -> Array[Script]:
+		return [FactoryLeaseProduct]
+
+
+class MixedExternalDependencyConsumerSystem extends GFSystem:
+	func get_required_utilities() -> Array[Script]:
+		return [StableDependencyProviderUtility]
+
+	func get_required_factories() -> Array[Script]:
+		return [FactoryLeaseProduct]
+
+
+class FactoryInvocationDuringDisposeUtility extends GFUtility:
+	var child_architecture: GFArchitecture = null
+	var requested_script: Script = null
+	var factory_result: Object = null
+
+	func dispose() -> void:
+		if child_architecture != null and requested_script != null:
+			factory_result = child_architecture.create_instance(
+				requested_script
+			)
+
+
+class TransientFallbackProduct extends Node:
+	pass
+
+
+class TransientFallbackAfterOwnerDeniedFactory extends RefCounted:
+	var child_architecture: GFArchitecture = null
+	var nested_result_was_null: bool = false
+	var rejected_instance_ref: WeakRef = null
+
+	func _init(child: GFArchitecture) -> void:
+		child_architecture = child
+
+	func create() -> Object:
+		var nested_result: Object = child_architecture.create_instance(
+			FactoryLeaseProduct
+		)
+		nested_result_was_null = nested_result == null
+		var fallback: TransientFallbackProduct = (
+			TransientFallbackProduct.new()
+		)
+		rejected_instance_ref = weakref(fallback)
+		return fallback
+
+
+class FactoryLifecycleGuardProduct extends Node:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+		state["instance_ref"] = weakref(self)
+
+	func dispose() -> void:
+		state["dispose_count"] = (
+			GFVariantData.get_option_int(state, "dispose_count")
+			+ 1
+		)
+
+	func release_dependencies() -> void:
+		state["release_count"] = (
+			GFVariantData.get_option_int(state, "release_count")
+			+ 1
+		)
+
+
+class DisposeOwnerDuringProvideFactory extends RefCounted:
+	var architecture: GFArchitecture
+	var state: Dictionary
+
+	func _init(
+		owner_architecture: GFArchitecture,
+		shared_state: Dictionary
+	) -> void:
+		architecture = owner_architecture
+		state = shared_state
+
+	func create() -> Object:
+		architecture.dispose()
+		return FactoryLifecycleGuardProduct.new(state)
+
+
+class DisposeRequesterDuringProvideFactory extends RefCounted:
+	var owner_architecture: GFArchitecture
+	var requester_architecture: GFArchitecture
+	var state: Dictionary
+
+	func _init(
+		binding_owner: GFArchitecture,
+		shared_state: Dictionary
+	) -> void:
+		owner_architecture = binding_owner
+		state = shared_state
+
+	func create() -> Object:
+		if requester_architecture != null:
+			requester_architecture.dispose()
+		var nested_result: Object = owner_architecture.create_instance(
+			LateTransientProduct
+		)
+		state["nested_result_was_null"] = nested_result == null
+		return FactoryLifecycleGuardProduct.new(state)
+
+
+class DisposeOwnerThenRequesterFactory extends RefCounted:
+	var owner_architecture: GFArchitecture
+	var requester_architecture: GFArchitecture
+	var state: Dictionary
+
+	func _init(
+		binding_owner: GFArchitecture,
+		shared_state: Dictionary
+	) -> void:
+		owner_architecture = binding_owner
+		state = shared_state
+
+	func create() -> Object:
+		owner_architecture.dispose()
+		var nested_result: Object = (
+			requester_architecture.create_instance(
+				LateTransientProduct
+			)
+			if requester_architecture != null
+			else null
+		)
+		state["nested_result_was_null"] = nested_result == null
+		return FactoryLifecycleGuardProduct.new(state)
+
+
+class FactoryRequesterGuardProduct extends FactoryLifecycleGuardProduct:
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		state["inject_count"] = (
+			GFVariantData.get_option_int(state, "inject_count")
+			+ 1
+		)
+		architecture.dispose()
+
+
+class InjectionDisposesRequesterFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		return FactoryRequesterGuardProduct.new(state)
+
+
+class ExternalRequesterGuardProduct extends Node:
+	var state: Dictionary
+	var requester_architecture: GFArchitecture
+	var injected_architecture: GFArchitecture
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		injected_architecture = architecture
+		state["inject_count"] = (
+			GFVariantData.get_option_int(state, "inject_count")
+			+ 1
+		)
+		if requester_architecture != null:
+			requester_architecture.dispose()
+
+	func inject(_architecture: GFArchitecture) -> void:
+		state["second_hook_count"] = (
+			GFVariantData.get_option_int(state, "second_hook_count")
+			+ 1
+		)
+
+	func dispose() -> void:
+		state["dispose_count"] = (
+			GFVariantData.get_option_int(state, "dispose_count")
+			+ 1
+		)
+
+	func release_dependencies() -> void:
+		state["release_count"] = (
+			GFVariantData.get_option_int(state, "release_count")
+			+ 1
+		)
+
+
+class QueueFreeingInjectionProduct extends Node:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+		state["instance_ref"] = weakref(self)
+
+	func inject_dependencies(_architecture: GFArchitecture) -> void:
+		state["inject_count"] = (
+			GFVariantData.get_option_int(state, "inject_count")
+			+ 1
+		)
+		queue_free()
+
+	func inject(_architecture: GFArchitecture) -> void:
+		state["second_hook_count"] = (
+			GFVariantData.get_option_int(state, "second_hook_count")
+			+ 1
+		)
+
+	func dispose() -> void:
+		state["dispose_count"] = (
+			GFVariantData.get_option_int(state, "dispose_count")
+			+ 1
+		)
+
+
+class QueueFreeingInjectionFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		return QueueFreeingInjectionProduct.new(state)
+
+
+class NestedLifecycleGuardProduct extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func dispose() -> void:
+		state["dispose_count"] = (
+			GFVariantData.get_option_int(state, "dispose_count")
+			+ 1
+		)
+
+	func release_dependencies() -> void:
+		state["release_count"] = (
+			GFVariantData.get_option_int(state, "release_count")
+			+ 1
+		)
+
+
+class NestedLifecycleGuardFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		return NestedLifecycleGuardProduct.new(state)
+
+
+class DisposeOwnerAfterNestedSingletonFactory extends RefCounted:
+	var architecture: GFArchitecture
+	var state: Dictionary
+
+	func _init(
+		owner_architecture: GFArchitecture,
+		shared_state: Dictionary
+	) -> void:
+		architecture = owner_architecture
+		state = shared_state
+
+	func create() -> Object:
+		var nested_result: Object = architecture.create_instance(
+			NestedLifecycleGuardProduct
+		)
+		if nested_result == null:
+			return null
+		architecture.dispose()
+		return FactoryLifecycleGuardProduct.new(state)
+
+
+class ChildEventFailureProduct extends Node:
+	const EVENT_ID: StringName = &"gf.test.factory.child_scope"
+
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+		state["instance_ref"] = weakref(self)
+
+	func _gf_set_dependency_scope(scope: GFArchitecture) -> void:
+		if scope == null:
+			state["scope_clear_count"] = (
+				GFVariantData.get_option_int(
+					state,
+					"scope_clear_count"
+				)
+				+ 1
+			)
+			return
+		state["scope_bind_count"] = (
+			GFVariantData.get_option_int(state, "scope_bind_count")
+			+ 1
+		)
+
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		var listener: GFEventListener = GFEventListener.from_callable(
+			Callable(self, &"_on_event"),
+			1
+		)
+		architecture.register_simple_event_owned(
+			self,
+			EVENT_ID,
+			listener
+		)
+		state["registered_listener_count"] = (
+			GFVariantData.get_option_int(
+				architecture.get_event_debug_stats(),
+				"listener_count"
+			)
+		)
+		var _nested_result: Object = architecture.create_instance(
+			ReentrantTopologyProduct
+		)
+
+	func inject(_architecture: GFArchitecture) -> void:
+		state["second_hook_count"] = (
+			GFVariantData.get_option_int(state, "second_hook_count")
+			+ 1
+		)
+
+	func dispose() -> void:
+		state["dispose_count"] = (
+			GFVariantData.get_option_int(state, "dispose_count")
+			+ 1
+		)
+
+	func release_dependencies() -> void:
+		state["release_count"] = (
+			GFVariantData.get_option_int(state, "release_count")
+			+ 1
+		)
+		queue_free()
+
+	func _on_event(_payload: Variant) -> void:
+		pass
+
+
+class ChildEventFailureFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		return ChildEventFailureProduct.new(state)
+
+
+class ReentrantTopologyProduct extends RefCounted:
+	pass
+
+
+class LateTransientProduct extends Node:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+		state["instance_ref"] = weakref(self)
+
+	func inject_dependencies(_architecture: GFArchitecture) -> void:
+		state["inject_count"] = (
+			GFVariantData.get_option_int(state, "inject_count")
+			+ 1
+		)
+
+
+class LateTransientFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		state["provider_count"] = (
+			GFVariantData.get_option_int(state, "provider_count")
+			+ 1
+		)
+		return LateTransientProduct.new(state)
+
+
+class CachedResolutionGuardProduct extends RefCounted:
+	pass
+
+
+class CachedResolutionGuardFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		state["provider_count"] = (
+			GFVariantData.get_option_int(state, "provider_count")
+			+ 1
+		)
+		return CachedResolutionGuardProduct.new()
+
+
+class TransferredTransientProduct extends Node:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func inject_dependencies(_architecture: GFArchitecture) -> void:
+		state["inject_count"] = (
+			GFVariantData.get_option_int(state, "inject_count")
+			+ 1
+		)
+
+	func dispose() -> void:
+		state["dispose_count"] = (
+			GFVariantData.get_option_int(state, "dispose_count")
+			+ 1
+		)
+
+	func release_dependencies() -> void:
+		state["release_count"] = (
+			GFVariantData.get_option_int(state, "release_count")
+			+ 1
+		)
+
+
+class TransferredTransientFactory extends RefCounted:
+	var state: Dictionary
+
+	func _init(shared_state: Dictionary) -> void:
+		state = shared_state
+
+	func create() -> Object:
+		state["provider_count"] = (
+			GFVariantData.get_option_int(state, "provider_count")
+			+ 1
+		)
+		return TransferredTransientProduct.new(state)
+
+
+class FailureAfterTransientTransferFactory extends RefCounted:
+	var architecture: GFArchitecture
+	var state: Dictionary
+	var transferred_instance: TransferredTransientProduct
+
+	func _init(
+		binding_owner: GFArchitecture,
+		shared_state: Dictionary
+	) -> void:
+		architecture = binding_owner
+		state = shared_state
+
+	func create() -> Object:
+		transferred_instance = architecture.create_instance(
+			TransferredTransientProduct
+		) as TransferredTransientProduct
+		var nested_factory: Callable = func() -> Object:
+			return ReentrantTopologyProduct.new()
+		var _mutation_result: bool = architecture.register_factory(
+			ReentrantTopologyProduct,
+			nested_factory
+		)
+		return FactoryLifecycleGuardProduct.new(state)
+
+
+class ReentrantTopologyFactory extends RefCounted:
+	var architecture: GFArchitecture
+	var state: Dictionary
+
+	func _init(
+		owner_architecture: GFArchitecture,
+		shared_state: Dictionary
+	) -> void:
+		architecture = owner_architecture
+		state = shared_state
+
+	func create() -> Object:
+		var nested_factory: Callable = func() -> Object:
+			return ReentrantTopologyProduct.new()
+		state["mutation_result"] = architecture.register_factory(
+			ReentrantTopologyProduct,
+			nested_factory
+		)
+		var nested_result: Object = architecture.create_instance(
+			LateTransientProduct
+		)
+		state["nested_result_was_null"] = nested_result == null
+		var cached_result: Object = architecture.create_instance(
+			CachedResolutionGuardProduct
+		)
+		state["cached_result_was_null"] = cached_result == null
+		return FactoryLifecycleGuardProduct.new(state)
+
+
+class ExternalLeaseActivationConsumerSystem extends GFSystem:
+	enum ActivationMode {
+		PENDING,
+		FAIL,
+	}
+
+	var activation_mode: ActivationMode = ActivationMode.PENDING
+	var activation_completion: GFAsyncCompletion = null
+
+	func _init(mode: ActivationMode) -> void:
+		activation_mode = mode
+
+	func get_required_utilities() -> Array[Script]:
+		return [StableDependencyProviderUtility]
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_completion = GFAsyncCompletion.new()
+		if activation_mode == ActivationMode.FAIL:
+			var _failed: bool = activation_completion.fail(
+				"[test] child activation rejected"
+			)
+		return activation_completion
+
+
+class FallbackProviderUtility extends GFUtility:
+	var dispose_count: int = 0
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class AlternateFallbackProviderUtility extends FallbackProviderUtility:
+	pass
+
+
+class FallbackConsumerSystem extends GFSystem:
+	func get_required_utilities() -> Array[Script]:
+		return [FallbackProviderUtility]
+
+
+class DriftPrimaryProviderUtility extends GFUtility:
+	pass
+
+
+class DriftAlternateProviderUtility extends GFUtility:
+	pass
+
+
+class DriftingDependencyConsumerSystem extends GFSystem:
+	var use_alternate: bool = false
+
+	func get_required_utilities() -> Array[Script]:
+		if use_alternate:
+			return [DriftAlternateProviderUtility]
+		return [DriftPrimaryProviderUtility]
+
+
+class UnrelatedHotUtility extends GFUtility:
+	var inject_count: int = 0
+	var dispose_count: int = 0
+
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		inject_count += 1
+		super.inject_dependencies(architecture)
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
 class DisposeDuringInjectionUtility extends GFUtility:
 	var dependencies_released: bool = false
+	var init_count: int = 0
+	var async_init_count: int = 0
+	var ready_count: int = 0
+	var activation_count: int = 0
+	var dispose_count: int = 0
 
 	func inject_dependencies(architecture: GFArchitecture) -> void:
 		super.inject_dependencies(architecture)
 		architecture.dispose()
+
+	func init() -> void:
+		init_count += 1
+
+	func async_init(_scope: GFAsyncScope) -> void:
+		async_init_count += 1
+
+	func ready() -> void:
+		ready_count += 1
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
 
 	func release_dependencies() -> void:
 		dependencies_released = true
@@ -353,6 +2708,189 @@ class PreInitializationReplacementUtility extends GFUtility:
 	func release_dependencies() -> void:
 		dependencies_released = true
 		super.release_dependencies()
+
+
+class DetachedDisposeReentryUtility extends GFUtility:
+	enum Reentry {
+		NONE,
+		FAIL_INITIALIZATION,
+		DISPOSE_ARCHITECTURE,
+	}
+
+	var reentry: Reentry = Reentry.NONE
+	var injected_architecture: GFArchitecture = null
+	var dispose_count: int = 0
+
+	func _init(reentry_mode: Reentry = Reentry.NONE) -> void:
+		reentry = reentry_mode
+
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		super.inject_dependencies(architecture)
+		injected_architecture = architecture
+
+	func dispose() -> void:
+		dispose_count += 1
+		if dispose_count != 1 or injected_architecture == null:
+			return
+		match reentry:
+			Reentry.FAIL_INITIALIZATION:
+				injected_architecture.fail_initialization(
+					"[test] detached previous dispose failure"
+				)
+			Reentry.DISPOSE_ARCHITECTURE:
+				injected_architecture.dispose()
+
+
+class ReadyInvalidatingUtility extends GFUtility:
+	var injected_architecture: GFArchitecture = null
+	var inject_count: int = 0
+	var init_count: int = 0
+	var async_init_count: int = 0
+	var ready_count: int = 0
+	var activation_count: int = 0
+	var dispose_count: int = 0
+
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		inject_count += 1
+		super.inject_dependencies(architecture)
+		injected_architecture = architecture
+
+	func init() -> void:
+		init_count += 1
+
+	func async_init(_scope: GFAsyncScope) -> void:
+		async_init_count += 1
+
+	func ready() -> void:
+		ready_count += 1
+		if injected_architecture != null:
+			injected_architecture.fail_initialization(
+				"[test] fail during hot candidate ready"
+			)
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class PlanHookInvalidatingUtility extends GFUtility:
+	enum Invalidation {
+		DISPOSE,
+		FAIL,
+	}
+
+	var architecture: GFArchitecture = null
+	var invalidation: Invalidation = Invalidation.DISPOSE
+	var model_hook_count: int = 0
+	var system_hook_count: int = 0
+	var utility_hook_count: int = 0
+	var factory_hook_count: int = 0
+	var inject_count: int = 0
+	var init_count: int = 0
+	var async_init_count: int = 0
+	var ready_count: int = 0
+	var activation_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(
+		target_architecture: GFArchitecture,
+		invalidation_mode: Invalidation
+	) -> void:
+		architecture = target_architecture
+		invalidation = invalidation_mode
+
+	func get_required_models() -> Array[Script]:
+		model_hook_count += 1
+		if architecture != null:
+			match invalidation:
+				Invalidation.DISPOSE:
+					architecture.dispose()
+				Invalidation.FAIL:
+					architecture.fail_initialization(
+						"[test] fail during lifecycle plan hook"
+					)
+		return []
+
+	func get_required_systems() -> Array[Script]:
+		system_hook_count += 1
+		return []
+
+	func get_required_utilities() -> Array[Script]:
+		utility_hook_count += 1
+		return []
+
+	func get_required_factories() -> Array[Script]:
+		factory_hook_count += 1
+		return []
+
+	func inject_dependencies(target_architecture: GFArchitecture) -> void:
+		inject_count += 1
+		super.inject_dependencies(target_architecture)
+
+	func init() -> void:
+		init_count += 1
+
+	func async_init(_scope: GFAsyncScope) -> void:
+		async_init_count += 1
+
+	func ready() -> void:
+		ready_count += 1
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class DeadlineCrossingActivationUtility extends GFUtility:
+	var block_msec: int = 0
+	var activation_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(block_duration_msec: int) -> void:
+		block_msec = block_duration_msec
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_count += 1
+		var release_at_msec: int = Time.get_ticks_msec() + block_msec
+		while Time.get_ticks_msec() < release_at_msec:
+			pass
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
+class DeadlineCrossingTopologyQuiesceUtility extends GFUtility:
+	var block_msec: int = 0
+	var quiesce_count: int = 0
+	var dispose_count: int = 0
+
+	func _init(block_duration_msec: int) -> void:
+		block_msec = block_duration_msec
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_count += 1
+		var release_at_msec: int = Time.get_ticks_msec() + block_msec
+		while Time.get_ticks_msec() < release_at_msec:
+			pass
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_count += 1
 
 
 class ReplacementSideEffectUtility extends GFUtility:
@@ -400,7 +2938,12 @@ class ReadyReentrantReplacementUtility extends GFUtility:
 
 	func ready() -> void:
 		if unregister_during_ready and injected_architecture != null:
-			injected_architecture.unregister_utility(ReadyReentrantReplacementUtility)
+			var _unregister_result: Variant = (
+				Callable(
+					injected_architecture,
+					&"unregister_utility"
+				).call(ReadyReentrantReplacementUtility)
+			)
 
 	func dispose() -> void:
 		dispose_count += 1

--- a/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_transactions.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_lifecycle_transactions.gd
@@ -163,7 +163,7 @@ func test_hot_registration_is_invisible_until_activation_commits() -> void:
 func test_pending_hot_replace_closes_acceptance_and_regular_tick_does_not_double_drive() -> void:
 	var architecture: GFArchitecture = GFArchitecture.new()
 	var previous: PendingHotRegistrationUtility = (
-		PendingHotRegistrationUtility.new(false)
+		PendingHotRegistrationUtility.new(false, true)
 	)
 	assert_true(await architecture.register_utility_instance(previous))
 	assert_true(await architecture.init())
@@ -189,6 +189,14 @@ func test_pending_hot_replace_closes_acceptance_and_regular_tick_does_not_double
 		previous,
 		"替换提交前注册表必须继续公开旧实例。"
 	)
+	assert_false(
+		architecture.is_module_ready(replacement),
+		"尚未提交的 staged replacement 不得公开 ready 状态。"
+	)
+	assert_false(
+		replacement.is_ready_in_architecture(),
+		"staged replacement 的模块便捷查询也不得越过原子提交点。"
+	)
 	var previous_tick_count: int = previous.tick_count
 	var replacement_tick_count: int = replacement.tick_count
 	architecture.tick(0.1)
@@ -200,6 +208,29 @@ func test_pending_hot_replace_closes_acceptance_and_regular_tick_does_not_double
 	)
 
 	assert_true(replacement.complete_activation())
+	assert_true(
+		await _wait_for_module_quiesce_start(previous),
+		"candidate activation 后应等待旧模块 quiesce。"
+	)
+	assert_false(GFVariantData.get_option_bool(replace_state, "done"))
+	assert_same(
+		architecture.get_local_utility(PendingHotRegistrationUtility),
+		previous,
+		"旧模块 quiesce 完成前注册表仍必须公开旧实例。"
+	)
+	assert_false(
+		architecture.is_module_ready(replacement),
+		"旧模块 quiesce 期间 staged replacement 仍不得公开 ready。"
+	)
+	assert_false(
+		architecture.is_module_active(replacement),
+		"完成 activation 但尚未提交的 replacement 不得公开 active。"
+	)
+	assert_false(
+		replacement.is_ready_in_architecture(),
+		"staged replacement 在整个事务提交前都必须保持不可见。"
+	)
+	assert_true(previous.complete_quiesce(), "测试门闩应成功完成旧模块 quiesce。")
 	await _wait_for_transaction_state(replace_state)
 
 	assert_true(GFVariantData.get_option_bool(replace_state, "result"))
@@ -209,6 +240,11 @@ func test_pending_hot_replace_closes_acceptance_and_regular_tick_does_not_double
 		replacement,
 		"替换成功后注册表应原子切换到新实例。"
 	)
+	assert_true(architecture.is_module_ready(replacement))
+	assert_true(architecture.is_module_active(replacement))
+	assert_true(replacement.is_ready_in_architecture())
+	assert_false(architecture.is_module_ready(previous))
+	assert_false(architecture.is_module_active(previous))
 	assert_eq(previous.dispose_count, 1)
 	architecture.dispose()
 	assert_eq(replacement.dispose_count, 1)
@@ -962,6 +998,69 @@ func test_parent_external_dependency_lease_blocks_topology_until_child_shutdown(
 	)
 	assert_eq(provider.dispose_count, 1)
 	parent.dispose()
+
+
+func test_child_shutdown_retains_parent_lease_through_cleanup_hooks() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	assert_true(await parent.register_utility_instance(provider))
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	var cleanup_probe: ParentShutdownDuringCleanupUtility = (
+		ParentShutdownDuringCleanupUtility.new(parent)
+	)
+	assert_true(await child.register_utility_instance(cleanup_probe))
+	assert_true(await child.init())
+
+	var child_shutdown: GFArchitectureShutdownResult = await child.shutdown_async()
+	assert_true(child_shutdown.is_successful(), "child 应正常完成关闭。")
+	assert_true(
+		await _wait_for_cleanup_parent_shutdown(cleanup_probe),
+		"child dispose 中发起的父级 shutdown 应有界返回。"
+	)
+	_assert_cleanup_parent_shutdown_was_blocked(cleanup_probe)
+	assert_false(parent.is_disposed(), "child 清理完成前的重入不得终结 parent。")
+	assert_true(parent.is_accepting_runtime_work(), "ERR_BUSY 后 parent 应保持 READY。")
+	assert_eq(provider.dispose_count, 0, "child 清理期间 parent provider 必须保持存活。")
+
+	var parent_shutdown: GFArchitectureShutdownResult = await parent.shutdown_async()
+	assert_true(parent_shutdown.is_successful(), "child 显式释放租约后 parent 应可关闭。")
+	assert_eq(provider.dispose_count, 1, "parent 最终关闭应只释放 provider 一次。")
+
+
+func test_child_init_failure_retains_parent_lease_through_cleanup_hooks() -> void:
+	var parent: GFArchitecture = GFArchitecture.new()
+	var provider: StableDependencyProviderUtility = (
+		StableDependencyProviderUtility.new()
+	)
+	assert_true(await parent.register_utility_instance(provider))
+	assert_true(await parent.init())
+	var child: GFArchitecture = GFArchitecture.new(parent)
+	var cleanup_probe: ParentShutdownDuringCleanupUtility = (
+		ParentShutdownDuringCleanupUtility.new(parent)
+	)
+	assert_true(await child.register_utility_instance(cleanup_probe))
+	assert_true(
+		await child.register_utility_instance(FailingChildActivationUtility.new())
+	)
+
+	assert_false(await child.init(), "测试 child 应在 activation 阶段失败。")
+	assert_true(
+		await _wait_for_cleanup_parent_shutdown(cleanup_probe),
+		"child 失败清理中的父级 shutdown 应有界返回。"
+	)
+	_assert_cleanup_parent_shutdown_was_blocked(cleanup_probe)
+	assert_false(parent.is_disposed(), "child 失败清理不得提前终结 parent。")
+	assert_true(parent.is_accepting_runtime_work(), "child 失败后 parent 仍应保持 READY。")
+	assert_eq(provider.dispose_count, 0, "child 失败清理期间 provider 必须保持存活。")
+	assert_push_error("[GFArchitecture] activation 失败")
+
+	var parent_shutdown: GFArchitectureShutdownResult = await parent.shutdown_async()
+	assert_true(parent_shutdown.is_successful(), "child 失败清理释放租约后 parent 应可关闭。")
+	assert_eq(provider.dispose_count, 1, "parent 最终关闭应只释放 provider 一次。")
+	child.dispose()
 
 
 func test_parent_factory_dependency_lease_blocks_shutdown_without_freezing_module_topology() -> void:
@@ -1959,6 +2058,51 @@ func _wait_for_transaction_state(state: Dictionary) -> void:
 		await get_tree().process_frame
 
 
+func _wait_for_module_quiesce_start(
+	module: PendingHotRegistrationUtility,
+	max_frames: int = 30
+) -> bool:
+	for _frame: int in range(max_frames):
+		if module.quiesce_completion != null:
+			return true
+		await get_tree().process_frame
+	return module.quiesce_completion != null
+
+
+func _wait_for_cleanup_parent_shutdown(
+	probe: ParentShutdownDuringCleanupUtility,
+	max_frames: int = 30
+) -> bool:
+	for _frame: int in range(max_frames):
+		if probe.parent_shutdown_done:
+			return true
+		await get_tree().process_frame
+	return probe.parent_shutdown_done
+
+
+func _assert_cleanup_parent_shutdown_was_blocked(
+	probe: ParentShutdownDuringCleanupUtility
+) -> void:
+	assert_eq(probe.dispose_count, 1, "child cleanup probe 必须且只应 dispose 一次。")
+	assert_eq(probe.release_count, 1, "child cleanup probe 必须且只应 release 一次。")
+	assert_false(
+		probe.parent_disposed_during_release,
+		"parent 必须 outlive child 的 release_dependencies()。"
+	)
+	assert_not_null(probe.parent_shutdown_result, "重入父级 shutdown 应返回 typed 结果。")
+	if probe.parent_shutdown_result != null:
+		assert_eq(
+			probe.parent_shutdown_result.get_status(),
+			GFArchitectureShutdownResult.Status.FAILED,
+			"child 仍持有 lease 时父级 shutdown 必须失败。"
+		)
+		assert_eq(
+			probe.parent_shutdown_result.get_error_code(),
+			ERR_BUSY,
+			"child cleanup 期间父级 shutdown 应以 ERR_BUSY fail closed。"
+		)
+
+
 func _assert_plan_hook_invalidation_stopped(
 	candidate: PlanHookInvalidatingUtility
 ) -> void:
@@ -2000,13 +2144,19 @@ class CancellingAsyncUtility extends GFUtility:
 
 class PendingHotRegistrationUtility extends GFUtility:
 	var block_activation: bool = true
+	var block_quiesce: bool = false
 	var activation_completion: GFAsyncCompletion = null
+	var quiesce_completion: GFAsyncCompletion = null
 	var activation_count: int = 0
 	var tick_count: int = 0
 	var dispose_count: int = 0
 
-	func _init(should_block_activation: bool = true) -> void:
+	func _init(
+		should_block_activation: bool = true,
+		should_block_quiesce: bool = false
+	) -> void:
 		block_activation = should_block_activation
+		block_quiesce = should_block_quiesce
 		tick_enabled = true
 
 	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
@@ -2016,6 +2166,12 @@ class PendingHotRegistrationUtility extends GFUtility:
 			var _succeeded: bool = activation_completion.succeed()
 		return activation_completion
 
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_completion = GFAsyncCompletion.new()
+		if not block_quiesce:
+			var _succeeded: bool = quiesce_completion.succeed()
+		return quiesce_completion
+
 	func tick(_delta: float) -> void:
 		tick_count += 1
 
@@ -2023,6 +2179,12 @@ class PendingHotRegistrationUtility extends GFUtility:
 		return (
 			activation_completion != null
 			and activation_completion.succeed()
+		)
+
+	func complete_quiesce() -> bool:
+		return (
+			quiesce_completion != null
+			and quiesce_completion.succeed()
 		)
 
 	func dispose() -> void:
@@ -2080,6 +2242,42 @@ class StableDependencyProviderUtility extends GFUtility:
 
 	func dispose() -> void:
 		dispose_count += 1
+
+
+class ParentShutdownDuringCleanupUtility extends GFUtility:
+	var parent_architecture: GFArchitecture = null
+	var parent_shutdown_result: GFArchitectureShutdownResult = null
+	var parent_shutdown_done: bool = false
+	var parent_disposed_during_release: bool = false
+	var dispose_count: int = 0
+	var release_count: int = 0
+
+	func _init(parent: GFArchitecture) -> void:
+		parent_architecture = parent
+
+	func get_required_utilities() -> Array[Script]:
+		return [StableDependencyProviderUtility]
+
+	func dispose() -> void:
+		dispose_count += 1
+		@warning_ignore("missing_await")
+		_capture_parent_shutdown()
+
+	func release_dependencies() -> void:
+		release_count += 1
+		parent_disposed_during_release = parent_architecture.is_disposed()
+		super.release_dependencies()
+
+	func _capture_parent_shutdown() -> void:
+		parent_shutdown_result = await parent_architecture.shutdown_async()
+		parent_shutdown_done = true
+
+
+class FailingChildActivationUtility extends GFUtility:
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _failed: bool = completion.fail("[test] child activation failure")
+		return completion
 
 
 class StableDependencyConsumerSystem extends GFSystem:

--- a/tests/gf_core/kernel/core/test_gf_architecture_shutdown_result.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_shutdown_result.gd
@@ -1,0 +1,172 @@
+# GFArchitectureShutdownResult 有界不可变快照回归测试。
+extends GutTest
+
+
+# --- 测试用例 ---
+
+func test_create_normalizes_timing_and_module_schema() -> void:
+	var module_results: Array[Dictionary] = [
+		{
+			"kind": &"utility",
+			"script": "res://tests/test_shutdown_utility.gd",
+			"instance_id": 42,
+			"status": &"succeeded",
+			"reason": "drained",
+			"duration_msec": 7,
+			"untrusted_extra": {"payload": "must not escape"},
+		},
+	]
+
+	var result: GFArchitectureShutdownResult = GFArchitectureShutdownResult.create(
+		GFArchitectureShutdownResult.Status.SUCCEEDED,
+		20,
+		10,
+		module_results,
+		[],
+		-3,
+		ERR_CANT_CREATE,
+		"ignored for successful status"
+	)
+	module_results[0]["reason"] = "mutated after create"
+
+	assert_true(result.is_successful())
+	assert_eq(result.get_status_name(), &"succeeded")
+	assert_eq(result.get_started_at_msec(), 20)
+	assert_eq(result.get_completed_at_msec(), 20)
+	assert_eq(result.get_duration_msec(), 0)
+	assert_eq(result.get_duplicate_request_count(), 0)
+	assert_eq(result.get_error_code(), OK)
+	var stored_results: Array[Dictionary] = result.get_module_results()
+	assert_eq(stored_results.size(), 1)
+	assert_eq(stored_results[0].size(), 6)
+	assert_eq(_get_string_field(stored_results[0], "reason"), "drained")
+	assert_false(stored_results[0].has("untrusted_extra"))
+
+
+func test_collection_getters_to_dict_and_duplicate_result_are_copy_safe() -> void:
+	var module_results: Array[Dictionary] = [
+		{
+			"kind": &"system",
+			"script": "res://tests/test_shutdown_system.gd",
+			"instance_id": 73,
+			"status": &"failed",
+			"reason": "injected",
+			"duration_msec": 12,
+		},
+	]
+	var unfinished_modules: Array[Dictionary] = [
+		{
+			"kind": &"model",
+			"script": "res://tests/test_shutdown_model.gd",
+			"instance_id": 91,
+			"status": &"pending",
+			"reason": "deadline",
+			"duration_msec": 15,
+		},
+	]
+	var result: GFArchitectureShutdownResult = GFArchitectureShutdownResult.failed(
+		ERR_CANT_CREATE,
+		"injected failure",
+		module_results,
+		unfinished_modules,
+		100,
+		140,
+		2
+	)
+
+	var first_results: Array[Dictionary] = result.get_module_results()
+	first_results[0]["reason"] = "caller mutation"
+	var first_unfinished: Array[Dictionary] = result.get_unfinished_modules()
+	first_unfinished.clear()
+	var report: Dictionary = result.to_dict()
+	var report_results_value: Variant = report.get("module_results")
+	assert_true(report_results_value is Array)
+	if report_results_value is Array:
+		var report_results: Array = report_results_value
+		var report_entry_value: Variant = report_results[0]
+		if report_entry_value is Dictionary:
+			var report_entry: Dictionary = report_entry_value
+			report_entry["reason"] = "report mutation"
+
+	var duplicated_result: GFArchitectureShutdownResult = result.duplicate_result()
+
+	assert_not_same(duplicated_result, result)
+	assert_eq(_get_string_field(result.get_module_results()[0], "reason"), "injected")
+	assert_eq(result.get_unfinished_modules().size(), 1)
+	assert_eq(
+		_get_string_field(duplicated_result.get_module_results()[0], "reason"),
+		"injected"
+	)
+	assert_eq(
+		_get_string_field(duplicated_result.get_unfinished_modules()[0], "reason"),
+		"deadline"
+	)
+	assert_eq(duplicated_result.get_duplicate_request_count(), 2)
+	assert_eq(duplicated_result.get_duration_msec(), 40)
+
+
+func test_module_result_collections_are_bounded() -> void:
+	var module_results: Array[Dictionary] = []
+	var _resize_error: Error = module_results.resize(300) as Error
+	for index: int in range(300):
+		module_results[index] = {
+			"kind": &"utility",
+			"script": "res://tests/bounded.gd",
+			"instance_id": index,
+			"status": &"succeeded",
+			"reason": "",
+			"duration_msec": index,
+		}
+
+	var result: GFArchitectureShutdownResult = GFArchitectureShutdownResult.succeeded(
+		module_results
+	)
+
+	assert_eq(result.get_module_results().size(), 256)
+
+
+func test_status_factories_preserve_typed_terminal_meaning() -> void:
+	var cancelled_result: GFArchitectureShutdownResult = (
+		GFArchitectureShutdownResult.cancelled("caller_cancelled")
+	)
+	var timed_out_result: GFArchitectureShutdownResult = (
+		GFArchitectureShutdownResult.timed_out("deadline")
+	)
+	var forced_result: GFArchitectureShutdownResult = (
+		GFArchitectureShutdownResult.forced("forced fallback")
+	)
+	var disposed_result: GFArchitectureShutdownResult = (
+		GFArchitectureShutdownResult.already_disposed(10, 11, 3)
+	)
+
+	assert_eq(cancelled_result.get_status(), GFArchitectureShutdownResult.Status.CANCELLED)
+	assert_eq(cancelled_result.get_cancel_reason(), "caller_cancelled")
+	assert_eq(cancelled_result.get_error_code(), ERR_SKIP)
+	assert_eq(timed_out_result.get_status(), GFArchitectureShutdownResult.Status.TIMED_OUT)
+	assert_eq(timed_out_result.get_error_code(), ERR_TIMEOUT)
+	assert_eq(forced_result.get_status(), GFArchitectureShutdownResult.Status.FORCED)
+	assert_false(forced_result.is_successful())
+	assert_eq(disposed_result.get_status(), GFArchitectureShutdownResult.Status.ALREADY_DISPOSED)
+	assert_true(disposed_result.is_successful())
+	assert_eq(disposed_result.get_duplicate_request_count(), 3)
+
+
+func test_cancel_reason_is_bounded_before_result_storage() -> void:
+	var unbounded_reason: String = "x".repeat(2048)
+	var result: GFArchitectureShutdownResult = (
+		GFArchitectureShutdownResult.cancelled(unbounded_reason)
+	)
+
+	assert_eq(result.get_cancel_reason().length(), 1024)
+	assert_eq(result.get_cancel_reason(), unbounded_reason.left(1024))
+	assert_true(result.to_dict().get("cancel_reason") is String)
+
+
+# --- 私有/辅助方法 ---
+
+func _get_string_field(entry: Dictionary, key: String) -> String:
+	var value: Variant = entry.get(key)
+	if value is String:
+		var text: String = value
+		return text
+	return ""

--- a/tests/gf_core/kernel/core/test_gf_architecture_shutdown_result.gd.uid
+++ b/tests/gf_core/kernel/core/test_gf_architecture_shutdown_result.gd.uid
@@ -1,0 +1,1 @@
+uid://d0mdlt2v0xgn7

--- a/tests/gf_core/kernel/core/test_gf_architecture_tick_scheduler_reentry.gd
+++ b/tests/gf_core/kernel/core/test_gf_architecture_tick_scheduler_reentry.gd
@@ -1,4 +1,4 @@
-## 验证架构 tick 调度拒绝重入，并只在最外层迭代结束后刷新缓存。
+## 验证架构 tick 调度的生命周期准入、delta 收束、重入和延迟缓存刷新。
 extends GutTest
 
 
@@ -42,6 +42,23 @@ class FollowerTickSystem extends GFSystem:
 
 
 class CountingTickSystem extends GFSystem:
+	var tick_calls: int = 0
+	var physics_tick_calls: int = 0
+	var tick_deltas: Array[float] = []
+
+	func _init() -> void:
+		tick_enabled = true
+		physics_tick_enabled = true
+
+	func tick(delta: float) -> void:
+		tick_calls += 1
+		tick_deltas.append(delta)
+
+	func physics_tick(_delta: float) -> void:
+		physics_tick_calls += 1
+
+
+class CountingTickUtility extends GFUtility:
 	var tick_calls: int = 0
 	var physics_tick_calls: int = 0
 
@@ -117,8 +134,8 @@ func test_nested_drive_is_rejected_without_flushing_outer_cache() -> void:
 	var follower: FollowerTickSystem = FollowerTickSystem.new(order)
 	systems[ReentrantTickSystem] = reentrant
 	systems[FollowerTickSystem] = follower
-	lifecycle_stages[reentrant] = 3
-	lifecycle_stages[follower] = 3
+	lifecycle_stages[reentrant] = 4
+	lifecycle_stages[follower] = 4
 	var _configured_scheduler: GFArchitectureTickScheduler = scheduler.configure(
 		systems,
 		utilities,
@@ -226,16 +243,164 @@ func test_physics_steps_provider_reentry_is_rejected_before_recursion() -> void:
 	assert_eq(counter.physics_tick_calls, 2, "物理步长回调返回后 drive guard 必须恢复。")
 
 
+func test_regular_drives_require_committed_lifecycle_stage() -> void:
+	var counter: CountingTickSystem = CountingTickSystem.new()
+	var lifecycle_stages: Dictionary = {
+		counter: 3,
+	}
+	var scheduler: GFArchitectureTickScheduler = GFArchitectureTickScheduler.new().configure(
+		{CountingTickSystem: counter},
+		{},
+		lifecycle_stages
+	)
+
+	scheduler.drive_tick(0.25, null)
+	scheduler.drive_physics_tick(0.25, null)
+
+	assert_eq(counter.tick_calls, 0, "仅完成 ready 的模块不得进入普通 tick。")
+	assert_eq(counter.physics_tick_calls, 0, "仅完成 ready 的模块不得进入 physics_tick。")
+
+	lifecycle_stages[counter] = 4
+	scheduler.drive_tick(0.25, null)
+	scheduler.drive_physics_tick(0.25, null)
+
+	assert_eq(counter.tick_calls, 1, "完成 activation 的模块应进入普通 tick。")
+	assert_eq(counter.physics_tick_calls, 1, "完成 activation 的模块应进入 physics_tick。")
+
+
+func test_lifecycle_drive_is_bounded_to_ready_allowed_tick_records() -> void:
+	var allowed_counter: CountingTickSystem = CountingTickSystem.new()
+	var unrelated_counter: CountingTickUtility = CountingTickUtility.new()
+	var lifecycle_stages: Dictionary = {
+		allowed_counter: 3,
+		unrelated_counter: 4,
+	}
+	var scheduler: GFArchitectureTickScheduler = GFArchitectureTickScheduler.new().configure(
+		{CountingTickSystem: allowed_counter},
+		{CountingTickUtility: unrelated_counter},
+		lifecycle_stages
+	)
+
+	scheduler.drive_lifecycle_tick(0.5, {allowed_counter: true})
+
+	assert_eq(allowed_counter.tick_calls, 1, "生命周期驱动应推进显式允许且已 ready 的模块。")
+	assert_almost_eq(
+		allowed_counter.tick_deltas[0],
+		0.1,
+		0.0001,
+		"生命周期 delta 必须限制到 0.1 秒。"
+	)
+	assert_eq(allowed_counter.physics_tick_calls, 0, "生命周期驱动不得调用 physics_tick。")
+	assert_eq(unrelated_counter.tick_calls, 0, "生命周期驱动不得推进集合外模块。")
+	assert_eq(unrelated_counter.physics_tick_calls, 0, "生命周期驱动不得推进集合外物理回调。")
+
+	lifecycle_stages[allowed_counter] = 2
+	scheduler.drive_lifecycle_tick(0.05, {allowed_counter: true})
+	assert_eq(allowed_counter.tick_calls, 1, "尚未 ready 的允许模块也不得被推进。")
+
+	lifecycle_stages.clear()
+	scheduler.drive_lifecycle_tick(0.05, {allowed_counter: true})
+	assert_eq(allowed_counter.tick_calls, 1, "生命周期阶段被清空后缓存记录不得继续推进。")
+
+
+func test_lifecycle_drive_normalizes_non_monotonic_delta() -> void:
+	var counter: CountingTickSystem = CountingTickSystem.new()
+	var scheduler: GFArchitectureTickScheduler = _make_counting_scheduler(counter, 3)
+	var allowed_instances: Dictionary = {
+		counter: true,
+	}
+
+	scheduler.drive_lifecycle_tick(0.05, {})
+	scheduler.drive_lifecycle_tick(-0.25, allowed_instances)
+	scheduler.drive_lifecycle_tick(NAN, allowed_instances)
+	scheduler.drive_lifecycle_tick(INF, allowed_instances)
+	scheduler.drive_lifecycle_tick(0.05, allowed_instances)
+	scheduler.drive_lifecycle_tick(0.5, allowed_instances)
+
+	assert_eq(counter.tick_deltas.size(), 5, "有效记录应在每次生命周期推进中恰好执行一次。")
+	assert_almost_eq(counter.tick_deltas[0], 0.0, 0.0001, "负 delta 应收束为零。")
+	assert_almost_eq(counter.tick_deltas[1], 0.0, 0.0001, "NaN delta 应收束为零。")
+	assert_almost_eq(counter.tick_deltas[2], 0.0, 0.0001, "Infinity delta 应收束为零。")
+	assert_almost_eq(counter.tick_deltas[3], 0.05, 0.0001, "正常 caller delta 应保持。")
+	assert_almost_eq(counter.tick_deltas[4], 0.1, 0.0001, "过大 delta 应限制到 0.1 秒。")
+
+
+func test_lifecycle_drive_reuses_reentry_and_deferred_refresh_guard() -> void:
+	var systems: Dictionary = {}
+	var lifecycle_stages: Dictionary = {}
+	var scheduler: GFArchitectureTickScheduler = GFArchitectureTickScheduler.new()
+	var order: Array[String] = []
+	var reentrant: ReentrantTickSystem = ReentrantTickSystem.new(scheduler, order)
+	var follower: FollowerTickSystem = FollowerTickSystem.new(order)
+	reentrant.tick_priority = -10
+	follower.tick_priority = 10
+	systems[ReentrantTickSystem] = reentrant
+	systems[FollowerTickSystem] = follower
+	lifecycle_stages[reentrant] = 3
+	lifecycle_stages[follower] = 3
+	var _configured_scheduler: GFArchitectureTickScheduler = scheduler.configure(
+		systems,
+		{},
+		lifecycle_stages
+	)
+	var allowed_instances: Dictionary = {
+		reentrant: true,
+		follower: true,
+	}
+
+	scheduler.drive_lifecycle_tick(0.25, allowed_instances)
+
+	assert_eq(
+		order,
+		["follower", "reentrant"],
+		"生命周期驱动应复用 tick 缓存顺序，并拒绝嵌套 drive。"
+	)
+	_assert_reentry_warning()
+
+	order.clear()
+	scheduler.drive_lifecycle_tick(0.25, allowed_instances)
+	assert_eq(
+		order,
+		["follower", "reentrant"],
+		"外层生命周期驱动结束后延迟 refresh 应保留排序。"
+	)
+
+
+func test_uncommitted_lifecycle_candidate_is_never_exposed_to_regular_tick() -> void:
+	var lifecycle_stages: Dictionary = {}
+	var scheduler: GFArchitectureTickScheduler = (
+		GFArchitectureTickScheduler.new().configure(
+			{},
+			{},
+			lifecycle_stages
+		)
+	)
+	var candidate: CountingTickUtility = CountingTickUtility.new()
+	lifecycle_stages[candidate] = 3
+	assert_true(scheduler.add_lifecycle_candidate(candidate))
+
+	scheduler.drive_tick(0.1, null)
+	scheduler.drive_lifecycle_tick(0.1, {candidate: true})
+	scheduler.drive_physics_tick(0.1, null)
+
+	assert_eq(candidate.tick_calls, 1)
+	assert_eq(candidate.physics_tick_calls, 0)
+	scheduler.remove_lifecycle_candidate(candidate)
+	scheduler.drive_lifecycle_tick(0.1, {candidate: true})
+	assert_eq(candidate.tick_calls, 1, "移除候选后不得继续驱动临时记录。")
+
+
 # --- 私有/辅助方法 ---
 
 func _make_counting_scheduler(
-	counter: CountingTickSystem
+	counter: CountingTickSystem,
+	lifecycle_stage: int = 4
 ) -> GFArchitectureTickScheduler:
 	var systems: Dictionary = {
 		CountingTickSystem: counter,
 	}
 	var lifecycle_stages: Dictionary = {
-		counter: 3,
+		counter: lifecycle_stage,
 	}
 	var scheduler: GFArchitectureTickScheduler = GFArchitectureTickScheduler.new()
 	return scheduler.configure(systems, {}, lifecycle_stages)

--- a/tests/gf_core/kernel/core/test_gf_assignment_lifecycle.gd
+++ b/tests/gf_core/kernel/core/test_gf_assignment_lifecycle.gd
@@ -103,6 +103,18 @@ class FailingQuiesceUtility extends GFUtility:
 		dispose_call_count += 1
 
 
+class ExternalLeaseProviderUtility extends GFUtility:
+	var dispose_call_count: int = 0
+
+	func dispose() -> void:
+		dispose_call_count += 1
+
+
+class ExternalLeaseConsumerSystem extends GFSystem:
+	func get_required_utilities() -> Array[Script]:
+		return [ExternalLeaseProviderUtility]
+
+
 # --- Godot 生命周期方法 ---
 
 func before_each() -> void:
@@ -259,6 +271,68 @@ func test_failed_old_shutdown_rejects_and_cleans_unpublished_candidate() -> void
 		"architecture_identity_changed",
 		"terminal 旧 identity 被清理时必须发布身份变化。"
 	)
+
+	facade._exit_tree()
+	facade.free()
+
+
+func test_busy_old_shutdown_preserves_committed_identity_for_retry() -> void:
+	var facade: GF_AUTOLOAD_NODE_SCRIPT = GF_AUTOLOAD_NODE_SCRIPT.new()
+	var previous_architecture: GFArchitecture = GFArchitecture.new()
+	var provider: ExternalLeaseProviderUtility = ExternalLeaseProviderUtility.new()
+	assert_true(
+		await previous_architecture.register_utility_instance(provider),
+		"父架构的外部依赖 provider 应成功注册。"
+	)
+	assert_true(
+		await facade.set_architecture(previous_architecture),
+		"父架构应先完成 facade 提交。"
+	)
+	var child_architecture: GFArchitecture = GFArchitecture.new(previous_architecture)
+	assert_true(
+		await child_architecture.register_system_instance(
+			ExternalLeaseConsumerSystem.new()
+		),
+		"child 的外部依赖 consumer 应成功注册。"
+	)
+	assert_true(await child_architecture.init(), "child 应取得父架构外部依赖租约。")
+	var rejected_candidate: GFArchitecture = GFArchitecture.new()
+	watch_signals(facade)
+
+	var rejected_result: bool = await facade.set_architecture(rejected_candidate)
+
+	assert_false(rejected_result, "活动 child 租约应拒绝 facade replacement。")
+	assert_true(rejected_candidate.is_disposed(), "被拒绝的未发布 candidate 应完成释放。")
+	assert_true(previous_architecture.is_inited(), "ERR_BUSY 不得终结既有父架构。")
+	assert_true(
+		previous_architecture.is_accepting_runtime_work(),
+		"ERR_BUSY 不得关闭既有父架构的工作准入。"
+	)
+	assert_false(previous_architecture.is_disposed(), "ERR_BUSY 不得强制 dispose 父架构。")
+	assert_true(facade.has_architecture(), "可重试失败后 facade 应保留可用 identity。")
+	assert_same(
+		facade.get_architecture(),
+		previous_architecture,
+		"可重试失败不得清除或替换已提交 identity。"
+	)
+	assert_signal_not_emitted(
+		facade,
+		"architecture_identity_changed",
+		"未改变 identity 的 ERR_BUSY replacement 不得发布身份变化。"
+	)
+
+	var child_shutdown: GFArchitectureShutdownResult = (
+		await child_architecture.shutdown_async()
+	)
+	assert_true(child_shutdown.is_successful(), "child 关闭后应释放父架构租约。")
+	var retry_candidate: GFArchitecture = GFArchitecture.new()
+	assert_true(
+		await facade.set_architecture(retry_candidate),
+		"child 释放租约后，使用新 candidate 重试 replacement 应成功。"
+	)
+	assert_true(previous_architecture.is_disposed(), "成功重试应正常终结旧父架构。")
+	assert_eq(provider.dispose_call_count, 1, "父级 provider 必须且只应释放一次。")
+	assert_same(facade.get_architecture(), retry_candidate, "重试 candidate 应成为最终 identity。")
 
 	facade._exit_tree()
 	facade.free()
@@ -448,6 +522,100 @@ func test_concurrent_same_candidate_assignment_preserves_original_scope() -> voi
 		_project_setting_bool(CLEANUP_SETTING),
 		"首个 assignment 成功完成时不应执行取消 cleanup。"
 	)
+
+	facade._exit_tree()
+	facade.free()
+
+
+func test_quiescing_candidate_cannot_steal_pending_assignment() -> void:
+	var facade: GF_AUTOLOAD_NODE_SCRIPT = GF_AUTOLOAD_NODE_SCRIPT.new()
+	var quiescing_candidate: GFArchitecture = GFArchitecture.new()
+	var quiesce_utility: BlockingQuiesceUtility = BlockingQuiesceUtility.new()
+	assert_true(
+		await quiescing_candidate.register_utility_instance(quiesce_utility),
+		"quiescing candidate 的测试 Utility 应成功注册。"
+	)
+	assert_true(await quiescing_candidate.init(), "测试 candidate 应先进入 READY。")
+	var shutdown_state: Dictionary = {
+		"done": false,
+		"result": null,
+	}
+	GF_ASYNC_CALL_SCRIPT.run_detached(
+		Callable(self, &"_capture_shutdown_result"),
+		[quiescing_candidate, shutdown_state]
+	)
+	assert_true(
+		await _wait_for_quiesce_start(quiesce_utility),
+		"测试 candidate 应进入 QUIESCING。"
+	)
+
+	var pending_candidate: GFArchitecture = GFArchitecture.new()
+	var activation_utility: BlockingActivationUtility = BlockingActivationUtility.new()
+	assert_true(
+		await pending_candidate.register_utility_instance(activation_utility),
+		"合法 pending candidate 的测试 Utility 应成功注册。"
+	)
+	var pending_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	GF_ASYNC_CALL_SCRIPT.run_detached(
+		Callable(self, &"_capture_assignment_result"),
+		[facade, pending_candidate, pending_state]
+	)
+	assert_true(
+		await _wait_for_activation_start(activation_utility),
+		"合法 candidate 应先停在 activation pending。"
+	)
+	var pending_scope: GFAsyncScope = facade._pending_architecture_assignment_scope
+	var pending_serial: int = facade._architecture_assignment_serial
+
+	var rejected_result: bool = await facade.set_architecture(quiescing_candidate)
+
+	assert_false(rejected_result, "QUIESCING candidate 必须在进入赋值事务前被拒绝。")
+	assert_eq(
+		facade._architecture_assignment_serial,
+		pending_serial,
+		"拒绝 QUIESCING candidate 不得推进 assignment serial。"
+	)
+	assert_same(
+		facade._pending_architecture_assignment,
+		pending_candidate,
+		"拒绝 QUIESCING candidate 不得抢占合法 pending 槽。"
+	)
+	assert_same(
+		facade._pending_architecture_assignment_scope,
+		pending_scope,
+		"拒绝 QUIESCING candidate 不得替换合法 pending scope。"
+	)
+	assert_true(pending_scope.is_active(), "合法 pending scope 不得被取消。")
+	assert_false(pending_candidate.is_disposed(), "合法 pending candidate 不得被清理。")
+	assert_true(quiescing_candidate.is_quiescing(), "入口拒绝不得强制终结外部 candidate。")
+
+	activation_utility.complete_activation()
+	assert_true(
+		await _wait_for_result(pending_state),
+		"合法 pending assignment 应在 activation 完成后有界返回。"
+	)
+	assert_true(
+		GFVariantData.get_option_bool(pending_state, "result"),
+		"被非法 candidate 竞争后，原 assignment 仍应成功提交。"
+	)
+	assert_same(facade.get_architecture(), pending_candidate, "合法 candidate 应保留提交权。")
+
+	quiesce_utility.complete_quiesce()
+	assert_true(
+		await _wait_for_result(shutdown_state),
+		"外部 quiescing candidate 应能独立完成 shutdown。"
+	)
+	var raw_shutdown_result: Variant = shutdown_state.get("result")
+	assert_true(
+		raw_shutdown_result is GFArchitectureShutdownResult,
+		"外部 shutdown 应返回 typed 结果。"
+	)
+	if raw_shutdown_result is GFArchitectureShutdownResult:
+		var shutdown_result: GFArchitectureShutdownResult = raw_shutdown_result
+		assert_true(shutdown_result.is_successful(), "入口拒绝不得破坏外部 shutdown。")
 
 	facade._exit_tree()
 	facade.free()
@@ -896,6 +1064,14 @@ func _capture_assignment_result(
 	state: Dictionary
 ) -> void:
 	state["result"] = await facade.set_architecture(architecture_instance)
+	state["done"] = true
+
+
+func _capture_shutdown_result(
+	architecture: GFArchitecture,
+	state: Dictionary
+) -> void:
+	state["result"] = await architecture.shutdown_async()
 	state["done"] = true
 
 

--- a/tests/gf_core/kernel/core/test_gf_assignment_lifecycle.gd
+++ b/tests/gf_core/kernel/core/test_gf_assignment_lifecycle.gd
@@ -55,6 +55,54 @@ class DisposeReentrantSetArchitecture extends GFArchitecture:
 		reentrant_set_result = GFVariantData.to_bool(raw_set_result)
 
 
+class BlockingActivationUtility extends GFUtility:
+	var activation_started: bool = false
+	var activation_completion: GFAsyncCompletion = null
+	var dispose_call_count: int = 0
+
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		activation_started = true
+		activation_completion = GFAsyncCompletion.new()
+		return activation_completion
+
+	func dispose() -> void:
+		dispose_call_count += 1
+
+	func complete_activation() -> void:
+		if activation_completion != null:
+			var _completed: bool = activation_completion.succeed()
+
+
+class BlockingQuiesceUtility extends GFUtility:
+	var quiesce_started: bool = false
+	var quiesce_completion: GFAsyncCompletion = null
+	var dispose_call_count: int = 0
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_started = true
+		quiesce_completion = GFAsyncCompletion.new()
+		return quiesce_completion
+
+	func dispose() -> void:
+		dispose_call_count += 1
+
+	func complete_quiesce() -> void:
+		if quiesce_completion != null:
+			var _completed: bool = quiesce_completion.succeed()
+
+
+class FailingQuiesceUtility extends GFUtility:
+	var dispose_call_count: int = 0
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _failed: bool = completion.fail("[test] old architecture quiesce failed")
+		return completion
+
+	func dispose() -> void:
+		dispose_call_count += 1
+
+
 # --- Godot 生命周期方法 ---
 
 func before_each() -> void:
@@ -70,6 +118,225 @@ func after_each() -> void:
 
 
 # --- 测试用例 ---
+
+func test_candidate_is_not_published_before_stage_four_activation_completes() -> void:
+	var facade: GF_AUTOLOAD_NODE_SCRIPT = GF_AUTOLOAD_NODE_SCRIPT.new()
+	var candidate: GFArchitecture = GFArchitecture.new()
+	var activation_utility: BlockingActivationUtility = BlockingActivationUtility.new()
+	var assignment_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	assert_true(
+		await candidate.register_utility_instance(activation_utility),
+		"测试 activation Utility 应成功注册到 candidate。"
+	)
+
+	GF_ASYNC_CALL_SCRIPT.run_detached(
+		Callable(self, &"_capture_assignment_result"),
+		[facade, candidate, assignment_state]
+	)
+	assert_true(
+		await _wait_for_activation_start(activation_utility),
+		"candidate 应进入第四阶段 activation。"
+	)
+
+	assert_false(facade.has_architecture(), "activation 完成前 candidate 不得发布。")
+	assert_false(
+		GFVariantData.get_option_bool(assignment_state, "done"),
+		"activation 完成前 assignment 不得提前返回。"
+	)
+	assert_true(candidate.is_activating(), "candidate 应保持 ACTIVATING 状态。")
+
+	activation_utility.complete_activation()
+	assert_true(
+		await _wait_for_result(assignment_state),
+		"activation 完成后 assignment 应有界返回。"
+	)
+
+	assert_true(
+		GFVariantData.get_option_bool(assignment_state, "result"),
+		"完整第四阶段成功后 candidate 应提交。"
+	)
+	assert_true(candidate.is_inited(), "已提交 candidate 必须处于 READY。")
+	assert_same(facade.get_architecture(), candidate, "最终 identity 应为已激活 candidate。")
+
+	facade._exit_tree()
+	facade.free()
+
+
+func test_replacement_waits_for_old_architecture_shutdown_before_publish() -> void:
+	var facade: GF_AUTOLOAD_NODE_SCRIPT = GF_AUTOLOAD_NODE_SCRIPT.new()
+	var previous_architecture: GFArchitecture = GFArchitecture.new()
+	var quiesce_utility: BlockingQuiesceUtility = BlockingQuiesceUtility.new()
+	var candidate: GFArchitecture = GFArchitecture.new()
+	var assignment_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	assert_true(
+		await previous_architecture.register_utility_instance(quiesce_utility),
+		"测试 quiesce Utility 应成功注册到旧架构。"
+	)
+	assert_true(
+		await facade.set_architecture(previous_architecture),
+		"旧架构应先完成提交。"
+	)
+
+	GF_ASYNC_CALL_SCRIPT.run_detached(
+		Callable(self, &"_capture_assignment_result"),
+		[facade, candidate, assignment_state]
+	)
+	assert_true(
+		await _wait_for_quiesce_start(quiesce_utility),
+		"replacement 应先进入旧架构 quiesce。"
+	)
+
+	assert_true(candidate.is_inited(), "candidate 应先完成第四阶段再关闭旧架构。")
+	assert_false(
+		facade.has_architecture(),
+		"QUIESCING 旧架构不得继续作为可获取的全局 identity。"
+	)
+	assert_false(
+		GFVariantData.get_option_bool(assignment_state, "done"),
+		"旧架构 shutdown 完成前 replacement 不得发布。"
+	)
+
+	quiesce_utility.complete_quiesce()
+	assert_true(
+		await _wait_for_result(assignment_state),
+		"旧架构完成 quiesce 后 replacement 应有界返回。"
+	)
+
+	assert_true(
+		GFVariantData.get_option_bool(assignment_state, "result"),
+		"成功 shutdown 后 replacement 应提交。"
+	)
+	assert_true(previous_architecture.is_disposed(), "旧架构必须进入 DISPOSED。")
+	assert_eq(quiesce_utility.dispose_call_count, 1, "旧模块必须恰好 dispose 一次。")
+	assert_same(facade.get_architecture(), candidate, "candidate 应成为唯一全局 identity。")
+
+	facade._exit_tree()
+	facade.free()
+
+
+func test_failed_old_shutdown_rejects_and_cleans_unpublished_candidate() -> void:
+	var facade: GF_AUTOLOAD_NODE_SCRIPT = GF_AUTOLOAD_NODE_SCRIPT.new()
+	var previous_architecture: GFArchitecture = GFArchitecture.new()
+	var failing_utility: FailingQuiesceUtility = FailingQuiesceUtility.new()
+	var candidate: GFArchitecture = GFArchitecture.new()
+	assert_true(
+		await previous_architecture.register_utility_instance(failing_utility),
+		"失败 quiesce Utility 应成功注册到旧架构。"
+	)
+	assert_true(
+		await facade.set_architecture(previous_architecture),
+		"旧架构应先完成提交。"
+	)
+	watch_signals(facade)
+
+	var assignment_result: bool = await facade.set_architecture(candidate)
+	await get_tree().process_frame
+
+	assert_false(assignment_result, "typed shutdown 失败必须拒绝 replacement。")
+	assert_true(previous_architecture.is_disposed(), "失败 shutdown 仍必须终结旧架构。")
+	assert_eq(failing_utility.dispose_call_count, 1, "失败 shutdown 也必须恰好 dispose 一次。")
+	assert_true(candidate.is_disposed(), "未发布 candidate 必须被强制清理。")
+	assert_false(facade.has_architecture(), "失败 replacement 后不得持有 terminal 旧 identity。")
+	assert_null(facade._architecture, "失败 replacement 后全局 identity 必须清空。")
+	var shutdown_result: GFArchitectureShutdownResult = (
+		previous_architecture.get_last_shutdown_result()
+	)
+	assert_not_null(shutdown_result, "旧架构必须保留 typed shutdown 结果。")
+	if shutdown_result != null:
+		assert_eq(
+			shutdown_result.get_status(),
+			GFArchitectureShutdownResult.Status.FAILED,
+			"quiesce 失败必须保留 FAILED 终态。"
+		)
+	assert_signal_emitted(
+		facade,
+		"architecture_identity_changed",
+		"terminal 旧 identity 被清理时必须发布身份变化。"
+	)
+
+	facade._exit_tree()
+	facade.free()
+
+
+func test_newer_replacement_owns_commit_after_shared_old_shutdown() -> void:
+	var facade: GF_AUTOLOAD_NODE_SCRIPT = GF_AUTOLOAD_NODE_SCRIPT.new()
+	var previous_architecture: GFArchitecture = GFArchitecture.new()
+	var quiesce_utility: BlockingQuiesceUtility = BlockingQuiesceUtility.new()
+	var intermediate_candidate: GFArchitecture = GFArchitecture.new()
+	var latest_candidate: GFArchitecture = GFArchitecture.new()
+	var intermediate_state: Dictionary = {
+		"done": false,
+		"result": true,
+	}
+	var latest_state: Dictionary = {
+		"done": false,
+		"result": false,
+	}
+	assert_true(
+		await previous_architecture.register_utility_instance(quiesce_utility),
+		"测试 quiesce Utility 应成功注册到旧架构。"
+	)
+	assert_true(
+		await facade.set_architecture(previous_architecture),
+		"旧架构应先完成提交。"
+	)
+
+	GF_ASYNC_CALL_SCRIPT.run_detached(
+		Callable(self, &"_capture_assignment_result"),
+		[facade, intermediate_candidate, intermediate_state]
+	)
+	assert_true(
+		await _wait_for_quiesce_start(quiesce_utility),
+		"首个 replacement 应进入旧架构 quiesce。"
+	)
+	GF_ASYNC_CALL_SCRIPT.run_detached(
+		Callable(self, &"_capture_assignment_result"),
+		[facade, latest_candidate, latest_state]
+	)
+	await get_tree().process_frame
+
+	assert_true(
+		intermediate_candidate.is_disposed(),
+		"更新 replacement 必须立即清理失去提交权的 candidate。"
+	)
+	assert_false(
+		GFVariantData.get_option_bool(intermediate_state, "done"),
+		"旧 shutdown 返回前陈旧 continuation 可以等待，但不得拥有提交权。"
+	)
+
+	quiesce_utility.complete_quiesce()
+	assert_true(
+		await _wait_for_result(intermediate_state),
+		"陈旧 replacement 应在共享 shutdown 完成后有界返回。"
+	)
+	assert_true(
+		await _wait_for_result(latest_state),
+		"最新 replacement 应在共享 shutdown 完成后有界返回。"
+	)
+
+	assert_false(
+		GFVariantData.get_option_bool(intermediate_state, "result"),
+		"陈旧 replacement 的迟到写回必须被 serial 门禁拒绝。"
+	)
+	assert_true(
+		GFVariantData.get_option_bool(latest_state, "result"),
+		"最新 replacement 应保留唯一提交权。"
+	)
+	assert_same(
+		facade.get_architecture(),
+		latest_candidate,
+		"共享 shutdown 完成后不得由陈旧 continuation 覆盖最新 identity。"
+	)
+
+	facade._exit_tree()
+	facade.free()
+
 
 ## 验证新赋值会取消尚未提交的 Installer scope，且旧 candidate 不会迟到提交。
 func test_replacement_cancels_pending_assignment_scope() -> void:
@@ -677,6 +944,28 @@ func _wait_for_result(state: Dictionary, max_frames: int = 30) -> bool:
 			return true
 		await get_tree().process_frame
 	return GFVariantData.to_bool(state.get("done", false))
+
+
+func _wait_for_activation_start(
+	activation_utility: BlockingActivationUtility,
+	max_frames: int = 30
+) -> bool:
+	for _frame_index: int in range(max_frames):
+		if activation_utility.activation_started:
+			return true
+		await get_tree().process_frame
+	return activation_utility.activation_started
+
+
+func _wait_for_quiesce_start(
+	quiesce_utility: BlockingQuiesceUtility,
+	max_frames: int = 30
+) -> bool:
+	for _frame_index: int in range(max_frames):
+		if quiesce_utility.quiesce_started:
+			return true
+		await get_tree().process_frame
+	return quiesce_utility.quiesce_started
 
 
 func _project_setting_bool(setting_name: String) -> bool:

--- a/tests/gf_core/kernel/core/test_gf_controller_event_lifecycle.gd
+++ b/tests/gf_core/kernel/core/test_gf_controller_event_lifecycle.gd
@@ -60,6 +60,10 @@ func after_each() -> void:
 func test_tree_reentry_restores_desired_event_bindings() -> void:
 	var architecture: GFArchitecture = GFArchitecture.new()
 	Gf._architecture = architecture
+	assert_true(
+		await architecture.init(),
+		"树重入测试必须先完成 Architecture activation。"
+	)
 	var controller: EventController = EventController.new()
 	add_child(controller)
 	controller.listen(&"tree_reentry")
@@ -115,6 +119,10 @@ func test_global_observer_tracks_resolved_autoload_instance() -> void:
 func test_reparent_migrates_bindings_to_nearest_context_architecture() -> void:
 	var global_architecture: GFArchitecture = GFArchitecture.new()
 	Gf._architecture = global_architecture
+	assert_true(
+		await global_architecture.init(),
+		"全局 Architecture 必须先完成 activation。"
+	)
 	var context: EmptyScopedContext = EmptyScopedContext.new()
 	var controller: EventController = EventController.new()
 	add_child(context)
@@ -124,6 +132,10 @@ func test_reparent_migrates_bindings_to_nearest_context_architecture() -> void:
 
 	controller.reparent(context)
 	var scoped_architecture: GFArchitecture = context.get_architecture()
+	assert_true(
+		await scoped_architecture.init(),
+		"Scoped Architecture 必须完成 activation 后才能接收迁移绑定。"
+	)
 	global_architecture.send_simple_event(&"context_migration", "stale_global")
 	scoped_architecture.send_simple_event(&"context_migration", "scoped")
 
@@ -146,6 +158,10 @@ func test_pool_acquire_retries_until_architecture_becomes_available() -> void:
 	await get_tree().process_frame
 
 	var late_architecture: GFArchitecture = Gf.create_architecture()
+	assert_true(
+		await late_architecture.init(),
+		"迟到 Architecture 必须完成 activation 后才能恢复事件绑定。"
+	)
 	late_architecture.send_simple_event(&"late_pool_architecture", "restored")
 
 	assert_eq(
@@ -162,6 +178,10 @@ func test_live_global_architecture_replacement_migrates_event_bindings() -> void
 	var first_architecture: GFArchitecture = GFArchitecture.new()
 	var replacement_architecture: GFArchitecture = GFArchitecture.new()
 	Gf._architecture = first_architecture
+	assert_true(
+		await first_architecture.init(),
+		"被替换的全局 Architecture 必须先完成 activation。"
+	)
 	var controller: EventController = EventController.new()
 	add_child(controller)
 	controller.listen(&"live_global_replacement")
@@ -186,6 +206,10 @@ func test_same_global_architecture_retry_restores_cleared_event_bindings() -> vo
 	add_child(controller)
 	controller.listen(&"same_identity_retry")
 	var architecture: GFArchitecture = Gf.create_architecture()
+	assert_true(
+		await architecture.init(),
+		"同 identity 重试测试必须先完成首次 activation。"
+	)
 	architecture.send_simple_event(&"same_identity_retry", "before_failure")
 
 	architecture.fail_initialization("[test] same identity initialization failure")
@@ -281,6 +305,10 @@ func test_failed_context_stays_closed_when_shared_architecture_retries() -> void
 
 func test_stale_failure_signal_cannot_clear_replacement_bindings() -> void:
 	var failed_architecture: GFArchitecture = Gf.create_architecture()
+	assert_true(
+		await failed_architecture.init(),
+		"失败重入测试必须先完成初始 Architecture activation。"
+	)
 	var replacement_architecture: GFArchitecture = GFArchitecture.new()
 	var replacement_state: Dictionary = {
 		"result": false,
@@ -332,6 +360,10 @@ func test_stale_failure_signal_cannot_clear_replacement_bindings() -> void:
 func test_binding_revision_rebuilds_type_assignable_and_simple_desired_set() -> void:
 	var architecture: GFArchitecture = GFArchitecture.new()
 	Gf._architecture = architecture
+	assert_true(
+		await architecture.init(),
+		"绑定 revision 测试必须先完成 Architecture activation。"
+	)
 	var controller: EventController = EventController.new()
 	add_child(controller)
 	var counts: Dictionary = {

--- a/tests/gf_core/kernel/core/test_gf_kernel_runtime.gd
+++ b/tests/gf_core/kernel/core/test_gf_kernel_runtime.gd
@@ -1,0 +1,117 @@
+# GFKernelRuntime 激活、静默与释放状态转换回归测试。
+extends GutTest
+
+
+# --- 测试用例 ---
+
+func test_activation_requires_current_initialization_generation() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+	var lifecycle_generation: int = runtime.begin_initialization()
+
+	assert_eq(runtime.begin_initialization(), -1)
+	assert_true(runtime.is_initializing())
+	assert_false(runtime.begin_activation(lifecycle_generation + 1))
+	assert_true(runtime.is_initializing())
+	assert_true(runtime.begin_activation(lifecycle_generation))
+	assert_true(runtime.is_activating())
+	assert_eq(runtime.begin_initialization(), -1)
+	assert_false(runtime.finish_activation(lifecycle_generation + 1))
+	assert_true(runtime.is_activating())
+	assert_true(runtime.finish_activation(lifecycle_generation))
+	assert_true(runtime.is_ready())
+	assert_eq(runtime.begin_initialization(), -1)
+	assert_eq(runtime.get_state_name(), "ready")
+
+
+func test_failed_runtime_requires_clear_failure_before_retry() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+	var first_generation: int = runtime.begin_initialization()
+	var first_transaction: Dictionary = runtime.begin_transaction("first")
+
+	assert_true(runtime.fail_initialization(first_generation))
+	assert_true(runtime.has_failed())
+	assert_eq(runtime.begin_initialization(), -1)
+	assert_true(runtime.is_transaction_failed(first_transaction))
+	assert_true(runtime.is_transaction_invalidated(first_transaction))
+	assert_true(runtime.clear_failure())
+	assert_eq(runtime.get_state(), GFKernelRuntime.LifecycleState.NEW)
+	assert_false(runtime.clear_failure())
+
+	var retry_generation: int = runtime.begin_initialization()
+	assert_gt(retry_generation, first_generation)
+	assert_true(runtime.is_initializing())
+	assert_true(runtime.begin_activation(retry_generation))
+	assert_true(runtime.finish_activation(retry_generation))
+	assert_true(runtime.is_ready())
+
+
+func test_disposed_runtime_rejects_initialization_retry() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+	assert_true(runtime.begin_dispose())
+	assert_eq(runtime.begin_initialization(), -1)
+	runtime.finish_dispose()
+
+	assert_true(runtime.is_disposed())
+	assert_eq(runtime.begin_initialization(), -1)
+	assert_false(runtime.clear_failure())
+
+
+func test_quiesce_preserves_generation_and_accepted_transactions_until_dispose() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+	var lifecycle_generation: int = runtime.begin_initialization()
+	assert_true(runtime.begin_activation(lifecycle_generation))
+	assert_true(runtime.finish_activation(lifecycle_generation))
+	var transaction: Dictionary = runtime.begin_transaction("accepted-before-quiesce")
+
+	assert_true(runtime.begin_quiesce())
+	assert_true(runtime.is_quiescing())
+	assert_true(runtime.is_lifecycle_active())
+	assert_eq(runtime.get_lifecycle_generation(), lifecycle_generation)
+	assert_false(runtime.is_transaction_invalidated(transaction))
+	assert_false(runtime.begin_quiesce())
+
+	assert_true(runtime.begin_dispose())
+	assert_true(runtime.is_disposing())
+	assert_eq(runtime.get_lifecycle_generation(), lifecycle_generation + 1)
+	assert_true(runtime.is_transaction_invalidated(transaction))
+	runtime.finish_dispose()
+	assert_true(runtime.is_disposed())
+	assert_false(runtime.is_lifecycle_active())
+
+
+func test_direct_dispose_is_a_safe_force_fallback_from_new_state() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+	var initial_generation: int = runtime.get_lifecycle_generation()
+	var transaction: Dictionary = runtime.begin_transaction("pre-init")
+
+	assert_true(runtime.begin_dispose())
+	assert_true(runtime.is_disposing())
+	assert_eq(runtime.get_lifecycle_generation(), initial_generation + 1)
+	assert_true(runtime.is_transaction_invalidated(transaction))
+	assert_false(runtime.begin_dispose())
+	runtime.finish_dispose()
+	assert_true(runtime.is_disposed())
+	assert_eq(runtime.get_state_name(), "disposed")
+
+
+func test_finish_dispose_cannot_skip_disposing_state() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+
+	runtime.finish_dispose()
+
+	assert_eq(runtime.get_state(), GFKernelRuntime.LifecycleState.NEW)
+	assert_false(runtime.is_disposed())
+
+
+func test_activation_failure_advances_generation_and_invalidates_transactions() -> void:
+	var runtime: GFKernelRuntime = GFKernelRuntime.new()
+	var lifecycle_generation: int = runtime.begin_initialization()
+	var transaction: Dictionary = runtime.begin_transaction("activation")
+	assert_true(runtime.begin_activation(lifecycle_generation))
+
+	assert_true(runtime.fail_initialization(lifecycle_generation))
+
+	assert_true(runtime.has_failed())
+	assert_eq(runtime.get_lifecycle_generation(), lifecycle_generation + 1)
+	assert_true(runtime.is_transaction_invalidated(transaction))
+	assert_true(runtime.is_transaction_failed(transaction))

--- a/tests/gf_core/kernel/core/test_gf_kernel_runtime.gd.uid
+++ b/tests/gf_core/kernel/core/test_gf_kernel_runtime.gd.uid
@@ -1,0 +1,1 @@
+uid://b3c2cm8hcqq2n

--- a/tests/gf_core/kernel/core/test_gf_node_context_lifecycle.gd
+++ b/tests/gf_core/kernel/core/test_gf_node_context_lifecycle.gd
@@ -192,6 +192,34 @@ class ScopedManualNoTimeoutContext extends GFNodeContext:
 		context_wait_timeout_seconds = 0.0
 
 
+class TreeExitShutdownProbeUtility extends GFUtility:
+	var quiesce_call_count: int = 0
+	var dispose_call_count: int = 0
+
+	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		quiesce_call_count += 1
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _completed: bool = completion.succeed()
+		return completion
+
+	func dispose() -> void:
+		dispose_call_count += 1
+
+
+class TreeExitShutdownProbeContext extends GFNodeContext:
+	var shutdown_probe: TreeExitShutdownProbeUtility = null
+
+	func _init() -> void:
+		scope_mode = GFNodeContext.ScopeMode.SCOPED
+		context_wait_timeout_seconds = 0.0
+
+	func install(architecture_instance: GFArchitecture, _scope: GFAsyncScope) -> void:
+		shutdown_probe = TreeExitShutdownProbeUtility.new()
+		var _registered: bool = await architecture_instance.register_utility_instance(
+			shutdown_probe
+		)
+
+
 # --- GUT 生命周期方法 ---
 
 func before_each() -> void:
@@ -203,6 +231,73 @@ func after_each() -> void:
 
 
 # --- 测试方法 ---
+
+func test_context_ready_requires_architecture_stage_four_commit() -> void:
+	var context: ScopedManualNoTimeoutContext = ScopedManualNoTimeoutContext.new()
+	watch_signals(context)
+	add_child(context)
+	await get_tree().process_frame
+	var original_architecture: GFArchitecture = context.get_architecture()
+	if original_architecture != null:
+		original_architecture.dispose()
+	var probe_architecture: SchedulingProbeArchitecture = (
+		SchedulingProbeArchitecture.new()
+	)
+	context._architecture = probe_architecture
+	context._owns_architecture = true
+	context._context_state = GFNodeContext._ContextState.INITIALIZING
+	context._capture_parent_architecture(null)
+
+	context._mark_context_ready(probe_architecture)
+
+	assert_false(
+		context.is_context_ready(),
+		"尚未提交 stage4 的架构不得发布 context_ready。"
+	)
+	assert_signal_not_emitted(
+		context,
+		"context_ready",
+		"stage4 前不得发出 context_ready。"
+	)
+
+	probe_architecture.reported_ready = true
+	context._mark_context_ready(probe_architecture)
+
+	assert_true(context.is_context_ready(), "stage4 完成后 Context 应进入 READY。")
+	assert_signal_emitted(
+		context,
+		"context_ready",
+		"stage4 完成后应发出 context_ready。"
+	)
+
+	context.queue_free()
+	await get_tree().process_frame
+
+
+func test_tree_exit_keeps_forced_synchronous_dispose_fallback() -> void:
+	var context: TreeExitShutdownProbeContext = TreeExitShutdownProbeContext.new()
+	add_child(context)
+	var context_architecture: GFArchitecture = await context.wait_until_ready()
+	var shutdown_probe: TreeExitShutdownProbeUtility = context.shutdown_probe
+
+	assert_not_null(context_architecture, "测试 Context 应先完成四阶段初始化。")
+	assert_not_null(shutdown_probe, "测试 Context 应安装 shutdown probe。")
+
+	context.queue_free()
+	await get_tree().process_frame
+
+	assert_true(context_architecture.is_disposed(), "tree exit 必须同步强制释放 owned 架构。")
+	assert_eq(
+		shutdown_probe.quiesce_call_count,
+		0,
+		"SceneTree 退出路径不得启动不可等待的异步 quiesce。"
+	)
+	assert_eq(
+		shutdown_probe.dispose_call_count,
+		1,
+		"tree exit 强制路径必须恰好 dispose 模块一次。"
+	)
+
 
 func test_node_context_dispatches_owned_ticks_only_while_context_is_ready() -> void:
 	var context: ScopedNoTimeoutContext = ScopedNoTimeoutContext.new()

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -130,6 +130,31 @@ class ReentrantUnregisterUtility extends GFUtility:
 				).call(ReentrantUnregisterUtility)
 			)
 
+
+class ReentrantReleaseRegisterUtility extends GFUtility:
+	var injected_architecture: GFArchitecture = null
+	var dispose_count: int = 0
+	var release_count: int = 0
+	var reentrant_register_result: bool = true
+
+	func inject_dependencies(architecture: GFArchitecture) -> void:
+		super.inject_dependencies(architecture)
+		injected_architecture = architecture
+
+	func dispose() -> void:
+		dispose_count += 1
+
+	func release_dependencies() -> void:
+		release_count += 1
+		if injected_architecture != null:
+			var raw_register_result: Variant = Callable(
+				injected_architecture,
+				&"register_utility_instance"
+			).call(self)
+			reentrant_register_result = GFVariantData.to_bool(raw_register_result)
+		super.release_dependencies()
+
+
 class OverrideInjectedLookupUtility extends GFUtility:
 	var injected_architecture: GFArchitecture = null
 
@@ -1302,6 +1327,37 @@ func test_unregister_utility_rejects_dispose_reentrant_unregister_exactly_once()
 	assert_null(arch.get_utility(ReentrantUnregisterUtility), "注销过程应先从注册表摘除实例。")
 	assert_push_error("[GFArchitecture] unregister_utility 失败：生命周期 Hook 内禁止重入修改注册表。")
 	arch.dispose()
+
+
+func test_unregister_utility_rejects_release_reentrant_registration() -> void:
+	var arch: GFArchitecture = GFArchitecture.new()
+	var utility: ReentrantReleaseRegisterUtility = (
+		ReentrantReleaseRegisterUtility.new()
+	)
+	assert_true(await arch.register_utility_instance(utility))
+
+	assert_true(await arch.unregister_utility(ReentrantReleaseRegisterUtility))
+
+	assert_false(
+		utility.reentrant_register_result,
+		"release_dependencies() 不得把已释放实例重新注册到架构。"
+	)
+	assert_null(
+		arch.get_local_utility(ReentrantReleaseRegisterUtility),
+		"注销完成后注册表不得残留已 dispose 且已释放依赖的实例。"
+	)
+	assert_eq(utility.dispose_count, 1, "注销必须且只应调用一次 dispose()。")
+	assert_eq(
+		utility.release_count,
+		1,
+		"注销必须且只应调用一次 release_dependencies()。"
+	)
+	assert_push_error(
+		"[GFArchitecture] register_utility 失败：生命周期 Hook 内禁止重入修改注册表。"
+	)
+	arch.dispose()
+	assert_eq(utility.dispose_count, 1, "架构后续 dispose 不得再次释放已注销实例。")
+	assert_eq(utility.release_count, 1, "架构后续 dispose 不得再次释放已注销依赖。")
 
 
 func test_architecture_dispose_releases_module_dependencies_after_dispose() -> void:

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -123,7 +123,12 @@ class ReentrantUnregisterUtility extends GFUtility:
 	func dispose() -> void:
 		dispose_count += 1
 		if injected_architecture != null:
-			injected_architecture.unregister_utility(ReentrantUnregisterUtility)
+			var _unregister_result: Variant = (
+				Callable(
+					injected_architecture,
+					&"unregister_utility"
+				).call(ReentrantUnregisterUtility)
+			)
 
 class OverrideInjectedLookupUtility extends GFUtility:
 	var injected_architecture: GFArchitecture = null
@@ -319,6 +324,18 @@ class DisposableFactoryCommand extends GFCommand:
 	func _on_factory_owned_event(_payload: Variant) -> void:
 		event_count += 1
 
+
+class MismatchedExternalFactoryInstance extends RefCounted:
+	var release_count: int = 0
+	var dispose_count: int = 0
+
+	func release_dependencies() -> void:
+		release_count += 1
+
+	func dispose() -> void:
+		dispose_count += 1
+
+
 class ReentrantFactoryCommand extends GFCommand:
 	var injected_architecture: GFArchitecture = null
 	var dispose_count: int = 0
@@ -373,12 +390,13 @@ class ScalingTimeProvider extends GFTimeProvider:
 
 class RegisteringUtility extends GFUtility:
 	var utility_to_register: TickUtility
+	var registration_succeeded: bool = true
 
 	func _init(target_utility: TickUtility) -> void:
 		utility_to_register = target_utility
 
 	func ready() -> void:
-		var _registered_utility: bool = await Gf.register_utility(utility_to_register)
+		registration_succeeded = await Gf.register_utility(utility_to_register)
 
 
 class SlowInitUtility extends GFUtility:
@@ -512,7 +530,12 @@ class UnregisteringTickSystem extends GFSystem:
 
 	func tick(_delta: float) -> void:
 		tick_order.append("unregistering")
-		_get_architecture().unregister_system(TickVictimSystem)
+		var _unregister_result: Variant = (
+			Callable(
+				_get_architecture(),
+				&"unregister_system"
+			).call(TickVictimSystem)
+		)
 
 
 class LowPriorityTickSystem extends GFSystem:
@@ -578,6 +601,7 @@ class ReplaceableAsyncUtility extends GFUtility:
 
 class ReadyLookupReplacementUtility extends GFUtility:
 	var ready_lookup: ReadyLookupReplacementUtility = null
+	var activation_lookup: ReadyLookupReplacementUtility = null
 	var disposed: bool = false
 
 	func ready() -> void:
@@ -585,9 +609,18 @@ class ReadyLookupReplacementUtility extends GFUtility:
 		if value is ReadyLookupReplacementUtility:
 			ready_lookup = value
 
+	func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		var value: Variant = get_utility(ReadyLookupReplacementUtility)
+		if value is ReadyLookupReplacementUtility:
+			activation_lookup = value
+		var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+		var _succeeded: bool = completion.succeed()
+		return completion
+
 	func dispose() -> void:
 		disposed = true
 		ready_lookup = null
+		activation_lookup = null
 
 
 class ReadyFailingReplacementUtility extends GFUtility:
@@ -884,6 +917,7 @@ func test_get_utility_proxy() -> void:
 ## 验证 Gf.send_query 正确代理并返回结果
 func test_send_query_proxy() -> void:
 	var query: DummyQuery = DummyQuery.new()
+	await Gf.init()
 	var result: String = GFVariantData.to_text(Gf.send_query(query))
 	assert_eq(result, "query_success", "Gf.send_query 应当正确执行并返回结果")
 
@@ -891,6 +925,7 @@ func test_send_query_proxy() -> void:
 ## 验证 GFQuery 基类可访问当前架构的 Utility。
 func test_query_can_get_utility_from_injected_architecture() -> void:
 	var query: UtilityLookupQuery = UtilityLookupQuery.new()
+	await Gf.init()
 	var result: DummyUtility = _dummy_utility(Gf.send_query(query))
 
 	assert_eq(result, Gf.get_utility(DummyUtility), "GFQuery.get_utility 应当解析当前架构中的 Utility。")
@@ -978,8 +1013,8 @@ func test_dynamic_register_after_init_does_not_tick_before_ready() -> void:
 	assert_eq(utility.tick_count, tick_count_after_ready + 1, "ready 后应恢复正常 tick。")
 
 
-## 验证初始化期间动态注册的 Utility 也会补跑完整生命周期。
-func test_register_during_init_receives_full_lifecycle() -> void:
+## 验证生命周期计划冻结后，初始化期间动态注册会被拒绝。
+func test_register_during_init_is_rejected_after_lifecycle_plan_freezes() -> void:
 	if Gf.has_architecture():
 		Gf.get_architecture().dispose()
 	Gf._architecture = null
@@ -988,17 +1023,18 @@ func test_register_during_init_receives_full_lifecycle() -> void:
 	var registering_utility: RegisteringUtility = RegisteringUtility.new(late_utility)
 
 	await Gf.register_utility(registering_utility)
-	await Gf.init()
+	var initialized: bool = await Gf.init()
 
-	assert_true(late_utility.initialized, "初始化过程中动态注册的 Utility 也应执行 init()。")
-	assert_true(late_utility.async_ready_called, "初始化过程中动态注册的 Utility 也应执行 async_init()。")
-	assert_true(late_utility.ready_called, "初始化过程中动态注册的 Utility 也应执行 ready()。")
+	assert_true(initialized, "拒绝初始化期注册不应破坏已冻结生命周期计划的推进。")
+	assert_false(registering_utility.registration_succeeded, "初始化期间 register_utility 应返回 false。")
+	assert_false(late_utility.initialized, "被拒绝的 Utility 不应执行 init()。")
+	assert_false(late_utility.async_ready_called, "被拒绝的 Utility 不应执行 async_init()。")
+	assert_false(late_utility.ready_called, "被拒绝的 Utility 不应执行 ready()。")
+	assert_null(Gf.get_utility(TickUtility), "被拒绝的 Utility 不应写入注册表。")
+	assert_push_error("[GFArchitecture] register_utility 失败：生命周期计划已经冻结，初始化期间禁止修改注册表。")
 
-	Gf.get_architecture().tick(0.25)
-	assert_eq(late_utility.tick_count, 1, "初始化过程中动态注册的 Utility 完成后应参与后续 tick。")
 
-
-## 验证三阶段生命周期在每个阶段按 Model -> Utility -> System 推进。
+## 验证生命周期各阶段按 Model -> Utility -> System 推进。
 func test_lifecycle_stage_order_prefers_utilities_before_systems() -> void:
 	if Gf.has_architecture():
 		Gf.get_architecture().dispose()
@@ -1077,9 +1113,9 @@ func test_module_registry_alias_unregister_does_not_remove_targets() -> void:
 	assert_eq(arch.get_system(RegistrySystemBase), system, "System alias 应解析到目标实例。")
 	assert_eq(arch.get_utility(RegistryUtilityBase), utility, "Utility alias 应解析到目标实例。")
 
-	arch.unregister_model(RegistryModelBase)
-	arch.unregister_system(RegistrySystemBase)
-	arch.unregister_utility(RegistryUtilityBase)
+	assert_false(await arch.unregister_model(RegistryModelBase))
+	assert_false(await arch.unregister_system(RegistrySystemBase))
+	assert_false(await arch.unregister_utility(RegistryUtilityBase))
 
 	assert_push_error_count(3, "通过 alias 调用 unregister_* 应提示使用 unregister_*_alias。")
 	assert_false(model.disposed, "unregister_model(alias) 不应释放目标 Model。")
@@ -1101,9 +1137,9 @@ func test_module_registry_alias_unregister_does_not_remove_targets() -> void:
 	assert_false(system.disposed, "注销 alias 不应释放目标 System。")
 	assert_false(utility.disposed, "注销 alias 不应释放目标 Utility。")
 
-	arch.unregister_model(RegistryConcreteModel)
-	arch.unregister_system(RegistryConcreteSystem)
-	arch.unregister_utility(RegistryConcreteUtility)
+	assert_true(await arch.unregister_model(RegistryConcreteModel))
+	assert_true(await arch.unregister_system(RegistryConcreteSystem))
+	assert_true(await arch.unregister_utility(RegistryConcreteUtility))
 
 	assert_true(model.disposed, "直接注销目标 Model 才应释放实例。")
 	assert_true(system.disposed, "直接注销目标 System 才应释放实例。")
@@ -1124,7 +1160,7 @@ func test_assignable_lookup_cache_invalidates_when_registry_changes() -> void:
 	assert_null(arch.get_utility(UtilityBase), "新增第二个实现后，旧的基类查询缓存不应继续返回旧实例。")
 	assert_push_warning("[GFArchitecture] get_utility() 匹配到多个本地实例，本次查询不会回退父架构；请使用显式 alias 注册以消除歧义。")
 
-	arch.unregister_utility(AlternateConcreteUtility)
+	assert_true(await arch.unregister_utility(AlternateConcreteUtility))
 	assert_eq(arch.get_utility(UtilityBase), concrete, "移除歧义实现后，基类查询应重新解析唯一实现。")
 	arch.dispose()
 
@@ -1189,8 +1225,8 @@ func test_replace_utility_timeout_keeps_old_instance() -> void:
 	arch.dispose()
 
 
-## 验证已初始化架构替换模块时，ready 阶段查询应解析到替换后的新实例。
-func test_replace_utility_ready_lookup_resolves_replacement_instance() -> void:
+## 验证替换候选完成 ready/activation 前不会提前覆盖旧注册表。
+func test_replace_utility_commits_registry_after_candidate_activation() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var old_utility: ReadyLookupReplacementUtility = ReadyLookupReplacementUtility.new()
 	var new_utility: ReadyLookupReplacementUtility = ReadyLookupReplacementUtility.new()
@@ -1199,7 +1235,9 @@ func test_replace_utility_ready_lookup_resolves_replacement_instance() -> void:
 	await arch.init()
 	await arch.replace_utility(ReadyLookupReplacementUtility, new_utility)
 
-	assert_eq(new_utility.ready_lookup, new_utility, "替换实例 ready() 中的查询应返回新实例。")
+	assert_eq(new_utility.ready_lookup, old_utility, "替换候选 ready() 中的查询应继续返回旧实例。")
+	assert_eq(new_utility.activation_lookup, old_utility, "替换候选 activation 中的查询应继续返回旧实例。")
+	assert_eq(arch.get_utility(ReadyLookupReplacementUtility), new_utility, "候选激活成功后 lookup 应返回已提交的新实例。")
 	assert_true(old_utility.disposed, "替换成功后旧实例应被释放。")
 	assert_false(new_utility.disposed, "替换成功的新实例不应被释放。")
 	arch.dispose()
@@ -1233,7 +1271,7 @@ func test_register_injects_architecture_when_hook_exists() -> void:
 
 	assert_eq(utility.injected_architecture, arch, "注册时应把当前架构注入到模块。")
 	assert_eq(utility.get_utility(InjectedUtility), utility, "覆写 inject_dependencies 且未调用 super 时，基类访问仍应绑定当前架构。")
-	arch.unregister_utility(InjectedUtility)
+	assert_true(await arch.unregister_utility(InjectedUtility))
 	assert_null(utility.get_utility(InjectedUtility), "注销后即使自定义注入 Hook 未调用 super，也不应回退全局架构。")
 	assert_push_error("[GFUtility] 依赖作用域已释放，无法继续访问架构。")
 	arch.dispose()
@@ -1244,7 +1282,7 @@ func test_unregister_utility_releases_cached_dependencies_after_dispose() -> voi
 	var utility: ReleasingUtility = ReleasingUtility.new()
 
 	await arch.register_utility_instance(utility)
-	arch.unregister_utility(ReleasingUtility)
+	assert_true(await arch.unregister_utility(ReleasingUtility))
 
 	assert_eq(utility.release_order, ["dispose", "release_dependencies"], "注销模块时应先 dispose，再释放依赖引用。")
 	assert_null(utility.cached_dependency, "release_dependencies 应能释放模块缓存的依赖引用。")
@@ -1253,15 +1291,16 @@ func test_unregister_utility_releases_cached_dependencies_after_dispose() -> voi
 	arch.dispose()
 
 
-func test_unregister_utility_detaches_before_dispose_reentrant_unregister() -> void:
+func test_unregister_utility_rejects_dispose_reentrant_unregister_exactly_once() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var utility: ReentrantUnregisterUtility = ReentrantUnregisterUtility.new()
 
 	await arch.register_utility_instance(utility)
-	arch.unregister_utility(ReentrantUnregisterUtility)
+	assert_true(await arch.unregister_utility(ReentrantUnregisterUtility))
 
 	assert_eq(utility.dispose_count, 1, "dispose() 中重入 unregister_utility 不应重复释放同一实例。")
 	assert_null(arch.get_utility(ReentrantUnregisterUtility), "注销过程应先从注册表摘除实例。")
+	assert_push_error("[GFArchitecture] unregister_utility 失败：生命周期 Hook 内禁止重入修改注册表。")
 	arch.dispose()
 
 
@@ -1296,7 +1335,7 @@ func test_unregistered_utility_does_not_fallback_to_global_architecture() -> voi
 	var utility: DummyUtility = DummyUtility.new()
 
 	await arch.register_utility_instance(utility)
-	arch.unregister_utility(DummyUtility)
+	assert_true(await arch.unregister_utility(DummyUtility))
 
 	assert_null(utility.get_utility(DummyUtility), "注销后的 Utility 不应回退访问全局架构。")
 	assert_push_error("[GFUtility] 依赖作用域已释放，无法继续访问架构。")
@@ -1312,7 +1351,11 @@ func test_released_internal_scope_does_not_fallback_to_global_architecture() -> 
 	Gf._architecture = global_arch
 
 	await local_arch.register_utility_instance(utility)
-	local_arch.unregister_utility(DirectArchitectureLookupUtility)
+	assert_true(
+		await local_arch.unregister_utility(
+			DirectArchitectureLookupUtility
+		)
+	)
 	var resolved: GFArchitecture = utility.get_architecture_directly()
 
 	Gf._architecture = previous_global_architecture
@@ -1471,6 +1514,7 @@ func test_binder_registers_modules_alias_and_factory_lifetimes() -> void:
 	var registered_singleton_factory: bool = await binder.bind_factory(FactoryCommand).from_factory(func() -> Object:
 		return FactoryCommand.new()
 	).as_singleton()
+	await arch.init()
 
 	var transient_a: InjectedFactoryCommand = _injected_factory_command(arch.create_instance(InjectedFactoryCommand))
 	var transient_b: InjectedFactoryCommand = _injected_factory_command(arch.create_instance(InjectedFactoryCommand))
@@ -1533,17 +1577,46 @@ func test_factory_binding_warns_when_alias_is_ignored() -> void:
 	arch.dispose()
 
 
-func test_register_factory_instance_does_not_dispose_external_instance() -> void:
+func test_architecture_dispose_does_not_dispose_external_factory_instance() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var command: DisposableFactoryCommand = DisposableFactoryCommand.new()
 
 	var _registered_factory_instance: bool = arch.register_factory_instance(DisposableFactoryCommand, command)
+	await arch.init()
 	var resolved: Object = arch.create_instance(DisposableFactoryCommand)
-	var _unregistered_factory: bool = arch.unregister_factory(DisposableFactoryCommand)
+	arch.dispose()
 
 	assert_same(resolved, command, "外部实例工厂应返回传入实例。")
-	assert_eq(command.dispose_count, 0, "注销外部实例工厂不应调用项目对象的 dispose()。")
+	assert_eq(command.dispose_count, 0, "架构释放外部实例工厂时不应调用项目对象的 dispose()。")
+
+
+func test_rejected_external_factory_instance_keeps_project_ownership() -> void:
+	var arch: GFArchitecture = GFArchitecture.new()
+	var external_instance: MismatchedExternalFactoryInstance = (
+		MismatchedExternalFactoryInstance.new()
+	)
+	assert_true(
+		arch.register_factory_instance(
+			DisposableFactoryCommand,
+			external_instance
+		)
+	)
+	assert_true(await arch.init())
+
+	assert_null(arch.create_instance(DisposableFactoryCommand))
+	assert_push_error("绑定来源返回的实例脚本必须继承或等于绑定键")
 	arch.dispose()
+
+	assert_eq(
+		external_instance.release_count,
+		0,
+		"未被注入的外部实例即使类型不匹配，也不得被框架清空项目依赖。"
+	)
+	assert_eq(
+		external_instance.dispose_count,
+		0,
+		"拒绝外部实例不能转移所有权或调用 dispose。"
+	)
 
 
 ## 验证项目 Installer 会在 Gf.init() 初始化前自动注册模块。
@@ -1736,7 +1809,7 @@ func test_enabled_extension_installer_registers_services_before_init() -> void:
 	)
 	ProjectSettings.set_setting(GFExtensionSettings.AUTO_INSTALL_ENABLED_INSTALLERS_SETTING, previous_auto_install)
 
-	assert_not_null(save_graph_utility, "启用扩展 installer 应在三阶段初始化前注册扩展级服务。")
+	assert_not_null(save_graph_utility, "启用扩展 installer 应在生命周期初始化前注册扩展级服务。")
 	assert_not_null(save_profile_utility, "Save 扩展 installer 应同时注册 profile 协调器。")
 
 
@@ -2432,6 +2505,8 @@ func test_factory_create_instance_injects_architecture() -> void:
 	var _registered_factory: bool = child_arch.register_factory(FactoryCommand, func() -> Object:
 		return FactoryCommand.new()
 	)
+	await parent_arch.init()
+	await child_arch.init()
 
 	var command: FactoryCommand = _factory_command(child_arch.create_instance(FactoryCommand))
 
@@ -2449,6 +2524,8 @@ func test_parent_transient_factory_injects_requesting_child_architecture() -> vo
 	var _registered_factory: bool = parent_arch.register_factory(InjectedFactoryCommand, func() -> Object:
 		return InjectedFactoryCommand.new()
 	)
+	await parent_arch.init()
+	await child_arch.init()
 
 	var command: InjectedFactoryCommand = _injected_factory_command(child_arch.create_instance(InjectedFactoryCommand))
 
@@ -2496,7 +2573,7 @@ func test_child_architecture_drops_parent_time_provider_after_unregister() -> vo
 	child_arch.tick(10.0)
 	assert_almost_eq(system.last_delta, 5.0, 0.0001, "子架构应先使用父级 TimeProvider。")
 
-	parent_arch.unregister_utility(ScalingTimeProvider)
+	assert_true(await parent_arch.unregister_utility(ScalingTimeProvider))
 	child_arch.tick(10.0)
 
 	assert_almost_eq(system.last_delta, 10.0, 0.0001, "父级 TimeProvider 注销后，子架构应回退到原始 delta。")
@@ -2556,7 +2633,7 @@ func test_architecture_dispose_rejects_parent_reinjection_from_completion_signal
 		"dispose 完成信号的同步回调不得重新注入父架构强引用。"
 	)
 	assert_push_error(
-		"[GFArchitecture] set_parent_architecture 失败：架构正在 dispose 或已 dispose，不能设置父级架构。"
+		"[GFArchitecture] set_parent_architecture 失败：生命周期计划开始后父级架构关系不可变。"
 	)
 	slow_utility.async_continue.emit()
 	await get_tree().process_frame
@@ -2600,9 +2677,7 @@ func test_diagnostics_report_corrupt_parent_cycle() -> void:
 	assert_true(GFVariantData.get_option_bool(binding_report, "parent_chain_cycle_detected"), "binding diagnostics 应显式报告父链循环。")
 	assert_eq(GFVariantData.get_option_string(binding_issue, "kind"), "parent_chain_cycle", "binding issue 应使用稳定 cycle kind。")
 
-	var dependency_report: Dictionary = child_arch.get_dependency_diagnostics({
-		"include_parent_lookup": true,
-	})
+	var dependency_report: Dictionary = child_arch.get_dependency_diagnostics()
 	var dependency_issues: Array = GFVariantData.get_option_array(dependency_report, "issues")
 	var dependency_issue: Dictionary = GFVariantData.as_dictionary(dependency_issues[0])
 	var missing_dependencies: Array = GFVariantData.get_option_array(dependency_report, "missing_dependencies")
@@ -2665,6 +2740,7 @@ func test_singleton_factory_recreates_freed_cached_instance() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var factory: CountingFactory = CountingFactory.new()
 	var _registered_factory: bool = arch.register_factory(FactoryNode, Callable(factory, "create"), GFBindingLifetimes.Lifetime.SINGLETON)
+	await arch.init()
 
 	var first: FactoryNode = _factory_node(arch.create_instance(FactoryNode))
 	first.free()
@@ -2682,6 +2758,7 @@ func test_singleton_factory_does_not_cache_wrong_type_failure() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var factory: RecoveringFactory = RecoveringFactory.new()
 	var _registered_factory: bool = arch.register_factory(FactoryNode, Callable(factory, "create"), GFBindingLifetimes.Lifetime.SINGLETON)
+	await arch.init()
 
 	var first: Object = arch.create_instance(FactoryNode)
 	var second: FactoryNode = _factory_node(arch.create_instance(FactoryNode))
@@ -2700,6 +2777,7 @@ func test_singleton_factory_rejects_recursive_resolution() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var factory: CyclicFactory = CyclicFactory.new(arch)
 	var _registered_factory: bool = arch.register_factory(FactoryNode, Callable(factory, "create"), GFBindingLifetimes.Lifetime.SINGLETON)
+	await arch.init()
 
 	var resolved: Object = arch.create_instance(FactoryNode)
 
@@ -2714,6 +2792,7 @@ func test_singleton_factory_rejects_provider_value_after_recursive_resolution() 
 	var arch: GFArchitecture = GFArchitecture.new()
 	var factory: FallbackAfterRecursiveFactory = FallbackAfterRecursiveFactory.new(arch)
 	var _registered_factory: bool = arch.register_factory(FactoryNode, Callable(factory, "create"), GFBindingLifetimes.Lifetime.SINGLETON)
+	await arch.init()
 
 	var first: Object = arch.create_instance(FactoryNode)
 	var second: FactoryNode = _factory_node(arch.create_instance(FactoryNode))
@@ -2753,6 +2832,7 @@ func test_singleton_factory_resolution_context_rolls_back_cross_binding_chain() 
 		Callable(factory_c, "create"),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await arch.init()
 
 	var resolved_a: Object = arch.create_instance(CrossChainFactoryACommand)
 	var rejected_b: CrossChainFactoryBCommand = _cross_chain_factory_b_command(factory_b.created_instances[0])
@@ -2782,6 +2862,8 @@ func test_parent_singleton_factory_keeps_owner_architecture_injection() -> void:
 			return InjectedFactoryCommand.new(),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await parent_arch.init()
+	await child_arch.init()
 
 	var first: InjectedFactoryCommand = _injected_factory_command(child_arch.create_instance(InjectedFactoryCommand))
 	var second: InjectedFactoryCommand = _injected_factory_command(child_arch.create_instance(InjectedFactoryCommand))
@@ -2794,8 +2876,8 @@ func test_parent_singleton_factory_keeps_owner_architecture_injection() -> void:
 	parent_arch.dispose()
 
 
-## 验证注销 Singleton 工厂会释放缓存实例的依赖作用域。
-func test_unregister_singleton_factory_releases_cached_instance_scope() -> void:
+## 验证 activation 后注销 Singleton 工厂会被拒绝，最终由架构释放缓存实例作用域。
+func test_unregister_singleton_factory_is_rejected_after_activation() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var utility: ParentScopedUtility = ParentScopedUtility.new()
 	await arch.register_utility_instance(utility)
@@ -2805,20 +2887,25 @@ func test_unregister_singleton_factory_releases_cached_instance_scope() -> void:
 			return FactoryCommand.new(),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await arch.init()
 
 	var command: FactoryCommand = _factory_command(arch.create_instance(FactoryCommand))
 
 	assert_eq(command.get_parent_utility_from_command(), utility, "工厂实例应先能访问注入架构中的依赖。")
 
-	var _unregistered_factory: bool = arch.unregister_factory(FactoryCommand)
+	var unregistered_factory: bool = arch.unregister_factory(FactoryCommand)
 
-	assert_null(command.get_parent_utility_from_command(), "工厂注销后旧 Singleton 实例不应继续访问旧架构。")
-	assert_push_error("[GFCommand] 依赖作用域已释放，无法继续访问架构。")
+	assert_false(unregistered_factory, "activation 后 unregister_factory 应返回 false。")
+	assert_true(arch.has_factory(FactoryCommand), "被拒绝的注销不应移除 Singleton factory。")
+	assert_eq(command.get_parent_utility_from_command(), utility, "被拒绝的注销不应提前释放 Singleton 实例作用域。")
+	assert_push_error("[GFArchitecture] unregister_factory 失败：activation 后 factory 拓扑不可变。")
 	arch.dispose()
+	assert_null(command.get_parent_utility_from_command(), "架构 dispose 后 Singleton 实例不应继续访问旧架构。")
+	assert_push_error("[GFCommand] 依赖作用域已释放，无法继续访问架构。")
 
 
-## 验证替换 Singleton 工厂会释放旧缓存实例的依赖作用域。
-func test_replace_singleton_factory_releases_previous_cached_instance_scope() -> void:
+## 验证 activation 后替换 Singleton 工厂会被拒绝且保留原缓存实例。
+func test_replace_singleton_factory_is_rejected_after_activation() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var utility: ParentScopedUtility = ParentScopedUtility.new()
 	await arch.register_utility_instance(utility)
@@ -2828,9 +2915,10 @@ func test_replace_singleton_factory_releases_previous_cached_instance_scope() ->
 			return FactoryCommand.new(),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await arch.init()
 
 	var previous: FactoryCommand = _factory_command(arch.create_instance(FactoryCommand))
-	var _replaced_factory: bool = arch.replace_factory(
+	var replaced_factory: bool = arch.replace_factory(
 		FactoryCommand,
 		func() -> Object:
 			return FactoryCommand.new(),
@@ -2838,15 +2926,17 @@ func test_replace_singleton_factory_releases_previous_cached_instance_scope() ->
 	)
 	var replacement: FactoryCommand = _factory_command(arch.create_instance(FactoryCommand))
 
-	assert_ne(previous, replacement, "替换工厂后应使用新的 Singleton 缓存实例。")
-	assert_eq(replacement.get_parent_utility_from_command(), utility, "新 Singleton 实例应接收当前架构注入。")
-	assert_null(previous.get_parent_utility_from_command(), "旧 Singleton 实例不应继续访问被替换前的架构作用域。")
-	assert_push_error("[GFCommand] 依赖作用域已释放，无法继续访问架构。")
+	assert_false(replaced_factory, "activation 后 replace_factory 应返回 false。")
+	assert_eq(previous, replacement, "被拒绝的替换应保留原 Singleton 缓存实例。")
+	assert_eq(previous.get_parent_utility_from_command(), utility, "被拒绝的替换不应提前释放原实例作用域。")
+	assert_push_error("[GFArchitecture] replace_factory 失败：activation 后 factory 拓扑不可变。")
 	arch.dispose()
+	assert_null(previous.get_parent_utility_from_command(), "架构 dispose 后原 Singleton 实例作用域应被释放。")
+	assert_push_error("[GFCommand] 依赖作用域已释放，无法继续访问架构。")
 
 
-## 验证注销 Singleton 工厂会释放缓存实例的生命周期归属。
-func test_unregister_singleton_factory_disposes_cached_instance_and_owned_events() -> void:
+## 验证 activation 后 Singleton 工厂注销被拒绝，最终由架构清理实例与事件。
+func test_unregister_singleton_factory_is_rejected_until_architecture_dispose() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var _registered_factory: bool = arch.register_factory(
 		DisposableFactoryCommand,
@@ -2854,20 +2944,27 @@ func test_unregister_singleton_factory_disposes_cached_instance_and_owned_events
 			return DisposableFactoryCommand.new(),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await arch.init()
 
 	var command: DisposableFactoryCommand = _disposable_factory_command(arch.create_instance(DisposableFactoryCommand))
 	arch.send_simple_event(&"factory_owned_event")
 
-	var _unregistered_factory: bool = arch.unregister_factory(DisposableFactoryCommand)
+	var unregistered_factory: bool = arch.unregister_factory(DisposableFactoryCommand)
 	arch.send_simple_event(&"factory_owned_event")
 
-	assert_eq(command.dispose_count, 1, "注销 Singleton 工厂应调用缓存实例的 dispose()。")
-	assert_eq(command.event_count, 1, "注销 Singleton 工厂后，缓存实例的 owner 事件监听应被清理。")
+	assert_false(unregistered_factory, "activation 后 unregister_factory 应返回 false。")
+	assert_eq(command.dispose_count, 0, "被拒绝的注销不应提前释放 Singleton 缓存实例。")
+	assert_eq(command.event_count, 2, "被拒绝的注销不应清理 Singleton 实例拥有的事件监听。")
+	assert_push_error("[GFArchitecture] unregister_factory 失败：activation 后 factory 拓扑不可变。")
 	arch.dispose()
+	var after_dispose_stats: Dictionary = arch.get_event_debug_stats()
+	var after_dispose_simple_events: Dictionary = GFVariantData.get_option_dictionary(after_dispose_stats, "simple_events")
+	assert_eq(command.dispose_count, 1, "架构 dispose 应 exactly-once 释放 Singleton 缓存实例。")
+	assert_eq(GFVariantData.get_option_int(after_dispose_simple_events, "factory_owned_event"), 0, "架构 dispose 应清理 Singleton 实例拥有的事件监听。")
 
 
-## 验证注销 Singleton 工厂会先摘除绑定，再释放缓存实例。
-func test_unregister_singleton_factory_detaches_before_dispose_reentrant_unregister() -> void:
+## 验证架构释放 Singleton 工厂期间的重入注销会被门禁拒绝，且只释放一次。
+func test_architecture_dispose_rejects_factory_unregister_reentry_exactly_once() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	var _registered_factory: bool = arch.register_factory(
 		ReentrantFactoryCommand,
@@ -2875,13 +2972,14 @@ func test_unregister_singleton_factory_detaches_before_dispose_reentrant_unregis
 			return ReentrantFactoryCommand.new(),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await arch.init()
 
 	var command: ReentrantFactoryCommand = _reentrant_factory_command(arch.create_instance(ReentrantFactoryCommand))
-	var _unregistered_factory: bool = arch.unregister_factory(ReentrantFactoryCommand)
+	arch.dispose()
 
 	assert_eq(command.dispose_count, 1, "factory 缓存实例 dispose() 中重入 unregister_factory 不应重复释放。")
-	assert_false(arch.has_factory(ReentrantFactoryCommand), "注销过程应先从 factory 注册表摘除绑定。")
-	arch.dispose()
+	assert_false(arch.has_factory(ReentrantFactoryCommand), "架构 dispose 后 factory 注册表应为空。")
+	assert_push_error("[GFArchitecture] unregister_factory 失败：架构已 dispose，不能继续修改注册表。")
 
 
 ## 验证架构销毁会释放 Singleton 工厂缓存实例的生命周期归属。
@@ -2893,6 +2991,7 @@ func test_architecture_dispose_disposes_singleton_factory_cached_instance() -> v
 			return DisposableFactoryCommand.new(),
 		GFBindingLifetimes.Lifetime.SINGLETON
 	)
+	await arch.init()
 
 	var command: DisposableFactoryCommand = _disposable_factory_command(arch.create_instance(DisposableFactoryCommand))
 	arch.send_simple_event(&"factory_owned_event")
@@ -2917,7 +3016,7 @@ func test_unregister_utility_removes_owned_event_listeners() -> void:
 	await arch.init()
 
 	arch.send_simple_event(&"owned_event")
-	arch.unregister_utility(OwnedEventUtility)
+	assert_true(await arch.unregister_utility(OwnedEventUtility))
 	arch.send_simple_event(&"owned_event")
 
 	assert_eq(utility.event_count, 1, "Utility 注销后不应继续收到 owner-bound 事件。")
@@ -2935,6 +3034,7 @@ func test_architecture_assignable_event_listener_receives_child_event() -> void:
 			1
 		)
 	)
+	await arch.init()
 
 	arch.send_event(ChildArchitectureEvent.new())
 
@@ -2947,6 +3047,7 @@ func test_architecture_event_debugging_exposes_trace() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
 	arch.configure_event_debugging(4, true, 2)
 	arch.register_simple_event(&"trace_event", GFEventListener.from_callable(func(_payload: Variant) -> void: pass, 1))
+	await arch.init()
 
 	arch.send_simple_event(&"trace_event")
 	var trace: Array = arch.get_event_dispatch_trace()
@@ -2967,6 +3068,7 @@ func test_architecture_event_debugging_exposes_trace() -> void:
 func test_facade_event_debugging_proxies_architecture() -> void:
 	Gf.configure_event_debugging(0, true, 2)
 	Gf.listen_simple(&"facade_trace_event", GFEventListener.from_callable(func(_payload: Variant) -> void: pass, 1))
+	await Gf.init()
 
 	Gf.send_simple_event(&"facade_trace_event")
 	var trace: Array[Dictionary] = Gf.get_event_dispatch_trace()
@@ -3006,7 +3108,7 @@ func test_architecture_debug_lifecycle_state_reports_modules_and_factories() -> 
 	var factory_entry: Dictionary = GFVariantData.as_dictionary(after_factories.values()[0])
 
 	assert_true(GFVariantData.get_option_bool(after_init, "inited"), "初始化后诊断快照应报告已初始化。")
-	assert_eq(GFVariantData.get_option_int(after_utility_entry, "stage"), 3, "初始化后模块应进入 ready 阶段。")
+	assert_eq(GFVariantData.get_option_int(after_utility_entry, "stage"), 4, "初始化后模块应进入 active 阶段。")
 	assert_true(GFVariantData.get_option_bool(after_utility_entry, "has_tick"), "诊断快照应报告 tick 能力。")
 	assert_eq(GFVariantData.get_option_int(factory_entry, "lifetime"), GFBindingLifetimes.Lifetime.SINGLETON, "诊断快照应报告工厂生命周期。")
 
@@ -3161,10 +3263,9 @@ func test_command_execution_scope_is_single_use_and_lifecycle_bound() -> void:
 	assert_push_error_count(1, "只有重复发送同一 Command 实例应输出错误。")
 
 
-## 验证声明式依赖严格模式会在生命周期推进前失败。
-func test_fail_on_missing_declared_dependencies_blocks_init() -> void:
+## 验证声明式依赖缺失始终以 fail-closed 方式阻止生命周期推进。
+func test_missing_declared_dependencies_always_block_init() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
-	arch.fail_on_missing_declared_dependencies = true
 	await arch.register_utility_instance(MissingDependencyUtility.new())
 	watch_signals(arch)
 
@@ -3173,9 +3274,12 @@ func test_fail_on_missing_declared_dependencies_blocks_init() -> void:
 	assert_false(initialized, "声明依赖缺失时 init() 应返回 false。")
 	assert_false(arch.is_inited(), "声明依赖缺失时架构不应初始化成功。")
 	assert_true(arch.has_initialization_failed(), "声明依赖缺失应标记初始化失败。")
-	assert_true(arch.last_initialization_error.contains("声明式依赖校验失败"), "失败原因应说明依赖校验失败。")
-	assert_signal_emitted(arch, "initialization_failed", "严格依赖校验失败时应发出 initialization_failed。")
-	assert_push_error_count(1, "严格依赖校验失败应输出错误。")
+	assert_true(
+		arch.last_initialization_error.contains("生命周期依赖计划编译失败"),
+		"失败原因应说明依赖计划编译失败。"
+	)
+	assert_signal_emitted(arch, "initialization_failed", "依赖校验失败时应发出 initialization_failed。")
+	assert_push_error_count(1, "依赖校验失败应输出错误。")
 	arch.dispose()
 
 
@@ -3192,7 +3296,6 @@ func test_set_architecture_keeps_previous_architecture_when_new_init_fails() -> 
 	assert_eq(Gf.get_architecture(), old_arch, "旧架构应先成功成为全局架构。")
 
 	var failing_arch: GFArchitecture = GFArchitecture.new()
-	failing_arch.fail_on_missing_declared_dependencies = true
 	await failing_arch.register_utility_instance(MissingDependencyUtility.new())
 	var failing_set: bool = await Gf.set_architecture(failing_arch)
 
@@ -3417,7 +3520,7 @@ func test_disposed_architecture_rejects_reuse_and_late_registration() -> void:
 	assert_true(command_result == null, "dispose 后 send_command 应返回 null。")
 	assert_push_error("[GFArchitecture] register_utility 失败：架构已 dispose，不能继续修改注册表。")
 	assert_push_error("[GFArchitecture] init 失败：架构正在或已经 dispose，不能重新初始化。")
-	assert_push_error("[GFArchitecture] create_instance 失败：架构已 dispose。")
+	assert_push_error("[GFArchitecture] create_instance 失败：架构已 dispose，不能继续执行。")
 	assert_push_error("[GFArchitecture] send_command 失败：架构已 dispose，不能继续执行。")
 	assert_push_error("[GFArchitecture] send_event 失败：架构已 dispose，不能继续执行。")
 	assert_push_error("[GFArchitecture] register_event 失败：架构已 dispose，不能继续修改运行时状态。")
@@ -3457,6 +3560,7 @@ func test_architecture_null_inputs_are_rejected() -> void:
 ## 验证命令/查询误传没有 execute() 的对象时会输出警告并安全返回 null。
 func test_architecture_warns_when_command_or_query_lacks_execute() -> void:
 	var arch: GFArchitecture = GFArchitecture.new()
+	await arch.init()
 
 	var command_result: Variant = arch.send_command(NoExecuteObject.new())
 	var query_result: Variant = arch.send_query(NoExecuteObject.new())

--- a/tests/gf_core/standard/state_machine/pure/test_gf_state_machine.gd
+++ b/tests/gf_core/standard/state_machine/pure/test_gf_state_machine.gd
@@ -806,14 +806,30 @@ func test_state_dispose_unregisters_owned_event_listeners() -> void:
 
 func test_state_can_send_command_and_query_through_state_machine_architecture() -> void:
 	var parent_arch: GFArchitecture = GFArchitecture.new()
-	await Gf.set_architecture(parent_arch)
-	await parent_arch.register_utility_instance(DummyUtility.new())
+	assert_true(
+		await Gf.set_architecture(parent_arch),
+		"父 Architecture 必须先完成 activation。"
+	)
+	assert_true(
+		await parent_arch.register_utility_instance(DummyUtility.new()),
+		"父 Architecture 应接受运行时 Utility 注册。"
+	)
 
 	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
 	var context: ContextUtility = ContextUtility.new()
 	var local_utility: DummyUtility = DummyUtility.new()
-	await child_arch.register_utility_instance(context)
-	await child_arch.register_utility_instance(local_utility)
+	assert_true(
+		await child_arch.register_utility_instance(context),
+		"Context Utility 应在子 Architecture activation 前注册成功。"
+	)
+	assert_true(
+		await child_arch.register_utility_instance(local_utility),
+		"本地 Utility 应在子 Architecture activation 前注册成功。"
+	)
+	assert_true(
+		await child_arch.init(),
+		"子 Architecture 必须完成 activation 后才能接收 Command 与 Query。"
+	)
 
 	_fsm.dispose()
 	_fsm = GFStateMachine.new(context)

--- a/tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd
@@ -506,7 +506,9 @@ func test_dispose_disconnects_log_signal() -> void:
 	var log_callable: Callable = Callable(console, "_on_log_emitted")
 	assert_true(log_util.log_emitted.is_connected(log_callable), "ready 后控制台应连接日志信号。")
 
-	arch.unregister_utility(_script_from_object(console))
+	assert_true(
+		await arch.unregister_utility(_script_from_object(console))
+	)
 	assert_false(log_util.log_emitted.is_connected(log_callable), "dispose 后应断开日志信号，避免悬挂监听。")
 
 

--- a/tests/gf_core/standard/utilities/nodes/test_gf_object_pool_utility.gd
+++ b/tests/gf_core/standard/utilities/nodes/test_gf_object_pool_utility.gd
@@ -160,6 +160,10 @@ func test_acquire_release_calls_node_hooks() -> void:
 
 func test_pooled_controller_events_pause_on_release_and_resume_on_acquire() -> void:
 	var architecture: GFArchitecture = _setup_test_architecture()
+	assert_true(
+		await architecture.init(),
+		"对象池 Controller 事件测试必须先完成 Architecture activation。"
+	)
 	var controller_scene: PackedScene = _make_pooled_controller_scene()
 	var controller: PooledEventController = _acquire_pooled_controller(controller_scene)
 
@@ -179,6 +183,10 @@ func test_pooled_controller_events_pause_on_release_and_resume_on_acquire() -> v
 
 func test_prewarmed_controller_events_stay_paused_until_acquire() -> void:
 	var architecture: GFArchitecture = _setup_test_architecture()
+	assert_true(
+		await architecture.init(),
+		"对象池预热事件测试必须先完成 Architecture activation。"
+	)
 	var controller_scene: PackedScene = _make_pooled_controller_scene()
 
 	_pool.prewarm(controller_scene, _parent, 1)

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -75,6 +75,8 @@ func after_each() -> void:
 			"test_async_handle.json",
 			"nested/async_signal_alias.json",
 			"test_wait_async.json",
+			"test_quiesce_async.json",
+			"test_quiesce_rejected.json",
 			"recover_from_backup.json",
 			"recover_from_temp.json",
 			"recover_from_stale_temp.json",
@@ -1106,6 +1108,44 @@ func test_wait_for_async_tasks_drains_queued_tasks() -> void:
 	assert_true(_storage._async_tasks.is_empty(), "等待后不应残留运行中任务。")
 	assert_true(_storage._async_queue.is_empty(), "等待后不应残留排队任务。")
 	assert_eq(GFVariantData.get_option_int(_load_payload("test_wait_async.json"), "value"), 2, "等待应处理完整队列并保留最后一次写入。")
+
+
+func test_quiesce_closes_io_admission_and_drains_accepted_queue() -> void:
+	_storage.max_async_thread_count = 1
+	var first: GFStorageAsyncOperation = _storage.save_data_request_async(
+		"test_quiesce_async.json",
+		{"value": 1}
+	)
+	var second: GFStorageAsyncOperation = _storage.save_data_request_async(
+		"test_quiesce_async.json",
+		{"value": 2}
+	)
+	var completion: GFAsyncCompletion = _storage.begin_quiesce(GFAsyncScope.new())
+
+	assert_false(completion.is_completed(), "同文件队列仍有已接纳工作时不得提前完成 quiesce。")
+	assert_eq(
+		_storage.save_data("test_quiesce_rejected.json", {"value": 3}),
+		ERR_UNAVAILABLE,
+		"quiesce 必须立即关闭同步 I/O 准入。"
+	)
+	var rejected: GFStorageAsyncOperation = _storage.save_data_request_async(
+		"test_quiesce_rejected.json",
+		{"value": 4}
+	)
+	assert_true(rejected.is_completed(), "quiesce 后的新异步请求必须立即进入终态。")
+	assert_eq(rejected.get_result().get_error_code(), ERR_UNAVAILABLE)
+
+	for _frame: int in range(120):
+		_storage.tick(0.0)
+		if completion.is_completed():
+			break
+		await get_tree().process_frame
+
+	assert_true(first.is_completed())
+	assert_true(second.is_completed())
+	assert_true(first.get_result().is_successful())
+	assert_true(second.get_result().is_successful())
+	assert_true(completion.is_successful(), "已接纳队列、线程和锁全部收敛后 quiesce 应成功。")
 
 
 func test_load_data_applies_version_defaults() -> void:

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -400,11 +400,21 @@ func test_dispose_blocks_reentrant_tick_and_wait_from_starting_queued_tasks() ->
 		GFStorageAsyncResult.WriteFailureKind.UNAVAILABLE,
 		"dispose 期间排队任务应稳定终止为 UNAVAILABLE。"
 	)
+	var observer: GFStorageUtility = GFStorageUtility.new()
+	observer.save_dir_name = _storage.save_dir_name
+	observer.encrypt_key = _storage.encrypt_key
+	observer.init()
+	var persisted_result: GFStorageReadResult = observer.load_data("queued_async.json")
+	assert_true(
+		persisted_result.ok,
+		"独立 observer 应能读取 dispose 前已落盘的首个异步写入：%s" % persisted_result.error
+	)
 	assert_eq(
-		GFVariantData.get_option_int(_load_payload("queued_async.json"), "value"),
+		GFVariantData.get_option_int(persisted_result.payload, "value"),
 		1,
 		"重入回调不得让排队写入产生磁盘副作用。"
 	)
+	observer.dispose()
 
 
 func test_dispose_clears_transient_state_and_releases_helpers() -> void:

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -2966,7 +2966,9 @@ def compact_api_member(class_name: str, member: dict[str, Any]) -> dict[str, Any
 
 def api_diff_breaking_allowed(base_tag: str, release_version: str) -> bool:
 	base_version = parse_semver(base_tag)
-	release_parts = parse_semver(release_version)
+	release_parts = parse_semver(
+		api_diff_release_target_version(release_version)
+	)
 	if base_version is None or release_parts is None:
 		return False
 	return release_parts[0] > base_version[0]
@@ -2974,7 +2976,9 @@ def api_diff_breaking_allowed(base_tag: str, release_version: str) -> bool:
 
 def api_diff_compatible_feature_allowed(base_tag: str, release_version: str) -> bool:
 	base_version = parse_semver(base_tag)
-	release_parts = parse_semver(release_version)
+	release_parts = parse_semver(
+		api_diff_release_target_version(release_version)
+	)
 	if base_version is None or release_parts is None:
 		return False
 	return (
@@ -2987,7 +2991,7 @@ def api_diff_compatible_feature_allowed(base_tag: str, release_version: str) -> 
 
 
 def find_latest_semver_tag_before(version: str) -> str:
-	release_parts = parse_semver(version)
+	release_parts = parse_semver(api_diff_release_target_version(version))
 	if release_parts is None:
 		return ""
 	tags = [
@@ -3000,6 +3004,10 @@ def find_latest_semver_tag_before(version: str) -> str:
 		return ""
 	tags.sort(key=lambda item: item[1])
 	return tags[-1][0]
+
+
+def api_diff_release_target_version(version: str) -> str:
+	return governed_release_target_version(version)
 
 
 def api_search(query: str, kind: str = "all", limit: int = 20) -> dict[str, Any]:
@@ -19109,15 +19117,33 @@ def maintenance_self_test() -> dict[str, Any]:
 	record_result(
 		"api_baseline_diff_requires_major_for_breaking_changes",
 		not api_diff_breaking_allowed("4.4.0", "4.5.0")
-		and api_diff_breaking_allowed("4.4.0", "5.0.0"),
+		and api_diff_breaking_allowed("4.4.0", "5.0.0")
+		and api_diff_breaking_allowed("10.0.0", "11.0.0-dev.0")
+		and not api_diff_breaking_allowed("10.0.0", "10.1.0-dev.0"),
 		"breaking API baseline changes should require a major version bump.",
 	)
 	record_result(
 		"api_baseline_diff_requires_minor_for_compatible_features",
 		not api_diff_compatible_feature_allowed("8.0.1", "8.0.2")
 		and api_diff_compatible_feature_allowed("8.0.1", "8.1.0")
-		and api_diff_compatible_feature_allowed("8.0.1", "9.0.0"),
+		and api_diff_compatible_feature_allowed("8.0.1", "9.0.0")
+		and api_diff_compatible_feature_allowed(
+			"10.0.0",
+			"11.0.0-dev.0",
+		)
+		and not api_diff_compatible_feature_allowed(
+			"10.0.0",
+			"10.0.1-dev.0",
+		),
 		"backward-compatible public API additions should require at least a minor version bump.",
+	)
+	record_result(
+		"api_baseline_diff_derives_governed_release_target",
+		api_diff_release_target_version("11.0.0-dev.0") == "11.0.0"
+		and api_diff_release_target_version("11.0.0") == "11.0.0"
+		and api_diff_release_target_version("11.0.0-rc.1") == ""
+		and api_diff_release_target_version("11.0.0-dev.0+ci") == "",
+		"API baseline selection and version enforcement must share the governed release core used by the Changelog gate.",
 	)
 	record_result(
 		"changelog_policy_derives_governed_release_target",
@@ -29528,6 +29554,10 @@ def changelog_policy() -> dict[str, Any]:
 
 
 def changelog_release_target_version(framework_version: str) -> str:
+	return governed_release_target_version(framework_version)
+
+
+def governed_release_target_version(framework_version: str) -> str:
 	parsed = gf_semver.parse_semver(framework_version)
 	if parsed is None or parsed.build:
 		return ""


### PR DESCRIPTION
## Summary

- introduce an explicit `NEW → INITIALIZING → ACTIVATING → READY → QUIESCING → DISPOSING → DISPOSED` architecture lifecycle with a frozen activation plan
- activate modules in dependency-safe stages, freeze the effective tick closure, and reject invalid topology/lifecycle transitions fail-closed
- add typed, shared single-flight shutdown results with deadlines, quiesce/drain hooks, exactly-once disposal, and Storage/Save/NodeContext handoff boundaries
- harden facade assignment ownership, staged topology visibility, parent/child external dependency leases, scoped factory ownership, rollback, release reentry, and lifecycle invalidation
- update generated API references, Chinese documentation, changelog, maintenance coverage, and regression tests

## Base and history

This PR now targets `main` directly and was rebased onto `668b2efc` after PR #77 merged. The topic branch contains no merge commits and is ready for the repository's normal squash-merge flow.

## Validation

- AI API generation: 864 files, 789 classes, 7,786 public methods; documentation coverage complete
- API Catalog/Reference: 794 classes, 11,671 members; generated outputs current
- isolated GDScript LSP: 1,255 files, 0 diagnostics, 0 timeouts
- focused lifecycle GUT after the final test cleanup: 85/85 tests, 921 assertions
- `framework-gut`: 344 scripts, 5,561/5,561 tests, 46,648 assertions
- `full`: 41/41 checks completed, 0 failures
- lifecycle gate: 0 unhandled warnings, 0 orphans
- project settings drift and `git diff --check`: clean
- final workspace fingerprint: `95d1c9cefbe643bb5b5a7c1029bacbb591fa471761a5a14db151199cd0d01e8e`

Closes #63
Closes #64