### PR TITLE
Add transactional save profile sessions

### DIFF
--- a/addons/gf/extensions/save/extension.gd
+++ b/addons/gf/extensions/save/extension.gd
@@ -6,6 +6,9 @@ extends GFInstaller
 
 const _GF_SAVE_GRAPH_UTILITY_SCRIPT = preload("res://addons/gf/extensions/save/graph/gf_save_graph_utility.gd")
 const _GF_SAVE_PROFILE_UTILITY_SCRIPT = preload("res://addons/gf/extensions/save/profile/gf_save_profile_utility.gd")
+const _GF_SAVE_PROFILE_TRANSACTION_COORDINATOR_SCRIPT = preload(
+	"res://addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd"
+)
 const _GF_STORAGE_UTILITY_SCRIPT = preload("res://addons/gf/standard/utilities/storage/gf_storage_utility.gd")
 
 
@@ -35,3 +38,17 @@ func install(architecture: GFArchitecture, _scope: GFAsyncScope) -> void:
 		var registered_save_profile: bool = await architecture.register_utility_instance(_GF_SAVE_PROFILE_UTILITY_SCRIPT.new())
 		if not registered_save_profile:
 			push_error("[GFSaveExtension] GFSaveProfileUtility registration failed.")
+	if (
+		architecture.get_local_utility(
+			_GF_SAVE_PROFILE_TRANSACTION_COORDINATOR_SCRIPT
+		) == null
+	):
+		var registered_profile_transactions: bool = (
+			await architecture.register_utility_instance(
+				_GF_SAVE_PROFILE_TRANSACTION_COORDINATOR_SCRIPT.new()
+			)
+		)
+		if not registered_profile_transactions:
+			push_error(
+				"[GFSaveExtension] GFSaveProfileTransactionCoordinator registration failed."
+			)

--- a/addons/gf/extensions/save/gf_extension.json
+++ b/addons/gf/extensions/save/gf_extension.json
@@ -2,7 +2,7 @@
   "id": "gf.save",
   "display_name": "GF Save",
   "version": "11.0.0-dev.0",
-  "extension_version": "6.0.0",
+  "extension_version": "6.1.0",
   "kind": "extension",
   "description": "Save profiles, versioned section orchestration, save graph composition, serializers, pipelines, scopes, sources, and slot workflows.",
   "dependencies": ["gf.kernel", "gf.standard"],

--- a/addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd
@@ -1,0 +1,276 @@
+## GFSaveProfileMutationRequest: mutate-and-persist 的一次性所有权请求。
+##
+## 请求在创建时原子接管每个 `GFSaveSectionMutation`，随后只允许协调器 claim
+## 一次。调用方必须放弃传入的 Dictionary、Array 及其全部嵌套 alias；请求
+## 不公开任何候选 payload getter，也不接受 Callable 或可执行 patch。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFSaveProfileMutationRequest
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _PERSISTED_VALUE_VALIDATOR_SCRIPT = preload(
+	"res://addons/gf/extensions/save/core/gf_save_persisted_value_validator.gd"
+)
+const _MAX_EPHEMERAL_DEPTH: int = 64
+const _MAX_EPHEMERAL_ITEMS: int = 100_000
+
+
+# --- 私有变量 ---
+
+var _ready: bool = false
+var _claimed: bool = false
+var _mutation_records: Array[Dictionary] = []
+var _document_metadata: Dictionary = {}
+var _context: Dictionary = {}
+var _result_metadata: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 创建请求并接管全部候选 section 与元数据。
+##
+## Mutation 必须非空、可用且 section ID 唯一。方法会先完成全部预检，再按输入
+## 顺序 claim，因而校验失败不会部分消费 Mutation。输入顺序只用于所有权收集；
+## 协调器始终按已注册 Profile 的 Provider 顺序 capture/apply。成功返回后，调用方必须永久
+## 放弃 mutations 数组、三个 Dictionary 及其全部嵌套 alias。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param mutations: 待接管的完整候选 sections；输入顺序不定义应用顺序。
+## [br]
+## @param document_metadata: 写入候选文档的持久化元数据。
+## [br]
+## @param context: Provider 操作使用的临时纯数据上下文。
+## [br]
+## @param result_metadata: 只写入当前事务结果的调用方纯数据元数据。
+## [br]
+## @schema document_metadata: Dictionary accepted by the Save persisted-value contract whose source aliases are abandoned after success.
+## [br]
+## @schema context: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+## [br]
+## @schema result_metadata: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+## [br]
+## @return 可用请求；输入无效时返回 null，且不消费任何 Mutation。
+static func take_ownership(
+	mutations: Array[GFSaveSectionMutation],
+	document_metadata: Dictionary = {},
+	context: Dictionary = {},
+	result_metadata: Dictionary = {}
+) -> GFSaveProfileMutationRequest:
+	if mutations.is_empty():
+		return null
+	var document_report: Dictionary = _PERSISTED_VALUE_VALIDATOR_SCRIPT.validate(
+		document_metadata
+	)
+	if not GFVariantData.get_option_bool(document_report, "ok", false):
+		return null
+	if not _is_ephemeral_dictionary_supported(context):
+		return null
+	if not _is_ephemeral_dictionary_supported(result_metadata):
+		return null
+
+	var section_ids: Dictionary = {}
+	for mutation: GFSaveSectionMutation in mutations:
+		if mutation == null or not mutation.is_available():
+			return null
+		var section_id: StringName = mutation.get_section_id()
+		if section_id == &"" or section_ids.has(section_id):
+			return null
+		section_ids[section_id] = true
+
+	var records: Array[Dictionary] = []
+	for mutation: GFSaveSectionMutation in mutations:
+		var record: Dictionary = mutation.claim_for_framework()
+		if record.is_empty():
+			# 预检后仅当前同步调用可 claim；若契约被外部重入破坏，释放已接管记录。
+			for claimed_record: Dictionary in records:
+				claimed_record.clear()
+			return null
+		records.append(record)
+
+	var request: GFSaveProfileMutationRequest = GFSaveProfileMutationRequest.new()
+	request._mutation_records = records
+	request._document_metadata = document_metadata
+	request._context = context
+	request._result_metadata = result_metadata
+	request._ready = true
+	return request
+
+
+## 检查请求是否仍可由协调器接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未 claim 时返回 true。
+func is_available() -> bool:
+	return _ready and not _claimed
+
+
+## 检查请求是否已经被协调器接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已成功 claim 时返回 true。
+func is_claimed() -> bool:
+	return _claimed
+
+
+## 获取候选 section 数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未 claim 时返回候选数；claim 后为 0。
+func get_mutation_count() -> int:
+	return _mutation_records.size()
+
+
+## 获取候选 section ID 的隔离快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 按请求收集顺序排列的 section ID；不包含候选载荷。
+func get_section_ids() -> PackedStringArray:
+	var section_ids: PackedStringArray = PackedStringArray()
+	for record: Dictionary in _mutation_records:
+		var _appended: bool = section_ids.append(
+			String(GFVariantData.get_option_string_name(record, "section_id"))
+		)
+	return section_ids
+
+
+# --- 框架内部方法 ---
+
+## 获取不含请求载荷的所有权快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 包含 available、claimed、mutation_count、section_ids 和 mutations 的快照。
+## [br]
+## @schema return: Payload-free Dictionary with available, claimed, mutation_count, section_ids, and mutations descriptors containing section_id and schema_version.
+func inspect_for_framework() -> Dictionary:
+	return {
+		"available": is_available(),
+		"claimed": _claimed,
+		"mutation_count": _mutation_records.size(),
+		"section_ids": get_section_ids(),
+		"mutations": _get_mutation_descriptors(),
+	}
+
+
+## 一次性移出候选记录与请求元数据。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 所有权记录；请求不可用时返回空字典。
+## [br]
+## @schema return: Internal Dictionary with mutations, document_metadata, context, and result_metadata ownership fields.
+func claim_for_framework() -> Dictionary:
+	if not is_available():
+		return {}
+	var claim: Dictionary = {
+		"mutations": _mutation_records,
+		"document_metadata": _document_metadata,
+		"context": _context,
+		"result_metadata": _result_metadata,
+	}
+	_mutation_records = []
+	_document_metadata = {}
+	_context = {}
+	_result_metadata = {}
+	_ready = false
+	_claimed = true
+	return claim
+
+
+# --- 私有/辅助方法 ---
+
+func _get_mutation_descriptors() -> Array[Dictionary]:
+	var descriptors: Array[Dictionary] = []
+	for record: Dictionary in _mutation_records:
+		descriptors.append({
+			"section_id": GFVariantData.get_option_string_name(record, "section_id"),
+			"schema_version": GFVariantData.get_option_int(record, "schema_version"),
+		})
+	return descriptors
+
+static func _is_ephemeral_dictionary_supported(value: Dictionary) -> bool:
+	var state: Dictionary = {
+		"items": 0,
+		"visited": [],
+	}
+	return _is_ephemeral_value_supported(value, 0, state)
+
+
+static func _is_ephemeral_value_supported(
+	value: Variant,
+	depth: int,
+	state: Dictionary
+) -> bool:
+	if depth > _MAX_EPHEMERAL_DEPTH:
+		return false
+	var item_count: int = GFVariantData.get_option_int(state, "items") + 1
+	state["items"] = item_count
+	if item_count > _MAX_EPHEMERAL_ITEMS:
+		return false
+
+	match typeof(value):
+		TYPE_OBJECT, TYPE_CALLABLE, TYPE_SIGNAL, TYPE_RID:
+			return false
+		TYPE_ARRAY:
+			var array_value: Array = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, array_value):
+				return false
+			visited.append(array_value)
+			for entry: Variant in array_value:
+				if not _is_ephemeral_value_supported(entry, depth + 1, state):
+					var _removed_array_failure: Variant = visited.pop_back()
+					return false
+			var _removed_array: Variant = visited.pop_back()
+		TYPE_DICTIONARY:
+			var dictionary_value: Dictionary = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, dictionary_value):
+				return false
+			visited.append(dictionary_value)
+			for key: Variant in dictionary_value.keys():
+				if (
+					not _is_ephemeral_value_supported(key, depth + 1, state)
+					or not _is_ephemeral_value_supported(dictionary_value[key], depth + 1, state)
+				):
+					var _removed_dictionary_failure: Variant = visited.pop_back()
+					return false
+			var _removed_dictionary: Variant = visited.pop_back()
+	return true
+
+
+static func _get_visited(state: Dictionary) -> Array:
+	return GFVariantData.as_array(GFVariantData.get_option_value(state, "visited"))
+
+
+static func _contains_collection_identity(collections: Array, candidate: Variant) -> bool:
+	for collection: Variant in collections:
+		if is_same(collection, candidate):
+			return true
+	return false

--- a/addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd.uid
@@ -1,0 +1,1 @@
+uid://ds6vvpm14ilvv

--- a/addons/gf/extensions/save/profile/gf_save_profile_operation.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_operation.gd
@@ -59,6 +59,8 @@ var _result: GFSaveProfileResult = null
 var _completion_emitted: bool = false
 var _context: Dictionary = {}
 var _result_metadata: Dictionary = {}
+var _strict_recovery: bool = false
+var _manager_permit: RefCounted = null
 
 
 # --- 公共方法 ---
@@ -160,6 +162,10 @@ func get_result() -> GFSaveProfileResult:
 ## [br]
 ## @param result_metadata: 调用方结果元数据。
 ## [br]
+## @param strict_recovery: 仅 load 可设为 true；忽略保留当前状态的低层恢复动作。
+## [br]
+## @param manager_permit: 可选受管 load capability；Utility 会在应用 Provider 前复核。
+## [br]
 ## @schema context: Dictionary with caller-defined ephemeral operation data.
 ## [br]
 ## @schema result_metadata: Dictionary with caller-defined result metadata.
@@ -171,9 +177,16 @@ func configure_for_framework(
 	requested_generation: int,
 	started_at_msec: int,
 	context: Dictionary = {},
-	result_metadata: Dictionary = {}
+	result_metadata: Dictionary = {},
+	strict_recovery: bool = false,
+	manager_permit: RefCounted = null
 ) -> bool:
-	if _operation != &"" or operation not in [OPERATION_LOAD, OPERATION_FLUSH]:
+	if (
+		_operation != &""
+		or operation not in [OPERATION_LOAD, OPERATION_FLUSH]
+		or (strict_recovery and operation != OPERATION_LOAD)
+		or (manager_permit != null and operation != OPERATION_LOAD)
+	):
 		return false
 	_operation = operation
 	_profile_id = profile_id
@@ -181,6 +194,8 @@ func configure_for_framework(
 	_started_at_msec = maxi(started_at_msec, 0)
 	_context = context.duplicate(true)
 	_result_metadata = result_metadata.duplicate(true)
+	_strict_recovery = strict_recovery
+	_manager_permit = manager_permit
 	return true
 
 
@@ -250,6 +265,7 @@ func complete_for_framework(result: GFSaveProfileResult) -> bool:
 	_result = result.duplicate_result()
 	_context = {}
 	_result_metadata = {}
+	_manager_permit = null
 	return true
 
 
@@ -303,3 +319,25 @@ func get_context_for_framework() -> Dictionary:
 ## @schema return: Dictionary with caller-defined result metadata.
 func get_metadata_for_framework() -> Dictionary:
 	return _result_metadata.duplicate(true)
+
+
+## 检查读取是否必须忽略保留当前状态的恢复策略。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 受管事务要求严格读取时返回 true。
+func requires_strict_recovery_for_framework() -> bool:
+	return _operation == OPERATION_LOAD and _strict_recovery
+
+
+## 获取受管 load 绑定的 opaque capability。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 非受管 load 返回 null；调用方只能执行对象身份复核。
+func get_manager_permit_for_framework() -> RefCounted:
+	return _manager_permit if _operation == OPERATION_LOAD else null

--- a/addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd
@@ -1,0 +1,607 @@
+## GFSaveProfileReconcileLease: outcome_unknown 的持续所有权与对账围栏。
+##
+## Lease 保留同一对象身份，直到所有相关底层请求 late-settle 并由显式 reconcile
+## 操作解除 domain 围栏。结果副本不会复制 Lease；因此调用方连接 `settled`、
+## 轮询状态和提交对账时观察的是同一条生命周期。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFSaveProfileReconcileLease
+extends RefCounted
+
+
+# --- 信号 ---
+
+## Lease 首次离开 waiting 时发出。
+##
+## 正常 late settlement 进入 ready；Utility 先释放则进入 disposed_unresolved。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 当前同一身份 Lease。
+## [br]
+## @param state: `STATE_READY` 或 `STATE_DISPOSED_UNRESOLVED`。
+signal settled(lease: GFSaveProfileReconcileLease, state: StringName)
+
+
+# --- 常量 ---
+
+## 仍在等待至少一个底层请求 late-settle。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_WAITING: StringName = &"waiting"
+
+## 已取得有界 settlement evidence，可以开始显式对账。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_READY: StringName = &"ready"
+
+## 一个 reconcile 操作已经接管 Lease。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_RECONCILING: StringName = &"reconciling"
+
+## 对账已经完成，Provider domain 围栏可以释放。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_RESOLVED: StringName = &"resolved"
+
+## Utility 已释放，但不确定副作用尚未完成对账。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_DISPOSED_UNRESOLVED: StringName = &"disposed_unresolved"
+
+const _MAX_EVIDENCE_DEPTH: int = 16
+const _MAX_EVIDENCE_ITEMS: int = 2048
+const _MAX_EVIDENCE_STRING_LENGTH: int = 2048
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _lease_id: int = 0
+var _transaction_id: int = 0
+var _operation: StringName = &""
+var _reconcile_profile_id: StringName = &""
+var _source_profile_id: StringName = &""
+var _target_profile_id: StringName = &""
+var _domain_id: int = 0
+var _domain_generation: int = 0
+var _epoch: int = 0
+var _storage_request_ids: PackedInt64Array = PackedInt64Array()
+var _state: StringName = STATE_DISPOSED_UNRESOLVED
+var _settlement_evidence: Dictionary = {}
+var _resolution_evidence: Dictionary = {}
+var _settled_signal_emitted: bool = false
+
+
+# --- 公共方法 ---
+
+## 获取 Utility 生命周期内唯一的 Lease ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 Lease ID；未配置时为 0。
+func get_lease_id() -> int:
+	return _lease_id
+
+
+## 获取产生当前 Lease 的事务 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数事务 ID；未配置时为 0。
+func get_transaction_id() -> int:
+	return _transaction_id
+
+
+## 获取产生 outcome_unknown 的事务类型。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `GFSaveProfileTransactionOperation.OPERATION_*` 常量之一。
+func get_operation() -> StringName:
+	return _operation
+
+
+## 获取显式对账应重新读取的 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非空 Profile ID。
+func get_reconcile_profile_id() -> StringName:
+	return _reconcile_profile_id
+
+
+## 获取原事务来源 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 来源 Profile ID；不适用时为空。
+func get_source_profile_id() -> StringName:
+	return _source_profile_id
+
+
+## 获取原事务目标 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 目标 Profile ID；不适用时为空。
+func get_target_profile_id() -> StringName:
+	return _target_profile_id
+
+
+## 获取运行时 Provider domain ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Utility 生命周期内唯一的正整数 domain ID。
+func get_domain_id() -> int:
+	return _domain_id
+
+
+## 获取 Lease 创建时的 domain generation。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 domain generation。
+func get_domain_generation() -> int:
+	return _domain_generation
+
+
+## 获取 Lease 创建时的 Utility lifecycle epoch。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 lifecycle epoch。
+func get_epoch() -> int:
+	return _epoch
+
+
+## 获取支撑 outcome_unknown 的底层 Storage 请求 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 按发起顺序排列的正整数请求 ID。
+func get_storage_request_ids() -> PackedInt64Array:
+	return _storage_request_ids.duplicate()
+
+
+## 获取当前 Lease 状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATE_*` 常量之一。
+func get_state() -> StringName:
+	return _state
+
+
+## 检查 Lease 是否仍等待 late settlement。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return waiting 时返回 true。
+func is_waiting() -> bool:
+	return _configured and _state == STATE_WAITING
+
+
+## 检查 Lease 是否可由 reconcile 操作接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return ready 时返回 true。
+func is_ready() -> bool:
+	return _state == STATE_READY
+
+
+## 检查 Lease 是否已进入不可再对账的终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return resolved 或 disposed_unresolved 时返回 true。
+func is_terminal() -> bool:
+	return _state in [STATE_RESOLVED, STATE_DISPOSED_UNRESOLVED]
+
+
+## 获取不含文档或 Provider payload 的 settlement evidence。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 有界 evidence 副本。
+## [br]
+## @schema return: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+func get_settlement_evidence() -> Dictionary:
+	return _settlement_evidence.duplicate(true)
+
+
+## 获取成功对账后提交的最终证据。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return resolved 前为空；resolved 后返回有界 evidence 副本。
+## [br]
+## @schema return: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+func get_resolution_evidence() -> Dictionary:
+	return _resolution_evidence.duplicate(true)
+
+
+# --- 框架内部方法 ---
+
+## 由 Save Profile 事务协调器一次性绑定不确定写入身份。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease_id: Utility 生命周期内唯一的正整数 Lease ID。
+## [br]
+## @param transaction_id: 产生该 Lease 的正整数事务 ID。
+## [br]
+## @param operation: 产生 outcome_unknown 的事务类型。
+## [br]
+## @param reconcile_profile_id: 对账时必须重新读取的 Profile ID。
+## [br]
+## @param source_profile_id: 原事务来源 Profile ID；不适用时为空。
+## [br]
+## @param target_profile_id: 原事务目标 Profile ID；不适用时为空。
+## [br]
+## @param domain_id: Utility 生命周期内唯一的正整数 Provider domain ID。
+## [br]
+## @param domain_generation: 创建时的正整数 domain generation。
+## [br]
+## @param epoch: 创建时的正整数 Utility lifecycle epoch。
+## [br]
+## @param storage_request_ids: 支撑不确定结果的正整数 Storage 请求 ID；纯内存故障围栏可为空。
+## [br]
+## @return 输入合法且首次配置时返回 true。
+func configure_for_framework(
+	lease_id: int,
+	transaction_id: int,
+	operation: StringName,
+	reconcile_profile_id: StringName,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	domain_id: int,
+	domain_generation: int,
+	epoch: int,
+	storage_request_ids: PackedInt64Array
+) -> bool:
+	if _configured:
+		return false
+	if (
+		lease_id <= 0
+		or transaction_id <= 0
+		or operation == &""
+		or operation == GFSaveProfileTransactionOperation.OPERATION_RECONCILE
+		or reconcile_profile_id == &""
+		or domain_id <= 0
+		or domain_generation <= 0
+		or epoch <= 0
+		or not _has_only_positive_request_ids(storage_request_ids)
+	):
+		return false
+	_configured = true
+	_lease_id = lease_id
+	_transaction_id = transaction_id
+	_operation = operation
+	_reconcile_profile_id = reconcile_profile_id
+	_source_profile_id = source_profile_id
+	_target_profile_id = target_profile_id
+	_domain_id = domain_id
+	_domain_generation = domain_generation
+	_epoch = epoch
+	_storage_request_ids = storage_request_ids.duplicate()
+	_state = STATE_WAITING
+	return true
+
+
+## 获取不含文档或 Provider payload 的 Lease 快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return Lease 身份、围栏、状态与 settlement evidence。
+## [br]
+## @schema return: Payload-free Dictionary with lease identity, transaction identity, profile ids, domain fence, request ids, state, settlement_evidence, and resolution_evidence.
+func inspect_for_framework() -> Dictionary:
+	return {
+		"lease_id": _lease_id,
+		"transaction_id": _transaction_id,
+		"operation": _operation,
+		"reconcile_profile_id": _reconcile_profile_id,
+		"source_profile_id": _source_profile_id,
+		"target_profile_id": _target_profile_id,
+		"domain_id": _domain_id,
+		"domain_generation": _domain_generation,
+		"epoch": _epoch,
+		"storage_request_ids": _storage_request_ids.duplicate(),
+		"state": _state,
+		"settlement_evidence": _settlement_evidence.duplicate(true),
+		"resolution_evidence": _resolution_evidence.duplicate(true),
+	}
+
+
+## 提交全部 late settlement 的有界证据，并开放显式对账。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param settlement_evidence: 不含文档、section 或 Provider payload 的证据。
+## [br]
+## @schema settlement_evidence: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+## [br]
+## @return 首次从 waiting 转为 ready 时返回 true。
+func mark_ready_for_framework(settlement_evidence: Dictionary = {}) -> bool:
+	if not is_waiting() or not _is_evidence_supported(settlement_evidence):
+		return false
+	_settlement_evidence = settlement_evidence.duplicate(true)
+	_state = STATE_READY
+	_emit_settled_for_framework()
+	return true
+
+
+## 在身份和围栏匹配时接管一次对账尝试。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param expected_reconcile_profile_id: 本次对账重新读取的 Profile ID。
+## [br]
+## @param expected_domain_id: 当前 Provider domain ID。
+## [br]
+## @param expected_domain_generation: 当前 domain generation。
+## [br]
+## @param expected_epoch: 当前 Utility lifecycle epoch。
+## [br]
+## @return 匹配时返回 payload-free Lease 记录并转为 reconciling；否则为空。
+## [br]
+## @schema return: Payload-free Dictionary with lease identity, transaction identity, profile ids, domain fence, request ids, and settlement_evidence.
+func claim_for_framework(
+	expected_reconcile_profile_id: StringName,
+	expected_domain_id: int,
+	expected_domain_generation: int,
+	expected_epoch: int
+) -> Dictionary:
+	if not is_ready():
+		return {}
+	if (
+		expected_reconcile_profile_id != _reconcile_profile_id
+		or expected_domain_id != _domain_id
+		or expected_domain_generation != _domain_generation
+		or expected_epoch != _epoch
+	):
+		return {}
+	_state = STATE_RECONCILING
+	return inspect_for_framework()
+
+
+## 对账尝试失败后把同一 Lease 恢复为 ready，以允许显式重试。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 首次从 reconciling 恢复为 ready 时返回 true。
+func release_reconcile_for_framework() -> bool:
+	if _state != STATE_RECONCILING:
+		return false
+	_state = STATE_READY
+	return true
+
+
+## 提交成功对账的有界证据并结束 Lease。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param resolution_evidence: 不含文档、section 或 Provider payload 的最终证据。
+## [br]
+## @schema resolution_evidence: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+## [br]
+## @return 首次从 reconciling 转为 resolved 时返回 true。
+func mark_resolved_for_framework(resolution_evidence: Dictionary = {}) -> bool:
+	if _state != STATE_RECONCILING or not _is_evidence_supported(resolution_evidence):
+		return false
+	_resolution_evidence = resolution_evidence.duplicate(true)
+	_state = STATE_RESOLVED
+	return true
+
+
+## 在 Utility 释放时保留未完成对账的可诊断终态。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 首次转为 disposed_unresolved 时返回 true。
+func mark_disposed_unresolved_for_framework() -> bool:
+	if not _configured or is_terminal():
+		return false
+	var was_waiting: bool = _state == STATE_WAITING
+	_state = STATE_DISPOSED_UNRESOLVED
+	if was_waiting:
+		_emit_settled_for_framework()
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+static func _has_only_positive_request_ids(request_ids: PackedInt64Array) -> bool:
+	for request_id: int in request_ids:
+		if request_id <= 0:
+			return false
+	return true
+
+
+static func _is_evidence_supported(evidence: Dictionary) -> bool:
+	var state: Dictionary = {
+		"items": 0,
+		"visited": [],
+	}
+	return _is_evidence_value_supported(evidence, 0, state)
+
+
+static func _is_evidence_value_supported(
+	value: Variant,
+	depth: int,
+	state: Dictionary
+) -> bool:
+	if depth > _MAX_EVIDENCE_DEPTH:
+		return false
+	var item_count: int = GFVariantData.get_option_int(state, "items") + 1
+	state["items"] = item_count
+	if item_count > _MAX_EVIDENCE_ITEMS:
+		return false
+
+	match typeof(value):
+		TYPE_NIL, TYPE_BOOL, TYPE_INT:
+			return true
+		TYPE_FLOAT:
+			var number: float = value
+			return not is_nan(number) and not is_inf(number)
+		TYPE_STRING:
+			var text: String = value
+			return text.length() <= _MAX_EVIDENCE_STRING_LENGTH
+		TYPE_STRING_NAME:
+			var identifier: StringName = value
+			return String(identifier).length() <= _MAX_EVIDENCE_STRING_LENGTH
+		TYPE_PACKED_BYTE_ARRAY:
+			var values: PackedByteArray = value
+			return _consume_packed_items(values.size(), state)
+		TYPE_PACKED_INT32_ARRAY:
+			var values: PackedInt32Array = value
+			return _consume_packed_items(values.size(), state)
+		TYPE_PACKED_INT64_ARRAY:
+			var values: PackedInt64Array = value
+			return _consume_packed_items(values.size(), state)
+		TYPE_PACKED_FLOAT32_ARRAY:
+			var values: PackedFloat32Array = value
+			if not _consume_packed_items(values.size(), state):
+				return false
+			for number: float in values:
+				if is_nan(number) or is_inf(number):
+					return false
+			return true
+		TYPE_PACKED_FLOAT64_ARRAY:
+			var values: PackedFloat64Array = value
+			if not _consume_packed_items(values.size(), state):
+				return false
+			for number: float in values:
+				if is_nan(number) or is_inf(number):
+					return false
+			return true
+		TYPE_PACKED_STRING_ARRAY:
+			var values: PackedStringArray = value
+			if not _consume_packed_items(values.size(), state):
+				return false
+			for text: String in values:
+				if text.length() > _MAX_EVIDENCE_STRING_LENGTH:
+					return false
+			return true
+		TYPE_ARRAY:
+			var array_value: Array = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, array_value):
+				return false
+			visited.append(array_value)
+			for entry: Variant in array_value:
+				if not _is_evidence_value_supported(entry, depth + 1, state):
+					var _removed_array_failure: Variant = visited.pop_back()
+					return false
+			var _removed_array: Variant = visited.pop_back()
+			return true
+		TYPE_DICTIONARY:
+			var dictionary_value: Dictionary = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, dictionary_value):
+				return false
+			visited.append(dictionary_value)
+			for key: Variant in dictionary_value.keys():
+				if (
+					typeof(key) not in [TYPE_STRING, TYPE_STRING_NAME]
+					or not _is_evidence_value_supported(key, depth + 1, state)
+				):
+					var _removed_invalid_key: Variant = visited.pop_back()
+					return false
+				if not _is_evidence_value_supported(dictionary_value[key], depth + 1, state):
+					var _removed_dictionary_failure: Variant = visited.pop_back()
+					return false
+			var _removed_dictionary: Variant = visited.pop_back()
+			return true
+		_:
+			return false
+
+
+static func _consume_packed_items(item_count: int, state: Dictionary) -> bool:
+	var next_count: int = GFVariantData.get_option_int(state, "items") + item_count
+	state["items"] = next_count
+	return next_count <= _MAX_EVIDENCE_ITEMS
+
+
+static func _get_visited(state: Dictionary) -> Array:
+	return GFVariantData.as_array(GFVariantData.get_option_value(state, "visited"))
+
+
+static func _contains_collection_identity(collections: Array, candidate: Variant) -> bool:
+	for collection: Variant in collections:
+		if is_same(collection, candidate):
+			return true
+	return false
+
+
+func _emit_settled_for_framework() -> void:
+	if _settled_signal_emitted:
+		return
+	_settled_signal_emitted = true
+	settled.emit(self, _state)

--- a/addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd.uid
@@ -1,0 +1,1 @@
+uid://b5efpvievjwah

--- a/addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd
@@ -1,0 +1,183 @@
+## GFSaveProfileReconcileRequest: uncertain 写入对账的一次性请求句柄。
+##
+## 请求只携带调用方纯数据上下文和结果元数据，不携带 Recovery/Reconcile Lease
+## 身份。Lease 必须作为独立类型化参数提交，避免从 Dictionary 恢复所有权。
+## `take_ownership()` 成功后，调用方必须放弃两个 Dictionary 及其嵌套 alias。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFSaveProfileReconcileRequest
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _MAX_DEPTH: int = 64
+const _MAX_ITEMS: int = 100_000
+
+
+# --- 私有变量 ---
+
+var _ready: bool = false
+var _claimed: bool = false
+var _context: Dictionary = {}
+var _result_metadata: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 创建请求并接管 context 与 result_metadata 的逻辑唯一所有权。
+##
+## 输入必须是有界纯 Variant 数据，不能包含 Callable、Object、Signal、RID 或
+## 循环集合。该请求不接受可执行恢复策略或 patch；项目策略应在提交前完成决策。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param context: 对账流程使用的临时纯数据上下文。
+## [br]
+## @param result_metadata: 只写入当前对账结果的调用方纯数据元数据。
+## [br]
+## @schema context: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+## [br]
+## @schema result_metadata: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+## [br]
+## @return 可用请求；输入无效时返回 null。
+static func take_ownership(
+	context: Dictionary = {},
+	result_metadata: Dictionary = {}
+) -> GFSaveProfileReconcileRequest:
+	if not _is_dictionary_supported(context) or not _is_dictionary_supported(result_metadata):
+		return null
+	var request: GFSaveProfileReconcileRequest = GFSaveProfileReconcileRequest.new()
+	request._context = context
+	request._result_metadata = result_metadata
+	request._ready = true
+	return request
+
+
+## 检查请求是否仍可由协调器接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未 claim 时返回 true。
+func is_available() -> bool:
+	return _ready and not _claimed
+
+
+## 检查请求是否已经被协调器接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已成功 claim 时返回 true。
+func is_claimed() -> bool:
+	return _claimed
+
+
+# --- 框架内部方法 ---
+
+## 获取不含请求载荷的所有权快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 包含 available 与 claimed 的快照。
+## [br]
+## @schema return: Payload-free Dictionary with available and claimed.
+func inspect_for_framework() -> Dictionary:
+	return {
+		"available": is_available(),
+		"claimed": _claimed,
+	}
+
+
+## 一次性移出 context 与 result_metadata。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 所有权记录；请求不可用时返回空字典。
+## [br]
+## @schema return: Internal Dictionary with context and result_metadata ownership fields.
+func claim_for_framework() -> Dictionary:
+	if not is_available():
+		return {}
+	var claim: Dictionary = {
+		"context": _context,
+		"result_metadata": _result_metadata,
+	}
+	_context = {}
+	_result_metadata = {}
+	_ready = false
+	_claimed = true
+	return claim
+
+
+# --- 私有/辅助方法 ---
+
+static func _is_dictionary_supported(value: Dictionary) -> bool:
+	var state: Dictionary = {
+		"items": 0,
+		"visited": [],
+	}
+	return _is_value_supported(value, 0, state)
+
+
+static func _is_value_supported(value: Variant, depth: int, state: Dictionary) -> bool:
+	if depth > _MAX_DEPTH:
+		return false
+	var item_count: int = GFVariantData.get_option_int(state, "items") + 1
+	state["items"] = item_count
+	if item_count > _MAX_ITEMS:
+		return false
+
+	match typeof(value):
+		TYPE_OBJECT, TYPE_CALLABLE, TYPE_SIGNAL, TYPE_RID:
+			return false
+		TYPE_ARRAY:
+			var array_value: Array = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, array_value):
+				return false
+			visited.append(array_value)
+			for entry: Variant in array_value:
+				if not _is_value_supported(entry, depth + 1, state):
+					var _removed_array_failure: Variant = visited.pop_back()
+					return false
+			var _removed_array: Variant = visited.pop_back()
+		TYPE_DICTIONARY:
+			var dictionary_value: Dictionary = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, dictionary_value):
+				return false
+			visited.append(dictionary_value)
+			for key: Variant in dictionary_value.keys():
+				if (
+					not _is_value_supported(key, depth + 1, state)
+					or not _is_value_supported(dictionary_value[key], depth + 1, state)
+				):
+					var _removed_dictionary_failure: Variant = visited.pop_back()
+					return false
+			var _removed_dictionary: Variant = visited.pop_back()
+	return true
+
+
+static func _get_visited(state: Dictionary) -> Array:
+	return GFVariantData.as_array(GFVariantData.get_option_value(state, "visited"))
+
+
+static func _contains_collection_identity(collections: Array, candidate: Variant) -> bool:
+	for collection: Variant in collections:
+		if is_same(collection, candidate):
+			return true
+	return false

--- a/addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd.uid
@@ -1,0 +1,1 @@
+uid://cj6ryq2ew5bs7

--- a/addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd
@@ -1,0 +1,328 @@
+## GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。
+##
+## Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider
+## domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease；
+## domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFSaveProfileRecoveryLease
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 激活目标没有持久化文档。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_MISSING: StringName = &"missing"
+
+## 激活目标文档损坏或完整性无效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const REASON_CORRUPT: StringName = &"corrupt"
+
+## Lease 尚未被恢复操作消费。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_AVAILABLE: StringName = &"available"
+
+## Lease 已被一个恢复操作消费。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_CLAIMED: StringName = &"claimed"
+
+## Lease 的 domain generation 或 lifecycle epoch 已过期。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_STALE: StringName = &"stale"
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _lease_id: int = 0
+var _transaction_id: int = 0
+var _profile_id: StringName = &""
+var _reason: StringName = &""
+var _domain_id: int = 0
+var _domain_generation: int = 0
+var _epoch: int = 0
+var _state: StringName = STATE_STALE
+
+
+# --- 公共方法 ---
+
+## 获取 Utility 生命周期内唯一的 Lease ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 Lease ID；未配置时为 0。
+func get_lease_id() -> int:
+	return _lease_id
+
+
+## 获取产生当前 Lease 的事务 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数事务 ID；未配置时为 0。
+func get_transaction_id() -> int:
+	return _transaction_id
+
+
+## 获取待恢复 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Profile ID。
+func get_profile_id() -> StringName:
+	return _profile_id
+
+
+## 获取恢复原因。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `REASON_MISSING` 或 `REASON_CORRUPT`。
+func get_reason() -> StringName:
+	return _reason
+
+
+## 获取运行时 Provider domain ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Utility 生命周期内唯一的正整数 domain ID。
+func get_domain_id() -> int:
+	return _domain_id
+
+
+## 获取 Lease 创建时的 domain generation。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 domain generation。
+func get_domain_generation() -> int:
+	return _domain_generation
+
+
+## 获取 Lease 创建时的 Utility lifecycle epoch。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 lifecycle epoch。
+func get_epoch() -> int:
+	return _epoch
+
+
+## 获取当前 Lease 状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATE_*` 常量之一。
+func get_state() -> StringName:
+	return _state
+
+
+## 检查 Lease 是否仍可由 bootstrap/adopt 消费。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 可用时返回 true。
+func is_available() -> bool:
+	return _configured and _state == STATE_AVAILABLE
+
+
+## 检查 Lease 是否已经被消费。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已 claim 时返回 true。
+func is_claimed() -> bool:
+	return _state == STATE_CLAIMED
+
+
+## 检查 Lease 是否已经过期。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已标记 stale 或从未有效配置时返回 true。
+func is_stale() -> bool:
+	return _state == STATE_STALE
+
+
+# --- 框架内部方法 ---
+
+## 由 Save Profile 事务协调器一次性绑定恢复授权。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease_id: Utility 生命周期内唯一的正整数 Lease ID。
+## [br]
+## @param transaction_id: 产生该 Lease 的正整数事务 ID。
+## [br]
+## @param profile_id: 待恢复 Profile ID。
+## [br]
+## @param reason: `REASON_MISSING` 或 `REASON_CORRUPT`。
+## [br]
+## @param domain_id: Utility 生命周期内唯一的正整数 Provider domain ID。
+## [br]
+## @param domain_generation: 创建时的正整数 domain generation。
+## [br]
+## @param epoch: 创建时的正整数 Utility lifecycle epoch。
+## [br]
+## @return 输入合法且首次配置时返回 true。
+func configure_for_framework(
+	lease_id: int,
+	transaction_id: int,
+	profile_id: StringName,
+	reason: StringName,
+	domain_id: int,
+	domain_generation: int,
+	epoch: int
+) -> bool:
+	if _configured:
+		return false
+	if (
+		lease_id <= 0
+		or transaction_id <= 0
+		or profile_id == &""
+		or reason not in [REASON_MISSING, REASON_CORRUPT]
+		or domain_id <= 0
+		or domain_generation <= 0
+		or epoch <= 0
+	):
+		return false
+	_configured = true
+	_lease_id = lease_id
+	_transaction_id = transaction_id
+	_profile_id = profile_id
+	_reason = reason
+	_domain_id = domain_id
+	_domain_generation = domain_generation
+	_epoch = epoch
+	_state = STATE_AVAILABLE
+	return true
+
+
+## 获取不含恢复 payload 的 Lease 身份快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return Lease 身份、绑定 generation/epoch 与当前状态。
+## [br]
+## @schema return: Payload-free Dictionary with lease_id, transaction_id, profile_id, reason, domain_id, domain_generation, epoch, state, and available.
+func inspect_for_framework() -> Dictionary:
+	return {
+		"lease_id": _lease_id,
+		"transaction_id": _transaction_id,
+		"profile_id": _profile_id,
+		"reason": _reason,
+		"domain_id": _domain_id,
+		"domain_generation": _domain_generation,
+		"epoch": _epoch,
+		"state": _state,
+		"available": is_available(),
+	}
+
+
+## 在身份和版本围栏匹配时一次性消费 Lease。
+##
+## 任一绑定不匹配都把尚可用 Lease 标记为 stale，防止调用方修正参数后把已经
+## 失效的恢复决定重放到新状态。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param expected_profile_id: 当前恢复操作的目标 Profile ID。
+## [br]
+## @param expected_domain_id: 当前 Provider domain ID。
+## [br]
+## @param expected_domain_generation: 当前 domain generation。
+## [br]
+## @param expected_epoch: 当前 Utility lifecycle epoch。
+## [br]
+## @return 匹配时返回 Lease 身份记录并转为 claimed；否则返回空字典。
+## [br]
+## @schema return: Payload-free Dictionary with lease_id, transaction_id, profile_id, reason, domain_id, domain_generation, and epoch.
+func claim_for_framework(
+	expected_profile_id: StringName,
+	expected_domain_id: int,
+	expected_domain_generation: int,
+	expected_epoch: int
+) -> Dictionary:
+	if not is_available():
+		return {}
+	if (
+		expected_profile_id != _profile_id
+		or expected_domain_id != _domain_id
+		or expected_domain_generation != _domain_generation
+		or expected_epoch != _epoch
+	):
+		_state = STATE_STALE
+		return {}
+	_state = STATE_CLAIMED
+	return {
+		"lease_id": _lease_id,
+		"transaction_id": _transaction_id,
+		"profile_id": _profile_id,
+		"reason": _reason,
+		"domain_id": _domain_id,
+		"domain_generation": _domain_generation,
+		"epoch": _epoch,
+	}
+
+
+## 显式使尚可用 Lease 过期。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 本次确实从 available 转为 stale 时返回 true。
+func mark_stale_for_framework() -> bool:
+	if not is_available():
+		return false
+	_state = STATE_STALE
+	return true

--- a/addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd.uid
@@ -1,0 +1,1 @@
+uid://ddtv4kcig4rsn

--- a/addons/gf/extensions/save/profile/gf_save_profile_request.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_request.gd
@@ -72,6 +72,17 @@ func is_claimed() -> bool:
 
 # --- 框架内部方法 ---
 
+## 查询请求是否仍可由框架接管，不暴露任何请求载荷。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 请求已经初始化且尚未 claim 时返回 true。
+func is_available_for_framework() -> bool:
+	return _ready and not _claimed
+
+
 ## 一次性移出请求持有的三个 Dictionary。
 ##
 ## 该操作只转移引用，不遍历或深复制集合。失败返回空字典；成功后请求不可复用。
@@ -84,7 +95,7 @@ func is_claimed() -> bool:
 ## [br]
 ## @schema return: Internal Dictionary with document_metadata, context, and result_metadata ownership fields.
 func claim_for_framework() -> Dictionary:
-	if not _ready or _claimed:
+	if not is_available_for_framework():
 		return {}
 	var claim: Dictionary = {
 		"document_metadata": _document_metadata,

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
@@ -1,0 +1,3067 @@
+## GFSaveProfileTransactionCoordinator: 活动 Profile 身份与跨 Profile 事务协调器。
+##
+## Coordinator 在完全相同且同序的 Provider 实例拓扑上建立独立 domain，委托
+## `GFSaveProfileUtility` 完成 generation、Storage IO、重试与 detached settlement。
+## 它不解释业务 payload，也不拥有项目的身份到路径、云同步或恢复选择。
+## [br]
+## @api public
+## [br]
+## @category runtime_service
+## [br]
+## @since unreleased
+class_name GFSaveProfileTransactionCoordinator
+extends GFUtility
+
+
+# --- 信号 ---
+
+## 活动 Profile 身份完成原子提交后发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param previous_profile_id: 提交前活动 Profile；首次激活时为空。
+## [br]
+## @param current_profile_id: 提交后活动 Profile。
+signal active_profile_changed(
+	previous_profile_id: StringName,
+	current_profile_id: StringName
+)
+
+## 任一事务进入稳定终态时发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param result: 不包含持久化 payload 的隔离结果。
+signal transaction_completed(result: GFSaveProfileTransactionResult)
+
+
+# --- 常量 ---
+
+## Domain 尚未建立活动身份。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DOMAIN_STATE_INACTIVE: StringName = &"inactive"
+
+## Domain 已建立一个可直接 save/flush 的活动身份。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DOMAIN_STATE_ACTIVE: StringName = &"active"
+
+## Domain 正在执行一个事务。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DOMAIN_STATE_TRANSACTING: StringName = &"transacting"
+
+## Domain 被 outcome_unknown 或显式故障围栏占用，必须对账。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DOMAIN_STATE_RECONCILIATION_REQUIRED: StringName = &"reconciliation_required"
+
+## Coordinator 已释放。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DOMAIN_STATE_DISPOSED: StringName = &"disposed"
+
+const _STAGE_ACTIVATE_LOAD: StringName = &"activate_load"
+const _STAGE_SOURCE_FLUSH: StringName = &"source_flush"
+const _STAGE_TARGET_LOAD: StringName = &"target_load"
+const _STAGE_RECOVERY_SAVE: StringName = &"recovery_save"
+const _STAGE_MUTATION_FLUSH: StringName = &"mutation_flush"
+const _STAGE_MUTATION_QUEUED: StringName = &"mutation_queued"
+const _STAGE_MUTATION_APPLY: StringName = &"mutation_apply"
+const _STAGE_MUTATION_SAVE: StringName = &"mutation_save"
+const _STAGE_RECONCILE_LOAD: StringName = &"reconcile_load"
+
+
+# --- 私有变量 ---
+
+var _profile_utility: GFSaveProfileUtility = null
+var _profile_utility_explicit: bool = false
+var _profiles: Dictionary = {}
+var _domains: Dictionary = {}
+var _domain_id_by_profile: Dictionary = {}
+var _recovery_records: Dictionary = {}
+var _reconcile_records: Dictionary = {}
+var _next_domain_id: int = 1
+var _next_transaction_id: int = 1
+var _next_lease_id: int = 1
+var _disposed: bool = false
+var _dispose_requested: bool = false
+var _admission_open: bool = true
+var _notification_depth: int = 0
+var _processing_depth: int = 0
+var _pending_domain_ids: PackedInt64Array = PackedInt64Array()
+var _quiesce_completion: GFAsyncCompletion = null
+
+
+# --- Godot 生命周期方法 ---
+
+func _init() -> void:
+	tick_enabled = true
+	ignore_pause = true
+	ignore_time_scale = true
+
+
+# --- GF 生命周期方法 ---
+
+## 声明底层 Save Profile Utility 依赖。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 仅包含 `GFSaveProfileUtility`。
+func get_required_utilities() -> Array[Script]:
+	var dependencies: Array[Script] = [GFSaveProfileUtility]
+	return dependencies
+
+
+## 在架构 ready 阶段采用已注册的 Profile Utility。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func ready() -> void:
+	if _profile_utility_explicit:
+		return
+	var utility_value: Variant = get_utility(GFSaveProfileUtility)
+	if utility_value is GFSaveProfileUtility:
+		var profile_utility: GFSaveProfileUtility = utility_value
+		_set_profile_utility(profile_utility)
+
+
+## 开放事务准入；底层 Utility 不可用时失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _scope: 当前激活阶段的取消作用域。
+## [br]
+## @return 一次性激活完成源。
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
+	if _disposed or _profile_utility == null:
+		var _failed: bool = completion.fail(
+			"GFSaveProfileUtility must be configured before transaction activation."
+		)
+		return completion
+	if _quiesce_completion != null:
+		var _failed_quiesced: bool = completion.fail(
+			"Save Profile transaction coordinator cannot reactivate after quiesce."
+		)
+		return completion
+	_admission_open = true
+	var _succeeded: bool = completion.succeed()
+	return completion
+
+
+## 关闭新事务准入，并等待已接纳事务与 reconcile fence 收敛。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param scope: 当前静默阶段的取消作用域。
+## [br]
+## @return 全部 domain 可安全关闭时完成的一次性完成源。
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+	_admission_open = false
+	if _quiesce_completion != null:
+		return _quiesce_completion
+	_quiesce_completion = GFAsyncCompletion.new()
+	if scope != null:
+		var _bound: bool = _quiesce_completion.bind_cancel_token(scope)
+	for domain_value: Variant in _domains.values():
+		_update_domain_managed_access(_get_domain_value(domain_value))
+	_try_complete_quiesce()
+	return _quiesce_completion
+
+
+## 推进已接纳的同步 Provider mutation 阶段。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _delta: 未使用；底层 IO 由 Profile Utility 推进。
+func tick(_delta: float) -> void:
+	if _disposed:
+		return
+	if not _pending_domain_ids.is_empty():
+		var batch: PackedInt64Array = _pending_domain_ids.duplicate()
+		_pending_domain_ids = PackedInt64Array()
+		for domain_id: int in batch:
+			var domain: DomainState = _get_domain(domain_id)
+			if domain == null:
+				continue
+			domain.pending_tick = false
+			var transaction: TransactionState = domain.current_transaction
+			if transaction != null and transaction.stage == _STAGE_MUTATION_QUEUED:
+				_apply_mutation_candidates(domain, transaction)
+	_try_complete_quiesce()
+
+
+## 强制结束未完成事务并释放全部 manager capability。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func dispose() -> void:
+	if _disposed:
+		return
+	_admission_open = false
+	if _processing_depth > 0 or _notification_depth > 0:
+		_dispose_requested = true
+		return
+	_dispose_now()
+
+
+## 释放架构注入依赖。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func release_dependencies() -> void:
+	_disconnect_profile_utility()
+	super.release_dependencies()
+
+
+# --- 公共方法 ---
+
+## 显式注入底层 Profile Utility，供 standalone 场景与测试使用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile_utility: 已配置的底层 Profile Utility。
+## [br]
+## @return 当前 Coordinator；输入无效或已有受管 Profile 时返回 null。
+func setup(
+	profile_utility: GFSaveProfileUtility
+) -> GFSaveProfileTransactionCoordinator:
+	if _disposed or profile_utility == null or not _profiles.is_empty():
+		return null
+	_profile_utility_explicit = true
+	_set_profile_utility(profile_utility)
+	return self
+
+
+## 注册并声明一个受管 Profile。
+##
+## 完全相同且同序的 Provider 实例序列共享 domain；任意部分重叠或同实例异序
+## 会在触碰底层注册前失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile: Profile 声明。
+## [br]
+## @param migrations: 可选迁移注册表。
+## [br]
+## @return 底层注册报告，附加 managed 与 provider_domain_id 字段。
+## [br]
+## @schema return: GFValidationReportDictionary-compatible report with managed and provider_domain_id fields.
+func register_profile(
+	profile: GFSaveProfile,
+	migrations: GFSaveMigrationRegistry = null
+) -> Dictionary:
+	if _profile_utility == null:
+		return _make_registration_failure(
+			profile,
+			&"profile_utility_unconfigured",
+			"GFSaveProfileUtility must be configured before managed registration."
+		)
+	if not _admission_open or _disposed or _notification_depth > 0:
+		return _make_registration_failure(
+			profile,
+			&"coordinator_busy",
+			"Save Profile transaction coordinator is not accepting registrations."
+		)
+	if profile == null:
+		return _profile_utility.register_profile(profile, migrations)
+	var topology_check: Dictionary = _inspect_registration_topology(profile.providers)
+	if not GFVariantData.get_option_bool(topology_check, "ok", false):
+		return _make_registration_failure(
+			profile,
+			GFVariantData.get_option_string_name(topology_check, "kind"),
+			GFVariantData.get_option_string(topology_check, "error")
+		)
+	var report: Dictionary = _profile_utility.register_profile(profile, migrations)
+	if not GFVariantData.get_option_bool(report, "registered", false):
+		return report
+	var descriptor: Dictionary = (
+		_profile_utility.get_profile_descriptor_for_manager_for_framework(
+			profile.profile_id
+		)
+	)
+	var permit: RefCounted = _profile_utility.claim_profile_management_for_framework(
+		profile.profile_id,
+		self
+	)
+	if descriptor.is_empty() or permit == null:
+		if permit != null:
+			var _rolled_back_managed: bool = (
+				_profile_utility.unregister_profile_for_manager_for_framework(
+					profile.profile_id,
+					permit
+				)
+			)
+		else:
+			var _rolled_back_registration: bool = _profile_utility.unregister_profile(
+				profile.profile_id
+			)
+		return _make_registration_failure(
+			profile,
+			&"management_claim_failed",
+			"Registered Profile could not enter managed ownership."
+		)
+	var domain: DomainState = _attach_profile_to_domain(
+		profile.profile_id,
+		descriptor,
+		permit,
+		GFVariantData.get_option_int(topology_check, "matching_domain_id")
+	)
+	if domain == null:
+		var _released: bool = _profile_utility.release_profile_management_for_framework(
+			profile.profile_id,
+			permit
+		)
+		var _unregistered: bool = _profile_utility.unregister_profile(profile.profile_id)
+		return _make_registration_failure(
+			profile,
+			&"domain_attach_failed",
+			"Managed Provider domain could not be committed."
+		)
+	report["managed"] = true
+	report["provider_domain_id"] = domain.domain_id
+	return report
+
+
+## 注销一个无活动身份、事务或 fence 的受管 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @return 安全注销成功时返回 true。
+func unregister_profile(profile_id: StringName) -> bool:
+	var profile: ManagedProfile = _get_profile(profile_id)
+	var domain: DomainState = _get_domain_for_profile(profile_id)
+	if (
+		not _admission_open
+		or _disposed
+		or _notification_depth > 0
+		or profile == null
+		or domain == null
+		or domain.active_profile_id != &""
+		or domain.current_transaction != null
+		or domain.reconcile_lease != null
+	):
+		return false
+	if not _profile_utility.unregister_profile_for_manager_for_framework(
+		profile_id,
+		profile.permit
+	):
+		return false
+	_invalidate_recovery_leases(domain)
+	var _profile_erased: bool = _profiles.erase(profile_id)
+	var _domain_index_erased: bool = _domain_id_by_profile.erase(profile_id)
+	domain.profile_ids.erase(profile_id)
+	if domain.profile_ids.is_empty():
+		var _domain_erased: bool = _domains.erase(domain.domain_id)
+	return true
+
+
+## 获取指定受管 Profile 所在 domain 的活动身份。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 用于定位 Provider domain 的任一受管 Profile ID。
+## [br]
+## @return 活动 Profile ID；domain 未激活或 Profile 不存在时为空。
+func get_active_profile_id(profile_id: StringName) -> StringName:
+	var domain: DomainState = _get_domain_for_profile(profile_id)
+	return domain.active_profile_id if domain != null else &""
+
+
+## 获取无载荷 domain 调试快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 用于定位 Provider domain 的任一受管 Profile ID。
+## [br]
+## @return domain 状态、活动身份、generation、epoch 与事务/lease ID。
+## [br]
+## @schema return: Payload-free Dictionary with domain_id, state, active_profile_id, profile_ids, domain_generation, transaction_epoch, transaction_id, reconcile_lease_id, quiescing, and disposed fields.
+func get_domain_state_snapshot(profile_id: StringName) -> Dictionary:
+	var domain: DomainState = _get_domain_for_profile(profile_id)
+	if domain == null:
+		return {}
+	return {
+		"domain_id": domain.domain_id,
+		"state": domain.state,
+		"active_profile_id": domain.active_profile_id,
+		"profile_ids": _string_name_array_to_packed(domain.profile_ids),
+		"domain_generation": domain.domain_generation,
+		"transaction_epoch": domain.transaction_epoch,
+		"transaction_id": (
+			domain.current_transaction.operation.get_transaction_id()
+			if domain.current_transaction != null
+			else 0
+		),
+		"reconcile_lease_id": (
+			domain.reconcile_lease.get_lease_id()
+			if domain.reconcile_lease != null
+			else 0
+		),
+		"quiescing": not _admission_open,
+		"disposed": _disposed,
+	}
+
+
+## 严格读取一个已存在存档并建立首次活动身份。
+##
+## missing/corrupt 不会应用低层 `ACTION_USE_CURRENT_STATE`；结果分别返回只能用于
+## `bootstrap_profile()` 或 `adopt_profile()` 的类型化 Recovery Lease。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 已注册受管 Profile ID。
+## [br]
+## @param context: 迁移与 Provider apply 临时上下文。
+## [br]
+## @param metadata: 仅写入外层事务结果的调用方元数据。
+## [br]
+## @schema context: Dictionary with caller-defined ephemeral operation data.
+## [br]
+## @schema metadata: Dictionary with caller-defined result metadata.
+## [br]
+## @return 类型化 activate 操作。
+func activate_profile(
+	profile_id: StringName,
+	context: Dictionary = {},
+	metadata: Dictionary = {}
+) -> GFSaveProfileTransactionOperation:
+	var profile: ManagedProfile = _get_profile(profile_id)
+	var domain: DomainState = _get_domain_for_profile(profile_id)
+	var admission: Dictionary = _get_domain_admission_failure(domain)
+	if profile == null or domain == null:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Managed Profile is not registered.",
+			_STAGE_ACTIVATE_LOAD,
+			metadata
+		)
+	if not admission.is_empty():
+		return _reject_from_admission(
+			GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+			&"",
+			profile_id,
+			admission,
+			_STAGE_ACTIVATE_LOAD,
+			metadata
+		)
+	if domain.active_profile_id != &"":
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_ALREADY_ACTIVE,
+			ERR_ALREADY_IN_USE,
+			"Provider domain already has an active Profile.",
+			_STAGE_ACTIVATE_LOAD,
+			metadata
+		)
+	if not profile.load_enabled:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Target Profile does not support load.",
+			_STAGE_ACTIVATE_LOAD,
+			metadata
+		)
+	var transaction: TransactionState = _begin_domain_transaction(
+		domain,
+		GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+		&"",
+		profile_id,
+		metadata
+	)
+	transaction.context = context.duplicate(true)
+	transaction.stage = _STAGE_ACTIVATE_LOAD
+	_start_strict_load(domain, transaction, profile_id)
+	return transaction.operation
+
+
+## 从当前活动 Profile 原子切换到同一 Provider domain 的目标 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param target_profile_id: 同一 domain 内的目标 Profile ID。
+## [br]
+## @param context: 目标读取的迁移与 Provider 临时上下文。
+## [br]
+## @param metadata: 仅写入外层事务结果的调用方元数据。
+## [br]
+## @schema context: Dictionary with caller-defined ephemeral operation data.
+## [br]
+## @schema metadata: Dictionary with caller-defined result metadata.
+## [br]
+## @return 类型化 switch 操作。
+func switch_profile(
+	target_profile_id: StringName,
+	context: Dictionary = {},
+	metadata: Dictionary = {}
+) -> GFSaveProfileTransactionOperation:
+	var target: ManagedProfile = _get_profile(target_profile_id)
+	var domain: DomainState = _get_domain_for_profile(target_profile_id)
+	var source_id: StringName = domain.active_profile_id if domain != null else &""
+	var admission: Dictionary = _get_domain_admission_failure(domain)
+	if target == null or domain == null:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+			&"",
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Managed target Profile is not registered.",
+			_STAGE_SOURCE_FLUSH,
+			metadata
+		)
+	if not admission.is_empty():
+		return _reject_from_admission(
+			GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+			source_id,
+			target_profile_id,
+			admission,
+			_STAGE_SOURCE_FLUSH,
+			metadata
+		)
+	if source_id == &"":
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+			&"",
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_INACTIVE,
+			ERR_UNCONFIGURED,
+			"Provider domain has no active source Profile.",
+			_STAGE_SOURCE_FLUSH,
+			metadata
+		)
+	if source_id == target_profile_id:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+			source_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_ALREADY_ACTIVE,
+			ERR_ALREADY_IN_USE,
+			"Target Profile is already active.",
+			_STAGE_SOURCE_FLUSH,
+			metadata
+		)
+	var source: ManagedProfile = _get_profile(source_id)
+	if source == null or not source.save_enabled or not target.load_enabled:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+			source_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Source flush or target load capability is disabled.",
+			_STAGE_SOURCE_FLUSH,
+			metadata
+		)
+	var transaction: TransactionState = _begin_domain_transaction(
+		domain,
+		GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+		source_id,
+		target_profile_id,
+		metadata
+	)
+	transaction.context = context.duplicate(true)
+	transaction.stage = _STAGE_SOURCE_FLUSH
+	_start_flush(domain, transaction, source_id)
+	return transaction.operation
+
+
+## 使用 activate 返回的 missing lease 创建存档并首次激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 尚未过期的 missing Recovery Lease。
+## [br]
+## @param request: 当前 Provider 状态的保存请求；null 表示空元数据。
+## [br]
+## @return 类型化 bootstrap 操作；拒绝不会 claim lease 或 request。
+func bootstrap_profile(
+	lease: GFSaveProfileRecoveryLease,
+	request: GFSaveProfileRequest = null
+) -> GFSaveProfileTransactionOperation:
+	return _start_recovery_save(
+		GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP,
+		GFSaveProfileRecoveryLease.REASON_MISSING,
+		lease,
+		request
+	)
+
+
+## 使用 activate 返回的 corrupt lease 明确覆盖损坏存档并首次激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 尚未过期的 corrupt Recovery Lease。
+## [br]
+## @param request: 当前 Provider 状态的保存请求；null 表示空元数据。
+## [br]
+## @return 类型化 adopt 操作；拒绝不会 claim lease 或 request。
+func adopt_profile(
+	lease: GFSaveProfileRecoveryLease,
+	request: GFSaveProfileRequest = null
+) -> GFSaveProfileTransactionOperation:
+	return _start_recovery_save(
+		GFSaveProfileTransactionOperation.OPERATION_ADOPT,
+		GFSaveProfileRecoveryLease.REASON_CORRUPT,
+		lease,
+		request
+	)
+
+
+## 事务化应用一个或多个完整 section replacement 并持久化活动 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 当前 domain 的活动 Profile ID。
+## [br]
+## @param request: 一次性候选与元数据请求。
+## [br]
+## @return 类型化 mutate-and-persist 操作；边界拒绝不会 claim request。
+func mutate_and_persist(
+	profile_id: StringName,
+	request: GFSaveProfileMutationRequest
+) -> GFSaveProfileTransactionOperation:
+	var profile: ManagedProfile = _get_profile(profile_id)
+	var domain: DomainState = _get_domain_for_profile(profile_id)
+	var admission: Dictionary = _get_domain_admission_failure(domain)
+	if profile == null or domain == null:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Managed Profile is not registered.",
+			_STAGE_MUTATION_FLUSH
+		)
+	if not admission.is_empty():
+		return _reject_from_admission(
+			GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+			profile_id,
+			profile_id,
+			admission,
+			_STAGE_MUTATION_FLUSH
+		)
+	if domain.active_profile_id != profile_id:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INACTIVE,
+			ERR_UNCONFIGURED,
+			"Mutation target is not the active Profile.",
+			_STAGE_MUTATION_FLUSH
+		)
+	if not profile.save_enabled:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Mutation target does not support save.",
+			_STAGE_MUTATION_FLUSH
+		)
+	var request_check: Dictionary = _validate_mutation_request(profile, request)
+	if not GFVariantData.get_option_bool(request_check, "ok", false):
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_DATA,
+			GFVariantData.get_option_string(
+				request_check,
+				"error",
+				"Mutation request is invalid."
+			),
+			_STAGE_MUTATION_FLUSH
+		)
+	var claim: Dictionary = request.claim_for_framework()
+	if claim.is_empty():
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_PARAMETER,
+			"Mutation request could not be claimed.",
+			_STAGE_MUTATION_FLUSH
+		)
+	var transaction: TransactionState = _begin_domain_transaction(
+		domain,
+		GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+		profile_id,
+		profile_id,
+		_get_dictionary_claim(claim, "result_metadata")
+	)
+	transaction.context = _get_dictionary_claim(claim, "context")
+	transaction.document_metadata = _get_dictionary_claim(claim, "document_metadata")
+	transaction.mutation_records = _get_dictionary_array_claim(claim, "mutations")
+	transaction.stage = _STAGE_MUTATION_FLUSH
+	_start_flush(domain, transaction, profile_id)
+	return transaction.operation
+
+
+## 在 late generation 证据收敛后严格重载 lease 指定 Profile 并解除 fence。
+##
+## waiting lease 返回 `reconcile_pending`，且不 claim lease/request；调用方可在
+## `GFSaveProfileReconcileLease.settled` 后用同一 lease 与新请求重试。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 当前 Coordinator 持有的 Reconcile Lease。
+## [br]
+## @param request: 一次性 reconcile context 与结果元数据。
+## [br]
+## @return 类型化 reconcile 操作。
+func reconcile_profile(
+	lease: GFSaveProfileReconcileLease,
+	request: GFSaveProfileReconcileRequest = null
+) -> GFSaveProfileTransactionOperation:
+	var record: Dictionary = _get_reconcile_record(lease)
+	var profile_id: StringName = (
+		lease.get_reconcile_profile_id()
+		if lease != null
+		else &""
+	)
+	var domain: DomainState = (
+		_get_domain(lease.get_domain_id())
+		if lease != null
+		else null
+	)
+	if record.is_empty() or domain == null or domain.reconcile_lease != lease:
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Reconcile Lease is not owned by this Coordinator.",
+			_STAGE_RECONCILE_LOAD
+		)
+	_refresh_reconcile_lease(domain, lease)
+	if lease.is_waiting():
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_RECONCILE_PENDING,
+			ERR_BUSY,
+			"Detached write evidence has not reached a terminal state.",
+			_STAGE_RECONCILE_LOAD,
+			{},
+			null,
+			lease
+		)
+	var quiesce_continuation: bool = (
+		not _disposed
+		and not _dispose_requested
+		and not _admission_open
+		and _quiesce_completion != null
+		and _quiesce_completion.is_pending()
+	)
+	if (
+		(_disposed or _dispose_requested or not _admission_open)
+			and not quiesce_continuation
+		or _notification_depth > 0
+		or domain.current_transaction != null
+	):
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Provider domain is not accepting reconciliation.",
+			_STAGE_RECONCILE_LOAD,
+			{}
+		)
+	var owned_request: GFSaveProfileReconcileRequest = request
+	if owned_request == null:
+		owned_request = GFSaveProfileReconcileRequest.take_ownership({}, {})
+	if owned_request == null or not owned_request.is_available():
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_PARAMETER,
+			"Reconcile request is invalid or already claimed.",
+			_STAGE_RECONCILE_LOAD,
+			{}
+		)
+	var lease_claim: Dictionary = lease.claim_for_framework(
+		profile_id,
+		domain.domain_id,
+		domain.domain_generation,
+		domain.transaction_epoch
+	)
+	if lease_claim.is_empty():
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Reconcile Lease fence no longer matches the Provider domain.",
+			_STAGE_RECONCILE_LOAD,
+			{}
+		)
+	var request_claim: Dictionary = owned_request.claim_for_framework()
+	if request_claim.is_empty():
+		var _released_lease: bool = lease.release_reconcile_for_framework()
+		return _reject_transaction(
+			GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+			profile_id,
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_PARAMETER,
+			"Reconcile request could not be claimed.",
+			_STAGE_RECONCILE_LOAD,
+			{}
+		)
+	var transaction: TransactionState = _begin_reconcile_transaction(
+		domain,
+		lease,
+		_get_dictionary_claim(request_claim, "result_metadata")
+	)
+	transaction.context = _get_dictionary_claim(request_claim, "context")
+	transaction.stage = _STAGE_RECONCILE_LOAD
+	_start_strict_load(domain, transaction, profile_id)
+	return transaction.operation
+
+
+# --- 私有/辅助方法（底层操作编排） ---
+
+func _start_strict_load(
+	domain: DomainState,
+	transaction: TransactionState,
+	profile_id: StringName
+) -> void:
+	var profile: ManagedProfile = _get_profile(profile_id)
+	if profile == null or _profile_utility == null:
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Managed load target is unavailable.",
+			transaction.stage
+		)
+		return
+	var operation: GFSaveProfileOperation = (
+		_profile_utility.load_profile_strict_for_manager_for_framework(
+			profile_id,
+			transaction.context,
+			{},
+			profile.permit
+		)
+	)
+	_observe_profile_operation(domain, transaction, operation)
+
+
+func _start_flush(
+	domain: DomainState,
+	transaction: TransactionState,
+	profile_id: StringName
+) -> void:
+	var profile: ManagedProfile = _get_profile(profile_id)
+	if profile == null or _profile_utility == null:
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Managed flush source is unavailable.",
+			transaction.stage
+		)
+		return
+	var operation: GFSaveProfileOperation = (
+		_profile_utility.flush_profile_for_manager_for_framework(
+			profile_id,
+			{},
+			profile.permit
+		)
+	)
+	transaction.write_admitted = (
+		operation != null
+		and not operation.is_completed()
+		and operation.get_requested_generation() > 0
+	)
+	_observe_profile_operation(domain, transaction, operation)
+
+
+func _start_save(
+	domain: DomainState,
+	transaction: TransactionState,
+	profile_id: StringName,
+	request: GFSaveProfileRequest
+) -> void:
+	var profile: ManagedProfile = _get_profile(profile_id)
+	if profile == null or _profile_utility == null:
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Managed save target is unavailable.",
+			transaction.stage
+		)
+		return
+	var operation: GFSaveProfileOperation = (
+		_profile_utility.save_profile_for_manager_for_framework(
+			profile_id,
+			request,
+			profile.permit,
+			transaction.mutation_candidates
+		)
+	)
+	transaction.write_admitted = request != null and request.is_claimed()
+	transaction.mutation_candidates.clear()
+	_observe_profile_operation(domain, transaction, operation)
+
+
+func _observe_profile_operation(
+	domain: DomainState,
+	transaction: TransactionState,
+	operation: GFSaveProfileOperation
+) -> void:
+	if operation == null:
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_CANT_CREATE,
+			"GFSaveProfileUtility returned no operation.",
+			transaction.stage
+		)
+		return
+	transaction.profile_operation = operation
+	if operation.is_completed():
+		_on_profile_operation_completed(
+			operation.get_result(),
+			domain.domain_id,
+			transaction.operation.get_transaction_id()
+		)
+		return
+	var callback: Callable = Callable(self, "_on_profile_operation_completed").bind(
+		domain.domain_id,
+		transaction.operation.get_transaction_id()
+	)
+	transaction.profile_callback = callback
+	var _connected: Error = operation.completed.connect(
+		callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+
+
+func _handle_activate_load_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var evidence: Dictionary = _make_profile_result_evidence(result)
+	if result.is_successful() and result.get_status() == GFSaveProfileResult.STATUS_LOADED:
+		_commit_active_profile(domain, transaction.target_profile_id)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_ACTIVATED,
+			OK,
+			"",
+			_STAGE_ACTIVATE_LOAD,
+			evidence
+		)
+		return
+	if result.get_status() in [
+		GFSaveProfileResult.STATUS_MISSING,
+		GFSaveProfileResult.STATUS_CORRUPT,
+	]:
+		var reason: StringName = (
+			GFSaveProfileRecoveryLease.REASON_MISSING
+			if result.get_status() == GFSaveProfileResult.STATUS_MISSING
+			else GFSaveProfileRecoveryLease.REASON_CORRUPT
+		)
+		var lease: GFSaveProfileRecoveryLease = _create_recovery_lease(
+			domain,
+			transaction,
+			reason
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED,
+			result.get_error_code(),
+			"Explicit Bootstrap or Adopt is required before activation.",
+			_STAGE_ACTIVATE_LOAD,
+			evidence,
+			[],
+			lease
+		)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_ROLLBACK_FAILED:
+		var reconcile: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.target_profile_id,
+			result,
+			true
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_ROLLBACK_FAILED,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_ACTIVATE_LOAD,
+			evidence,
+			result.get_rollback_errors(),
+			null,
+			reconcile
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_TARGET_LOAD_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_ACTIVATE_LOAD,
+		evidence,
+		result.get_rollback_errors()
+	)
+
+
+func _handle_switch_flush_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var evidence: Dictionary = _make_profile_result_evidence(result)
+	if result.is_successful():
+		transaction.stage_evidence["source_flush"] = evidence
+		transaction.stage = _STAGE_TARGET_LOAD
+		_start_strict_load(domain, transaction, transaction.target_profile_id)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN:
+		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.source_profile_id,
+			result
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_SOURCE_FLUSH,
+			evidence,
+			[],
+			null,
+			lease
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_SOURCE_FLUSH_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_SOURCE_FLUSH,
+		evidence
+	)
+
+
+func _handle_switch_target_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var evidence: Dictionary = {
+		"source_flush": GFVariantData.get_option_dictionary(
+			transaction.stage_evidence,
+			"source_flush"
+		),
+		"target_load": _make_profile_result_evidence(result),
+	}
+	if result.is_successful() and result.get_status() == GFSaveProfileResult.STATUS_LOADED:
+		_commit_active_profile(domain, transaction.target_profile_id)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_SWITCHED,
+			OK,
+			"",
+			_STAGE_TARGET_LOAD,
+			evidence
+		)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_ROLLBACK_FAILED:
+		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.source_profile_id,
+			result,
+			true
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_ROLLBACK_FAILED,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_TARGET_LOAD,
+			evidence,
+			result.get_rollback_errors(),
+			null,
+			lease
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_TARGET_LOAD_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_TARGET_LOAD,
+		evidence,
+		result.get_rollback_errors()
+	)
+
+
+func _handle_recovery_save_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	transaction.result_metadata = result.get_metadata()
+	var evidence: Dictionary = _make_profile_result_evidence(result)
+	if result.is_successful():
+		_commit_active_profile(domain, transaction.target_profile_id)
+		var status: StringName = (
+			GFSaveProfileTransactionResult.STATUS_BOOTSTRAPPED
+			if transaction.operation.get_operation()
+				== GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP
+			else GFSaveProfileTransactionResult.STATUS_ADOPTED
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			status,
+			OK,
+			"",
+			_STAGE_RECOVERY_SAVE,
+			evidence
+		)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN:
+		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.target_profile_id,
+			result
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_RECOVERY_SAVE,
+			evidence,
+			[],
+			null,
+			lease
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_RECOVERY_SAVE,
+		evidence
+	)
+
+
+func _handle_mutation_flush_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var evidence: Dictionary = _make_profile_result_evidence(result)
+	if result.is_successful():
+		transaction.stage_evidence["flush"] = evidence
+		transaction.stage = _STAGE_MUTATION_QUEUED
+		_enqueue_domain_tick(domain)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN:
+		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.source_profile_id,
+			result
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_MUTATION_FLUSH,
+			evidence,
+			[],
+			null,
+			lease
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_MUTATION_FLUSH,
+		evidence
+	)
+
+
+func _apply_mutation_candidates(
+	domain: DomainState,
+	transaction: TransactionState
+) -> void:
+	if (
+		domain.current_transaction != transaction
+		or transaction.stage != _STAGE_MUTATION_QUEUED
+	):
+		return
+	transaction.stage = _STAGE_MUTATION_APPLY
+	_begin_processing()
+	var candidates: Array[GFSaveSection] = []
+	for record: Dictionary in transaction.mutation_records:
+		var section_id: StringName = GFVariantData.get_option_string_name(
+			record,
+			"section_id"
+		)
+		var schema_version: int = GFVariantData.get_option_int(record, "schema_version")
+		var metadata: Dictionary = GFVariantData.get_option_dictionary(record, "metadata")
+		var candidate: GFSaveSection = GFSaveSection.new().configure(
+			section_id,
+			schema_version,
+			GFVariantData.get_option_value(record, "payload"),
+			metadata
+		)
+		candidates.append(candidate)
+		record.clear()
+	transaction.mutation_records.clear()
+	var profile: ManagedProfile = _get_profile(transaction.target_profile_id)
+	var apply_result: Dictionary = (
+		_profile_utility.apply_profile_candidates_for_manager_for_framework(
+			transaction.target_profile_id,
+			candidates,
+			transaction.context,
+			profile.permit if profile != null else null
+		)
+		if _profile_utility != null
+		else {}
+	)
+	if not GFVariantData.get_option_bool(apply_result, "ok", false):
+		candidates.clear()
+		var rollback_errors: Array[GFSaveRollbackFailure] = _read_rollback_errors(
+			GFVariantData.get_option_value(apply_result, "rollback_errors", [])
+		)
+		var failure_stage: StringName = GFVariantData.get_option_string_name(
+			apply_result,
+			"failure_stage"
+		)
+		var status: StringName = (
+			GFSaveProfileTransactionResult.STATUS_SNAPSHOT_FAILED
+			if failure_stage == &"snapshot"
+			else GFSaveProfileTransactionResult.STATUS_APPLY_FAILED
+		)
+		var lease: GFSaveProfileReconcileLease = null
+		if not rollback_errors.is_empty():
+			status = GFSaveProfileTransactionResult.STATUS_ROLLBACK_FAILED
+			lease = _create_reconcile_fence(
+				domain,
+				transaction,
+				transaction.target_profile_id,
+				null,
+				true
+			)
+		transaction.forced_rollback_errors = rollback_errors
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			status,
+			_get_error_code(apply_result, "error_code", ERR_INVALID_DATA),
+			GFVariantData.get_option_string(
+				apply_result,
+				"error",
+				"Mutation candidate apply failed."
+			),
+			_STAGE_MUTATION_APPLY,
+			{
+				"failure_stage": failure_stage,
+				"failed_section_id": GFVariantData.get_option_string_name(
+					apply_result,
+					"failed_section_id"
+				),
+			},
+			rollback_errors,
+			null,
+			lease,
+			GFVariantData.get_option_string_name(apply_result, "failed_section_id")
+		)
+		_end_processing()
+		return
+	var provider_ids: PackedStringArray = _get_packed_string_array(
+		GFVariantData.get_option_value(apply_result, "provider_ids")
+	)
+	var snapshots: Dictionary = GFVariantData.get_option_dictionary(
+		apply_result,
+		"snapshots"
+	)
+	if _dispose_requested:
+		transaction.forced_rollback_errors = (
+			_profile_utility.rollback_profile_candidates_for_manager_for_framework(
+				transaction.target_profile_id,
+				provider_ids,
+				snapshots,
+				transaction.context,
+				profile.permit if profile != null else null
+			)
+			if _profile_utility != null
+			else _make_management_rollback_failures(provider_ids)
+		)
+		candidates.clear()
+		snapshots.clear()
+		_end_processing()
+		return
+	transaction.mutation_provider_ids = provider_ids
+	transaction.mutation_snapshots = snapshots
+	transaction.mutation_candidates = candidates
+	var save_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		transaction.document_metadata,
+		transaction.context.duplicate(true),
+		{}
+	)
+	transaction.document_metadata = {}
+	_end_processing()
+	if transaction.operation.is_completed():
+		return
+	transaction.stage = _STAGE_MUTATION_SAVE
+	_start_save(domain, transaction, transaction.target_profile_id, save_request)
+
+
+func _handle_mutation_save_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var evidence: Dictionary = {
+		"flush": GFVariantData.get_option_dictionary(
+			transaction.stage_evidence,
+			"flush"
+		),
+		"save": _make_profile_result_evidence(result),
+	}
+	if result.is_successful():
+		transaction.mutation_snapshots.clear()
+		transaction.mutation_provider_ids = PackedStringArray()
+		domain.domain_generation += 1
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_MUTATED,
+			OK,
+			"",
+			_STAGE_MUTATION_SAVE,
+			evidence
+		)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN:
+		transaction.mutation_snapshots.clear()
+		transaction.mutation_provider_ids = PackedStringArray()
+		var unknown_lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.target_profile_id,
+			result
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_MUTATION_SAVE,
+			evidence,
+			[],
+			null,
+			unknown_lease
+		)
+		return
+	_begin_processing()
+	var profile: ManagedProfile = _get_profile(transaction.target_profile_id)
+	var rollback_errors: Array[GFSaveRollbackFailure] = (
+		_profile_utility.rollback_profile_candidates_for_manager_for_framework(
+			transaction.target_profile_id,
+			transaction.mutation_provider_ids,
+			transaction.mutation_snapshots,
+			transaction.context,
+			profile.permit if profile != null else null
+		)
+		if _profile_utility != null
+		else _make_management_rollback_failures(
+			transaction.mutation_provider_ids
+		)
+	)
+	transaction.mutation_snapshots.clear()
+	transaction.mutation_provider_ids = PackedStringArray()
+	if not rollback_errors.is_empty():
+		var rollback_lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.target_profile_id,
+			result,
+			true
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_ROLLBACK_FAILED,
+			result.get_error_code(),
+			"Mutation persistence failed and runtime rollback was incomplete.",
+			_STAGE_MUTATION_SAVE,
+			evidence,
+			rollback_errors,
+			null,
+			rollback_lease
+		)
+		_end_processing()
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_MUTATION_SAVE,
+		evidence
+	)
+	_end_processing()
+
+
+func _handle_reconcile_load_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var lease: GFSaveProfileReconcileLease = transaction.reconcile_lease
+	var evidence: Dictionary = _make_profile_result_evidence(result)
+	if result.is_successful() and result.get_status() == GFSaveProfileResult.STATUS_LOADED:
+		var previous: StringName = domain.active_profile_id
+		domain.active_profile_id = transaction.target_profile_id
+		domain.domain_generation += 1
+		var _resolved: bool = lease.mark_resolved_for_framework({
+			"state": &"reloaded",
+			"profile_id": transaction.target_profile_id,
+			"profile_result": evidence,
+		})
+		var _record_erased: bool = _reconcile_records.erase(lease.get_lease_id())
+		domain.reconcile_lease = null
+		if previous != domain.active_profile_id:
+			_emit_active_profile_changed(previous, domain.active_profile_id)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_RECONCILED,
+			OK,
+			"",
+			_STAGE_RECONCILE_LOAD,
+			evidence,
+			[],
+			null,
+			lease
+		)
+		return
+	var _released: bool = lease.release_reconcile_for_framework()
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_RECONCILE_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_RECONCILE_LOAD,
+		evidence,
+		result.get_rollback_errors(),
+		null,
+		lease
+	)
+
+
+# --- 私有/辅助方法（事务建立与终态） ---
+
+func _start_recovery_save(
+	operation_kind: StringName,
+	expected_reason: StringName,
+	lease: GFSaveProfileRecoveryLease,
+	request: GFSaveProfileRequest
+) -> GFSaveProfileTransactionOperation:
+	var profile_id: StringName = lease.get_profile_id() if lease != null else &""
+	var profile: ManagedProfile = _get_profile(profile_id)
+	var domain: DomainState = _get_domain_for_profile(profile_id)
+	var record: Dictionary = _get_recovery_record(lease)
+	if (
+		lease == null
+		or record.is_empty()
+		or profile == null
+		or domain == null
+		or lease.get_reason() != expected_reason
+		or not lease.is_available()
+	):
+		return _reject_transaction(
+			operation_kind,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Recovery Lease is invalid, stale, or has the wrong recovery reason.",
+			_STAGE_RECOVERY_SAVE
+		)
+	var admission: Dictionary = _get_domain_admission_failure(domain)
+	if not admission.is_empty():
+		return _reject_from_admission(
+			operation_kind,
+			&"",
+			profile_id,
+			admission,
+			_STAGE_RECOVERY_SAVE
+		)
+	if domain.active_profile_id != &"":
+		return _reject_transaction(
+			operation_kind,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_ALREADY_ACTIVE,
+			ERR_ALREADY_IN_USE,
+			"Provider domain already has an active Profile.",
+			_STAGE_RECOVERY_SAVE
+		)
+	if not profile.save_enabled:
+		return _reject_transaction(
+			operation_kind,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Recovery target does not support save.",
+			_STAGE_RECOVERY_SAVE
+		)
+	if request != null and not request.is_available_for_framework():
+		return _reject_transaction(
+			operation_kind,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_PARAMETER,
+			"Recovery save request is uninitialized or was already claimed.",
+			_STAGE_RECOVERY_SAVE
+		)
+	var lease_claim: Dictionary = lease.claim_for_framework(
+		profile_id,
+		domain.domain_id,
+		domain.domain_generation,
+		domain.transaction_epoch
+	)
+	if lease_claim.is_empty():
+		return _reject_transaction(
+			operation_kind,
+			&"",
+			profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Recovery Lease no longer matches the Provider domain.",
+			_STAGE_RECOVERY_SAVE
+		)
+	var _record_erased: bool = _recovery_records.erase(lease.get_lease_id())
+	var transaction: TransactionState = _begin_domain_transaction(
+		domain,
+		operation_kind,
+		&"",
+		profile_id,
+		{}
+	)
+	transaction.stage = _STAGE_RECOVERY_SAVE
+	var owned_request: GFSaveProfileRequest = request
+	if owned_request == null:
+		owned_request = GFSaveProfileRequest.take_ownership({}, {}, {})
+	_start_save(domain, transaction, profile_id, owned_request)
+	return transaction.operation
+
+
+func _begin_domain_transaction(
+	domain: DomainState,
+	operation_kind: StringName,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	metadata: Dictionary
+) -> TransactionState:
+	_invalidate_recovery_leases(domain)
+	domain.transaction_epoch += 1
+	var transaction: TransactionState = _make_transaction_state(
+		operation_kind,
+		source_profile_id,
+		target_profile_id,
+		domain.active_profile_id,
+		metadata
+	)
+	domain.current_transaction = transaction
+	domain.state = DOMAIN_STATE_TRANSACTING
+	_update_domain_managed_access(domain)
+	return transaction
+
+
+func _begin_reconcile_transaction(
+	domain: DomainState,
+	lease: GFSaveProfileReconcileLease,
+	metadata: Dictionary
+) -> TransactionState:
+	var profile_id: StringName = lease.get_reconcile_profile_id()
+	var transaction: TransactionState = _make_transaction_state(
+		GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+		profile_id,
+		profile_id,
+		domain.active_profile_id,
+		metadata
+	)
+	transaction.reconcile_lease = lease
+	domain.current_transaction = transaction
+	domain.state = DOMAIN_STATE_TRANSACTING
+	_update_domain_managed_access(domain)
+	return transaction
+
+
+func _make_transaction_state(
+	operation_kind: StringName,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	active_profile_before: StringName,
+	metadata: Dictionary
+) -> TransactionState:
+	var transaction: TransactionState = TransactionState.new()
+	var operation: GFSaveProfileTransactionOperation = (
+		GFSaveProfileTransactionOperation.new()
+	)
+	var transaction_id: int = _next_transaction_id
+	_next_transaction_id += 1
+	var started_at_msec: int = Time.get_ticks_msec()
+	var _configured: bool = operation.configure_for_framework(
+		operation_kind,
+		transaction_id,
+		source_profile_id,
+		target_profile_id,
+		started_at_msec
+	)
+	var _started: bool = operation.start_for_framework()
+	transaction.operation = operation
+	transaction.source_profile_id = source_profile_id
+	transaction.target_profile_id = target_profile_id
+	transaction.active_profile_before = active_profile_before
+	transaction.result_metadata = metadata.duplicate(true)
+	return transaction
+
+
+func _finish_domain_transaction(
+	domain: DomainState,
+	transaction: TransactionState,
+	status: StringName,
+	error_code: Error,
+	error: String,
+	phase: StringName,
+	stage_evidence: Dictionary = {},
+	rollback_errors: Array[GFSaveRollbackFailure] = [],
+	recovery_lease: GFSaveProfileRecoveryLease = null,
+	reconcile_lease: GFSaveProfileReconcileLease = null,
+	failed_section_id: StringName = &""
+) -> void:
+	if transaction == null or transaction.operation == null:
+		return
+	if transaction.operation.is_completed():
+		return
+	var active_after: StringName = (
+		domain.active_profile_id
+		if domain != null
+		else transaction.active_profile_before
+	)
+	var result: GFSaveProfileTransactionResult = GFSaveProfileTransactionResult.new()
+	var configured: bool = result.configure_for_framework({
+		"status": status,
+		"operation": transaction.operation.get_operation(),
+		"transaction_id": transaction.operation.get_transaction_id(),
+		"source_profile_id": transaction.source_profile_id,
+		"target_profile_id": transaction.target_profile_id,
+		"active_profile_before": transaction.active_profile_before,
+		"active_profile_after": active_after,
+		"phase": phase,
+		"error_code": int(error_code),
+		"error": error,
+		"failed_section_id": failed_section_id,
+		"rollback_errors": rollback_errors,
+		"stage_evidence": stage_evidence,
+		"recovery_lease": recovery_lease,
+		"reconcile_lease": reconcile_lease,
+		"metadata": transaction.result_metadata,
+		"started_at_msec": transaction.operation.get_started_at_msec_for_framework(),
+		"completed_at_msec": Time.get_ticks_msec(),
+	})
+	if not configured:
+		push_error("[GFSaveProfileTransactionCoordinator] Invalid terminal result contract.")
+		result = GFSaveProfileTransactionResult.new()
+		configured = result.configure_for_framework({
+			"status": GFSaveProfileTransactionResult.STATUS_DISPOSED,
+			"operation": transaction.operation.get_operation(),
+			"transaction_id": transaction.operation.get_transaction_id(),
+			"source_profile_id": transaction.source_profile_id,
+			"target_profile_id": transaction.target_profile_id,
+			"active_profile_before": transaction.active_profile_before,
+			"active_profile_after": active_after,
+			"phase": &"terminal_contract",
+			"error_code": int(ERR_BUG),
+			"error": "Transaction terminal contract validation failed.",
+			"failed_section_id": &"",
+			"rollback_errors": [],
+			"stage_evidence": {},
+			"recovery_lease": null,
+			"reconcile_lease": reconcile_lease,
+			"metadata": {},
+			"started_at_msec": (
+				transaction.operation.get_started_at_msec_for_framework()
+			),
+			"completed_at_msec": Time.get_ticks_msec(),
+		})
+	if not configured:
+		push_error(
+			"[GFSaveProfileTransactionCoordinator] Fallback terminal contract failed."
+		)
+		return
+	if domain != null and domain.current_transaction == transaction:
+		domain.current_transaction = null
+		domain.pending_tick = false
+		domain.state = (
+			DOMAIN_STATE_RECONCILIATION_REQUIRED
+			if domain.reconcile_lease != null
+			else (
+				DOMAIN_STATE_ACTIVE
+				if domain.active_profile_id != &""
+				else DOMAIN_STATE_INACTIVE
+			)
+		)
+		_update_domain_managed_access(domain)
+	_disconnect_transaction_profile_operation(transaction)
+	transaction.clear_payload_for_framework()
+	var completed: bool = transaction.operation.complete_for_framework(result)
+	if completed:
+		_notification_depth += 1
+		transaction_completed.emit(result.duplicate_result())
+		var _emitted: bool = transaction.operation.emit_completed_for_framework()
+		_notification_depth -= 1
+	if _dispose_requested and _processing_depth == 0 and _notification_depth == 0:
+		_dispose_now()
+		return
+	_try_complete_quiesce()
+
+
+func _reject_transaction(
+	operation_kind: StringName,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	status: StringName,
+	error_code: Error,
+	error: String,
+	phase: StringName,
+	metadata: Dictionary = {},
+	recovery_lease: GFSaveProfileRecoveryLease = null,
+	reconcile_lease: GFSaveProfileReconcileLease = null
+) -> GFSaveProfileTransactionOperation:
+	var domain: DomainState = _get_domain_for_profile(target_profile_id)
+	if domain == null:
+		domain = _get_domain_for_profile(source_profile_id)
+	var active_before: StringName = domain.active_profile_id if domain != null else &""
+	var transaction: TransactionState = _make_transaction_state(
+		operation_kind,
+		source_profile_id,
+		target_profile_id,
+		active_before,
+		metadata
+	)
+	_finish_domain_transaction(
+		null,
+		transaction,
+		status,
+		error_code,
+		error,
+		phase,
+		{},
+		[],
+		recovery_lease,
+		reconcile_lease
+	)
+	return transaction.operation
+
+
+func _reject_from_admission(
+	operation_kind: StringName,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	admission: Dictionary,
+	phase: StringName,
+	metadata: Dictionary = {}
+) -> GFSaveProfileTransactionOperation:
+	return _reject_transaction(
+		operation_kind,
+		source_profile_id,
+		target_profile_id,
+		GFVariantData.get_option_string_name(
+			admission,
+			"status",
+			GFSaveProfileTransactionResult.STATUS_BUSY
+		),
+		_get_error_code(admission, "error_code", ERR_BUSY),
+		GFVariantData.get_option_string(
+			admission,
+			"error",
+			"Provider domain is busy."
+		),
+		phase,
+		metadata
+	)
+
+
+# --- 私有/辅助方法（Domain 与 Lease 管理） ---
+
+func _commit_active_profile(domain: DomainState, profile_id: StringName) -> void:
+	if domain == null or domain.active_profile_id == profile_id:
+		return
+	var previous_profile_id: StringName = domain.active_profile_id
+	domain.active_profile_id = profile_id
+	domain.domain_generation += 1
+	_invalidate_recovery_leases(domain)
+	_emit_active_profile_changed(previous_profile_id, profile_id)
+
+
+func _emit_active_profile_changed(
+	previous_profile_id: StringName,
+	current_profile_id: StringName
+) -> void:
+	_notification_depth += 1
+	active_profile_changed.emit(previous_profile_id, current_profile_id)
+	_notification_depth -= 1
+
+
+func _create_recovery_lease(
+	domain: DomainState,
+	transaction: TransactionState,
+	reason: StringName
+) -> GFSaveProfileRecoveryLease:
+	var lease: GFSaveProfileRecoveryLease = GFSaveProfileRecoveryLease.new()
+	var configured: bool = lease.configure_for_framework(
+		_next_lease_id,
+		transaction.operation.get_transaction_id(),
+		transaction.target_profile_id,
+		reason,
+		domain.domain_id,
+		domain.domain_generation,
+		domain.transaction_epoch
+	)
+	if not configured:
+		return null
+	_next_lease_id += 1
+	_recovery_records[lease.get_lease_id()] = {
+		"lease": lease,
+		"domain_id": domain.domain_id,
+		"reason": reason,
+	}
+	return lease
+
+
+func _create_reconcile_fence(
+	domain: DomainState,
+	transaction: TransactionState,
+	profile_id: StringName,
+	profile_result: GFSaveProfileResult = null,
+	force_ready: bool = false
+) -> GFSaveProfileReconcileLease:
+	if domain == null or transaction == null or profile_id == &"":
+		return null
+	var request_ids: PackedInt64Array = PackedInt64Array()
+	var generation: int = 0
+	if profile_result != null:
+		request_ids = profile_result.get_storage_request_ids()
+		generation = profile_result.get_requested_generation()
+	elif transaction.profile_operation != null:
+		generation = transaction.profile_operation.get_requested_generation()
+	var initial_evidence: Dictionary = {}
+	if _profile_utility != null and generation > 0:
+		initial_evidence = _profile_utility.get_generation_evidence_for_framework(
+			profile_id,
+			generation
+		)
+		if request_ids.is_empty():
+			request_ids = _get_int64_array(
+				GFVariantData.get_option_value(
+					initial_evidence,
+					"storage_request_ids"
+				)
+			)
+	var lease: GFSaveProfileReconcileLease = GFSaveProfileReconcileLease.new()
+	var configured: bool = lease.configure_for_framework(
+		_next_lease_id,
+		transaction.operation.get_transaction_id(),
+		transaction.operation.get_operation(),
+		profile_id,
+		transaction.source_profile_id,
+		transaction.target_profile_id,
+		domain.domain_id,
+		domain.domain_generation,
+		domain.transaction_epoch,
+		request_ids
+	)
+	if not configured:
+		return null
+	_next_lease_id += 1
+	domain.reconcile_lease = lease
+	domain.state = DOMAIN_STATE_RECONCILIATION_REQUIRED
+	_reconcile_records[lease.get_lease_id()] = {
+		"lease": lease,
+		"domain_id": domain.domain_id,
+		"profile_id": profile_id,
+		"generation": generation,
+	}
+	_update_domain_managed_access(domain)
+	if force_ready:
+		var _marked_memory_ready: bool = _mark_reconcile_ready(lease, {
+			"state": &"memory_state_uncertain",
+			"profile_id": profile_id,
+			"generation": generation,
+		})
+	else:
+		_refresh_reconcile_lease(domain, lease)
+	return lease
+
+
+func _refresh_reconcile_lease(
+	domain: DomainState,
+	lease: GFSaveProfileReconcileLease
+) -> void:
+	if (
+		domain == null
+		or lease == null
+		or not lease.is_waiting()
+		or domain.reconcile_lease != lease
+	):
+		return
+	var record: Dictionary = _get_reconcile_record(lease)
+	if record.is_empty():
+		return
+	var profile_id: StringName = GFVariantData.get_option_string_name(
+		record,
+		"profile_id"
+	)
+	var generation: int = GFVariantData.get_option_int(record, "generation")
+	if generation <= 0 or _profile_utility == null:
+		return
+	var evidence: Dictionary = _profile_utility.get_generation_evidence_for_framework(
+		profile_id,
+		generation
+	)
+	var evidence_state: StringName = GFVariantData.get_option_string_name(
+		evidence,
+		"state"
+	)
+	if evidence_state not in [&"persisted", &"failed", &"unresolved"]:
+		return
+	var _marked_ready: bool = _mark_reconcile_ready(lease, evidence)
+
+
+func _mark_reconcile_ready(
+	lease: GFSaveProfileReconcileLease,
+	evidence: Dictionary
+) -> bool:
+	if lease == null:
+		return false
+	_notification_depth += 1
+	var marked: bool = lease.mark_ready_for_framework(evidence)
+	_notification_depth -= 1
+	return marked
+
+
+func _mark_reconcile_disposed(
+	lease: GFSaveProfileReconcileLease
+) -> bool:
+	if lease == null:
+		return false
+	_notification_depth += 1
+	var marked: bool = lease.mark_disposed_unresolved_for_framework()
+	_notification_depth -= 1
+	return marked
+
+
+func _invalidate_recovery_leases(domain: DomainState) -> void:
+	if domain == null:
+		return
+	var stale_ids: PackedInt64Array = PackedInt64Array()
+	for lease_id_value: Variant in _recovery_records.keys():
+		if typeof(lease_id_value) != TYPE_INT:
+			continue
+		var lease_id: int = lease_id_value
+		var record: Dictionary = GFVariantData.as_dictionary(
+			GFVariantData.get_option_value(_recovery_records, lease_id)
+		)
+		if GFVariantData.get_option_int(record, "domain_id") != domain.domain_id:
+			continue
+		var lease_value: Variant = GFVariantData.get_option_value(record, "lease")
+		if lease_value is GFSaveProfileRecoveryLease:
+			var lease: GFSaveProfileRecoveryLease = lease_value
+			var _marked_stale: bool = lease.mark_stale_for_framework()
+		var _appended: bool = stale_ids.append(lease_id)
+	for lease_id: int in stale_ids:
+		var _erased: bool = _recovery_records.erase(lease_id)
+
+
+func _get_recovery_record(lease: GFSaveProfileRecoveryLease) -> Dictionary:
+	if lease == null:
+		return {}
+	var record: Dictionary = GFVariantData.as_dictionary(
+		GFVariantData.get_option_value(_recovery_records, lease.get_lease_id())
+	)
+	return record if GFVariantData.get_option_value(record, "lease") == lease else {}
+
+
+func _get_reconcile_record(lease: GFSaveProfileReconcileLease) -> Dictionary:
+	if lease == null:
+		return {}
+	var record: Dictionary = GFVariantData.as_dictionary(
+		GFVariantData.get_option_value(_reconcile_records, lease.get_lease_id())
+	)
+	return record if GFVariantData.get_option_value(record, "lease") == lease else {}
+
+
+func _get_domain_admission_failure(domain: DomainState) -> Dictionary:
+	if domain == null:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE,
+			"error_code": int(ERR_DOES_NOT_EXIST),
+			"error": "Managed Provider domain does not exist.",
+		}
+	if _disposed:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_DISPOSED,
+			"error_code": int(ERR_UNAVAILABLE),
+			"error": "Save Profile transaction coordinator is disposed.",
+		}
+	if not _admission_open:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_BUSY,
+			"error_code": int(ERR_BUSY),
+			"error": "Save Profile transaction coordinator is quiescing.",
+		}
+	if _notification_depth > 0:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_BUSY,
+			"error_code": int(ERR_BUSY),
+			"error": "Reentrant transaction admission is not allowed from a callback.",
+		}
+	if domain.current_transaction != null:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_BUSY,
+			"error_code": int(ERR_BUSY),
+			"error": "Provider domain already has a running transaction.",
+		}
+	if domain.reconcile_lease != null:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_BUSY,
+			"error_code": int(ERR_BUSY),
+			"error": "Provider domain requires explicit reconciliation.",
+		}
+	return {}
+
+
+func _inspect_registration_topology(
+	providers: Array[GFSaveSectionProvider]
+) -> Dictionary:
+	var provider_instance_ids: PackedInt64Array = PackedInt64Array()
+	for provider: GFSaveSectionProvider in providers:
+		if provider == null:
+			return {
+				"ok": false,
+				"kind": &"invalid_provider_topology",
+				"error": "Provider topology cannot contain a null Provider.",
+			}
+		var instance_id: int = provider.get_instance_id()
+		if instance_id == 0:
+			return {
+				"ok": false,
+				"kind": &"invalid_provider_topology",
+				"error": "Provider topology contains an invalid instance identity.",
+			}
+		var _appended: bool = provider_instance_ids.append(instance_id)
+	var matching_domain_id: int = 0
+	for domain_value: Variant in _domains.values():
+		var domain: DomainState = _get_domain_value(domain_value)
+		if domain == null:
+			continue
+		if _int64_arrays_equal(
+			domain.provider_instance_ids,
+			provider_instance_ids
+		):
+			matching_domain_id = domain.domain_id
+			continue
+		if _int64_arrays_overlap(
+			domain.provider_instance_ids,
+			provider_instance_ids
+		):
+			return {
+				"ok": false,
+				"kind": &"overlapping_provider_domain",
+				"error": (
+					"Provider instances overlap an existing domain without an exact "
+					+ "ordered topology match."
+				),
+			}
+	return {
+		"ok": true,
+		"matching_domain_id": matching_domain_id,
+		"provider_instance_ids": provider_instance_ids,
+	}
+
+
+func _attach_profile_to_domain(
+	profile_id: StringName,
+	descriptor: Dictionary,
+	permit: RefCounted,
+	matching_domain_id: int
+) -> DomainState:
+	if profile_id == &"" or permit == null or _profiles.has(profile_id):
+		return null
+	var providers: Array[GFSaveSectionProvider] = _read_providers(
+		GFVariantData.get_option_value(descriptor, "providers")
+	)
+	if providers.is_empty():
+		return null
+	var domain: DomainState = _get_domain(matching_domain_id)
+	if domain == null:
+		domain = DomainState.new()
+		domain.domain_id = _next_domain_id
+		_next_domain_id += 1
+		for provider: GFSaveSectionProvider in providers:
+			var instance_id: int = provider.get_instance_id()
+			var _appended_id: bool = domain.provider_instance_ids.append(instance_id)
+		_domains[domain.domain_id] = domain
+	var profile: ManagedProfile = ManagedProfile.new()
+	profile.profile_id = profile_id
+	profile.schema_id = GFVariantData.get_option_string_name(descriptor, "schema_id")
+	profile.schema_version = GFVariantData.get_option_int(descriptor, "schema_version")
+	profile.save_enabled = GFVariantData.get_option_bool(descriptor, "save_enabled")
+	profile.load_enabled = GFVariantData.get_option_bool(descriptor, "load_enabled")
+	profile.providers = providers
+	profile.permit = permit
+	profile.domain_id = domain.domain_id
+	domain.profile_ids.append(profile_id)
+	_profiles[profile_id] = profile
+	_domain_id_by_profile[profile_id] = domain.domain_id
+	_update_domain_managed_access(domain)
+	return domain
+
+
+func _validate_mutation_request(
+	profile: ManagedProfile,
+	request: GFSaveProfileMutationRequest
+) -> Dictionary:
+	if profile == null or request == null:
+		return {"ok": false, "error": "Mutation request is required."}
+	var inspection: Dictionary = request.inspect_for_framework()
+	if not GFVariantData.get_option_bool(inspection, "available", false):
+		return {"ok": false, "error": "Mutation request is not available."}
+	var descriptors: Array = GFVariantData.get_option_array(inspection, "mutations")
+	if descriptors.is_empty():
+		return {"ok": false, "error": "Mutation request must contain a section."}
+	var provider_by_id: Dictionary = {}
+	for provider: GFSaveSectionProvider in profile.providers:
+		if provider != null:
+			provider_by_id[provider.section_id] = provider
+	var seen_ids: Dictionary = {}
+	for descriptor_value: Variant in descriptors:
+		var descriptor: Dictionary = GFVariantData.as_dictionary(descriptor_value)
+		var section_id: StringName = GFVariantData.get_option_string_name(
+			descriptor,
+			"section_id"
+		)
+		if section_id == &"" or seen_ids.has(section_id):
+			return {
+				"ok": false,
+				"error": "Mutation section IDs must be non-empty and unique.",
+			}
+		seen_ids[section_id] = true
+		var provider_value: Variant = GFVariantData.get_option_value(
+			provider_by_id,
+			section_id
+		)
+		if not provider_value is GFSaveSectionProvider:
+			return {
+				"ok": false,
+				"error": "Mutation section is not owned by the target Profile.",
+			}
+		var provider: GFSaveSectionProvider = provider_value
+		if (
+			not provider.save_enabled
+			or not provider.load_enabled
+			or provider.schema_version
+				!= GFVariantData.get_option_int(descriptor, "schema_version")
+		):
+			return {
+				"ok": false,
+				"error": (
+					"Mutation section must match a readable and writable Provider schema."
+				),
+			}
+	return {"ok": true}
+
+
+func _update_domain_managed_access(domain: DomainState) -> void:
+	if domain == null or _profile_utility == null:
+		return
+	var allow_active_direct_operations: bool = (
+		_admission_open
+		and not _disposed
+		and not _dispose_requested
+		and domain.state == DOMAIN_STATE_ACTIVE
+		and domain.current_transaction == null
+		and domain.reconcile_lease == null
+	)
+	for profile_id: StringName in domain.profile_ids:
+		var profile: ManagedProfile = _get_profile(profile_id)
+		if profile == null or profile.permit == null:
+			continue
+		var access: int = GFSaveProfileUtility.MANAGED_ACCESS_BLOCKED
+		if allow_active_direct_operations and profile_id == domain.active_profile_id:
+			access = GFSaveProfileUtility.MANAGED_ACCESS_SAVE_FLUSH
+		var _updated: bool = _profile_utility.set_profile_managed_access_for_framework(
+			profile_id,
+			profile.permit,
+			access
+		)
+
+
+func _make_registration_failure(
+	profile: GFSaveProfile,
+	kind: StringName,
+	error: String
+) -> Dictionary:
+	var report: Dictionary = {"issues": []}
+	var _issue: Variant = GFValidationReportDictionary.append_issue(
+		report,
+		"error",
+		kind,
+		error,
+		{"path": "coordinator"}
+	)
+	report["registered"] = false
+	report["managed"] = false
+	report["provider_domain_id"] = 0
+	report["profile_id"] = profile.profile_id if profile != null else &""
+	report["schema_id"] = (
+		profile.get_effective_schema_id()
+		if profile != null
+		else &""
+	)
+	report["canonical_file_name"] = ""
+	return GFValidationReportDictionary.finalize_report(
+		report,
+		"Managed Save profile registration",
+		{
+			"include_issue_count": true,
+			"fallback_action": "Resolve the managed Profile registration issue.",
+			"no_action": "Managed Save Profile registration is valid.",
+		}
+	)
+
+
+func _make_profile_result_evidence(result: GFSaveProfileResult) -> Dictionary:
+	if result == null:
+		return {}
+	return {
+		"status": result.get_status(),
+		"operation": result.get_operation(),
+		"profile_id": result.get_profile_id(),
+		"requested_generation": result.get_requested_generation(),
+		"persisted_generation": result.get_persisted_generation(),
+		"attempt_count": result.get_attempt_count(),
+		"coalesced": result.was_coalesced(),
+		"recovered": result.was_recovered(),
+		"recovery_action": result.get_recovery_action(),
+		"failed_section_id": result.get_failed_section_id(),
+		"error_code": int(result.get_error_code()),
+		"error": result.get_error(),
+		"duration_msec": result.get_duration_msec(),
+		"preparation_duration_msec": result.get_preparation_duration_msec(),
+		"storage_duration_msec": result.get_storage_duration_msec(),
+		"preparation_work_units": result.get_preparation_work_units(),
+		"storage_request_ids": result.get_storage_request_ids(),
+	}
+
+
+func _enqueue_domain_tick(domain: DomainState) -> void:
+	if domain == null or domain.pending_tick:
+		return
+	domain.pending_tick = true
+	var _appended: bool = _pending_domain_ids.append(domain.domain_id)
+
+
+# --- 私有/辅助方法（依赖与关闭） ---
+
+func _dispose_now() -> void:
+	if _disposed:
+		return
+	_disposed = true
+	_dispose_requested = false
+	for domain_value: Variant in _domains.values():
+		var domain: DomainState = _get_domain_value(domain_value)
+		if domain == null:
+			continue
+		_dispose_domain(domain)
+	_domains.clear()
+	_profiles.clear()
+	_domain_id_by_profile.clear()
+	_recovery_records.clear()
+	_reconcile_records.clear()
+	_pending_domain_ids = PackedInt64Array()
+	_disconnect_profile_utility()
+	_try_complete_quiesce()
+
+
+func _set_profile_utility(profile_utility: GFSaveProfileUtility) -> void:
+	if _profile_utility == profile_utility:
+		return
+	_disconnect_profile_utility()
+	_profile_utility = profile_utility
+	if _profile_utility == null:
+		return
+	var callback: Callable = Callable(
+		self,
+		"_on_profile_generation_evidence_changed"
+	)
+	if not _profile_utility.profile_generation_evidence_changed.is_connected(callback):
+		var _connected: Error = (
+			_profile_utility.profile_generation_evidence_changed.connect(callback)
+			as Error
+		)
+
+
+func _disconnect_profile_utility() -> void:
+	if _profile_utility == null:
+		return
+	var callback: Callable = Callable(
+		self,
+		"_on_profile_generation_evidence_changed"
+	)
+	if _profile_utility.profile_generation_evidence_changed.is_connected(callback):
+		_profile_utility.profile_generation_evidence_changed.disconnect(callback)
+	_profile_utility = null
+
+
+func _disconnect_transaction_profile_operation(
+	transaction: TransactionState
+) -> void:
+	if transaction == null:
+		return
+	if (
+		transaction.profile_operation != null
+		and transaction.profile_callback.is_valid()
+		and transaction.profile_operation.completed.is_connected(
+			transaction.profile_callback
+		)
+	):
+		transaction.profile_operation.completed.disconnect(
+			transaction.profile_callback
+		)
+	transaction.profile_callback = Callable()
+	transaction.profile_operation = null
+
+
+func _dispose_domain(domain: DomainState) -> void:
+	if domain == null or domain.state == DOMAIN_STATE_DISPOSED:
+		return
+	var transaction: TransactionState = domain.current_transaction
+	if transaction != null and not transaction.operation.is_completed():
+		var write_outcome_uncertain: bool = transaction.write_admitted
+		var lease: GFSaveProfileReconcileLease = transaction.reconcile_lease
+		if write_outcome_uncertain and lease == null:
+			var reconcile_profile_id: StringName = transaction.source_profile_id
+			if transaction.stage in [_STAGE_RECOVERY_SAVE, _STAGE_MUTATION_SAVE]:
+				reconcile_profile_id = transaction.target_profile_id
+			lease = _create_reconcile_fence(
+				domain,
+				transaction,
+				reconcile_profile_id
+			)
+		var load_apply_uncertain: bool = transaction.stage in [
+			_STAGE_ACTIVATE_LOAD,
+			_STAGE_TARGET_LOAD,
+		]
+		if load_apply_uncertain and lease == null:
+			var load_reconcile_profile_id: StringName = (
+				transaction.source_profile_id
+				if transaction.stage == _STAGE_TARGET_LOAD
+				else transaction.target_profile_id
+			)
+			lease = _create_reconcile_fence(
+				domain,
+				transaction,
+				load_reconcile_profile_id,
+				null,
+				true
+			)
+		if lease == null and not transaction.forced_rollback_errors.is_empty():
+			lease = _create_reconcile_fence(
+				domain,
+				transaction,
+				transaction.target_profile_id,
+				null,
+				true
+			)
+		if lease != null:
+			var _marked_disposed: bool = _mark_reconcile_disposed(lease)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			(
+				GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN
+				if write_outcome_uncertain
+				else GFSaveProfileTransactionResult.STATUS_DISPOSED
+			),
+			ERR_UNAVAILABLE,
+			"Save Profile transaction coordinator was disposed.",
+			transaction.stage,
+			{},
+			transaction.forced_rollback_errors,
+			null,
+			lease
+		)
+	if domain.reconcile_lease != null:
+		var reconcile_lease: GFSaveProfileReconcileLease = domain.reconcile_lease
+		var _disposed_lease: bool = _mark_reconcile_disposed(reconcile_lease)
+		var _record_erased: bool = _reconcile_records.erase(
+			reconcile_lease.get_lease_id()
+		)
+		domain.reconcile_lease = null
+	_invalidate_recovery_leases(domain)
+	domain.state = DOMAIN_STATE_DISPOSED
+	for profile_id: StringName in domain.profile_ids:
+		var profile: ManagedProfile = _get_profile(profile_id)
+		if profile == null or profile.permit == null or _profile_utility == null:
+			continue
+		var _blocked: bool = _profile_utility.set_profile_managed_access_for_framework(
+			profile_id,
+			profile.permit,
+			GFSaveProfileUtility.MANAGED_ACCESS_BLOCKED
+		)
+		var _abandoned: bool = _profile_utility.abandon_profile_management_for_framework(
+			profile_id,
+			profile.permit
+		)
+		profile.permit = null
+
+
+func _try_complete_quiesce() -> void:
+	if (
+		_quiesce_completion == null
+		or not _quiesce_completion.is_pending()
+		or _processing_depth > 0
+		or _notification_depth > 0
+	):
+		return
+	for domain_value: Variant in _domains.values():
+		var domain: DomainState = _get_domain_value(domain_value)
+		if (
+			domain != null
+			and (
+				domain.current_transaction != null
+				or domain.reconcile_lease != null
+				or domain.pending_tick
+			)
+		):
+			return
+		if domain != null and _domain_has_unsettled_profile_work(domain):
+			return
+	var _succeeded: bool = _quiesce_completion.succeed()
+
+
+func _domain_has_unsettled_profile_work(domain: DomainState) -> bool:
+	if domain == null:
+		return false
+	if _profile_utility == null:
+		return true
+	for profile_id: StringName in domain.profile_ids:
+		var snapshot: Dictionary = _profile_utility.get_profile_state_snapshot(
+			profile_id
+		)
+		if snapshot.is_empty():
+			continue
+		if (
+			GFVariantData.get_option_string_name(snapshot, "state")
+				!= GFSaveProfileUtility.STATE_IDLE
+			or GFVariantData.get_option_int(snapshot, "save_queue_size") > 0
+			or GFVariantData.get_option_int(snapshot, "load_queue_size") > 0
+			or GFVariantData.get_option_int(snapshot, "flush_queue_size") > 0
+			or GFVariantData.get_option_int(snapshot, "current_generation") > 0
+			or GFVariantData.get_option_int(snapshot, "detached_write_count") > 0
+			or GFVariantData.get_option_bool(snapshot, "schedule_enqueued")
+			or GFVariantData.get_option_bool(snapshot, "preparation_enqueued")
+		):
+			return true
+	return false
+
+
+func _begin_processing() -> void:
+	_processing_depth += 1
+
+
+func _end_processing() -> void:
+	_processing_depth = maxi(_processing_depth - 1, 0)
+	if _processing_depth == 0 and _dispose_requested:
+		_dispose_now()
+
+
+# --- 私有/辅助方法（类型与集合辅助） ---
+
+func _get_profile(profile_id: StringName) -> ManagedProfile:
+	return _get_profile_value(GFVariantData.get_option_value(_profiles, profile_id))
+
+
+func _get_profile_value(value: Variant) -> ManagedProfile:
+	if value is ManagedProfile:
+		var profile: ManagedProfile = value
+		return profile
+	return null
+
+
+func _get_domain(domain_id: int) -> DomainState:
+	return _get_domain_value(GFVariantData.get_option_value(_domains, domain_id))
+
+
+func _get_domain_value(value: Variant) -> DomainState:
+	if value is DomainState:
+		var domain: DomainState = value
+		return domain
+	return null
+
+
+func _get_domain_for_profile(profile_id: StringName) -> DomainState:
+	return _get_domain(
+		GFVariantData.get_option_int(_domain_id_by_profile, profile_id)
+	)
+
+
+func _read_providers(value: Variant) -> Array[GFSaveSectionProvider]:
+	var providers: Array[GFSaveSectionProvider] = []
+	if not value is Array:
+		return providers
+	var values: Array = value
+	for entry: Variant in values:
+		if entry is GFSaveSectionProvider:
+			var provider: GFSaveSectionProvider = entry
+			providers.append(provider)
+	return providers
+
+
+func _get_dictionary_claim(source: Dictionary, key: String) -> Dictionary:
+	var value: Variant = GFVariantData.get_option_value(source, key)
+	return value if value is Dictionary else {}
+
+
+func _get_dictionary_array_claim(
+	source: Dictionary,
+	key: String
+) -> Array[Dictionary]:
+	var records: Array[Dictionary] = []
+	var value: Variant = GFVariantData.get_option_value(source, key)
+	if not value is Array:
+		return records
+	var values: Array = value
+	for entry: Variant in values:
+		if entry is Dictionary:
+			var record: Dictionary = entry
+			records.append(record)
+	return records
+
+
+func _read_rollback_errors(value: Variant) -> Array[GFSaveRollbackFailure]:
+	var errors: Array[GFSaveRollbackFailure] = []
+	if not value is Array:
+		return errors
+	var values: Array = value
+	for entry: Variant in values:
+		if entry is GFSaveRollbackFailure:
+			var failure: GFSaveRollbackFailure = entry
+			errors.append(failure)
+	return errors
+
+
+func _make_management_rollback_failures(
+	provider_ids: PackedStringArray
+) -> Array[GFSaveRollbackFailure]:
+	var failures: Array[GFSaveRollbackFailure] = []
+	for index: int in range(provider_ids.size() - 1, -1, -1):
+		var failure: GFSaveRollbackFailure = GFSaveRollbackFailure.new()
+		var _configured: bool = failure.configure_for_framework(
+			StringName(provider_ids[index]),
+			ERR_UNAVAILABLE
+		)
+		failures.append(failure)
+	return failures
+
+
+func _get_packed_string_array(value: Variant) -> PackedStringArray:
+	if value is PackedStringArray:
+		var packed: PackedStringArray = value
+		return packed.duplicate()
+	var result: PackedStringArray = PackedStringArray()
+	if value is Array:
+		var values: Array = value
+		for entry: Variant in values:
+			if entry is String:
+				var string_value: String = entry
+				var _appended_string: bool = result.append(string_value)
+			elif entry is StringName:
+				var string_name_value: StringName = entry
+				var _appended_name: bool = result.append(String(string_name_value))
+	return result
+
+
+func _get_int64_array(value: Variant) -> PackedInt64Array:
+	if value is PackedInt64Array:
+		var packed: PackedInt64Array = value
+		return packed.duplicate()
+	var result: PackedInt64Array = PackedInt64Array()
+	if value is Array:
+		var values: Array = value
+		for entry: Variant in values:
+			if typeof(entry) == TYPE_INT:
+				var integer_value: int = entry
+				var _appended: bool = result.append(integer_value)
+	return result
+
+
+func _string_name_array_to_packed(values: Array[StringName]) -> PackedStringArray:
+	var result: PackedStringArray = PackedStringArray()
+	for value: StringName in values:
+		var _appended: bool = result.append(String(value))
+	return result
+
+
+func _int64_arrays_equal(
+	left: PackedInt64Array,
+	right: PackedInt64Array
+) -> bool:
+	if left.size() != right.size():
+		return false
+	for index: int in range(left.size()):
+		if left[index] != right[index]:
+			return false
+	return true
+
+
+func _int64_arrays_overlap(
+	left: PackedInt64Array,
+	right: PackedInt64Array
+) -> bool:
+	for value: int in left:
+		if right.has(value):
+			return true
+	return false
+
+
+func _get_error_code(
+	source: Dictionary,
+	key: String,
+	fallback: Error
+) -> Error:
+	return GFVariantData.get_option_int(source, key, int(fallback)) as Error
+
+
+# --- 信号处理函数 ---
+
+func _on_profile_operation_completed(
+	result: GFSaveProfileResult,
+	domain_id: int,
+	transaction_id: int
+) -> void:
+	if _disposed:
+		return
+	var domain: DomainState = _get_domain(domain_id)
+	var transaction: TransactionState = (
+		domain.current_transaction
+		if domain != null
+		else null
+	)
+	if (
+		domain == null
+		or transaction == null
+		or transaction.operation.get_transaction_id() != transaction_id
+		or result == null
+	):
+		return
+	_disconnect_transaction_profile_operation(transaction)
+	transaction.write_admitted = (
+		result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN
+	)
+	match transaction.stage:
+		_STAGE_ACTIVATE_LOAD:
+			_handle_activate_load_result(domain, transaction, result)
+		_STAGE_SOURCE_FLUSH:
+			_handle_switch_flush_result(domain, transaction, result)
+		_STAGE_TARGET_LOAD:
+			_handle_switch_target_result(domain, transaction, result)
+		_STAGE_RECOVERY_SAVE:
+			_handle_recovery_save_result(domain, transaction, result)
+		_STAGE_MUTATION_FLUSH:
+			_handle_mutation_flush_result(domain, transaction, result)
+		_STAGE_MUTATION_SAVE:
+			_handle_mutation_save_result(domain, transaction, result)
+		_STAGE_RECONCILE_LOAD:
+			_handle_reconcile_load_result(domain, transaction, result)
+		_:
+			_finish_domain_transaction(
+				domain,
+				transaction,
+				GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+				ERR_BUG,
+				"Transaction entered an invalid Profile operation stage.",
+				transaction.stage
+			)
+
+
+func _on_profile_generation_evidence_changed(
+	profile_id: StringName,
+	generation: int
+) -> void:
+	if _disposed:
+		return
+	var records: Array = _reconcile_records.values()
+	for record_value: Variant in records:
+		var record: Dictionary = GFVariantData.as_dictionary(record_value)
+		if (
+			GFVariantData.get_option_string_name(record, "profile_id") != profile_id
+			or GFVariantData.get_option_int(record, "generation") != generation
+		):
+			continue
+		var lease_value: Variant = GFVariantData.get_option_value(record, "lease")
+		if not lease_value is GFSaveProfileReconcileLease:
+			continue
+		var lease: GFSaveProfileReconcileLease = lease_value
+		_refresh_reconcile_lease(_get_domain(lease.get_domain_id()), lease)
+	if _dispose_requested and _processing_depth == 0 and _notification_depth == 0:
+		_dispose_now()
+	else:
+		_try_complete_quiesce()
+
+
+# --- 内部类（内部状态类型） ---
+
+## 单个受管 Profile 的已校验注册描述与 Utility 管理能力。
+## [br]
+## @api framework_internal
+## [br]
+## @category internal_helper
+## [br]
+## @since unreleased
+class ManagedProfile extends RefCounted:
+	## 受管 Profile 的稳定 ID。
+	## [br]
+	## @api framework_internal
+	var profile_id: StringName = &""
+
+	## 注册时锁定的文档 schema ID。
+	## [br]
+	## @api framework_internal
+	var schema_id: StringName = &""
+
+	## 注册时锁定的文档 schema 版本。
+	## [br]
+	## @api framework_internal
+	var schema_version: int = 0
+
+	## 该 Profile 是否允许持久化操作。
+	## [br]
+	## @api framework_internal
+	var save_enabled: bool = false
+
+	## 该 Profile 是否允许严格读取操作。
+	## [br]
+	## @api framework_internal
+	var load_enabled: bool = false
+
+	## 注册时锁定的有序 Provider 实例序列。
+	## [br]
+	## @api framework_internal
+	var providers: Array[GFSaveSectionProvider] = []
+
+	## 底层 Profile Utility 发放的 opaque 管理 capability。
+	## [br]
+	## @api framework_internal
+	var permit: RefCounted = null
+
+	## 所属 Provider 拓扑 domain 的稳定 ID。
+	## [br]
+	## @api framework_internal
+	var domain_id: int = 0
+
+
+## 共享同一有序 Provider 实例拓扑的 Profile 事务隔离状态。
+## [br]
+## @api framework_internal
+## [br]
+## @category internal_helper
+## [br]
+## @since unreleased
+class DomainState extends RefCounted:
+	## domain 的稳定运行时 ID。
+	## [br]
+	## @api framework_internal
+	var domain_id: int = 0
+
+	## 用于精确拓扑匹配的有序 Provider 实例 ID。
+	## [br]
+	## @api framework_internal
+	var provider_instance_ids: PackedInt64Array = PackedInt64Array()
+
+	## 当前注册到该 domain 的 Profile ID。
+	## [br]
+	## @api framework_internal
+	var profile_ids: Array[StringName] = []
+
+	## 当前内存权威状态对应的 Profile ID；空值表示未激活。
+	## [br]
+	## @api framework_internal
+	var active_profile_id: StringName = &""
+
+	## domain 当前的事务状态机状态。
+	## [br]
+	## @api framework_internal
+	var state: StringName = DOMAIN_STATE_INACTIVE
+
+	## 每次权威内存或激活身份提交后递增的 domain 代际。
+	## [br]
+	## @api framework_internal
+	var domain_generation: int = 1
+
+	## 每次接纳 domain 事务时递增的事务 epoch。
+	## [br]
+	## @api framework_internal
+	var transaction_epoch: int = 0
+
+	## 当前独占 domain 的事务状态。
+	## [br]
+	## @api framework_internal
+	var current_transaction: TransactionState = null
+
+	## 当前封锁 domain 的对账 Lease。
+	## [br]
+	## @api framework_internal
+	var reconcile_lease: GFSaveProfileReconcileLease = null
+
+	## 当前 domain 是否已排入一次 mutation tick。
+	## [br]
+	## @api framework_internal
+	var pending_tick: bool = false
+
+
+## 单个已接纳 Profile 事务从建立到终态的隔离运行状态。
+## [br]
+## @api framework_internal
+## [br]
+## @category internal_helper
+## [br]
+## @since unreleased
+class TransactionState extends RefCounted:
+	## 向调用方暴露的类型化事务操作句柄。
+	## [br]
+	## @api framework_internal
+	var operation: GFSaveProfileTransactionOperation = null
+
+	## 事务源 Profile ID；不需要源 Profile 时为空。
+	## [br]
+	## @api framework_internal
+	var source_profile_id: StringName = &""
+
+	## 事务目标 Profile ID。
+	## [br]
+	## @api framework_internal
+	var target_profile_id: StringName = &""
+
+	## 事务接纳前的激活 Profile ID。
+	## [br]
+	## @api framework_internal
+	var active_profile_before: StringName = &""
+
+	## 当前事务阶段。
+	## [br]
+	## @api framework_internal
+	var stage: StringName = &""
+
+	## 从类型化请求转移到该事务的项目上下文。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema context: Dictionary with caller-defined ephemeral operation data.
+	var context: Dictionary = {}
+
+	## mutation 持久化时转移给保存请求的文档元数据。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema document_metadata: Dictionary accepted by the Save persisted-value contract.
+	var document_metadata: Dictionary = {}
+
+	## 构造事务终态结果时附带的元数据。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema result_metadata: Dictionary with caller-defined result metadata.
+	var result_metadata: Dictionary = {}
+
+	## 当前由底层 Profile Utility 执行的操作句柄。
+	## [br]
+	## @api framework_internal
+	var profile_operation: GFSaveProfileOperation = null
+
+	## 当前底层操作的一次性完成回调。
+	## [br]
+	## @api framework_internal
+	var profile_callback: Callable = Callable()
+
+	## 从 mutation 请求转移的 section 全量替换描述。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema mutation_records: Array[Dictionary] whose entries contain section_id, schema_version, payload, and metadata.
+	var mutation_records: Array[Dictionary] = []
+
+	## 已应用到内存且等待精确持久化的 section 候选值。
+	## [br]
+	## @api framework_internal
+	var mutation_candidates: Array[GFSaveSection] = []
+
+	## mutation 按稳定 Provider 顺序实际触及的 section ID。
+	## [br]
+	## @api framework_internal
+	var mutation_provider_ids: PackedStringArray = PackedStringArray()
+
+	## 按 section ID 索引的 mutation 应用前 Provider 快照。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema mutation_snapshots: Internal Dictionary keyed by section ID with GFSaveSection values.
+	var mutation_snapshots: Dictionary = {}
+
+	## 在多阶段事务中保留的有界前置阶段证据。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema stage_evidence: Dictionary keyed by stage name with bounded payload-free Profile result evidence.
+	var stage_evidence: Dictionary = {}
+
+	## 与当前对账事务绑定的 Lease。
+	## [br]
+	## @api framework_internal
+	var reconcile_lease: GFSaveProfileReconcileLease = null
+
+	## 强制回滚阶段收集的 Provider 失败。
+	## [br]
+	## @api framework_internal
+	var forced_rollback_errors: Array[GFSaveRollbackFailure] = []
+
+	## 底层写入是否已获准，用于区分 disposed 与 outcome-unknown。
+	## [br]
+	## @api framework_internal
+	var write_admitted: bool = false
+
+	## 在终态提交前清空不应跨操作生命期保留的请求与 mutation payload。
+	## [br]
+	## @api framework_internal
+	func clear_payload_for_framework() -> void:
+		context.clear()
+		document_metadata.clear()
+		result_metadata.clear()
+		for record: Dictionary in mutation_records:
+			record.clear()
+		mutation_records.clear()
+		mutation_candidates.clear()
+		mutation_provider_ids = PackedStringArray()
+		mutation_snapshots.clear()

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd.uid
@@ -1,0 +1,1 @@
+uid://rxidpr2s5xu2

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd
@@ -1,0 +1,291 @@
+## GFSaveProfileTransactionOperation: Profile 身份与持久化事务的异步句柄。
+##
+## 句柄由 Save Profile 事务协调器完成一次且只完成一次。调用方可在连接信号前
+## 检查 `is_completed()`，避免同步拒绝或立即终态造成竞态。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFSaveProfileTransactionOperation
+extends RefCounted
+
+
+# --- 信号 ---
+
+## 事务进入终态时发出一次。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param result: 不包含 Provider payload 的隔离终态结果。
+signal completed(result: GFSaveProfileTransactionResult)
+
+
+# --- 常量 ---
+
+## 激活已存在的 Profile 存档。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_ACTIVATE: StringName = &"activate"
+
+## 从当前活跃 Profile 事务切换到另一个已存在 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_SWITCH: StringName = &"switch"
+
+## 用当前 Provider 状态显式创建缺失 Profile 并激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_BOOTSTRAP: StringName = &"bootstrap"
+
+## 显式采用当前 Provider 状态作为恢复后的活跃 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_ADOPT: StringName = &"adopt"
+
+## 应用完整候选 section 并持久化。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_MUTATE_AND_PERSIST: StringName = &"mutate_and_persist"
+
+## 对账此前 outcome_unknown 的事务。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_RECONCILE: StringName = &"reconcile"
+
+
+# --- 私有变量 ---
+
+var _operation: StringName = &""
+var _transaction_id: int = 0
+var _source_profile_id: StringName = &""
+var _target_profile_id: StringName = &""
+var _started_at_msec: int = 0
+var _running: bool = false
+var _result: GFSaveProfileTransactionResult = null
+var _completion_emitted: bool = false
+
+
+# --- 公共方法 ---
+
+## 获取事务类型。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `OPERATION_*` 常量之一。
+func get_operation() -> StringName:
+	return _operation
+
+
+## 获取 Utility 生命周期内唯一的事务 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数事务 ID；尚未配置时为 0。
+func get_transaction_id() -> int:
+	return _transaction_id
+
+
+## 获取事务来源 Profile ID。
+##
+## activate、bootstrap 与 adopt 没有来源身份；mutate-and-persist 和 reconcile
+## 使用当前受管 Profile 作为来源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 来源 Profile ID；不适用时为空。
+func get_source_profile_id() -> StringName:
+	return _source_profile_id
+
+
+## 获取事务目标 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 目标 Profile ID；不适用时为空。
+func get_target_profile_id() -> StringName:
+	return _target_profile_id
+
+
+## 检查事务是否等待调度。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未运行或完成时返回 true。
+func is_pending() -> bool:
+	return not _running and _result == null
+
+
+## 检查事务是否正在运行。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已启动但无终态时返回 true。
+func is_running() -> bool:
+	return _running and _result == null
+
+
+## 检查事务是否已有终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已完成时返回 true。
+func is_completed() -> bool:
+	return _result != null
+
+
+## 获取终态结果副本。
+##
+## 结果副本中的 Recovery/Reconcile Lease 保留原始句柄身份，其他集合均隔离复制。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已完成结果；等待中返回 null。
+func get_result() -> GFSaveProfileTransactionResult:
+	return _result.duplicate_result() if _result != null else null
+
+
+# --- 框架内部方法 ---
+
+## 由 Save Profile 事务协调器一次性配置句柄身份。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param operation: `OPERATION_*` 常量之一。
+## [br]
+## @param transaction_id: Utility 生命周期内唯一的正整数事务 ID。
+## [br]
+## @param source_profile_id: 来源 Profile ID；不适用时为空。
+## [br]
+## @param target_profile_id: 目标 Profile ID；不适用时为空。
+## [br]
+## @param started_at_msec: 非负单调开始时间。
+## [br]
+## @return 输入合法且首次配置时返回 true。
+func configure_for_framework(
+	operation: StringName,
+	transaction_id: int,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	started_at_msec: int
+) -> bool:
+	if _operation != &"" or operation not in _get_valid_operations():
+		return false
+	if transaction_id <= 0:
+		return false
+	_operation = operation
+	_transaction_id = transaction_id
+	_source_profile_id = source_profile_id
+	_target_profile_id = target_profile_id
+	_started_at_msec = maxi(started_at_msec, 0)
+	return true
+
+
+## 由 Save Profile 事务协调器标记为运行中。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 从 pending 转为 running 时返回 true。
+func start_for_framework() -> bool:
+	if _operation == &"" or not is_pending():
+		return false
+	_running = true
+	return true
+
+
+## 写入唯一终态，但暂不发出外部信号。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param result: 与当前句柄事务身份一致的唯一终态结果。
+## [br]
+## @return 首次写入匹配终态时返回 true。
+func complete_for_framework(result: GFSaveProfileTransactionResult) -> bool:
+	if _result != null or result == null:
+		return false
+	if (
+		result.get_transaction_id() != _transaction_id
+		or result.get_operation() != _operation
+		or result.get_source_profile_id() != _source_profile_id
+		or result.get_target_profile_id() != _target_profile_id
+	):
+		return false
+	_running = false
+	_result = result.duplicate_result()
+	return true
+
+
+## 在协调器提交稳定状态后发出终态信号。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 首次发出终态信号时返回 true。
+func emit_completed_for_framework() -> bool:
+	if _result == null or _completion_emitted:
+		return false
+	_completion_emitted = true
+	completed.emit(_result.duplicate_result())
+	return true
+
+
+## 获取当前事务开始时间。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 非负单调毫秒时间。
+func get_started_at_msec_for_framework() -> int:
+	return _started_at_msec
+
+
+# --- 私有/辅助方法 ---
+
+static func _get_valid_operations() -> Array[StringName]:
+	return [
+		OPERATION_ACTIVATE,
+		OPERATION_SWITCH,
+		OPERATION_BOOTSTRAP,
+		OPERATION_ADOPT,
+		OPERATION_MUTATE_AND_PERSIST,
+		OPERATION_RECONCILE,
+	]

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd.uid
@@ -1,0 +1,1 @@
+uid://csltrfjldw8ij

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd
@@ -1,0 +1,888 @@
+## GFSaveProfileTransactionResult: Profile 事务的不可变终态快照。
+##
+## 结果不保留文档、section、Provider snapshot 或候选 payload，只保留有界阶段
+## 证据、类型化回滚失败、调用方元数据和必要的 Lease。`duplicate_result()` 会
+## 隔离复制集合，但刻意保留 Recovery/Reconcile Lease 的同一对象身份。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFSaveProfileTransactionResult
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 已存在 Profile 已成功激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ACTIVATED: StringName = &"activated"
+
+## 活跃身份已成功切换。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_SWITCHED: StringName = &"switched"
+
+## 缺失 Profile 已从当前状态显式创建并激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_BOOTSTRAPPED: StringName = &"bootstrapped"
+
+## 当前状态已被显式采用为恢复后的活跃 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ADOPTED: StringName = &"adopted"
+
+## 候选 sections 已应用并持久化。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_MUTATED: StringName = &"mutated"
+
+## outcome_unknown 已通过显式重新读取完成对账。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_RECONCILED: StringName = &"reconciled"
+
+## Profile ID、Provider topology 或事务身份无效。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_PROFILE: StringName = &"invalid_profile"
+
+## 一次性请求无效、已被 claim 或含不支持的数据。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_REQUEST: StringName = &"invalid_request"
+
+## Recovery/Reconcile Lease 无效、已消费或绑定已经过期。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_LEASE: StringName = &"invalid_lease"
+
+## 请求要求活跃 Profile，但当前 Provider domain 未激活。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INACTIVE: StringName = &"inactive"
+
+## activate/bootstrap/adopt 的目标 domain 已有活跃 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ALREADY_ACTIVE: StringName = &"already_active"
+
+## Provider domain 正在执行互斥事务或发生不安全回调重入。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_BUSY: StringName = &"busy"
+
+## Profile 配置不支持请求的读取或写入阶段。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_UNSUPPORTED_OPERATION: StringName = &"unsupported_operation"
+
+## activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_RECOVERY_REQUIRED: StringName = &"recovery_required"
+
+## switch 无法把来源 Profile flush 到调用时 generation barrier。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_SOURCE_FLUSH_FAILED: StringName = &"source_flush_failed"
+
+## switch 已 flush 来源，但无法读取或应用目标 Profile。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_TARGET_LOAD_FAILED: StringName = &"target_load_failed"
+
+## Provider 回滚或候选应用前的快照采集失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_SNAPSHOT_FAILED: StringName = &"snapshot_failed"
+
+## 至少一个候选 section 应用失败，且内存回滚成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_APPLY_FAILED: StringName = &"apply_failed"
+
+## 恢复来源或候选内存状态时至少一个 Provider 回滚失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"
+
+## 候选持久化确定失败，且内存回滚已成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_PERSIST_FAILED: StringName = &"persist_failed"
+
+## 写请求已进入底层，但其最终物理副作用无法确认。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_OUTCOME_UNKNOWN: StringName = &"outcome_unknown"
+
+## Reconcile Lease 仍在等待 late settlement evidence。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_RECONCILE_PENDING: StringName = &"reconcile_pending"
+
+## 显式重新读取或证据校验未能完成对账。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_RECONCILE_FAILED: StringName = &"reconcile_failed"
+
+## Utility 释放时事务仍未完成。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_DISPOSED: StringName = &"disposed"
+
+const _MAX_EVIDENCE_DEPTH: int = 16
+const _MAX_EVIDENCE_ITEMS: int = 2048
+const _MAX_EVIDENCE_STRING_LENGTH: int = 2048
+const _MAX_ERROR_LENGTH: int = 2048
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _status: StringName = &""
+var _operation: StringName = &""
+var _transaction_id: int = 0
+var _source_profile_id: StringName = &""
+var _target_profile_id: StringName = &""
+var _active_profile_before: StringName = &""
+var _active_profile_after: StringName = &""
+var _phase: StringName = &""
+var _error_code: Error = FAILED
+var _error: String = ""
+var _failed_section_id: StringName = &""
+var _rollback_errors: Array[GFSaveRollbackFailure] = []
+var _stage_evidence: Dictionary = {}
+var _recovery_lease: GFSaveProfileRecoveryLease = null
+var _reconcile_lease: GFSaveProfileReconcileLease = null
+var _metadata: Dictionary = {}
+var _started_at_msec: int = 0
+var _completed_at_msec: int = 0
+
+
+# --- 公共方法 ---
+
+## 检查事务是否成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 终态属于成功状态时返回 true。
+func is_successful() -> bool:
+	return _status in _get_success_statuses()
+
+
+## 获取稳定终态状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATUS_*` 常量之一。
+func get_status() -> StringName:
+	return _status
+
+
+## 获取事务类型。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `GFSaveProfileTransactionOperation.OPERATION_*` 常量之一。
+func get_operation() -> StringName:
+	return _operation
+
+
+## 获取 Utility 生命周期内唯一的事务 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数事务 ID。
+func get_transaction_id() -> int:
+	return _transaction_id
+
+
+## 获取事务来源 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 来源 Profile ID；不适用时为空。
+func get_source_profile_id() -> StringName:
+	return _source_profile_id
+
+
+## 获取事务目标 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 目标 Profile ID；不适用时为空。
+func get_target_profile_id() -> StringName:
+	return _target_profile_id
+
+
+## 获取事务开始前的活跃 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 开始前活跃身份；domain 未激活时为空。
+func get_active_profile_before() -> StringName:
+	return _active_profile_before
+
+
+## 获取事务终态后的活跃 Profile ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 终态活跃身份；未激活或身份未知时为空。
+func get_active_profile_after() -> StringName:
+	return _active_profile_after
+
+
+## 获取失败或成功发生的稳定阶段名。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 协调器定义的 payload-free 阶段名。
+func get_phase() -> StringName:
+	return _phase
+
+
+## 获取 Godot Error 码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时为 OK。
+func get_error_code() -> Error:
+	return _error_code
+
+
+## 获取稳定错误描述。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时为空；失败说明最多 2048 个字符。
+func get_error() -> String:
+	return _error
+
+
+## 获取首个失败 section ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非 section 失败时为空。
+func get_failed_section_id() -> StringName:
+	return _failed_section_id
+
+
+## 获取类型化 Provider 回滚失败证据。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 按回滚顺序排列的隔离副本。
+func get_rollback_errors() -> Array[GFSaveRollbackFailure]:
+	return _duplicate_rollback_errors(_rollback_errors)
+
+
+## 获取不含文档、section 或 Provider payload 的阶段证据。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 有界 evidence 副本。
+## [br]
+## @schema return: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+func get_stage_evidence() -> Dictionary:
+	return _stage_evidence.duplicate(true)
+
+
+## 获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return recovery_required 结果中的 Lease；其他结果通常为 null。
+func get_recovery_lease() -> GFSaveProfileRecoveryLease:
+	return _recovery_lease
+
+
+## 获取持续围栏 outcome_unknown 的同一身份 Reconcile Lease。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 需要或正在对账时的 Lease；不适用时为 null。
+func get_reconcile_lease() -> GFSaveProfileReconcileLease:
+	return _reconcile_lease
+
+
+## 获取调用方结果元数据副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 调用方在一次性请求中移交的结果元数据。
+## [br]
+## @schema return: Dictionary with caller-defined result metadata.
+func get_metadata() -> Dictionary:
+	return _metadata.duplicate(true)
+
+
+## 获取事务开始时间。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非负单调毫秒时间。
+func get_started_at_msec() -> int:
+	return _started_at_msec
+
+
+## 获取事务完成时间。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 不早于开始时间的单调毫秒时间。
+func get_completed_at_msec() -> int:
+	return _completed_at_msec
+
+
+## 获取事务耗时。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 非负单调毫秒耗时。
+func get_duration_msec() -> int:
+	return maxi(_completed_at_msec - _started_at_msec, 0)
+
+
+## 创建隔离结果副本。
+##
+## Recovery/Reconcile Lease 不复制，以维持原始恢复授权和持续对账生命周期。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新结果对象。
+func duplicate_result() -> GFSaveProfileTransactionResult:
+	var copy: GFSaveProfileTransactionResult = GFSaveProfileTransactionResult.new()
+	if not _configured:
+		return copy
+	var _configured_copy: bool = copy.configure_for_framework({
+		"status": _status,
+		"operation": _operation,
+		"transaction_id": _transaction_id,
+		"source_profile_id": _source_profile_id,
+		"target_profile_id": _target_profile_id,
+		"active_profile_before": _active_profile_before,
+		"active_profile_after": _active_profile_after,
+		"phase": _phase,
+		"error_code": int(_error_code),
+		"error": _error,
+		"failed_section_id": _failed_section_id,
+		"rollback_errors": _rollback_errors,
+		"stage_evidence": _stage_evidence,
+		"recovery_lease": _recovery_lease,
+		"reconcile_lease": _reconcile_lease,
+		"metadata": _metadata,
+		"started_at_msec": _started_at_msec,
+		"completed_at_msec": _completed_at_msec,
+	})
+	assert(
+		_configured_copy,
+		"GFSaveProfileTransactionResult invariant failed while duplicating a terminal result."
+	)
+	return copy
+
+
+## 转换为不包含持久化 payload 或 Lease 对象的报告字典。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 事务身份、终态、阶段证据、Lease 摘要、错误与时间信息。
+## [br]
+## @schema return: Payload-free Dictionary with transaction identity, status, active identities, phase, rollback failures, evidence, lease summaries, metadata, errors, and timing.
+func to_dict() -> Dictionary:
+	return {
+		"ok": is_successful(),
+		"status": _status,
+		"operation": _operation,
+		"transaction_id": _transaction_id,
+		"source_profile_id": _source_profile_id,
+		"target_profile_id": _target_profile_id,
+		"active_profile_before": _active_profile_before,
+		"active_profile_after": _active_profile_after,
+		"phase": _phase,
+		"error_code": int(_error_code),
+		"error": _error,
+		"failed_section_id": _failed_section_id,
+		"rollback_errors": _rollback_errors_to_dicts(),
+		"stage_evidence": _stage_evidence.duplicate(true),
+		"recovery_lease": _get_recovery_lease_summary(),
+		"reconcile_lease": _get_reconcile_lease_summary(),
+		"metadata": _metadata.duplicate(true),
+		"started_at_msec": _started_at_msec,
+		"completed_at_msec": _completed_at_msec,
+		"duration_msec": get_duration_msec(),
+	}
+
+
+# --- 框架内部方法 ---
+
+## 由 Save Profile 事务协调器一次性配置终态。
+##
+## `stage_evidence` 只接受有界、payload-free 数据；Recovery/Reconcile Lease
+## 在写入和结果复制时保留同一对象身份。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param options: 完整终态字段。
+## [br]
+## @schema options: Dictionary with status, operation, transaction_id, source_profile_id, target_profile_id, active_profile_before, active_profile_after, phase, error_code, error, failed_section_id, rollback_errors, stage_evidence, recovery_lease, reconcile_lease, metadata, started_at_msec, and completed_at_msec.
+## [br]
+## @return 输入合法且首次配置时返回 true。
+func configure_for_framework(options: Dictionary) -> bool:
+	if _configured:
+		return false
+	var status: StringName = GFVariantData.get_option_string_name(options, "status")
+	var operation: StringName = GFVariantData.get_option_string_name(options, "operation")
+	var transaction_id: int = GFVariantData.get_option_int(options, "transaction_id")
+	var stage_evidence: Dictionary = GFVariantData.get_option_dictionary(
+		options,
+		"stage_evidence"
+	)
+	if (
+		status not in _get_valid_statuses()
+		or operation not in _get_valid_operations()
+		or transaction_id <= 0
+		or not _is_evidence_supported(stage_evidence)
+	):
+		return false
+
+	var rollback_errors: Array[GFSaveRollbackFailure] = []
+	var rollback_value: Variant = GFVariantData.get_option_value(options, "rollback_errors", [])
+	if not _read_rollback_errors(rollback_value, rollback_errors):
+		return false
+	var recovery_lease: GFSaveProfileRecoveryLease = _read_recovery_lease(options)
+	var reconcile_lease: GFSaveProfileReconcileLease = _read_reconcile_lease(options)
+	if not _leases_match_status(
+		status,
+		operation,
+		transaction_id,
+		GFVariantData.get_option_string_name(options, "target_profile_id"),
+		recovery_lease,
+		reconcile_lease
+	):
+		return false
+
+	_configured = true
+	_status = status
+	_operation = operation
+	_transaction_id = transaction_id
+	_source_profile_id = GFVariantData.get_option_string_name(options, "source_profile_id")
+	_target_profile_id = GFVariantData.get_option_string_name(options, "target_profile_id")
+	_active_profile_before = GFVariantData.get_option_string_name(
+		options,
+		"active_profile_before"
+	)
+	_active_profile_after = GFVariantData.get_option_string_name(
+		options,
+		"active_profile_after"
+	)
+	_phase = GFVariantData.get_option_string_name(options, "phase")
+	_error_code = (
+		OK
+		if is_successful()
+		else GFVariantData.get_option_int(options, "error_code", int(FAILED)) as Error
+	)
+	_error = (
+		""
+		if is_successful()
+		else GFVariantData.get_option_string(options, "error").strip_edges().left(
+			_MAX_ERROR_LENGTH
+		)
+	)
+	_failed_section_id = GFVariantData.get_option_string_name(options, "failed_section_id")
+	_rollback_errors = _duplicate_rollback_errors(rollback_errors)
+	_stage_evidence = stage_evidence.duplicate(true)
+	_recovery_lease = recovery_lease
+	_reconcile_lease = reconcile_lease
+	_metadata = GFVariantData.get_option_dictionary(options, "metadata")
+	_started_at_msec = maxi(GFVariantData.get_option_int(options, "started_at_msec"), 0)
+	_completed_at_msec = maxi(
+		GFVariantData.get_option_int(options, "completed_at_msec"),
+		_started_at_msec
+	)
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+static func _get_success_statuses() -> Array[StringName]:
+	return [
+		STATUS_ACTIVATED,
+		STATUS_SWITCHED,
+		STATUS_BOOTSTRAPPED,
+		STATUS_ADOPTED,
+		STATUS_MUTATED,
+		STATUS_RECONCILED,
+	]
+
+
+static func _get_valid_statuses() -> Array[StringName]:
+	return _get_success_statuses() + [
+		STATUS_INVALID_PROFILE,
+		STATUS_INVALID_REQUEST,
+		STATUS_INVALID_LEASE,
+		STATUS_INACTIVE,
+		STATUS_ALREADY_ACTIVE,
+		STATUS_BUSY,
+		STATUS_UNSUPPORTED_OPERATION,
+		STATUS_RECOVERY_REQUIRED,
+		STATUS_SOURCE_FLUSH_FAILED,
+		STATUS_TARGET_LOAD_FAILED,
+		STATUS_SNAPSHOT_FAILED,
+		STATUS_APPLY_FAILED,
+		STATUS_ROLLBACK_FAILED,
+		STATUS_PERSIST_FAILED,
+		STATUS_OUTCOME_UNKNOWN,
+		STATUS_RECONCILE_PENDING,
+		STATUS_RECONCILE_FAILED,
+		STATUS_DISPOSED,
+	]
+
+
+static func _get_valid_operations() -> Array[StringName]:
+	return [
+		GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+		GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+		GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP,
+		GFSaveProfileTransactionOperation.OPERATION_ADOPT,
+		GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
+		GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
+	]
+
+
+static func _read_rollback_errors(
+	value: Variant,
+	output: Array[GFSaveRollbackFailure]
+) -> bool:
+	if not value is Array:
+		return false
+	var values: Array = value
+	for entry: Variant in values:
+		if not entry is GFSaveRollbackFailure:
+			return false
+		var failure: GFSaveRollbackFailure = entry
+		output.append(failure)
+	return true
+
+
+static func _read_recovery_lease(options: Dictionary) -> GFSaveProfileRecoveryLease:
+	var value: Variant = GFVariantData.get_option_value(options, "recovery_lease")
+	if value is GFSaveProfileRecoveryLease:
+		var lease: GFSaveProfileRecoveryLease = value
+		return lease
+	return null
+
+
+static func _read_reconcile_lease(options: Dictionary) -> GFSaveProfileReconcileLease:
+	var value: Variant = GFVariantData.get_option_value(options, "reconcile_lease")
+	if value is GFSaveProfileReconcileLease:
+		var lease: GFSaveProfileReconcileLease = value
+		return lease
+	return null
+
+
+static func _leases_match_status(
+	status: StringName,
+	operation: StringName,
+	transaction_id: int,
+	target_profile_id: StringName,
+	recovery_lease: GFSaveProfileRecoveryLease,
+	reconcile_lease: GFSaveProfileReconcileLease
+) -> bool:
+	if status == STATUS_RECOVERY_REQUIRED:
+		if (
+			recovery_lease == null
+			or operation != GFSaveProfileTransactionOperation.OPERATION_ACTIVATE
+		):
+			return false
+		if (
+			recovery_lease.get_transaction_id() != transaction_id
+			or recovery_lease.get_profile_id() != target_profile_id
+			or recovery_lease.get_reason() not in [
+				GFSaveProfileRecoveryLease.REASON_MISSING,
+				GFSaveProfileRecoveryLease.REASON_CORRUPT,
+			]
+		):
+			return false
+	elif recovery_lease != null:
+		return false
+
+	if status == STATUS_OUTCOME_UNKNOWN:
+		if reconcile_lease == null:
+			return false
+		if (
+			reconcile_lease.get_transaction_id() != transaction_id
+			or reconcile_lease.get_operation() != operation
+		):
+			return false
+	elif (
+		reconcile_lease != null
+		and status not in [
+			STATUS_ROLLBACK_FAILED,
+			STATUS_RECONCILE_PENDING,
+			STATUS_RECONCILE_FAILED,
+			STATUS_RECONCILED,
+			STATUS_DISPOSED,
+		]
+	):
+		return false
+	return true
+
+
+static func _duplicate_rollback_errors(
+	errors: Array[GFSaveRollbackFailure]
+) -> Array[GFSaveRollbackFailure]:
+	var copies: Array[GFSaveRollbackFailure] = []
+	for failure: GFSaveRollbackFailure in errors:
+		if failure != null:
+			copies.append(failure.duplicate_failure())
+	return copies
+
+
+func _rollback_errors_to_dicts() -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for failure: GFSaveRollbackFailure in _rollback_errors:
+		if failure != null:
+			result.append(failure.to_dict())
+	return result
+
+
+func _get_recovery_lease_summary() -> Dictionary:
+	if _recovery_lease == null:
+		return {}
+	return {
+		"lease_id": _recovery_lease.get_lease_id(),
+		"transaction_id": _recovery_lease.get_transaction_id(),
+		"profile_id": _recovery_lease.get_profile_id(),
+		"reason": _recovery_lease.get_reason(),
+		"state": _recovery_lease.get_state(),
+	}
+
+
+func _get_reconcile_lease_summary() -> Dictionary:
+	if _reconcile_lease == null:
+		return {}
+	return {
+		"lease_id": _reconcile_lease.get_lease_id(),
+		"transaction_id": _reconcile_lease.get_transaction_id(),
+		"operation": _reconcile_lease.get_operation(),
+		"reconcile_profile_id": _reconcile_lease.get_reconcile_profile_id(),
+		"state": _reconcile_lease.get_state(),
+		"storage_request_ids": _reconcile_lease.get_storage_request_ids(),
+	}
+
+
+static func _is_evidence_supported(evidence: Dictionary) -> bool:
+	var state: Dictionary = {
+		"items": 0,
+		"visited": [],
+	}
+	return _is_evidence_value_supported(evidence, 0, state)
+
+
+static func _is_evidence_value_supported(
+	value: Variant,
+	depth: int,
+	state: Dictionary
+) -> bool:
+	if depth > _MAX_EVIDENCE_DEPTH:
+		return false
+	var item_count: int = GFVariantData.get_option_int(state, "items") + 1
+	state["items"] = item_count
+	if item_count > _MAX_EVIDENCE_ITEMS:
+		return false
+
+	match typeof(value):
+		TYPE_NIL, TYPE_BOOL, TYPE_INT:
+			return true
+		TYPE_FLOAT:
+			var number: float = value
+			return not is_nan(number) and not is_inf(number)
+		TYPE_STRING:
+			var text: String = value
+			return text.length() <= _MAX_EVIDENCE_STRING_LENGTH
+		TYPE_STRING_NAME:
+			var identifier: StringName = value
+			return String(identifier).length() <= _MAX_EVIDENCE_STRING_LENGTH
+		TYPE_PACKED_BYTE_ARRAY:
+			var values: PackedByteArray = value
+			return _consume_packed_items(values.size(), state)
+		TYPE_PACKED_INT32_ARRAY:
+			var values: PackedInt32Array = value
+			return _consume_packed_items(values.size(), state)
+		TYPE_PACKED_INT64_ARRAY:
+			var values: PackedInt64Array = value
+			return _consume_packed_items(values.size(), state)
+		TYPE_PACKED_FLOAT32_ARRAY:
+			var values: PackedFloat32Array = value
+			if not _consume_packed_items(values.size(), state):
+				return false
+			for number: float in values:
+				if is_nan(number) or is_inf(number):
+					return false
+			return true
+		TYPE_PACKED_FLOAT64_ARRAY:
+			var values: PackedFloat64Array = value
+			if not _consume_packed_items(values.size(), state):
+				return false
+			for number: float in values:
+				if is_nan(number) or is_inf(number):
+					return false
+			return true
+		TYPE_PACKED_STRING_ARRAY:
+			var values: PackedStringArray = value
+			if not _consume_packed_items(values.size(), state):
+				return false
+			for text: String in values:
+				if text.length() > _MAX_EVIDENCE_STRING_LENGTH:
+					return false
+			return true
+		TYPE_ARRAY:
+			var array_value: Array = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, array_value):
+				return false
+			visited.append(array_value)
+			for entry: Variant in array_value:
+				if not _is_evidence_value_supported(entry, depth + 1, state):
+					var _removed_array_failure: Variant = visited.pop_back()
+					return false
+			var _removed_array: Variant = visited.pop_back()
+			return true
+		TYPE_DICTIONARY:
+			var dictionary_value: Dictionary = value
+			var visited: Array = _get_visited(state)
+			if _contains_collection_identity(visited, dictionary_value):
+				return false
+			visited.append(dictionary_value)
+			for key: Variant in dictionary_value.keys():
+				if (
+					typeof(key) not in [TYPE_STRING, TYPE_STRING_NAME]
+					or not _is_evidence_value_supported(key, depth + 1, state)
+				):
+					var _removed_invalid_key: Variant = visited.pop_back()
+					return false
+				if not _is_evidence_value_supported(dictionary_value[key], depth + 1, state):
+					var _removed_dictionary_failure: Variant = visited.pop_back()
+					return false
+			var _removed_dictionary: Variant = visited.pop_back()
+			return true
+		_:
+			return false
+
+
+static func _consume_packed_items(item_count: int, state: Dictionary) -> bool:
+	var next_count: int = GFVariantData.get_option_int(state, "items") + item_count
+	state["items"] = next_count
+	return next_count <= _MAX_EVIDENCE_ITEMS
+
+
+static func _get_visited(state: Dictionary) -> Array:
+	return GFVariantData.as_array(GFVariantData.get_option_value(state, "visited"))
+
+
+static func _contains_collection_identity(collections: Array, candidate: Variant) -> bool:
+	for collection: Variant in collections:
+		if is_same(collection, candidate):
+			return true
+	return false

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd.uid
@@ -1,0 +1,1 @@
+uid://bqajj3mjut460

--- a/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
@@ -36,6 +36,20 @@ signal profile_operation_completed(result: GFSaveProfileResult)
 ## @param current_state: 变化后状态。
 signal profile_state_changed(profile_id: StringName, previous_state: StringName, current_state: StringName)
 
+## 受管事务可重新查询的 generation 证据发生变化时发出。
+##
+## 该信号不携带路径或载荷；观察方必须用 profile ID 与 generation 重新查询，
+## 不能把通知顺序当作持久化终态。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 证据所属 Profile ID。
+## [br]
+## @param generation: 发生变化的 generation。
+signal profile_generation_evidence_changed(profile_id: StringName, generation: int)
+
 
 # --- 常量 ---
 
@@ -87,6 +101,20 @@ const STATE_APPLYING: StringName = &"applying"
 ## [br]
 ## @since 10.0.0
 const STATE_DISPOSED: StringName = &"disposed"
+
+## 受管 Profile 禁止全部直接操作。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+const MANAGED_ACCESS_BLOCKED: int = 0
+
+## 受管 Profile 只允许直接 save 与 flush。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+const MANAGED_ACCESS_SAVE_FLUSH: int = 1
 
 const _PREPARATION_PHASE_PROVIDER_SCAN: StringName = &"provider_scan"
 const _PREPARATION_PHASE_PROVIDER_BEGIN: StringName = &"provider_begin"
@@ -151,6 +179,7 @@ var _active_preparation_head: ProfileState = null
 var _active_preparation_tail: ProfileState = null
 var _admission_open: bool = true
 var _quiesce_completion: GFAsyncCompletion = null
+var _next_management_serial: int = 1
 
 
 # --- Godot 生命周期方法 ---
@@ -243,6 +272,7 @@ func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
 ## @return 所有已接纳工作进入终态后成功的一次性完成源。
 func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
 	_admission_open = false
+	_block_all_managed_access_for_shutdown()
 	if _quiesce_completion != null:
 		return _quiesce_completion
 	_quiesce_completion = GFAsyncCompletion.new()
@@ -268,6 +298,7 @@ func tick(_delta: float) -> void:
 		var state: ProfileState = _get_state_value(state_value)
 		if state == null:
 			continue
+		_reap_expired_managed_permit_if_safe(state)
 		if state.mode == STATE_RETRY_WAIT and now_msec >= state.retry_due_msec:
 			_retry_current_io(state)
 		elif (
@@ -293,6 +324,7 @@ func dispose() -> void:
 	if _disposed:
 		return
 	_admission_open = false
+	_block_all_managed_access_for_shutdown()
 	if _processing_depth > 0:
 		_dispose_requested = true
 		return
@@ -411,20 +443,7 @@ func register_profile(
 ## @return 准入开放、回调安全且 profile 空闲并无任何待处理工作时返回 true。
 func unregister_profile(profile_id: StringName) -> bool:
 	var state: ProfileState = _get_state(profile_id)
-	if (
-		not _admission_open
-		or _dispose_requested
-		or _unsafe_callback_depth > 0
-		or state == null
-		or state.mode != STATE_IDLE
-		or _has_pending_operations(state)
-		or not state.detached_write_operations.is_empty()
-		or state.pending_schedule_enqueued
-		or state.active_preparation_enqueued
-	):
-		return false
-	var _erased: bool = _states.erase(profile_id)
-	return true
+	return _unregister_profile(state, null)
 
 
 ## 请求异步保存 profile。
@@ -445,82 +464,7 @@ func save_profile(
 	profile_id: StringName,
 	request: GFSaveProfileRequest = null
 ) -> GFSaveProfileOperation:
-	if not _admission_open:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_SAVE,
-			profile_id,
-			GFSaveProfileResult.STATUS_BUSY,
-			ERR_BUSY,
-			"Save Profile Utility is quiescing."
-		)
-	var state: ProfileState = _get_state(profile_id)
-	if state == null or _disposed:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_SAVE,
-			profile_id,
-			GFSaveProfileResult.STATUS_INVALID_PROFILE,
-			ERR_DOES_NOT_EXIST,
-			"Save profile is not registered."
-		)
-	if not state.save_enabled:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_SAVE,
-			profile_id,
-			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION,
-			ERR_UNAVAILABLE,
-			"Save is disabled for this Profile."
-		)
-	if _unsafe_callback_depth > 0 or _is_load_active(state):
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_SAVE,
-			profile_id,
-			GFSaveProfileResult.STATUS_BUSY,
-			ERR_BUSY,
-			"Save is not accepted during load/apply or a Provider callback."
-		)
-	var owned_request: GFSaveProfileRequest = request
-	if owned_request == null:
-		owned_request = GFSaveProfileRequest.take_ownership({}, {}, {})
-	var claim: Dictionary = owned_request.claim_for_framework()
-	if claim.is_empty():
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_SAVE,
-			profile_id,
-			GFSaveProfileResult.STATUS_INVALID_REQUEST,
-			ERR_INVALID_PARAMETER,
-			"Save request is invalid or already claimed."
-		)
-	var document_metadata_value: Variant = claim.get("document_metadata")
-	var context_value: Variant = claim.get("context")
-	var result_metadata_value: Variant = claim.get("result_metadata")
-	if (
-		not document_metadata_value is Dictionary
-		or not context_value is Dictionary
-		or not result_metadata_value is Dictionary
-	):
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_SAVE,
-			profile_id,
-			GFSaveProfileResult.STATUS_INVALID_REQUEST,
-			ERR_INVALID_DATA,
-			"Save request ownership record is invalid."
-		)
-	var document_metadata: Dictionary = document_metadata_value
-	var context: Dictionary = context_value
-	var result_metadata: Dictionary = result_metadata_value
-	_begin_processing()
-	state.generation += 1
-	state.latest_save_metadata = document_metadata
-	state.latest_save_context = context
-	var operation: GFSaveProfileOperation = _make_save_operation(
-		profile_id,
-		state.generation,
-		result_metadata
-	)
-	state.save_operations.append(operation)
-	_enqueue_schedule(state)
-	_end_processing()
-	return operation
+	return _request_save_profile(profile_id, request, null, [])
 
 
 ## 请求异步读取、迁移、校验并应用 profile。
@@ -547,51 +491,7 @@ func load_profile(
 	context: Dictionary = {},
 	metadata: Dictionary = {}
 ) -> GFSaveProfileOperation:
-	if not _admission_open:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_LOAD,
-			profile_id,
-			GFSaveProfileResult.STATUS_BUSY,
-			ERR_BUSY,
-			"Save Profile Utility is quiescing."
-		)
-	var state: ProfileState = _get_state(profile_id)
-	if state == null or _disposed:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_LOAD,
-			profile_id,
-			GFSaveProfileResult.STATUS_INVALID_PROFILE,
-			ERR_DOES_NOT_EXIST,
-			"Save profile is not registered."
-		)
-	if not state.load_enabled:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_LOAD,
-			profile_id,
-			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION,
-			ERR_UNAVAILABLE,
-			"Load is disabled for this Profile."
-		)
-	if _unsafe_callback_depth > 0:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_LOAD,
-			profile_id,
-			GFSaveProfileResult.STATUS_BUSY,
-			ERR_BUSY,
-			"Load is not accepted from a Provider or state callback."
-		)
-	_begin_processing()
-	var operation: GFSaveProfileOperation = _make_operation(
-		GFSaveProfileOperation.OPERATION_LOAD,
-		profile_id,
-		state.generation,
-		context,
-		metadata
-	)
-	state.load_operations.append(operation)
-	_enqueue_schedule(state)
-	_end_processing()
-	return operation
+	return _request_load_profile(profile_id, context, metadata, null, false)
 
 
 ## 等待调用时可见的最新 generation 持久化。
@@ -611,53 +511,7 @@ func flush_profile(
 	profile_id: StringName,
 	metadata: Dictionary = {}
 ) -> GFSaveProfileOperation:
-	if not _admission_open:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_FLUSH,
-			profile_id,
-			GFSaveProfileResult.STATUS_BUSY,
-			ERR_BUSY,
-			"Save Profile Utility is quiescing."
-		)
-	var state: ProfileState = _get_state(profile_id)
-	if state == null or _disposed:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_FLUSH,
-			profile_id,
-			GFSaveProfileResult.STATUS_INVALID_PROFILE,
-			ERR_DOES_NOT_EXIST,
-			"Save profile is not registered."
-		)
-	if not state.save_enabled:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_FLUSH,
-			profile_id,
-			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION,
-			ERR_UNAVAILABLE,
-			"Flush is disabled for this Profile."
-		)
-	if _unsafe_callback_depth > 0:
-		return _make_rejected_operation(
-			GFSaveProfileOperation.OPERATION_FLUSH,
-			profile_id,
-			GFSaveProfileResult.STATUS_BUSY,
-			ERR_BUSY,
-			"Flush is not accepted from a Provider or state callback."
-		)
-	_begin_processing()
-	var operation: GFSaveProfileOperation = _make_operation(
-		GFSaveProfileOperation.OPERATION_FLUSH,
-		profile_id,
-		state.generation,
-		{},
-		metadata
-	)
-	state.flush_operations.append(operation)
-	_complete_ready_flushes(state)
-	if not operation.is_completed():
-		_enqueue_schedule(state)
-	_end_processing()
-	return operation
+	return _request_flush_profile(profile_id, metadata, null)
 
 
 ## 获取已成功持久化的 generation。
@@ -716,7 +570,895 @@ func get_profile_state_snapshot(profile_id: StringName) -> Dictionary:
 	}
 
 
+# --- 框架内部方法 ---
+
+## 为事务协调器原子声明一个已注册 Profile 的管理所有权。
+##
+## 返回值是 Utility 创建的 opaque capability；调用方不得公开、复制或伪造它。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 已注册且空闲的 Profile ID。
+## [br]
+## @param owner: 管理该 Profile 的协调器实例。
+## [br]
+## @return 成功时返回 opaque permit；否则返回 null。
+func claim_profile_management_for_framework(
+	profile_id: StringName,
+	owner: Object
+) -> RefCounted:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or owner == null
+		or state == null
+		or state.memory_transaction_active
+		or state.managed_permit != null
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or not state.detached_write_operations.is_empty()
+	):
+		return null
+	var permit: ManagedProfilePermit = ManagedProfilePermit.new()
+	if not permit.configure_for_framework(owner, _next_management_serial):
+		return null
+	_next_management_serial += 1
+	state.managed_permit = permit
+	state.managed_access = MANAGED_ACCESS_BLOCKED
+	return permit
+
+
+## 更新受管 Profile 的直接操作权限。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @param access: `MANAGED_ACCESS_*` 常量之一。
+## [br]
+## @return BLOCKED 在 capability 匹配时立即生效；放宽权限还要求稳定且准入开放。
+func set_profile_managed_access_for_framework(
+	profile_id: StringName,
+	permit: RefCounted,
+	access: int
+) -> bool:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	if (
+		state == null
+		or not _is_valid_managed_permit(state, permit)
+		or access not in [MANAGED_ACCESS_BLOCKED, MANAGED_ACCESS_SAVE_FLUSH]
+	):
+		return false
+	if access == MANAGED_ACCESS_BLOCKED:
+		state.managed_access = MANAGED_ACCESS_BLOCKED
+		return true
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or state.memory_transaction_active
+	):
+		return false
+	state.managed_access = access
+	return true
+
+
+## 释放一个空闲 Profile 的管理 capability。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @return Profile 空闲且 capability 匹配时返回 true。
+func release_profile_management_for_framework(
+	profile_id: StringName,
+	permit: RefCounted
+) -> bool:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or state == null
+		or state.memory_transaction_active
+		or not _is_valid_managed_permit(state, permit)
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or not state.detached_write_operations.is_empty()
+	):
+		return false
+	state.managed_permit.invalidate_for_framework()
+	state.managed_permit = null
+	state.managed_access = MANAGED_ACCESS_BLOCKED
+	return true
+
+
+## 放弃一个 management capability，并立即关闭该 Profile 的全部受管与直接准入。
+##
+## 已接纳的低层工作不会被取消；Utility 会在 pending、内存事务与物理写入尾部
+## 全部收敛后自动清理失效 capability。该入口只减少权限，可用于 manager 关闭路径。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @return capability 身份匹配且已被失效时返回 true。
+func abandon_profile_management_for_framework(
+	profile_id: StringName,
+	permit: RefCounted
+) -> bool:
+	var state: ProfileState = _get_state(profile_id)
+	if (
+		_disposed
+		or state == null
+		or permit == null
+		or state.managed_permit == null
+		or state.managed_permit != permit
+	):
+		return false
+	state.managed_access = MANAGED_ACCESS_BLOCKED
+	state.managed_permit.invalidate_for_framework()
+	_reap_expired_managed_permit_if_safe(state)
+	return true
+
+
+## 以 manager capability 请求保存。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param request: 一次性保存请求。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @param section_overrides: 当前 generation 必须原样持久化的候选 section。
+## [br]
+## @return 低层保存操作；capability 无效时返回失败句柄且不 claim request。
+func save_profile_for_manager_for_framework(
+	profile_id: StringName,
+	request: GFSaveProfileRequest,
+	permit: RefCounted,
+	section_overrides: Array[GFSaveSection] = []
+) -> GFSaveProfileOperation:
+	return _request_save_profile(profile_id, request, permit, section_overrides)
+
+
+## 以 manager capability 请求严格读取。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param context: Provider 与迁移临时上下文。
+## [br]
+## @param metadata: 低层结果元数据。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @schema context: Dictionary with caller-defined ephemeral operation data.
+## [br]
+## @schema metadata: Dictionary with caller-defined result metadata.
+## [br]
+## @return 忽略 `ACTION_USE_CURRENT_STATE` 的低层读取操作。
+func load_profile_strict_for_manager_for_framework(
+	profile_id: StringName,
+	context: Dictionary,
+	metadata: Dictionary,
+	permit: RefCounted
+) -> GFSaveProfileOperation:
+	return _request_load_profile(profile_id, context, metadata, permit, true)
+
+
+## 以 manager capability 请求 flush。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param metadata: 低层结果元数据。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @schema metadata: Dictionary with caller-defined result metadata.
+## [br]
+## @return 低层 flush 操作。
+func flush_profile_for_manager_for_framework(
+	profile_id: StringName,
+	metadata: Dictionary,
+	permit: RefCounted
+) -> GFSaveProfileOperation:
+	return _request_flush_profile(profile_id, metadata, permit)
+
+
+## 以 manager capability 注销 Profile。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @return 注销成功时返回 true。
+func unregister_profile_for_manager_for_framework(
+	profile_id: StringName,
+	permit: RefCounted
+) -> bool:
+	return _unregister_profile(_get_state(profile_id), permit)
+
+
+## 获取事务协调器所需的无载荷编译描述。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 已注册 Profile ID。
+## [br]
+## @return 编译身份、能力与 Provider 引用；不存在时为空。
+## [br]
+## @schema return: Internal Dictionary with profile_id, schema_id, schema_version, save_enabled, load_enabled, providers, and generation fields.
+func get_profile_descriptor_for_manager_for_framework(profile_id: StringName) -> Dictionary:
+	var state: ProfileState = _get_state(profile_id)
+	if state == null:
+		return {}
+	return {
+		"profile_id": state.profile_id,
+		"schema_id": state.schema_id,
+		"schema_version": state.schema_version,
+		"save_enabled": state.save_enabled,
+		"load_enabled": state.load_enabled,
+		"providers": state.providers.duplicate(),
+		"generation": state.generation,
+	}
+
+
+## 查询 generation 的竞态安全持久化证据。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: Profile ID。
+## [br]
+## @param generation: 正数目标 generation。
+## [br]
+## @return payload-free evidence；Profile 或 generation 无效时为空。
+## [br]
+## @schema return: Internal Dictionary with state, profile_id, generation, persisted_generation, status, error_code, error, and storage_request_ids fields.
+func get_generation_evidence_for_framework(
+	profile_id: StringName,
+	generation: int
+) -> Dictionary:
+	var state: ProfileState = _get_state(profile_id)
+	if state == null or generation <= 0:
+		return {}
+	var evidence: Dictionary = {
+		"state": &"pending",
+		"profile_id": profile_id,
+		"generation": generation,
+		"persisted_generation": state.persisted_generation,
+		"status": &"",
+		"error_code": int(OK),
+		"error": "",
+		"storage_request_ids": PackedInt64Array(),
+	}
+	var barrier_failure: Dictionary = _get_barrier_failure(state, generation)
+	if not barrier_failure.is_empty():
+		var failure_status: StringName = GFVariantData.get_option_string_name(
+			barrier_failure,
+			"status"
+		)
+		evidence["state"] = (
+			&"outcome_unknown"
+			if failure_status == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN
+			else &"failed"
+		)
+		evidence["status"] = failure_status
+		evidence["error_code"] = GFVariantData.get_option_int(
+			barrier_failure,
+			"error_code",
+			int(FAILED)
+		)
+		evidence["error"] = GFVariantData.get_option_string(barrier_failure, "error")
+		evidence["storage_request_ids"] = _get_request_id_array(
+			GFVariantData.get_option_value(barrier_failure, "storage_request_ids")
+		)
+		return evidence
+	if generation <= state.persisted_generation:
+		evidence["state"] = &"persisted"
+		return evidence
+	if not _has_pending_save_covering_generation(state, generation):
+		evidence["state"] = &"unresolved"
+	return evidence
+
+
+## 捕获并应用受管 Profile 的完整 section replacement 候选。
+##
+## 本方法只执行内存阶段；调用方必须保留成功结果中的 snapshots，直到持久化
+## 确认或显式逆序回滚。结果不得进入外部日志。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管且空闲的活动 Profile ID。
+## [br]
+## @param candidates: 已完成边界校验的候选 section。
+## [br]
+## @param context: Provider apply/rollback 临时上下文。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @schema context: Dictionary with caller-defined ephemeral operation data.
+## [br]
+## @return 内部 apply 结果；成功结果含 provider_ids 与 snapshots。
+## [br]
+## @schema return: Internal Dictionary with ok, failure_stage, failed_section_id, error_code, error, rollback_errors, provider_ids, and snapshots fields.
+func apply_profile_candidates_for_manager_for_framework(
+	profile_id: StringName,
+	candidates: Array[GFSaveSection],
+	context: Dictionary,
+	permit: RefCounted
+) -> Dictionary:
+	var state: ProfileState = _get_state(profile_id)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or not _is_valid_managed_permit(state, permit)
+		or _unsafe_callback_depth > 0
+		or state.memory_transaction_active
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or not state.detached_write_operations.is_empty()
+		or candidates.is_empty()
+	):
+		return _make_candidate_failure(
+			&"admission",
+			&"",
+			ERR_BUSY,
+			"Managed Profile candidates are not admitted in the current state."
+		)
+	state.memory_transaction_active = true
+	_begin_processing()
+	var candidates_by_id: Dictionary = {}
+	for candidate: GFSaveSection in candidates:
+		if candidate == null:
+			return _finish_managed_memory_transaction(state, _make_candidate_failure(
+				&"validation",
+				&"",
+				ERR_INVALID_DATA,
+				"Candidate section is null."
+			))
+		var section_id: StringName = candidate.get_section_id()
+		if section_id == &"" or candidates_by_id.has(section_id):
+			return _finish_managed_memory_transaction(state, _make_candidate_failure(
+				&"validation",
+				section_id,
+				ERR_INVALID_DATA,
+				"Candidate section IDs must be non-empty and unique."
+			))
+		candidates_by_id[section_id] = candidate
+	var ordered_providers: Array[GFSaveSectionProvider] = []
+	var snapshots: Dictionary = {}
+	for provider: GFSaveSectionProvider in state.providers:
+		if provider == null or not candidates_by_id.has(provider.section_id):
+			continue
+		var candidate: GFSaveSection = _get_section_value(
+			GFVariantData.get_option_value(candidates_by_id, provider.section_id)
+		)
+		if (
+			candidate == null
+			or candidate.get_schema_version() != provider.schema_version
+			or not provider.load_enabled
+			or not provider.save_enabled
+			or not GFVariantData.get_option_bool(candidate.validate_section(), "ok", false)
+		):
+			return _finish_managed_memory_transaction(state, _make_candidate_failure(
+				&"validation",
+				provider.section_id,
+				ERR_INVALID_DATA,
+				"Candidate section does not match a mutable persisted Provider."
+			))
+		_enter_unsafe_callback()
+		var snapshot: GFSaveSection = provider.capture_section(context)
+		_exit_unsafe_callback()
+		var permit_remains_valid: bool = _is_valid_managed_permit(state, permit)
+		if (
+			snapshot == null
+			or _dispose_requested
+			or not _admission_open
+			or not permit_remains_valid
+		):
+			var snapshot_error_code: Error = ERR_INVALID_DATA
+			var snapshot_error: String = (
+				"Save section Provider failed to capture a mutation rollback snapshot."
+			)
+			if _dispose_requested:
+				snapshot_error_code = ERR_UNAVAILABLE
+				snapshot_error = "Save Profile Utility was disposed during mutation capture."
+			elif not _admission_open:
+				snapshot_error_code = ERR_BUSY
+				snapshot_error = "Save Profile Utility began quiescing during mutation capture."
+			elif not permit_remains_valid:
+				snapshot_error_code = ERR_UNAUTHORIZED
+				snapshot_error = (
+					"Managed Profile authority was abandoned during mutation capture."
+				)
+			return _finish_managed_memory_transaction(state, _make_candidate_failure(
+				&"snapshot",
+				provider.section_id,
+				snapshot_error_code,
+				snapshot_error
+			))
+		ordered_providers.append(provider)
+		snapshots[provider.section_id] = snapshot
+	if ordered_providers.size() != candidates_by_id.size():
+		return _finish_managed_memory_transaction(state, _make_candidate_failure(
+			&"validation",
+			&"",
+			ERR_DOES_NOT_EXIST,
+			"At least one candidate section is not owned by the Profile."
+		))
+	var attempted: Array[GFSaveSectionProvider] = []
+	for provider: GFSaveSectionProvider in ordered_providers:
+		attempted.append(provider)
+		var candidate: GFSaveSection = _get_section_value(
+			GFVariantData.get_option_value(candidates_by_id, provider.section_id)
+		)
+		_enter_unsafe_callback()
+		var apply_error: Error = provider.apply_section(candidate, context)
+		_exit_unsafe_callback()
+		var permit_remains_valid: bool = _is_valid_managed_permit(state, permit)
+		if (
+			apply_error == OK
+			and not _dispose_requested
+			and _admission_open
+			and permit_remains_valid
+		):
+			continue
+		var rollback_errors: Array[GFSaveRollbackFailure] = _rollback_providers(
+			attempted,
+			snapshots,
+			context
+		)
+		var terminal_apply_error: Error = apply_error
+		var apply_error_message: String = (
+			"Save section Provider failed to apply a mutation candidate."
+		)
+		if _dispose_requested:
+			terminal_apply_error = ERR_UNAVAILABLE
+			apply_error_message = "Save Profile Utility was disposed during mutation apply."
+		elif not _admission_open:
+			terminal_apply_error = ERR_BUSY
+			apply_error_message = "Save Profile Utility began quiescing during mutation apply."
+		elif not permit_remains_valid:
+			terminal_apply_error = ERR_UNAUTHORIZED
+			apply_error_message = "Managed Profile authority was abandoned during mutation apply."
+		var failure: Dictionary = _make_candidate_failure(
+			&"apply",
+			provider.section_id,
+			terminal_apply_error,
+			apply_error_message
+		)
+		failure["rollback_errors"] = rollback_errors
+		return _finish_managed_memory_transaction(state, failure)
+	var provider_ids: PackedStringArray = PackedStringArray()
+	for provider: GFSaveSectionProvider in ordered_providers:
+		var _appended: bool = provider_ids.append(String(provider.section_id))
+	return _finish_managed_memory_transaction(state, {
+		"ok": true,
+		"provider_ids": provider_ids,
+		"snapshots": snapshots,
+		"rollback_errors": [],
+	})
+
+
+## 逆序恢复一次已成功 apply 的受管候选集合。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param provider_ids: apply 时返回的稳定 Provider 顺序。
+## [br]
+## @param snapshots: apply 时返回的内部回滚快照。
+## [br]
+## @param context: Provider rollback 临时上下文。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @schema snapshots: Internal Dictionary keyed by section ID with GFSaveSection values.
+## [br]
+## @schema context: Dictionary with caller-defined ephemeral operation data.
+## [br]
+## @return 按逆序排列的回滚失败证据。
+func rollback_profile_candidates_for_manager_for_framework(
+	profile_id: StringName,
+	provider_ids: PackedStringArray,
+	snapshots: Dictionary,
+	context: Dictionary,
+	permit: RefCounted
+) -> Array[GFSaveRollbackFailure]:
+	var state: ProfileState = _get_state(profile_id)
+	var providers: Array[GFSaveSectionProvider] = []
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or not _is_valid_managed_permit(state, permit)
+		or _unsafe_callback_depth > 0
+		or state.memory_transaction_active
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or not state.detached_write_operations.is_empty()
+	):
+		return _make_management_rollback_failure(provider_ids)
+	state.memory_transaction_active = true
+	_begin_processing()
+	for provider_id: String in provider_ids:
+		var selected: GFSaveSectionProvider = null
+		for provider: GFSaveSectionProvider in state.providers:
+			if provider != null and provider.section_id == StringName(provider_id):
+				selected = provider
+				break
+		if selected == null:
+			return _finish_managed_memory_rollback(
+				state,
+				_make_management_rollback_failure(provider_ids)
+			)
+		providers.append(selected)
+	return _finish_managed_memory_rollback(
+		state,
+		_rollback_providers(providers, snapshots, context)
+	)
+
+
 # --- 私有/辅助方法 ---
+
+func _unregister_profile(state: ProfileState, managed_permit: RefCounted) -> bool:
+	_reap_expired_managed_permit_if_safe(state)
+	var managed_call: bool = _is_valid_managed_permit(state, managed_permit)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or state == null
+		or state.memory_transaction_active
+		or (managed_permit != null and not managed_call)
+		or (managed_permit == null and state.managed_permit != null)
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or not state.detached_write_operations.is_empty()
+		or state.pending_schedule_enqueued
+		or state.active_preparation_enqueued
+	):
+		return false
+	if state.managed_permit != null:
+		state.managed_permit.invalidate_for_framework()
+		state.managed_permit = null
+	var _erased: bool = _states.erase(state.profile_id)
+	return true
+
+
+func _request_save_profile(
+	profile_id: StringName,
+	request: GFSaveProfileRequest,
+	managed_permit: RefCounted,
+	section_overrides: Array[GFSaveSection]
+) -> GFSaveProfileOperation:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	var managed_call: bool = _is_valid_managed_permit(state, managed_permit)
+	if not _admission_open:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save Profile Utility is quiescing."
+		)
+	if state == null or _disposed:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Save profile is not registered."
+		)
+	if managed_permit != null and not managed_call:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_REQUEST,
+			ERR_UNAUTHORIZED,
+			"Managed Profile permit is invalid."
+		)
+	if not managed_call and not _is_direct_managed_operation_allowed(
+		state,
+		GFSaveProfileOperation.OPERATION_SAVE
+	):
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Managed Profile save is not admitted in the current domain state."
+		)
+	if (
+		state.managed_permit != null
+		and not state.detached_write_operations.is_empty()
+	):
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Managed Profile save is blocked until every detached write settles."
+		)
+	if not state.save_enabled:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Save is disabled for this Profile."
+		)
+	if (
+		_unsafe_callback_depth > 0
+		or state.memory_transaction_active
+		or _is_load_active(state)
+	):
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save is not accepted during load/apply or a Provider callback."
+		)
+	var compiled_overrides: Dictionary = _compile_section_overrides(
+		state,
+		section_overrides
+	)
+	if not section_overrides.is_empty() and compiled_overrides.size() != section_overrides.size():
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_DATA,
+			"Managed save section overrides do not match the Profile definition."
+		)
+	var owned_request: GFSaveProfileRequest = request
+	if owned_request == null:
+		owned_request = GFSaveProfileRequest.take_ownership({}, {}, {})
+	var claim: Dictionary = owned_request.claim_for_framework()
+	if claim.is_empty():
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_PARAMETER,
+			"Save request is invalid or already claimed."
+		)
+	var document_metadata_value: Variant = claim.get("document_metadata")
+	var context_value: Variant = claim.get("context")
+	var result_metadata_value: Variant = claim.get("result_metadata")
+	if (
+		not document_metadata_value is Dictionary
+		or not context_value is Dictionary
+		or not result_metadata_value is Dictionary
+	):
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_SAVE,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_DATA,
+			"Save request ownership record is invalid."
+		)
+	var document_metadata: Dictionary = document_metadata_value
+	var context: Dictionary = context_value
+	var result_metadata: Dictionary = result_metadata_value
+	_begin_processing()
+	state.generation += 1
+	state.latest_save_metadata = document_metadata
+	state.latest_save_context = context
+	state.latest_save_section_overrides = compiled_overrides
+	var operation: GFSaveProfileOperation = _make_save_operation(
+		profile_id,
+		state.generation,
+		result_metadata
+	)
+	state.save_operations.append(operation)
+	_enqueue_schedule(state)
+	_end_processing()
+	return operation
+
+
+func _request_load_profile(
+	profile_id: StringName,
+	context: Dictionary,
+	metadata: Dictionary,
+	managed_permit: RefCounted,
+	strict_recovery: bool
+) -> GFSaveProfileOperation:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	var managed_call: bool = _is_valid_managed_permit(state, managed_permit)
+	if not _admission_open:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save Profile Utility is quiescing."
+		)
+	if state == null or _disposed:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Save profile is not registered."
+		)
+	if managed_permit != null and not managed_call:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_REQUEST,
+			ERR_UNAUTHORIZED,
+			"Managed Profile permit is invalid."
+		)
+	if not managed_call and not _is_direct_managed_operation_allowed(
+		state,
+		GFSaveProfileOperation.OPERATION_LOAD
+	):
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Managed Profile load must use its transaction coordinator."
+		)
+	if not state.load_enabled:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Load is disabled for this Profile."
+		)
+	if _unsafe_callback_depth > 0 or state.memory_transaction_active:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_LOAD,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Load is not accepted from a Provider or state callback."
+		)
+	_begin_processing()
+	var operation: GFSaveProfileOperation = _make_operation(
+		GFSaveProfileOperation.OPERATION_LOAD,
+		profile_id,
+		state.generation,
+		context,
+		metadata,
+		strict_recovery,
+		managed_permit
+	)
+	state.load_operations.append(operation)
+	_enqueue_schedule(state)
+	_end_processing()
+	return operation
+
+
+func _request_flush_profile(
+	profile_id: StringName,
+	metadata: Dictionary,
+	managed_permit: RefCounted
+) -> GFSaveProfileOperation:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	var managed_call: bool = _is_valid_managed_permit(state, managed_permit)
+	if not _admission_open:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Save Profile Utility is quiescing."
+		)
+	if state == null or _disposed:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_PROFILE,
+			ERR_DOES_NOT_EXIST,
+			"Save profile is not registered."
+		)
+	if managed_permit != null and not managed_call:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_INVALID_REQUEST,
+			ERR_UNAUTHORIZED,
+			"Managed Profile permit is invalid."
+		)
+	if not managed_call and not _is_direct_managed_operation_allowed(
+		state,
+		GFSaveProfileOperation.OPERATION_FLUSH
+	):
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Managed Profile flush is not admitted in the current domain state."
+		)
+	if not state.save_enabled:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Flush is disabled for this Profile."
+		)
+	if _unsafe_callback_depth > 0 or state.memory_transaction_active:
+		return _make_rejected_operation(
+			GFSaveProfileOperation.OPERATION_FLUSH,
+			profile_id,
+			GFSaveProfileResult.STATUS_BUSY,
+			ERR_BUSY,
+			"Flush is not accepted from a Provider or state callback."
+		)
+	_begin_processing()
+	var operation: GFSaveProfileOperation = _make_operation(
+		GFSaveProfileOperation.OPERATION_FLUSH,
+		profile_id,
+		state.generation,
+		{},
+		metadata
+	)
+	state.flush_operations.append(operation)
+	_complete_ready_flushes(state)
+	if not operation.is_completed():
+		_enqueue_schedule(state)
+	_end_processing()
+	return operation
+
 
 func _enqueue_schedule(state: ProfileState) -> void:
 	if (
@@ -891,8 +1633,10 @@ func _start_save(state: ProfileState) -> void:
 	state.current_storage_request_ids = PackedInt64Array()
 	state.current_context = state.latest_save_context
 	state.current_metadata = state.latest_save_metadata
+	state.current_section_overrides = state.latest_save_section_overrides
 	state.latest_save_context = {}
 	state.latest_save_metadata = {}
+	state.latest_save_section_overrides = {}
 	state.current_preparation_provider_index = 0
 	state.current_preserved_section_index = 0
 	state.current_preparation_phase = _PREPARATION_PHASE_PROVIDER_SCAN
@@ -977,6 +1721,31 @@ func _advance_save_preparation(state: ProfileState, work_budget: int) -> int:
 				consumed += 1
 				state.current_preparation_work_units += 1
 				if provider == null or not provider.save_enabled:
+					continue
+				var override: GFSaveSection = _get_section_value(
+					GFVariantData.get_option_value(
+						state.current_section_overrides,
+						provider.section_id
+					)
+				)
+				if override != null:
+					var override_record: Dictionary = (
+						override.get_transfer_record_for_framework()
+					)
+					if override_record.is_empty():
+						_finish_save_failure(
+							state,
+							ERR_INVALID_DATA,
+							"Managed section override could not enter the save transfer.",
+							GFSaveProfileResult.STATUS_PREPARATION_FAILED,
+							provider.section_id
+						)
+						break
+					_store_current_section_record(
+						state,
+						provider.section_id,
+						override_record
+					)
 					continue
 				state.current_preparation_provider = provider
 				state.current_preparation_section_id = provider.section_id
@@ -1177,89 +1946,12 @@ func _schedule_retry(state: ProfileState, error_code: Error) -> bool:
 	return true
 
 
-# 存储终态
-
-func _on_storage_operation_completed(
-	result: GFStorageAsyncResult,
-	profile_id: StringName,
-	request_id: int
-) -> void:
-	if _disposed:
-		return
-	_begin_processing()
-	var state: ProfileState = _get_state(profile_id)
-	if (
-		state == null
-		or state.current_storage_operation == null
-		or state.current_storage_operation.get_request_id() != request_id
-		or result == null
-		or result.get_request_id() != request_id
-	):
-		_end_processing()
-		return
-	_complete_current_io_timing(state)
-	_clear_current_storage_operation(state)
-	if result.get_operation() == GFStorageAsyncOperation.OPERATION_SAVE:
-		if not result.is_successful():
-			if (
-				result.get_write_failure_kind()
-					== GFStorageAsyncResult.WriteFailureKind.PAYLOAD_INVALID
-			):
-				var adapted_validation: Dictionary = (
-					_PAYLOAD_VALIDATION_ADAPTER.adapt_for_framework(
-						result.get_write_validation_report(),
-						state.current_sections_entry_index,
-						state.current_section_ids_by_entry_index
-					)
-				)
-				_finish_save_failure(
-					state,
-					result.get_error_code(),
-					"Storage worker rejected the prepared Save payload.",
-					GFSaveProfileResult.STATUS_PREPARATION_FAILED,
-					GFVariantData.get_option_string_name(
-						adapted_validation,
-						"failed_section_id"
-					),
-					GFVariantData.get_option_dictionary(
-						adapted_validation,
-						"validation_report"
-					)
-				)
-			else:
-				_handle_save_failure(state, result.get_error_code(), "Storage save failed.")
-		else:
-			_finalize_save_timing_for_terminal(state)
-			state.persisted_generation = maxi(state.persisted_generation, state.current_generation)
-			_clear_generation_evidence_through(state, state.current_generation)
-			_complete_save_operations_success(state)
-			_clear_current(state)
-			_set_mode(state, STATE_IDLE)
-			_complete_ready_flushes(state)
-			_enqueue_schedule(state)
-	elif result.get_operation() == GFStorageAsyncOperation.OPERATION_LOAD:
-		var read_result: GFStorageReadResult = result.get_read_result()
-		if read_result == null:
-			_handle_load_failure(
-				state,
-				GFStorageReadResult.new().configure_failure(
-					"Storage returned no read result.",
-					FAILED,
-					{},
-					GFStorageReadResult.IntegrityStatus.NOT_CHECKED,
-					0,
-					GFStorageReadResult.FailureKind.IO_FAILED
-				)
-			)
-		elif not read_result.ok or not read_result.is_integrity_accepted():
-			_handle_load_failure(state, read_result)
-		else:
-			_process_loaded_document(state, read_result)
-	_end_processing()
 
 
 func _handle_save_failure(state: ProfileState, error_code: Error, error: String) -> void:
 	if _schedule_retry(state, error_code):
+		if state.unknown_write_generations.has(state.current_generation):
+			_emit_generation_evidence_changed(state, state.current_generation)
 		return
 	_finish_save_failure(
 		state,
@@ -1291,7 +1983,10 @@ func _handle_load_failure(state: ProfileState, result: GFStorageReadResult) -> v
 	):
 		status = GFSaveProfileResult.STATUS_CORRUPT
 		recovery_action = state.recovery_policy.corrupt_file_action
-	if recovery_action == GFSaveRecoveryPolicy.ACTION_USE_CURRENT_STATE:
+	if (
+		recovery_action == GFSaveRecoveryPolicy.ACTION_USE_CURRENT_STATE
+		and not _current_load_requires_strict_recovery(state)
+	):
 		_finish_load_success(
 			state,
 			GFSaveProfileResult.STATUS_RECOVERED,
@@ -1315,6 +2010,14 @@ func _handle_load_failure(state: ProfileState, result: GFStorageReadResult) -> v
 
 func _process_loaded_document(state: ProfileState, storage_result: GFStorageReadResult) -> void:
 	_set_mode(state, STATE_APPLYING)
+	if not _is_current_managed_load_authorized(state):
+		_finish_load_failure(
+			state,
+			GFSaveProfileResult.STATUS_DISPOSED,
+			ERR_UNAVAILABLE,
+			"Managed load capability was revoked before document apply."
+		)
+		return
 	var inspection: Dictionary = GFSaveDocument.inspect_dict(storage_result.payload)
 	if not GFVariantData.get_option_bool(inspection, "ok", false):
 		_handle_corrupt_document(state, storage_result, inspection)
@@ -1404,7 +2107,11 @@ func _process_loaded_document(state: ProfileState, storage_result: GFStorageRead
 		var status: StringName = GFSaveProfileResult.STATUS_APPLY_FAILED
 		if failure_stage == &"snapshot":
 			status = GFSaveProfileResult.STATUS_SNAPSHOT_FAILED
+		elif failure_stage == &"disposed":
+			status = GFSaveProfileResult.STATUS_DISPOSED
 		elif not rollback_errors.is_empty():
+			status = GFSaveProfileResult.STATUS_ROLLBACK_FAILED
+		if not rollback_errors.is_empty():
 			status = GFSaveProfileResult.STATUS_ROLLBACK_FAILED
 		_finish_load_failure(
 			state,
@@ -1447,9 +2154,13 @@ func _apply_document_transactionally(
 	for provider: GFSaveSectionProvider in state.providers:
 		if provider == null or not provider.load_enabled or not document.has_section(provider.section_id):
 			continue
+		if not _is_current_managed_load_authorized(state):
+			return _make_revoked_load_failure(provider.section_id)
 		_enter_unsafe_callback()
 		var snapshot: GFSaveSection = provider.capture_section(context)
 		_exit_unsafe_callback()
+		if not _is_current_managed_load_authorized(state):
+			return _make_revoked_load_failure(provider.section_id)
 		if snapshot == null:
 			return {
 				"ok": false,
@@ -1463,6 +2174,15 @@ func _apply_document_transactionally(
 		snapshots[provider.section_id] = snapshot
 	var attempted: Array[GFSaveSectionProvider] = []
 	for provider: GFSaveSectionProvider in providers:
+		if not _is_current_managed_load_authorized(state):
+			var revoked_rollback_errors: Array[GFSaveRollbackFailure] = (
+				_rollback_providers(attempted, snapshots, context)
+			)
+			var revoked_failure: Dictionary = _make_revoked_load_failure(
+				provider.section_id
+			)
+			revoked_failure["rollback_errors"] = revoked_rollback_errors
+			return revoked_failure
 		attempted.append(provider)
 		_enter_unsafe_callback()
 		var apply_error: Error = provider.apply_section(
@@ -1470,7 +2190,10 @@ func _apply_document_transactionally(
 			context
 		)
 		_exit_unsafe_callback()
-		if apply_error == OK:
+		var authorization_revoked: bool = (
+			not _is_current_managed_load_authorized(state)
+		)
+		if apply_error == OK and not authorization_revoked:
 			continue
 		var rollback_errors: Array[GFSaveRollbackFailure] = _rollback_providers(
 			attempted,
@@ -1479,12 +2202,28 @@ func _apply_document_transactionally(
 		)
 		return {
 			"ok": false,
-			"error_code": apply_error,
-			"error": "Save section provider failed to apply its section.",
+			"error_code": ERR_UNAVAILABLE if authorization_revoked else apply_error,
+			"error": (
+				"Managed load capability was revoked during Provider apply."
+				if authorization_revoked
+				else "Save section provider failed to apply its section."
+			),
 			"failed_section_id": provider.section_id,
 			"rollback_errors": rollback_errors,
+			"failure_stage": &"disposed" if authorization_revoked else &"apply",
 		}
 	return {"ok": true}
+
+
+func _make_revoked_load_failure(section_id: StringName) -> Dictionary:
+	return {
+		"ok": false,
+		"error_code": ERR_UNAVAILABLE,
+		"error": "Managed load capability was revoked before Provider apply.",
+		"failed_section_id": section_id,
+		"rollback_errors": [],
+		"failure_stage": &"disposed",
+	}
 
 
 func _rollback_providers(
@@ -1514,7 +2253,10 @@ func _handle_corrupt_document(
 	validation_report: Dictionary
 ) -> void:
 	var action: StringName = state.recovery_policy.corrupt_file_action
-	if action == GFSaveRecoveryPolicy.ACTION_USE_CURRENT_STATE:
+	if (
+		action == GFSaveRecoveryPolicy.ACTION_USE_CURRENT_STATE
+		and not _current_load_requires_strict_recovery(state)
+	):
 		_finish_load_success(
 			state,
 			GFSaveProfileResult.STATUS_RECOVERED,
@@ -1583,6 +2325,7 @@ func _complete_save_operations_success_through(
 	if generation >= state.generation:
 		state.latest_save_context = {}
 		state.latest_save_metadata = {}
+		state.latest_save_section_overrides = {}
 
 
 func _finish_save_failure(
@@ -1593,24 +2336,25 @@ func _finish_save_failure(
 	failed_section_id: StringName = &"",
 	validation_report: Dictionary = {}
 ) -> void:
+	var failed_generation: int = state.current_generation
 	_finalize_save_timing_for_terminal(state)
 	_record_generation_failure(
 		state,
-		state.current_generation,
+		failed_generation,
 		status,
 		error_code,
 		error,
 		failed_section_id,
 		state.current_storage_request_ids
 	)
-	state.last_failed_generation = maxi(state.last_failed_generation, state.current_generation)
+	state.last_failed_generation = maxi(state.last_failed_generation, failed_generation)
 	state.last_failure_status = status
 	state.last_failure_error_code = error_code
 	state.last_failure_error = error
 	state.last_failure_section_id = failed_section_id
 	var remaining: Array[GFSaveProfileOperation] = []
 	for operation: GFSaveProfileOperation in state.save_operations:
-		if operation.get_requested_generation() <= state.current_generation:
+		if operation.get_requested_generation() <= failed_generation:
 			_complete_operation(
 				state,
 				operation,
@@ -1631,13 +2375,16 @@ func _finish_save_failure(
 		else:
 			remaining.append(operation)
 	state.save_operations = remaining
-	if state.current_generation >= state.generation:
+	if failed_generation >= state.generation:
 		state.latest_save_context = {}
 		state.latest_save_metadata = {}
+		state.latest_save_section_overrides = {}
 	_clear_current(state)
 	_set_mode(state, STATE_IDLE)
 	_complete_ready_flushes(state)
 	_enqueue_schedule(state)
+	_reap_expired_managed_permit_if_safe(state)
+	_emit_generation_evidence_changed(state, failed_generation)
 
 
 func _finish_load_success(
@@ -1653,6 +2400,7 @@ func _finish_load_success(
 	_clear_current(state)
 	_set_mode(state, STATE_IDLE)
 	_enqueue_schedule(state)
+	_reap_expired_managed_permit_if_safe(state)
 
 
 func _finish_load_failure(
@@ -1670,13 +2418,18 @@ func _finish_load_failure(
 	_clear_current(state)
 	_set_mode(state, STATE_IDLE)
 	_enqueue_schedule(state)
+	_reap_expired_managed_permit_if_safe(state)
 
 
 func _complete_ready_flushes(state: ProfileState) -> void:
 	var remaining: Array[GFSaveProfileOperation] = []
 	for operation: GFSaveProfileOperation in state.flush_operations:
 		var target: int = operation.get_requested_generation()
-		if target <= state.persisted_generation:
+		if _has_pending_save_covering_generation(state, target):
+			remaining.append(operation)
+			continue
+		var barrier_failure: Dictionary = _get_barrier_failure(state, target)
+		if target <= state.persisted_generation and barrier_failure.is_empty():
 			var _started: bool = operation.start_for_framework()
 			_complete_operation(
 				state,
@@ -1686,10 +2439,7 @@ func _complete_ready_flushes(state: ProfileState) -> void:
 				OK,
 				""
 			)
-		elif _has_pending_save_covering_generation(state, target):
-			remaining.append(operation)
 		else:
-			var barrier_failure: Dictionary = _get_barrier_failure(state, target)
 			if barrier_failure.is_empty():
 				remaining.append(operation)
 				continue
@@ -1846,6 +2596,7 @@ func _clear_current(state: ProfileState) -> void:
 	state.current_payload_transfer = null
 	state.current_context = {}
 	state.current_metadata = {}
+	state.current_section_overrides = {}
 	state.retry_due_msec = 0
 	state.current_io_deadline_msec = 0
 	state.current_io_started_at_msec = -1
@@ -1859,7 +2610,9 @@ func _make_operation(
 	profile_id: StringName,
 	generation: int,
 	context: Dictionary,
-	result_metadata: Dictionary
+	result_metadata: Dictionary,
+	strict_recovery: bool = false,
+	manager_permit: RefCounted = null
 ) -> GFSaveProfileOperation:
 	var operation: GFSaveProfileOperation = GFSaveProfileOperation.new()
 	var _configured: bool = operation.configure_for_framework(
@@ -1868,7 +2621,9 @@ func _make_operation(
 		generation,
 		_clock.get_monotonic_msec(),
 		context,
-		result_metadata
+		result_metadata,
+		strict_recovery,
+		manager_permit
 	)
 	return operation
 
@@ -1946,6 +2701,9 @@ func _dispose_now() -> void:
 			continue
 		_set_mode(state, STATE_DISPOSED)
 		_complete_all_pending_as_disposed(state)
+		if state.managed_permit != null:
+			state.managed_permit.invalidate_for_framework()
+			state.managed_permit = null
 	_states.clear()
 	_pending_schedule_head = null
 	_pending_schedule_tail = null
@@ -1978,6 +2736,82 @@ func _is_load_active(state: ProfileState) -> bool:
 		state != null
 		and state.current_kind == GFSaveProfileOperation.OPERATION_LOAD
 		and state.mode != STATE_IDLE
+	)
+
+
+func _current_load_requires_strict_recovery(state: ProfileState) -> bool:
+	return (
+		state != null
+		and state.current_load_operation != null
+		and state.current_load_operation.requires_strict_recovery_for_framework()
+	)
+
+
+func _is_current_managed_load_authorized(state: ProfileState) -> bool:
+	if state == null or state.current_load_operation == null:
+		return false
+	var permit: RefCounted = (
+		state.current_load_operation.get_manager_permit_for_framework()
+	)
+	if permit == null:
+		return true
+	return _is_valid_managed_permit(state, permit)
+
+
+func _reap_expired_managed_permit_if_safe(state: ProfileState) -> void:
+	if (
+		state == null
+		or _unsafe_callback_depth > 0
+		or state.managed_permit == null
+		or state.managed_permit.is_active_for_framework()
+	):
+		return
+	state.managed_access = MANAGED_ACCESS_BLOCKED
+	if (
+		state.memory_transaction_active
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or state.current_storage_operation != null
+		or not state.detached_write_operations.is_empty()
+		or state.pending_schedule_enqueued
+		or state.active_preparation_enqueued
+	):
+		return
+	state.managed_permit.invalidate_for_framework()
+	state.managed_permit = null
+
+
+func _block_all_managed_access_for_shutdown() -> void:
+	for state_value: Variant in _states.values():
+		var state: ProfileState = _get_state_value(state_value)
+		if state != null and state.managed_permit != null:
+			state.managed_access = MANAGED_ACCESS_BLOCKED
+
+
+func _is_valid_managed_permit(
+	state: ProfileState,
+	permit_value: RefCounted
+) -> bool:
+	if state == null or state.managed_permit == null or permit_value == null:
+		return false
+	return state.managed_permit == permit_value and state.managed_permit.is_active_for_framework()
+
+
+func _is_direct_managed_operation_allowed(
+	state: ProfileState,
+	operation_kind: StringName
+) -> bool:
+	_reap_expired_managed_permit_if_safe(state)
+	if state == null or state.managed_permit == null:
+		return true
+	if not state.managed_permit.is_active_for_framework():
+		return false
+	return (
+		state.managed_access == MANAGED_ACCESS_SAVE_FLUSH
+		and operation_kind in [
+			GFSaveProfileOperation.OPERATION_SAVE,
+			GFSaveProfileOperation.OPERATION_FLUSH,
+		]
 	)
 
 
@@ -2206,125 +3040,9 @@ func _detach_current_write(state: ProfileState) -> void:
 		) as Error
 
 
-func _on_detached_write_completed(
-	result: GFStorageAsyncResult,
-	profile_id: StringName,
-	request_id: int,
-	generation: int
-) -> void:
-	if _disposed:
-		return
-	_begin_processing()
-	var state: ProfileState = _get_state(profile_id)
-	if state == null or not state.detached_write_operations.has(request_id):
-		_end_processing()
-		return
-	var record: Dictionary = GFVariantData.as_dictionary(
-		state.detached_write_operations.get(request_id, {})
-	)
-	var operation: GFStorageAsyncOperation = _get_storage_operation_value(
-		GFVariantData.get_option_value(record, "operation")
-	)
-	var callback: Callable = _get_callable_value(
-		GFVariantData.get_option_value(record, "callback", Callable())
-	)
-	if operation != null and callback.is_valid() and operation.completed.is_connected(callback):
-		operation.completed.disconnect(callback)
-	var owns_current_retry: bool = (
-		state.current_kind == GFSaveProfileOperation.OPERATION_SAVE
-		and state.current_generation == generation
-		and state.mode != STATE_IDLE
-	)
-	var record_storage_duration_msec: int = GFVariantData.get_option_int(
-		record,
-		"storage_duration_msec"
-	)
-	if owns_current_retry:
-		_account_detached_write_tails(state, generation)
-		record_storage_duration_msec = state.current_storage_duration_msec
-	else:
-		var now_msec: int = _clock.get_monotonic_msec()
-		record_storage_duration_msec += maxi(
-			now_msec - GFVariantData.get_option_int(
-				record,
-				"tail_accounted_at_msec",
-				now_msec
-			),
-			0
-		)
-	var _erased: bool = state.detached_write_operations.erase(request_id)
-	_remove_unknown_request_id(state, generation, request_id)
-	var successful: bool = (
-		result != null
-		and result.get_request_id() == request_id
-		and result.get_operation() == GFStorageAsyncOperation.OPERATION_SAVE
-		and result.is_successful()
-	)
-	if successful:
-		var attempt_count: int = GFVariantData.get_option_int(record, "attempt_count")
-		var preparation_duration_msec: int = GFVariantData.get_option_int(
-			record,
-			"preparation_duration_msec"
-		)
-		var storage_duration_msec: int = record_storage_duration_msec
-		var preparation_work_units: int = GFVariantData.get_option_int(
-			record,
-			"preparation_work_units"
-		)
-		var request_ids: PackedInt64Array = _get_request_id_array(
-			GFVariantData.get_option_value(record, "storage_request_ids", PackedInt64Array())
-		)
-		if owns_current_retry:
-			_complete_current_preparation_timing(state)
-			_complete_current_io_timing(state)
-			attempt_count = maxi(attempt_count, state.current_attempt_count)
-			preparation_duration_msec = maxi(
-				preparation_duration_msec,
-				state.current_preparation_duration_msec
-			)
-			storage_duration_msec = state.current_storage_duration_msec
-			preparation_work_units = maxi(
-				preparation_work_units,
-				state.current_preparation_work_units
-			)
-			for current_request_id: int in state.current_storage_request_ids:
-				_append_request_id(request_ids, current_request_id)
-			if state.current_storage_operation != null:
-				_detach_current_write(state)
-		state.persisted_generation = maxi(state.persisted_generation, generation)
-		_clear_generation_evidence_through(state, generation)
-		_complete_save_operations_success_through(
-			state,
-			generation,
-			attempt_count,
-			request_ids,
-			preparation_duration_msec,
-			storage_duration_msec,
-			preparation_work_units
-		)
-		if owns_current_retry:
-			_clear_current(state)
-			_set_mode(state, STATE_IDLE)
-	elif generation > state.persisted_generation:
-		var error_code: Error = result.get_error_code() if result != null else FAILED
-		if not state.unknown_write_generations.has(generation):
-			_record_generation_failure(
-				state,
-				generation,
-				GFSaveProfileResult.STATUS_STORAGE_FAILED,
-				error_code,
-				"Timed-out Storage write later completed with a failure.",
-				&"",
-				PackedInt64Array([request_id])
-			)
-	_complete_ready_flushes(state)
-	_enqueue_schedule(state)
-	_end_processing()
 
 
 func _get_barrier_failure(state: ProfileState, target_generation: int) -> Dictionary:
-	if target_generation <= state.persisted_generation:
-		return {}
 	var unknown_ids: PackedInt64Array = _get_unknown_request_ids_covering(
 		state,
 		target_generation
@@ -2337,6 +3055,8 @@ func _get_barrier_failure(state: ProfileState, target_generation: int) -> Dictio
 			"failed_section_id": &"",
 			"storage_request_ids": unknown_ids,
 		}
+	if target_generation <= state.persisted_generation:
+		return {}
 	var selected_generation: int = -1
 	var selected_failure: Dictionary = {}
 	for generation_value: Variant in state.generation_failures.keys():
@@ -2384,9 +3104,6 @@ func _clear_generation_evidence_through(state: ProfileState, generation: int) ->
 	for key: Variant in state.generation_failures.keys():
 		if GFVariantData.to_int(key, generation + 1) <= generation:
 			var _erased_failure: bool = state.generation_failures.erase(key)
-	for key: Variant in state.unknown_write_generations.keys():
-		if GFVariantData.to_int(key, generation + 1) <= generation:
-			var _erased_unknown: bool = state.unknown_write_generations.erase(key)
 
 
 func _get_unknown_request_ids_for_generation(
@@ -2518,6 +3235,85 @@ func _get_rollback_failure_array(value: Variant) -> Array[GFSaveRollbackFailure]
 			var failure: GFSaveRollbackFailure = entry
 			result.append(failure.duplicate_failure())
 	return result
+
+
+func _make_candidate_failure(
+	failure_stage: StringName,
+	failed_section_id: StringName,
+	error_code: Error,
+	error: String
+) -> Dictionary:
+	return {
+		"ok": false,
+		"failure_stage": failure_stage,
+		"failed_section_id": failed_section_id,
+		"error_code": int(error_code if error_code != OK else FAILED),
+		"error": error,
+		"rollback_errors": [],
+	}
+
+
+func _finish_managed_memory_transaction(
+	state: ProfileState,
+	result: Dictionary
+) -> Dictionary:
+	if state != null:
+		state.memory_transaction_active = false
+		_reap_expired_managed_permit_if_safe(state)
+	_end_processing()
+	return result
+
+
+func _finish_managed_memory_rollback(
+	state: ProfileState,
+	errors: Array[GFSaveRollbackFailure]
+) -> Array[GFSaveRollbackFailure]:
+	if state != null:
+		state.memory_transaction_active = false
+		_reap_expired_managed_permit_if_safe(state)
+	_end_processing()
+	return errors
+
+
+func _compile_section_overrides(
+	state: ProfileState,
+	sections: Array[GFSaveSection]
+) -> Dictionary:
+	var compiled: Dictionary = {}
+	if state == null:
+		return compiled
+	for section: GFSaveSection in sections:
+		if section == null or compiled.has(section.get_section_id()):
+			return {}
+		var matching_provider: GFSaveSectionProvider = null
+		for provider: GFSaveSectionProvider in state.providers:
+			if provider != null and provider.section_id == section.get_section_id():
+				matching_provider = provider
+				break
+		if (
+			matching_provider == null
+			or not matching_provider.save_enabled
+			or matching_provider.schema_version != section.get_schema_version()
+			or not GFVariantData.get_option_bool(section.validate_section(), "ok", false)
+		):
+			return {}
+		compiled[section.get_section_id()] = section.duplicate_section()
+	return compiled
+
+
+func _make_management_rollback_failure(
+	provider_ids: PackedStringArray
+) -> Array[GFSaveRollbackFailure]:
+	var failures: Array[GFSaveRollbackFailure] = []
+	if provider_ids.is_empty():
+		return failures
+	var failure: GFSaveRollbackFailure = GFSaveRollbackFailure.new()
+	var _configured: bool = failure.configure_for_framework(
+		StringName(provider_ids[provider_ids.size() - 1]),
+		ERR_UNAUTHORIZED
+	)
+	failures.append(failure)
+	return failures
 
 
 func _duplicate_recovery_policy(source: GFSaveRecoveryPolicy) -> GFSaveRecoveryPolicy:
@@ -2690,10 +3486,12 @@ func _try_complete_quiesce() -> void:
 		return
 	for state_value: Variant in _states.values():
 		var state: ProfileState = _get_state_value(state_value)
+		_reap_expired_managed_permit_if_safe(state)
 		if (
 			state != null
 			and (
-				state.mode != STATE_IDLE
+				state.memory_transaction_active
+				or state.mode != STATE_IDLE
 				or _has_pending_operations(state)
 				or state.current_storage_operation != null
 				or not state.detached_write_operations.is_empty()
@@ -2722,6 +3520,14 @@ func _set_mode(state: ProfileState, mode: StringName) -> void:
 	state.mode = mode
 	_enter_unsafe_callback()
 	profile_state_changed.emit(state.profile_id, previous, mode)
+	_exit_unsafe_callback()
+
+
+func _emit_generation_evidence_changed(state: ProfileState, generation: int) -> void:
+	if state == null or generation <= 0 or _disposed:
+		return
+	_enter_unsafe_callback()
+	profile_generation_evidence_changed.emit(state.profile_id, generation)
 	_exit_unsafe_callback()
 
 
@@ -2773,6 +3579,220 @@ func _get_migration_result_value(value: Variant) -> GFSaveMigrationResult:
 		var result: GFSaveMigrationResult = value
 		return result
 	return null
+
+
+# --- 信号处理函数 ---
+
+# 存储终态
+
+func _on_storage_operation_completed(
+	result: GFStorageAsyncResult,
+	profile_id: StringName,
+	request_id: int
+) -> void:
+	if _disposed:
+		return
+	_begin_processing()
+	var state: ProfileState = _get_state(profile_id)
+	if (
+		state == null
+		or state.current_storage_operation == null
+		or state.current_storage_operation.get_request_id() != request_id
+		or result == null
+		or result.get_request_id() != request_id
+	):
+		_end_processing()
+		return
+	_complete_current_io_timing(state)
+	_clear_current_storage_operation(state)
+	if result.get_operation() == GFStorageAsyncOperation.OPERATION_SAVE:
+		if not result.is_successful():
+			if (
+				result.get_write_failure_kind()
+					== GFStorageAsyncResult.WriteFailureKind.PAYLOAD_INVALID
+			):
+				var adapted_validation: Dictionary = (
+					_PAYLOAD_VALIDATION_ADAPTER.adapt_for_framework(
+						result.get_write_validation_report(),
+						state.current_sections_entry_index,
+						state.current_section_ids_by_entry_index
+					)
+				)
+				_finish_save_failure(
+					state,
+					result.get_error_code(),
+					"Storage worker rejected the prepared Save payload.",
+					GFSaveProfileResult.STATUS_PREPARATION_FAILED,
+					GFVariantData.get_option_string_name(
+						adapted_validation,
+						"failed_section_id"
+					),
+					GFVariantData.get_option_dictionary(
+						adapted_validation,
+						"validation_report"
+					)
+				)
+			else:
+				_handle_save_failure(state, result.get_error_code(), "Storage save failed.")
+		else:
+			var completed_generation: int = state.current_generation
+			_finalize_save_timing_for_terminal(state)
+			state.persisted_generation = maxi(
+				state.persisted_generation,
+				completed_generation
+			)
+			_clear_generation_evidence_through(state, completed_generation)
+			_complete_save_operations_success(state)
+			_clear_current(state)
+			_set_mode(state, STATE_IDLE)
+			_complete_ready_flushes(state)
+			_enqueue_schedule(state)
+			_reap_expired_managed_permit_if_safe(state)
+			_emit_generation_evidence_changed(state, completed_generation)
+	elif result.get_operation() == GFStorageAsyncOperation.OPERATION_LOAD:
+		var read_result: GFStorageReadResult = result.get_read_result()
+		if not _is_current_managed_load_authorized(state):
+			_finish_load_failure(
+				state,
+				GFSaveProfileResult.STATUS_DISPOSED,
+				ERR_UNAVAILABLE,
+				"Managed load capability was revoked before Provider apply."
+			)
+		elif read_result == null:
+			_handle_load_failure(
+				state,
+				GFStorageReadResult.new().configure_failure(
+					"Storage returned no read result.",
+					FAILED,
+					{},
+					GFStorageReadResult.IntegrityStatus.NOT_CHECKED,
+					0,
+					GFStorageReadResult.FailureKind.IO_FAILED
+				)
+			)
+		elif not read_result.ok or not read_result.is_integrity_accepted():
+			_handle_load_failure(state, read_result)
+		else:
+			_process_loaded_document(state, read_result)
+	_end_processing()
+
+
+func _on_detached_write_completed(
+	result: GFStorageAsyncResult,
+	profile_id: StringName,
+	request_id: int,
+	generation: int
+) -> void:
+	if _disposed:
+		return
+	_begin_processing()
+	var state: ProfileState = _get_state(profile_id)
+	if state == null or not state.detached_write_operations.has(request_id):
+		_end_processing()
+		return
+	var record: Dictionary = GFVariantData.as_dictionary(
+		state.detached_write_operations.get(request_id, {})
+	)
+	var operation: GFStorageAsyncOperation = _get_storage_operation_value(
+		GFVariantData.get_option_value(record, "operation")
+	)
+	var callback: Callable = _get_callable_value(
+		GFVariantData.get_option_value(record, "callback", Callable())
+	)
+	if operation != null and callback.is_valid() and operation.completed.is_connected(callback):
+		operation.completed.disconnect(callback)
+	var owns_current_retry: bool = (
+		state.current_kind == GFSaveProfileOperation.OPERATION_SAVE
+		and state.current_generation == generation
+		and state.mode != STATE_IDLE
+	)
+	var record_storage_duration_msec: int = GFVariantData.get_option_int(
+		record,
+		"storage_duration_msec"
+	)
+	if owns_current_retry:
+		_account_detached_write_tails(state, generation)
+		record_storage_duration_msec = state.current_storage_duration_msec
+	else:
+		var now_msec: int = _clock.get_monotonic_msec()
+		record_storage_duration_msec += maxi(
+			now_msec - GFVariantData.get_option_int(
+				record,
+				"tail_accounted_at_msec",
+				now_msec
+			),
+			0
+		)
+	var _erased: bool = state.detached_write_operations.erase(request_id)
+	_remove_unknown_request_id(state, generation, request_id)
+	var successful: bool = (
+		result != null
+		and result.get_request_id() == request_id
+		and result.get_operation() == GFStorageAsyncOperation.OPERATION_SAVE
+		and result.is_successful()
+	)
+	if successful:
+		var attempt_count: int = GFVariantData.get_option_int(record, "attempt_count")
+		var preparation_duration_msec: int = GFVariantData.get_option_int(
+			record,
+			"preparation_duration_msec"
+		)
+		var storage_duration_msec: int = record_storage_duration_msec
+		var preparation_work_units: int = GFVariantData.get_option_int(
+			record,
+			"preparation_work_units"
+		)
+		var request_ids: PackedInt64Array = _get_request_id_array(
+			GFVariantData.get_option_value(record, "storage_request_ids", PackedInt64Array())
+		)
+		if owns_current_retry:
+			_complete_current_preparation_timing(state)
+			_complete_current_io_timing(state)
+			attempt_count = maxi(attempt_count, state.current_attempt_count)
+			preparation_duration_msec = maxi(
+				preparation_duration_msec,
+				state.current_preparation_duration_msec
+			)
+			storage_duration_msec = state.current_storage_duration_msec
+			preparation_work_units = maxi(
+				preparation_work_units,
+				state.current_preparation_work_units
+			)
+			for current_request_id: int in state.current_storage_request_ids:
+				_append_request_id(request_ids, current_request_id)
+			if state.current_storage_operation != null:
+				_detach_current_write(state)
+		state.persisted_generation = maxi(state.persisted_generation, generation)
+		_clear_generation_evidence_through(state, generation)
+		_complete_save_operations_success_through(
+			state,
+			generation,
+			attempt_count,
+			request_ids,
+			preparation_duration_msec,
+			storage_duration_msec,
+			preparation_work_units
+		)
+		if owns_current_retry:
+			_clear_current(state)
+			_set_mode(state, STATE_IDLE)
+	elif generation > state.persisted_generation:
+		var error_code: Error = result.get_error_code() if result != null else FAILED
+		if not state.unknown_write_generations.has(generation):
+			_record_generation_failure(
+				state,
+				generation,
+				GFSaveProfileResult.STATUS_STORAGE_FAILED,
+				error_code,
+				"Timed-out Storage write later completed with a failure.",
+				&"",
+				PackedInt64Array([request_id])
+			)
+	_complete_ready_flushes(state)
+	_enqueue_schedule(state)
+	_reap_expired_managed_permit_if_safe(state)
+	_emit_generation_evidence_changed(state, generation)
+	_end_processing()
 
 
 # --- 内部类 ---
@@ -2851,6 +3871,21 @@ class ProfileState extends RefCounted:
 	## [br]
 	## @api framework_internal
 	var migrations: GFSaveMigrationRegistry = null
+
+	## 事务协调器持有的 opaque 管理 capability。
+	## [br]
+	## @api framework_internal
+	var managed_permit: ManagedProfilePermit = null
+
+	## 当前允许的直接受管操作集合。
+	## [br]
+	## @api framework_internal
+	var managed_access: int = MANAGED_ACCESS_BLOCKED
+
+	## 当前是否正在执行同步的受管内存事务。
+	## [br]
+	## @api framework_internal
+	var memory_transaction_active: bool = false
 
 	## 当前状态机状态。
 	## [br]
@@ -3094,6 +4129,13 @@ class ProfileState extends RefCounted:
 	## @schema current_metadata: Dictionary with caller-defined operation metadata.
 	var current_metadata: Dictionary = {}
 
+	## 当前 generation 由受管 mutation 固定的 section 候选。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema current_section_overrides: Internal Dictionary keyed by section ID with GFSaveSection values.
+	var current_section_overrides: Dictionary = {}
+
 	## 最新待保存 generation 的上下文。
 	## [br]
 	## @api framework_internal
@@ -3108,7 +4150,73 @@ class ProfileState extends RefCounted:
 	## @schema latest_save_metadata: Dictionary with caller-defined persisted document metadata.
 	var latest_save_metadata: Dictionary = {}
 
+	## 最新待保存 generation 的受管 section 候选。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @schema latest_save_section_overrides: Internal Dictionary keyed by section ID with GFSaveSection values.
+	var latest_save_section_overrides: Dictionary = {}
+
 	## 下一次重试的单调毫秒截止时间。
 	## [br]
 	## @api framework_internal
 	var retry_due_msec: int = 0
+
+
+## 受管 Profile 的不可伪造进程内 capability。
+## [br]
+## @api framework_internal
+## [br]
+## @category internal_helper
+## [br]
+## @since unreleased
+class ManagedProfilePermit extends RefCounted:
+	var _owner: WeakRef = null
+	var _serial: int = 0
+	var _active: bool = false
+
+	## 绑定唯一 owner 与正数 serial，首次配置成功后激活 capability。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @param owner: 持有 capability 的事务协调器。
+	## [br]
+	## @param serial: Utility 分配的正数单调身份。
+	## [br]
+	## @return 未配置且参数有效时返回 true。
+	func configure_for_framework(owner: Object, serial: int) -> bool:
+		if _active or owner == null or serial <= 0:
+			return false
+		_owner = weakref(owner)
+		_serial = serial
+		_active = true
+		return true
+
+
+	## 查询 capability 是否仍激活且 owner 仍然存活。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @return capability 可继续用于受管调用时返回 true。
+	func is_active_for_framework() -> bool:
+		return (
+			_active
+			and _serial > 0
+			and _owner != null
+			and _owner.get_ref() != null
+		)
+
+
+	## 不可逆地失效 capability 并清除 owner 与 serial。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	func invalidate_for_framework() -> void:
+		_active = false
+		_owner = null
+		_serial = 0

--- a/addons/gf/extensions/save/profile/gf_save_section_mutation.gd
+++ b/addons/gf/extensions/save/profile/gf_save_section_mutation.gd
@@ -1,0 +1,207 @@
+## GFSaveSectionMutation: 单个 Save section 的一次性候选替换句柄。
+##
+## Mutation 只描述完整候选 section，不接受可执行 Callable 或增量 patch。
+## `take_ownership()` 成功后，调用方必须永久放弃 payload、metadata 及其全部
+## 嵌套集合 alias；框架 claim 后句柄会立即清空载荷。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFSaveSectionMutation
+extends RefCounted
+
+
+# --- 常量 ---
+
+## Mutation 尚未被框架接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_AVAILABLE: StringName = &"available"
+
+## Mutation 已被框架接管，候选载荷不再可用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_CLAIMED: StringName = &"claimed"
+
+## Mutation 已被框架丢弃，候选载荷不再可用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATE_DISCARDED: StringName = &"discarded"
+
+const _PERSISTED_VALUE_VALIDATOR_SCRIPT = preload(
+	"res://addons/gf/extensions/save/core/gf_save_persisted_value_validator.gd"
+)
+
+
+# --- 私有变量 ---
+
+var _section_id: StringName = &""
+var _schema_version: int = 0
+var _payload: Variant = null
+var _metadata: Dictionary = {}
+var _state: StringName = STATE_DISCARDED
+
+
+# --- 公共方法 ---
+
+## 接管一个完整候选 section 的逻辑唯一所有权。
+##
+## 该方法不会深复制 payload 或 metadata。成功返回后，调用方不得继续读取、
+## 修改或复用原集合及其嵌套 alias。输入必须满足 Save persisted-value 契约；
+## Callable、Object、Signal、RID、循环集合和非有限数会被拒绝。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param section_id: 稳定 section ID。
+## [br]
+## @param schema_version: 候选 section 的正整数 schema 版本。
+## [br]
+## @param payload: 完整候选 section 载荷，不是 patch 或回调。
+## [br]
+## @param metadata: 候选 section 持久化元数据。
+## [br]
+## @schema payload: Variant accepted by the Save persisted-value contract.
+## [br]
+## @schema metadata: Dictionary accepted by the Save persisted-value contract.
+## [br]
+## @return 可用 Mutation；身份或候选数据无效时返回 null。
+static func take_ownership(
+	section_id: StringName,
+	schema_version: int,
+	payload: Variant,
+	metadata: Dictionary = {}
+) -> GFSaveSectionMutation:
+	if (
+		section_id == &""
+		or String(section_id) != String(section_id).strip_edges()
+		or schema_version <= 0
+	):
+		return null
+	var payload_report: Dictionary = _PERSISTED_VALUE_VALIDATOR_SCRIPT.validate(payload)
+	if not GFVariantData.get_option_bool(payload_report, "ok", false):
+		return null
+	var metadata_report: Dictionary = _PERSISTED_VALUE_VALIDATOR_SCRIPT.validate(metadata)
+	if not GFVariantData.get_option_bool(metadata_report, "ok", false):
+		return null
+
+	var mutation: GFSaveSectionMutation = GFSaveSectionMutation.new()
+	mutation._section_id = section_id
+	mutation._schema_version = schema_version
+	mutation._payload = payload
+	mutation._metadata = metadata
+	mutation._state = STATE_AVAILABLE
+	return mutation
+
+
+## 获取稳定 section ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return section ID。
+func get_section_id() -> StringName:
+	return _section_id
+
+
+## 获取候选 section schema 版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 正整数 schema 版本；无效句柄为 0。
+func get_schema_version() -> int:
+	return _schema_version
+
+
+## 获取当前所有权状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATE_*` 常量之一。
+func get_state() -> StringName:
+	return _state
+
+
+## 检查 Mutation 是否仍可被请求或框架接管。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未 claim 或 discard 时返回 true。
+func is_available() -> bool:
+	return _state == STATE_AVAILABLE
+
+
+# --- 框架内部方法 ---
+
+## 获取不含候选载荷的 Mutation 身份快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 包含 section_id、schema_version、state 和 available 的快照。
+## [br]
+## @schema return: Payload-free Dictionary with section_id, schema_version, state, and available.
+func inspect_for_framework() -> Dictionary:
+	return {
+		"section_id": _section_id,
+		"schema_version": _schema_version,
+		"state": _state,
+		"available": is_available(),
+	}
+
+
+## 一次性接管完整候选 section，并清空当前句柄。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 规范候选记录；不可用时返回空字典。
+## [br]
+## @schema return: Dictionary with section_id, schema_version, payload, and metadata.
+func claim_for_framework() -> Dictionary:
+	if not is_available():
+		return {}
+	var record: Dictionary = {
+		"section_id": _section_id,
+		"schema_version": _schema_version,
+		"payload": _payload,
+		"metadata": _metadata,
+	}
+	_payload = null
+	_metadata = {}
+	_state = STATE_CLAIMED
+	return record
+
+
+## 丢弃尚未被接管的候选载荷。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return 本次确实丢弃可用 Mutation 时返回 true。
+func discard_for_framework() -> bool:
+	if not is_available():
+		return false
+	_payload = null
+	_metadata = {}
+	_state = STATE_DISCARDED
+	return true

--- a/addons/gf/extensions/save/profile/gf_save_section_mutation.gd.uid
+++ b/addons/gf/extensions/save/profile/gf_save_section_mutation.gd.uid
@@ -1,0 +1,1 @@
+uid://udp51vfbt1gc

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "a74a0759730e2e83f5c5fc10ed6141f194dd6af7f0832fd268ca986aefa4a454",
-  "class_count": 770,
+  "source_digest": "9b4189282f86bd884d49d2a120c9d469fe831115d3db565c7f1820b8a50216cf",
+  "class_count": 778,
   "package_count": 52,
   "packages": [
     {
@@ -67758,6 +67758,53 @@
         }
       ]
     },
+    "GFSaveProfileMutationRequest": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd",
+      "summary": "GFSaveProfileMutationRequest: mutate-and-persist 的一次性所有权请求。 请求在创建时原子接管每个 `GFSaveSectionMutation`，随后只允许协调器 claim 一次。调用方必须放弃传入的 Dictionary、Array 及其全部嵌套 alias；请求",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "take_ownership",
+          "signature": "static func take_ownership( mutations: Array[GFSaveSectionMutation], document_metadata: Dictionary = {}, context: Dictionary = {}, result_metadata: Dictionary = {} ) -> GFSaveProfileMutationRequest",
+          "summary": "创建请求并接管全部候选 section 与元数据。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_available",
+          "signature": "func is_available() -> bool",
+          "summary": "检查请求是否仍可由协调器接管。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_claimed",
+          "signature": "func is_claimed() -> bool",
+          "summary": "检查请求是否已经被协调器接管。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_mutation_count",
+          "signature": "func get_mutation_count() -> int",
+          "summary": "获取候选 section 数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_section_ids",
+          "signature": "func get_section_ids() -> PackedStringArray",
+          "summary": "获取候选 section ID 的隔离快照。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFSaveProfileOperation": {
       "extends": "RefCounted",
       "module": "extensions/save",
@@ -67843,6 +67890,329 @@
           "name": "get_result",
           "signature": "func get_result() -> GFSaveProfileResult",
           "summary": "获取终态结果副本。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveProfileReconcileLease": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd",
+      "summary": "GFSaveProfileReconcileLease: outcome_unknown 的持续所有权与对账围栏。 Lease 保留同一对象身份，直到所有相关底层请求 late-settle 并由显式 reconcile 操作解除 domain 围栏。结果副本不会复制 Lease；因此调用方连接 `settled`、",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "settled",
+          "signature": "signal settled(lease: GFSaveProfileReconcileLease, state: StringName)",
+          "summary": "Lease 首次离开 waiting 时发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_WAITING",
+          "signature": "const STATE_WAITING: StringName = &\"waiting\"",
+          "summary": "仍在等待至少一个底层请求 late-settle。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_READY",
+          "signature": "const STATE_READY: StringName = &\"ready\"",
+          "summary": "已取得有界 settlement evidence，可以开始显式对账。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_RECONCILING",
+          "signature": "const STATE_RECONCILING: StringName = &\"reconciling\"",
+          "summary": "一个 reconcile 操作已经接管 Lease。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_RESOLVED",
+          "signature": "const STATE_RESOLVED: StringName = &\"resolved\"",
+          "summary": "对账已经完成，Provider domain 围栏可以释放。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_DISPOSED_UNRESOLVED",
+          "signature": "const STATE_DISPOSED_UNRESOLVED: StringName = &\"disposed_unresolved\"",
+          "summary": "Utility 已释放，但不确定副作用尚未完成对账。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_lease_id",
+          "signature": "func get_lease_id() -> int",
+          "summary": "获取 Utility 生命周期内唯一的 Lease ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_transaction_id",
+          "signature": "func get_transaction_id() -> int",
+          "summary": "获取产生当前 Lease 的事务 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_operation",
+          "signature": "func get_operation() -> StringName",
+          "summary": "获取产生 outcome_unknown 的事务类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_reconcile_profile_id",
+          "signature": "func get_reconcile_profile_id() -> StringName",
+          "summary": "获取显式对账应重新读取的 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_profile_id",
+          "signature": "func get_source_profile_id() -> StringName",
+          "summary": "获取原事务来源 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_target_profile_id",
+          "signature": "func get_target_profile_id() -> StringName",
+          "summary": "获取原事务目标 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_domain_id",
+          "signature": "func get_domain_id() -> int",
+          "summary": "获取运行时 Provider domain ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_domain_generation",
+          "signature": "func get_domain_generation() -> int",
+          "summary": "获取 Lease 创建时的 domain generation。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_epoch",
+          "signature": "func get_epoch() -> int",
+          "summary": "获取 Lease 创建时的 Utility lifecycle epoch。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_storage_request_ids",
+          "signature": "func get_storage_request_ids() -> PackedInt64Array",
+          "summary": "获取支撑 outcome_unknown 的底层 Storage 请求 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_state",
+          "signature": "func get_state() -> StringName",
+          "summary": "获取当前 Lease 状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_waiting",
+          "signature": "func is_waiting() -> bool",
+          "summary": "检查 Lease 是否仍等待 late settlement。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_ready",
+          "signature": "func is_ready() -> bool",
+          "summary": "检查 Lease 是否可由 reconcile 操作接管。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_terminal",
+          "signature": "func is_terminal() -> bool",
+          "summary": "检查 Lease 是否已进入不可再对账的终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_settlement_evidence",
+          "signature": "func get_settlement_evidence() -> Dictionary",
+          "summary": "获取不含文档或 Provider payload 的 settlement evidence。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_resolution_evidence",
+          "signature": "func get_resolution_evidence() -> Dictionary",
+          "summary": "获取成功对账后提交的最终证据。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveProfileReconcileRequest": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd",
+      "summary": "GFSaveProfileReconcileRequest: uncertain 写入对账的一次性请求句柄。 请求只携带调用方纯数据上下文和结果元数据，不携带 Recovery/Reconcile Lease 身份。Lease 必须作为独立类型化参数提交，避免从 Dictionary 恢复所有权。",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "take_ownership",
+          "signature": "static func take_ownership( context: Dictionary = {}, result_metadata: Dictionary = {} ) -> GFSaveProfileReconcileRequest",
+          "summary": "创建请求并接管 context 与 result_metadata 的逻辑唯一所有权。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_available",
+          "signature": "func is_available() -> bool",
+          "summary": "检查请求是否仍可由协调器接管。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_claimed",
+          "signature": "func is_claimed() -> bool",
+          "summary": "检查请求是否已经被协调器接管。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveProfileRecoveryLease": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd",
+      "summary": "GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。 Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease；",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "REASON_MISSING",
+          "signature": "const REASON_MISSING: StringName = &\"missing\"",
+          "summary": "激活目标没有持久化文档。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "REASON_CORRUPT",
+          "signature": "const REASON_CORRUPT: StringName = &\"corrupt\"",
+          "summary": "激活目标文档损坏或完整性无效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_AVAILABLE",
+          "signature": "const STATE_AVAILABLE: StringName = &\"available\"",
+          "summary": "Lease 尚未被恢复操作消费。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_CLAIMED",
+          "signature": "const STATE_CLAIMED: StringName = &\"claimed\"",
+          "summary": "Lease 已被一个恢复操作消费。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_STALE",
+          "signature": "const STATE_STALE: StringName = &\"stale\"",
+          "summary": "Lease 的 domain generation 或 lifecycle epoch 已过期。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_lease_id",
+          "signature": "func get_lease_id() -> int",
+          "summary": "获取 Utility 生命周期内唯一的 Lease ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_transaction_id",
+          "signature": "func get_transaction_id() -> int",
+          "summary": "获取产生当前 Lease 的事务 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_profile_id",
+          "signature": "func get_profile_id() -> StringName",
+          "summary": "获取待恢复 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_reason",
+          "signature": "func get_reason() -> StringName",
+          "summary": "获取恢复原因。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_domain_id",
+          "signature": "func get_domain_id() -> int",
+          "summary": "获取运行时 Provider domain ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_domain_generation",
+          "signature": "func get_domain_generation() -> int",
+          "summary": "获取 Lease 创建时的 domain generation。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_epoch",
+          "signature": "func get_epoch() -> int",
+          "summary": "获取 Lease 创建时的 Utility lifecycle epoch。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_state",
+          "signature": "func get_state() -> StringName",
+          "summary": "获取当前 Lease 状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_available",
+          "signature": "func is_available() -> bool",
+          "summary": "检查 Lease 是否仍可由 bootstrap/adopt 消费。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_claimed",
+          "signature": "func is_claimed() -> bool",
+          "summary": "检查 Lease 是否已经被消费。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_stale",
+          "signature": "func is_stale() -> bool",
+          "summary": "检查 Lease 是否已经过期。",
           "visibility": "public"
         }
       ]
@@ -68210,6 +68580,644 @@
           "name": "duplicate_result",
           "signature": "func duplicate_result() -> GFSaveProfileResult",
           "summary": "创建隔离结果副本。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveProfileTransactionCoordinator": {
+      "extends": "GFUtility",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd",
+      "summary": "GFSaveProfileTransactionCoordinator: 活动 Profile 身份与跨 Profile 事务协调器。 Coordinator 在完全相同且同序的 Provider 实例拓扑上建立独立 domain，委托 `GFSaveProfileUtility` 完成 generation、Storage IO、重试与 detached settlement。",
+      "visibility": "public",
+      "category": "runtime_service",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "active_profile_changed",
+          "signature": "signal active_profile_changed(",
+          "summary": "活动 Profile 身份完成原子提交后发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "signal",
+          "name": "transaction_completed",
+          "signature": "signal transaction_completed(result: GFSaveProfileTransactionResult)",
+          "summary": "任一事务进入稳定终态时发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DOMAIN_STATE_INACTIVE",
+          "signature": "const DOMAIN_STATE_INACTIVE: StringName = &\"inactive\"",
+          "summary": "Domain 尚未建立活动身份。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DOMAIN_STATE_ACTIVE",
+          "signature": "const DOMAIN_STATE_ACTIVE: StringName = &\"active\"",
+          "summary": "Domain 已建立一个可直接 save/flush 的活动身份。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DOMAIN_STATE_TRANSACTING",
+          "signature": "const DOMAIN_STATE_TRANSACTING: StringName = &\"transacting\"",
+          "summary": "Domain 正在执行一个事务。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DOMAIN_STATE_RECONCILIATION_REQUIRED",
+          "signature": "const DOMAIN_STATE_RECONCILIATION_REQUIRED: StringName = &\"reconciliation_required\"",
+          "summary": "Domain 被 outcome_unknown 或显式故障围栏占用，必须对账。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DOMAIN_STATE_DISPOSED",
+          "signature": "const DOMAIN_STATE_DISPOSED: StringName = &\"disposed\"",
+          "summary": "Coordinator 已释放。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_required_utilities",
+          "signature": "func get_required_utilities() -> Array[Script]",
+          "summary": "声明底层 Save Profile Utility 依赖。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "ready",
+          "signature": "func ready() -> void",
+          "summary": "在架构 ready 阶段采用已注册的 Profile Utility。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_activation",
+          "signature": "func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "开放事务准入；底层 Utility 不可用时失败。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "begin_quiesce",
+          "signature": "func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion",
+          "summary": "关闭新事务准入，并等待已接纳事务与 reconcile fence 收敛。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "tick",
+          "signature": "func tick(_delta: float) -> void",
+          "summary": "推进已接纳的同步 Provider mutation 阶段。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "dispose",
+          "signature": "func dispose() -> void",
+          "summary": "强制结束未完成事务并释放全部 manager capability。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "release_dependencies",
+          "signature": "func release_dependencies() -> void",
+          "summary": "释放架构注入依赖。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "setup",
+          "signature": "func setup( profile_utility: GFSaveProfileUtility ) -> GFSaveProfileTransactionCoordinator",
+          "summary": "显式注入底层 Profile Utility，供 standalone 场景与测试使用。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "register_profile",
+          "signature": "func register_profile( profile: GFSaveProfile, migrations: GFSaveMigrationRegistry = null ) -> Dictionary",
+          "summary": "注册并声明一个受管 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unregister_profile",
+          "signature": "func unregister_profile(profile_id: StringName) -> bool",
+          "summary": "注销一个无活动身份、事务或 fence 的受管 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_active_profile_id",
+          "signature": "func get_active_profile_id(profile_id: StringName) -> StringName",
+          "summary": "获取指定受管 Profile 所在 domain 的活动身份。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_domain_state_snapshot",
+          "signature": "func get_domain_state_snapshot(profile_id: StringName) -> Dictionary",
+          "summary": "获取无载荷 domain 调试快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "activate_profile",
+          "signature": "func activate_profile( profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation",
+          "summary": "严格读取一个已存在存档并建立首次活动身份。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "switch_profile",
+          "signature": "func switch_profile( target_profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation",
+          "summary": "从当前活动 Profile 原子切换到同一 Provider domain 的目标 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "bootstrap_profile",
+          "signature": "func bootstrap_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation",
+          "summary": "使用 activate 返回的 missing lease 创建存档并首次激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "adopt_profile",
+          "signature": "func adopt_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation",
+          "summary": "使用 activate 返回的 corrupt lease 明确覆盖损坏存档并首次激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "mutate_and_persist",
+          "signature": "func mutate_and_persist( profile_id: StringName, request: GFSaveProfileMutationRequest ) -> GFSaveProfileTransactionOperation",
+          "summary": "事务化应用一个或多个完整 section replacement 并持久化活动 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "reconcile_profile",
+          "signature": "func reconcile_profile( lease: GFSaveProfileReconcileLease, request: GFSaveProfileReconcileRequest = null ) -> GFSaveProfileTransactionOperation",
+          "summary": "在 late generation 证据收敛后严格重载 lease 指定 Profile 并解除 fence。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveProfileTransactionOperation": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd",
+      "summary": "GFSaveProfileTransactionOperation: Profile 身份与持久化事务的异步句柄。 句柄由 Save Profile 事务协调器完成一次且只完成一次。调用方可在连接信号前 检查 `is_completed()`，避免同步拒绝或立即终态造成竞态。",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "completed",
+          "signature": "signal completed(result: GFSaveProfileTransactionResult)",
+          "summary": "事务进入终态时发出一次。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_ACTIVATE",
+          "signature": "const OPERATION_ACTIVATE: StringName = &\"activate\"",
+          "summary": "激活已存在的 Profile 存档。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_SWITCH",
+          "signature": "const OPERATION_SWITCH: StringName = &\"switch\"",
+          "summary": "从当前活跃 Profile 事务切换到另一个已存在 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_BOOTSTRAP",
+          "signature": "const OPERATION_BOOTSTRAP: StringName = &\"bootstrap\"",
+          "summary": "用当前 Provider 状态显式创建缺失 Profile 并激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_ADOPT",
+          "signature": "const OPERATION_ADOPT: StringName = &\"adopt\"",
+          "summary": "显式采用当前 Provider 状态作为恢复后的活跃 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_MUTATE_AND_PERSIST",
+          "signature": "const OPERATION_MUTATE_AND_PERSIST: StringName = &\"mutate_and_persist\"",
+          "summary": "应用完整候选 section 并持久化。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_RECONCILE",
+          "signature": "const OPERATION_RECONCILE: StringName = &\"reconcile\"",
+          "summary": "对账此前 outcome_unknown 的事务。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_operation",
+          "signature": "func get_operation() -> StringName",
+          "summary": "获取事务类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_transaction_id",
+          "signature": "func get_transaction_id() -> int",
+          "summary": "获取 Utility 生命周期内唯一的事务 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_profile_id",
+          "signature": "func get_source_profile_id() -> StringName",
+          "summary": "获取事务来源 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_target_profile_id",
+          "signature": "func get_target_profile_id() -> StringName",
+          "summary": "获取事务目标 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_pending",
+          "signature": "func is_pending() -> bool",
+          "summary": "检查事务是否等待调度。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_running",
+          "signature": "func is_running() -> bool",
+          "summary": "检查事务是否正在运行。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_completed",
+          "signature": "func is_completed() -> bool",
+          "summary": "检查事务是否已有终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_result",
+          "signature": "func get_result() -> GFSaveProfileTransactionResult",
+          "summary": "获取终态结果副本。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveProfileTransactionResult": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd",
+      "summary": "GFSaveProfileTransactionResult: Profile 事务的不可变终态快照。 结果不保留文档、section、Provider snapshot 或候选 payload，只保留有界阶段 证据、类型化回滚失败、调用方元数据和必要的 Lease。`duplicate_result()` 会",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_ACTIVATED",
+          "signature": "const STATUS_ACTIVATED: StringName = &\"activated\"",
+          "summary": "已存在 Profile 已成功激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_SWITCHED",
+          "signature": "const STATUS_SWITCHED: StringName = &\"switched\"",
+          "summary": "活跃身份已成功切换。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_BOOTSTRAPPED",
+          "signature": "const STATUS_BOOTSTRAPPED: StringName = &\"bootstrapped\"",
+          "summary": "缺失 Profile 已从当前状态显式创建并激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_ADOPTED",
+          "signature": "const STATUS_ADOPTED: StringName = &\"adopted\"",
+          "summary": "当前状态已被显式采用为恢复后的活跃 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_MUTATED",
+          "signature": "const STATUS_MUTATED: StringName = &\"mutated\"",
+          "summary": "候选 sections 已应用并持久化。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_RECONCILED",
+          "signature": "const STATUS_RECONCILED: StringName = &\"reconciled\"",
+          "summary": "outcome_unknown 已通过显式重新读取完成对账。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_PROFILE",
+          "signature": "const STATUS_INVALID_PROFILE: StringName = &\"invalid_profile\"",
+          "summary": "Profile ID、Provider topology 或事务身份无效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_REQUEST",
+          "signature": "const STATUS_INVALID_REQUEST: StringName = &\"invalid_request\"",
+          "summary": "一次性请求无效、已被 claim 或含不支持的数据。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_LEASE",
+          "signature": "const STATUS_INVALID_LEASE: StringName = &\"invalid_lease\"",
+          "summary": "Recovery/Reconcile Lease 无效、已消费或绑定已经过期。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INACTIVE",
+          "signature": "const STATUS_INACTIVE: StringName = &\"inactive\"",
+          "summary": "请求要求活跃 Profile，但当前 Provider domain 未激活。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_ALREADY_ACTIVE",
+          "signature": "const STATUS_ALREADY_ACTIVE: StringName = &\"already_active\"",
+          "summary": "activate/bootstrap/adopt 的目标 domain 已有活跃 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_BUSY",
+          "signature": "const STATUS_BUSY: StringName = &\"busy\"",
+          "summary": "Provider domain 正在执行互斥事务或发生不安全回调重入。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_UNSUPPORTED_OPERATION",
+          "signature": "const STATUS_UNSUPPORTED_OPERATION: StringName = &\"unsupported_operation\"",
+          "summary": "Profile 配置不支持请求的读取或写入阶段。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_RECOVERY_REQUIRED",
+          "signature": "const STATUS_RECOVERY_REQUIRED: StringName = &\"recovery_required\"",
+          "summary": "activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_SOURCE_FLUSH_FAILED",
+          "signature": "const STATUS_SOURCE_FLUSH_FAILED: StringName = &\"source_flush_failed\"",
+          "summary": "switch 无法把来源 Profile flush 到调用时 generation barrier。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_TARGET_LOAD_FAILED",
+          "signature": "const STATUS_TARGET_LOAD_FAILED: StringName = &\"target_load_failed\"",
+          "summary": "switch 已 flush 来源，但无法读取或应用目标 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_SNAPSHOT_FAILED",
+          "signature": "const STATUS_SNAPSHOT_FAILED: StringName = &\"snapshot_failed\"",
+          "summary": "Provider 回滚或候选应用前的快照采集失败。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_APPLY_FAILED",
+          "signature": "const STATUS_APPLY_FAILED: StringName = &\"apply_failed\"",
+          "summary": "至少一个候选 section 应用失败，且内存回滚成功。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_ROLLBACK_FAILED",
+          "signature": "const STATUS_ROLLBACK_FAILED: StringName = &\"rollback_failed\"",
+          "summary": "恢复来源或候选内存状态时至少一个 Provider 回滚失败。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_PERSIST_FAILED",
+          "signature": "const STATUS_PERSIST_FAILED: StringName = &\"persist_failed\"",
+          "summary": "候选持久化确定失败，且内存回滚已成功。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_OUTCOME_UNKNOWN",
+          "signature": "const STATUS_OUTCOME_UNKNOWN: StringName = &\"outcome_unknown\"",
+          "summary": "写请求已进入底层，但其最终物理副作用无法确认。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_RECONCILE_PENDING",
+          "signature": "const STATUS_RECONCILE_PENDING: StringName = &\"reconcile_pending\"",
+          "summary": "Reconcile Lease 仍在等待 late settlement evidence。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_RECONCILE_FAILED",
+          "signature": "const STATUS_RECONCILE_FAILED: StringName = &\"reconcile_failed\"",
+          "summary": "显式重新读取或证据校验未能完成对账。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_DISPOSED",
+          "signature": "const STATUS_DISPOSED: StringName = &\"disposed\"",
+          "summary": "Utility 释放时事务仍未完成。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "检查事务是否成功。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> StringName",
+          "summary": "获取稳定终态状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_operation",
+          "signature": "func get_operation() -> StringName",
+          "summary": "获取事务类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_transaction_id",
+          "signature": "func get_transaction_id() -> int",
+          "summary": "获取 Utility 生命周期内唯一的事务 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_profile_id",
+          "signature": "func get_source_profile_id() -> StringName",
+          "summary": "获取事务来源 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_target_profile_id",
+          "signature": "func get_target_profile_id() -> StringName",
+          "summary": "获取事务目标 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_active_profile_before",
+          "signature": "func get_active_profile_before() -> StringName",
+          "summary": "获取事务开始前的活跃 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_active_profile_after",
+          "signature": "func get_active_profile_after() -> StringName",
+          "summary": "获取事务终态后的活跃 Profile ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_phase",
+          "signature": "func get_phase() -> StringName",
+          "summary": "获取失败或成功发生的稳定阶段名。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_code",
+          "signature": "func get_error_code() -> Error",
+          "summary": "获取 Godot Error 码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error",
+          "signature": "func get_error() -> String",
+          "summary": "获取稳定错误描述。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_failed_section_id",
+          "signature": "func get_failed_section_id() -> StringName",
+          "summary": "获取首个失败 section ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_rollback_errors",
+          "signature": "func get_rollback_errors() -> Array[GFSaveRollbackFailure]",
+          "summary": "获取类型化 Provider 回滚失败证据。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_stage_evidence",
+          "signature": "func get_stage_evidence() -> Dictionary",
+          "summary": "获取不含文档、section 或 Provider payload 的阶段证据。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_recovery_lease",
+          "signature": "func get_recovery_lease() -> GFSaveProfileRecoveryLease",
+          "summary": "获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_reconcile_lease",
+          "signature": "func get_reconcile_lease() -> GFSaveProfileReconcileLease",
+          "summary": "获取持续围栏 outcome_unknown 的同一身份 Reconcile Lease。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_metadata",
+          "signature": "func get_metadata() -> Dictionary",
+          "summary": "获取调用方结果元数据副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_started_at_msec",
+          "signature": "func get_started_at_msec() -> int",
+          "summary": "获取事务开始时间。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_completed_at_msec",
+          "signature": "func get_completed_at_msec() -> int",
+          "summary": "获取事务完成时间。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_duration_msec",
+          "signature": "func get_duration_msec() -> int",
+          "summary": "获取事务耗时。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_result",
+          "signature": "func duplicate_result() -> GFSaveProfileTransactionResult",
+          "summary": "创建隔离结果副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为不包含持久化 payload 或 Lease 对象的报告字典。",
           "visibility": "public"
         }
       ]
@@ -68739,6 +69747,74 @@
           "name": "from_dict",
           "signature": "static func from_dict(data: Dictionary) -> GFSaveSection",
           "summary": "从持久化字典创建分区。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSaveSectionMutation": {
+      "extends": "RefCounted",
+      "module": "extensions/save",
+      "package_id": "gf.extension.save",
+      "path": "addons/gf/extensions/save/profile/gf_save_section_mutation.gd",
+      "summary": "GFSaveSectionMutation: 单个 Save section 的一次性候选替换句柄。 Mutation 只描述完整候选 section，不接受可执行 Callable 或增量 patch。 `take_ownership()` 成功后，调用方必须永久放弃 payload、metadata 及其全部",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATE_AVAILABLE",
+          "signature": "const STATE_AVAILABLE: StringName = &\"available\"",
+          "summary": "Mutation 尚未被框架接管。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_CLAIMED",
+          "signature": "const STATE_CLAIMED: StringName = &\"claimed\"",
+          "summary": "Mutation 已被框架接管，候选载荷不再可用。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATE_DISCARDED",
+          "signature": "const STATE_DISCARDED: StringName = &\"discarded\"",
+          "summary": "Mutation 已被框架丢弃，候选载荷不再可用。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "take_ownership",
+          "signature": "static func take_ownership( section_id: StringName, schema_version: int, payload: Variant, metadata: Dictionary = {} ) -> GFSaveSectionMutation",
+          "summary": "接管一个完整候选 section 的逻辑唯一所有权。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_section_id",
+          "signature": "func get_section_id() -> StringName",
+          "summary": "获取稳定 section ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_schema_version",
+          "signature": "func get_schema_version() -> int",
+          "summary": "获取候选 section schema 版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_state",
+          "signature": "func get_state() -> StringName",
+          "summary": "获取当前所有权状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_available",
+          "signature": "func is_available() -> bool",
+          "summary": "检查 Mutation 是否仍可被请求或框架接管。",
           "visibility": "public"
         }
       ]

--- a/docs/api_catalog/classes/GFSaveProfileMutationRequest.xml
+++ b/docs/api_catalog/classes/GFSaveProfileMutationRequest.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileMutationRequest" path="addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd" module="extensions/save" extends="RefCounted" classDigest="34e35100a7637fc4b0037ba43a26a638cfcbdc59ec680200a2c44c14cd841f49">
+	<description>GFSaveProfileMutationRequest: mutate-and-persist 的一次性所有权请求。
+请求在创建时原子接管每个 `GFSaveSectionMutation`，随后只允许协调器 claim
+一次。调用方必须放弃传入的 Dictionary、Array 及其全部嵌套 alias；请求
+不公开任何候选 payload getter，也不接受 Callable 或可执行 patch。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="take_ownership">
+			<signature>static func take_ownership( mutations: Array[GFSaveSectionMutation], document_metadata: Dictionary = {}, context: Dictionary = {}, result_metadata: Dictionary = {} ) -&gt; GFSaveProfileMutationRequest:</signature>
+			<description>创建请求并接管全部候选 section 与元数据。
+Mutation 必须非空、可用且 section ID 唯一。方法会先完成全部预检，再按输入
+顺序 claim，因而校验失败不会部分消费 Mutation。输入顺序只用于所有权收集；
+协调器始终按已注册 Profile 的 Provider 顺序 capture/apply。成功返回后，调用方必须永久
+放弃 mutations 数组、三个 Dictionary 及其全部嵌套 alias。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">mutations: 待接管的完整候选 sections；输入顺序不定义应用顺序。</tag>
+				<tag name="param">document_metadata: 写入候选文档的持久化元数据。</tag>
+				<tag name="param">context: Provider 操作使用的临时纯数据上下文。</tag>
+				<tag name="param">result_metadata: 只写入当前事务结果的调用方纯数据元数据。</tag>
+				<tag name="return">可用请求；输入无效时返回 null，且不消费任何 Mutation。</tag>
+				<tag name="schema">document_metadata: Dictionary accepted by the Save persisted-value contract whose source aliases are abandoned after success.</tag>
+				<tag name="schema">context: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.</tag>
+				<tag name="schema">result_metadata: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_available">
+			<signature>func is_available() -&gt; bool:</signature>
+			<description>检查请求是否仍可由协调器接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未 claim 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_claimed">
+			<signature>func is_claimed() -&gt; bool:</signature>
+			<description>检查请求是否已经被协调器接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已成功 claim 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_mutation_count">
+			<signature>func get_mutation_count() -&gt; int:</signature>
+			<description>获取候选 section 数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未 claim 时返回候选数；claim 后为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_section_ids">
+			<signature>func get_section_ids() -&gt; PackedStringArray:</signature>
+			<description>获取候选 section ID 的隔离快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">按请求收集顺序排列的 section ID；不包含候选载荷。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveProfileReconcileLease.xml
+++ b/docs/api_catalog/classes/GFSaveProfileReconcileLease.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileReconcileLease" path="addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd" module="extensions/save" extends="RefCounted" classDigest="38d902cbb53d042a8333bfa914f9f50af9581286bd997cf5b730d0900ba50a36">
+	<description>GFSaveProfileReconcileLease: outcome_unknown 的持续所有权与对账围栏。
+Lease 保留同一对象身份，直到所有相关底层请求 late-settle 并由显式 reconcile
+操作解除 domain 围栏。结果副本不会复制 Lease；因此调用方连接 `settled`、
+轮询状态和提交对账时观察的是同一条生命周期。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="settled">
+			<signature>signal settled(lease: GFSaveProfileReconcileLease, state: StringName)</signature>
+			<description>Lease 首次离开 waiting 时发出。
+正常 late settlement 进入 ready；Utility 先释放则进入 disposed_unresolved。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">lease: 当前同一身份 Lease。</tag>
+				<tag name="param">state: `STATE_READY` 或 `STATE_DISPOSED_UNRESOLVED`。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums />
+	<constants>
+		<member kind="const" name="STATE_WAITING">
+			<signature>const STATE_WAITING: StringName = &amp;"waiting"</signature>
+			<description>仍在等待至少一个底层请求 late-settle。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_READY">
+			<signature>const STATE_READY: StringName = &amp;"ready"</signature>
+			<description>已取得有界 settlement evidence，可以开始显式对账。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_RECONCILING">
+			<signature>const STATE_RECONCILING: StringName = &amp;"reconciling"</signature>
+			<description>一个 reconcile 操作已经接管 Lease。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_RESOLVED">
+			<signature>const STATE_RESOLVED: StringName = &amp;"resolved"</signature>
+			<description>对账已经完成，Provider domain 围栏可以释放。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_DISPOSED_UNRESOLVED">
+			<signature>const STATE_DISPOSED_UNRESOLVED: StringName = &amp;"disposed_unresolved"</signature>
+			<description>Utility 已释放，但不确定副作用尚未完成对账。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="get_lease_id">
+			<signature>func get_lease_id() -&gt; int:</signature>
+			<description>获取 Utility 生命周期内唯一的 Lease ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 Lease ID；未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_transaction_id">
+			<signature>func get_transaction_id() -&gt; int:</signature>
+			<description>获取产生当前 Lease 的事务 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数事务 ID；未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_operation">
+			<signature>func get_operation() -&gt; StringName:</signature>
+			<description>获取产生 outcome_unknown 的事务类型。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`GFSaveProfileTransactionOperation.OPERATION_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_reconcile_profile_id">
+			<signature>func get_reconcile_profile_id() -&gt; StringName:</signature>
+			<description>获取显式对账应重新读取的 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非空 Profile ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_profile_id">
+			<signature>func get_source_profile_id() -&gt; StringName:</signature>
+			<description>获取原事务来源 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">来源 Profile ID；不适用时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_target_profile_id">
+			<signature>func get_target_profile_id() -&gt; StringName:</signature>
+			<description>获取原事务目标 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">目标 Profile ID；不适用时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_domain_id">
+			<signature>func get_domain_id() -&gt; int:</signature>
+			<description>获取运行时 Provider domain ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Utility 生命周期内唯一的正整数 domain ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_domain_generation">
+			<signature>func get_domain_generation() -&gt; int:</signature>
+			<description>获取 Lease 创建时的 domain generation。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 domain generation。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_epoch">
+			<signature>func get_epoch() -&gt; int:</signature>
+			<description>获取 Lease 创建时的 Utility lifecycle epoch。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 lifecycle epoch。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_storage_request_ids">
+			<signature>func get_storage_request_ids() -&gt; PackedInt64Array:</signature>
+			<description>获取支撑 outcome_unknown 的底层 Storage 请求 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">按发起顺序排列的正整数请求 ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_state">
+			<signature>func get_state() -&gt; StringName:</signature>
+			<description>获取当前 Lease 状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATE_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_waiting">
+			<signature>func is_waiting() -&gt; bool:</signature>
+			<description>检查 Lease 是否仍等待 late settlement。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">waiting 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_ready">
+			<signature>func is_ready() -&gt; bool:</signature>
+			<description>检查 Lease 是否可由 reconcile 操作接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">ready 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_terminal">
+			<signature>func is_terminal() -&gt; bool:</signature>
+			<description>检查 Lease 是否已进入不可再对账的终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">resolved 或 disposed_unresolved 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_settlement_evidence">
+			<signature>func get_settlement_evidence() -&gt; Dictionary:</signature>
+			<description>获取不含文档或 Provider payload 的 settlement evidence。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">有界 evidence 副本。</tag>
+				<tag name="schema">return: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_resolution_evidence">
+			<signature>func get_resolution_evidence() -&gt; Dictionary:</signature>
+			<description>获取成功对账后提交的最终证据。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">resolved 前为空；resolved 后返回有界 evidence 副本。</tag>
+				<tag name="schema">return: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveProfileReconcileRequest.xml
+++ b/docs/api_catalog/classes/GFSaveProfileReconcileRequest.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileReconcileRequest" path="addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd" module="extensions/save" extends="RefCounted" classDigest="4510be7d5530fdd252137d925988a18b0a5026ed8c1bcece539380e3e32ebb50">
+	<description>GFSaveProfileReconcileRequest: uncertain 写入对账的一次性请求句柄。
+请求只携带调用方纯数据上下文和结果元数据，不携带 Recovery/Reconcile Lease
+身份。Lease 必须作为独立类型化参数提交，避免从 Dictionary 恢复所有权。
+`take_ownership()` 成功后，调用方必须放弃两个 Dictionary 及其嵌套 alias。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="take_ownership">
+			<signature>static func take_ownership( context: Dictionary = {}, result_metadata: Dictionary = {} ) -&gt; GFSaveProfileReconcileRequest:</signature>
+			<description>创建请求并接管 context 与 result_metadata 的逻辑唯一所有权。
+输入必须是有界纯 Variant 数据，不能包含 Callable、Object、Signal、RID 或
+循环集合。该请求不接受可执行恢复策略或 patch；项目策略应在提交前完成决策。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">context: 对账流程使用的临时纯数据上下文。</tag>
+				<tag name="param">result_metadata: 只写入当前对账结果的调用方纯数据元数据。</tag>
+				<tag name="return">可用请求；输入无效时返回 null。</tag>
+				<tag name="schema">context: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.</tag>
+				<tag name="schema">result_metadata: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_available">
+			<signature>func is_available() -&gt; bool:</signature>
+			<description>检查请求是否仍可由协调器接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未 claim 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_claimed">
+			<signature>func is_claimed() -&gt; bool:</signature>
+			<description>检查请求是否已经被协调器接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已成功 claim 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveProfileRecoveryLease.xml
+++ b/docs/api_catalog/classes/GFSaveProfileRecoveryLease.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileRecoveryLease" path="addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd" module="extensions/save" extends="RefCounted" classDigest="d389e2a11ad3ed277cde8cc69819c28f56e512cac0574b406b6fc5d5d6cb117c">
+	<description>GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。
+Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider
+domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease；
+domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="REASON_MISSING">
+			<signature>const REASON_MISSING: StringName = &amp;"missing"</signature>
+			<description>激活目标没有持久化文档。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="REASON_CORRUPT">
+			<signature>const REASON_CORRUPT: StringName = &amp;"corrupt"</signature>
+			<description>激活目标文档损坏或完整性无效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_AVAILABLE">
+			<signature>const STATE_AVAILABLE: StringName = &amp;"available"</signature>
+			<description>Lease 尚未被恢复操作消费。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_CLAIMED">
+			<signature>const STATE_CLAIMED: StringName = &amp;"claimed"</signature>
+			<description>Lease 已被一个恢复操作消费。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_STALE">
+			<signature>const STATE_STALE: StringName = &amp;"stale"</signature>
+			<description>Lease 的 domain generation 或 lifecycle epoch 已过期。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="get_lease_id">
+			<signature>func get_lease_id() -&gt; int:</signature>
+			<description>获取 Utility 生命周期内唯一的 Lease ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 Lease ID；未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_transaction_id">
+			<signature>func get_transaction_id() -&gt; int:</signature>
+			<description>获取产生当前 Lease 的事务 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数事务 ID；未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_profile_id">
+			<signature>func get_profile_id() -&gt; StringName:</signature>
+			<description>获取待恢复 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Profile ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_reason">
+			<signature>func get_reason() -&gt; StringName:</signature>
+			<description>获取恢复原因。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`REASON_MISSING` 或 `REASON_CORRUPT`。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_domain_id">
+			<signature>func get_domain_id() -&gt; int:</signature>
+			<description>获取运行时 Provider domain ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Utility 生命周期内唯一的正整数 domain ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_domain_generation">
+			<signature>func get_domain_generation() -&gt; int:</signature>
+			<description>获取 Lease 创建时的 domain generation。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 domain generation。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_epoch">
+			<signature>func get_epoch() -&gt; int:</signature>
+			<description>获取 Lease 创建时的 Utility lifecycle epoch。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 lifecycle epoch。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_state">
+			<signature>func get_state() -&gt; StringName:</signature>
+			<description>获取当前 Lease 状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATE_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_available">
+			<signature>func is_available() -&gt; bool:</signature>
+			<description>检查 Lease 是否仍可由 bootstrap/adopt 消费。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">可用时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_claimed">
+			<signature>func is_claimed() -&gt; bool:</signature>
+			<description>检查 Lease 是否已经被消费。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已 claim 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_stale">
+			<signature>func is_stale() -&gt; bool:</signature>
+			<description>检查 Lease 是否已经过期。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已标记 stale 或从未有效配置时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveProfileTransactionCoordinator.xml
+++ b/docs/api_catalog/classes/GFSaveProfileTransactionCoordinator.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileTransactionCoordinator" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd" module="extensions/save" extends="GFUtility" classDigest="fd1e298116cf399f8859fe70a29525ecb676aebe37969175c2cd0e7734202843">
+	<description>GFSaveProfileTransactionCoordinator: 活动 Profile 身份与跨 Profile 事务协调器。
+Coordinator 在完全相同且同序的 Provider 实例拓扑上建立独立 domain，委托
+`GFSaveProfileUtility` 完成 generation、Storage IO、重试与 detached settlement。
+它不解释业务 payload，也不拥有项目的身份到路径、云同步或恢复选择。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_service</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="active_profile_changed">
+			<signature>signal active_profile_changed(</signature>
+			<description>活动 Profile 身份完成原子提交后发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">previous_profile_id: 提交前活动 Profile；首次激活时为空。</tag>
+				<tag name="param">current_profile_id: 提交后活动 Profile。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="signal" name="transaction_completed">
+			<signature>signal transaction_completed(result: GFSaveProfileTransactionResult)</signature>
+			<description>任一事务进入稳定终态时发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">result: 不包含持久化 payload 的隔离结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums />
+	<constants>
+		<member kind="const" name="DOMAIN_STATE_INACTIVE">
+			<signature>const DOMAIN_STATE_INACTIVE: StringName = &amp;"inactive"</signature>
+			<description>Domain 尚未建立活动身份。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DOMAIN_STATE_ACTIVE">
+			<signature>const DOMAIN_STATE_ACTIVE: StringName = &amp;"active"</signature>
+			<description>Domain 已建立一个可直接 save/flush 的活动身份。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DOMAIN_STATE_TRANSACTING">
+			<signature>const DOMAIN_STATE_TRANSACTING: StringName = &amp;"transacting"</signature>
+			<description>Domain 正在执行一个事务。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DOMAIN_STATE_RECONCILIATION_REQUIRED">
+			<signature>const DOMAIN_STATE_RECONCILIATION_REQUIRED: StringName = &amp;"reconciliation_required"</signature>
+			<description>Domain 被 outcome_unknown 或显式故障围栏占用，必须对账。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DOMAIN_STATE_DISPOSED">
+			<signature>const DOMAIN_STATE_DISPOSED: StringName = &amp;"disposed"</signature>
+			<description>Coordinator 已释放。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="get_required_utilities">
+			<signature>func get_required_utilities() -&gt; Array[Script]:</signature>
+			<description>声明底层 Save Profile Utility 依赖。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">仅包含 `GFSaveProfileUtility`。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="ready">
+			<signature>func ready() -&gt; void:</signature>
+			<description>在架构 ready 阶段采用已注册的 Profile Utility。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_activation">
+			<signature>func begin_activation(_scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>开放事务准入；底层 Utility 不可用时失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_scope: 当前激活阶段的取消作用域。</tag>
+				<tag name="return">一次性激活完成源。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="begin_quiesce">
+			<signature>func begin_quiesce(scope: GFAsyncScope) -&gt; GFAsyncCompletion:</signature>
+			<description>关闭新事务准入，并等待已接纳事务与 reconcile fence 收敛。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">scope: 当前静默阶段的取消作用域。</tag>
+				<tag name="return">全部 domain 可安全关闭时完成的一次性完成源。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="tick">
+			<signature>func tick(_delta: float) -&gt; void:</signature>
+			<description>推进已接纳的同步 Provider mutation 阶段。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_delta: 未使用；底层 IO 由 Profile Utility 推进。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="dispose">
+			<signature>func dispose() -&gt; void:</signature>
+			<description>强制结束未完成事务并释放全部 manager capability。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="release_dependencies">
+			<signature>func release_dependencies() -&gt; void:</signature>
+			<description>释放架构注入依赖。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="setup">
+			<signature>func setup( profile_utility: GFSaveProfileUtility ) -&gt; GFSaveProfileTransactionCoordinator:</signature>
+			<description>显式注入底层 Profile Utility，供 standalone 场景与测试使用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile_utility: 已配置的底层 Profile Utility。</tag>
+				<tag name="return">当前 Coordinator；输入无效或已有受管 Profile 时返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="register_profile">
+			<signature>func register_profile( profile: GFSaveProfile, migrations: GFSaveMigrationRegistry = null ) -&gt; Dictionary:</signature>
+			<description>注册并声明一个受管 Profile。
+完全相同且同序的 Provider 实例序列共享 domain；任意部分重叠或同实例异序
+会在触碰底层注册前失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile: Profile 声明。</tag>
+				<tag name="param">migrations: 可选迁移注册表。</tag>
+				<tag name="return">底层注册报告，附加 managed 与 provider_domain_id 字段。</tag>
+				<tag name="schema">return: GFValidationReportDictionary-compatible report with managed and provider_domain_id fields.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unregister_profile">
+			<signature>func unregister_profile(profile_id: StringName) -&gt; bool:</signature>
+			<description>注销一个无活动身份、事务或 fence 的受管 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile_id: 受管 Profile ID。</tag>
+				<tag name="return">安全注销成功时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_active_profile_id">
+			<signature>func get_active_profile_id(profile_id: StringName) -&gt; StringName:</signature>
+			<description>获取指定受管 Profile 所在 domain 的活动身份。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile_id: 用于定位 Provider domain 的任一受管 Profile ID。</tag>
+				<tag name="return">活动 Profile ID；domain 未激活或 Profile 不存在时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_domain_state_snapshot">
+			<signature>func get_domain_state_snapshot(profile_id: StringName) -&gt; Dictionary:</signature>
+			<description>获取无载荷 domain 调试快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile_id: 用于定位 Provider domain 的任一受管 Profile ID。</tag>
+				<tag name="return">domain 状态、活动身份、generation、epoch 与事务/lease ID。</tag>
+				<tag name="schema">return: Payload-free Dictionary with domain_id, state, active_profile_id, profile_ids, domain_generation, transaction_epoch, transaction_id, reconcile_lease_id, quiescing, and disposed fields.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="activate_profile">
+			<signature>func activate_profile( profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>严格读取一个已存在存档并建立首次活动身份。
+missing/corrupt 不会应用低层 `ACTION_USE_CURRENT_STATE`；结果分别返回只能用于
+`bootstrap_profile()` 或 `adopt_profile()` 的类型化 Recovery Lease。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile_id: 已注册受管 Profile ID。</tag>
+				<tag name="param">context: 迁移与 Provider apply 临时上下文。</tag>
+				<tag name="param">metadata: 仅写入外层事务结果的调用方元数据。</tag>
+				<tag name="return">类型化 activate 操作。</tag>
+				<tag name="schema">context: Dictionary with caller-defined ephemeral operation data.</tag>
+				<tag name="schema">metadata: Dictionary with caller-defined result metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="switch_profile">
+			<signature>func switch_profile( target_profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>从当前活动 Profile 原子切换到同一 Provider domain 的目标 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">target_profile_id: 同一 domain 内的目标 Profile ID。</tag>
+				<tag name="param">context: 目标读取的迁移与 Provider 临时上下文。</tag>
+				<tag name="param">metadata: 仅写入外层事务结果的调用方元数据。</tag>
+				<tag name="return">类型化 switch 操作。</tag>
+				<tag name="schema">context: Dictionary with caller-defined ephemeral operation data.</tag>
+				<tag name="schema">metadata: Dictionary with caller-defined result metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="bootstrap_profile">
+			<signature>func bootstrap_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>使用 activate 返回的 missing lease 创建存档并首次激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">lease: 尚未过期的 missing Recovery Lease。</tag>
+				<tag name="param">request: 当前 Provider 状态的保存请求；null 表示空元数据。</tag>
+				<tag name="return">类型化 bootstrap 操作；拒绝不会 claim lease 或 request。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="adopt_profile">
+			<signature>func adopt_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>使用 activate 返回的 corrupt lease 明确覆盖损坏存档并首次激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">lease: 尚未过期的 corrupt Recovery Lease。</tag>
+				<tag name="param">request: 当前 Provider 状态的保存请求；null 表示空元数据。</tag>
+				<tag name="return">类型化 adopt 操作；拒绝不会 claim lease 或 request。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="mutate_and_persist">
+			<signature>func mutate_and_persist( profile_id: StringName, request: GFSaveProfileMutationRequest ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>事务化应用一个或多个完整 section replacement 并持久化活动 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">profile_id: 当前 domain 的活动 Profile ID。</tag>
+				<tag name="param">request: 一次性候选与元数据请求。</tag>
+				<tag name="return">类型化 mutate-and-persist 操作；边界拒绝不会 claim request。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="reconcile_profile">
+			<signature>func reconcile_profile( lease: GFSaveProfileReconcileLease, request: GFSaveProfileReconcileRequest = null ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>在 late generation 证据收敛后严格重载 lease 指定 Profile 并解除 fence。
+waiting lease 返回 `reconcile_pending`，且不 claim lease/request；调用方可在
+`GFSaveProfileReconcileLease.settled` 后用同一 lease 与新请求重试。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">lease: 当前 Coordinator 持有的 Reconcile Lease。</tag>
+				<tag name="param">request: 一次性 reconcile context 与结果元数据。</tag>
+				<tag name="return">类型化 reconcile 操作。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveProfileTransactionOperation.xml
+++ b/docs/api_catalog/classes/GFSaveProfileTransactionOperation.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileTransactionOperation" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd" module="extensions/save" extends="RefCounted" classDigest="099afddec6e78fd3624ef311c449ab3613ef2b52256467b51fd4ab9e8e332103">
+	<description>GFSaveProfileTransactionOperation: Profile 身份与持久化事务的异步句柄。
+句柄由 Save Profile 事务协调器完成一次且只完成一次。调用方可在连接信号前
+检查 `is_completed()`，避免同步拒绝或立即终态造成竞态。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="completed">
+			<signature>signal completed(result: GFSaveProfileTransactionResult)</signature>
+			<description>事务进入终态时发出一次。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">result: 不包含 Provider payload 的隔离终态结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums />
+	<constants>
+		<member kind="const" name="OPERATION_ACTIVATE">
+			<signature>const OPERATION_ACTIVATE: StringName = &amp;"activate"</signature>
+			<description>激活已存在的 Profile 存档。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_SWITCH">
+			<signature>const OPERATION_SWITCH: StringName = &amp;"switch"</signature>
+			<description>从当前活跃 Profile 事务切换到另一个已存在 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_BOOTSTRAP">
+			<signature>const OPERATION_BOOTSTRAP: StringName = &amp;"bootstrap"</signature>
+			<description>用当前 Provider 状态显式创建缺失 Profile 并激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_ADOPT">
+			<signature>const OPERATION_ADOPT: StringName = &amp;"adopt"</signature>
+			<description>显式采用当前 Provider 状态作为恢复后的活跃 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_MUTATE_AND_PERSIST">
+			<signature>const OPERATION_MUTATE_AND_PERSIST: StringName = &amp;"mutate_and_persist"</signature>
+			<description>应用完整候选 section 并持久化。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_RECONCILE">
+			<signature>const OPERATION_RECONCILE: StringName = &amp;"reconcile"</signature>
+			<description>对账此前 outcome_unknown 的事务。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="get_operation">
+			<signature>func get_operation() -&gt; StringName:</signature>
+			<description>获取事务类型。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`OPERATION_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_transaction_id">
+			<signature>func get_transaction_id() -&gt; int:</signature>
+			<description>获取 Utility 生命周期内唯一的事务 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数事务 ID；尚未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_profile_id">
+			<signature>func get_source_profile_id() -&gt; StringName:</signature>
+			<description>获取事务来源 Profile ID。
+activate、bootstrap 与 adopt 没有来源身份；mutate-and-persist 和 reconcile
+使用当前受管 Profile 作为来源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">来源 Profile ID；不适用时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_target_profile_id">
+			<signature>func get_target_profile_id() -&gt; StringName:</signature>
+			<description>获取事务目标 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">目标 Profile ID；不适用时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_pending">
+			<signature>func is_pending() -&gt; bool:</signature>
+			<description>检查事务是否等待调度。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未运行或完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_running">
+			<signature>func is_running() -&gt; bool:</signature>
+			<description>检查事务是否正在运行。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已启动但无终态时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_completed">
+			<signature>func is_completed() -&gt; bool:</signature>
+			<description>检查事务是否已有终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_result">
+			<signature>func get_result() -&gt; GFSaveProfileTransactionResult:</signature>
+			<description>获取终态结果副本。
+结果副本中的 Recovery/Reconcile Lease 保留原始句柄身份，其他集合均隔离复制。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已完成结果；等待中返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveProfileTransactionResult.xml
+++ b/docs/api_catalog/classes/GFSaveProfileTransactionResult.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveProfileTransactionResult" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd" module="extensions/save" extends="RefCounted" classDigest="a649282a39a46c716c7a76a66b4613d301d42cc3416c29e677b4eaae0277c64c">
+	<description>GFSaveProfileTransactionResult: Profile 事务的不可变终态快照。
+结果不保留文档、section、Provider snapshot 或候选 payload，只保留有界阶段
+证据、类型化回滚失败、调用方元数据和必要的 Lease。`duplicate_result()` 会
+隔离复制集合，但刻意保留 Recovery/Reconcile Lease 的同一对象身份。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_ACTIVATED">
+			<signature>const STATUS_ACTIVATED: StringName = &amp;"activated"</signature>
+			<description>已存在 Profile 已成功激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_SWITCHED">
+			<signature>const STATUS_SWITCHED: StringName = &amp;"switched"</signature>
+			<description>活跃身份已成功切换。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_BOOTSTRAPPED">
+			<signature>const STATUS_BOOTSTRAPPED: StringName = &amp;"bootstrapped"</signature>
+			<description>缺失 Profile 已从当前状态显式创建并激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_ADOPTED">
+			<signature>const STATUS_ADOPTED: StringName = &amp;"adopted"</signature>
+			<description>当前状态已被显式采用为恢复后的活跃 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_MUTATED">
+			<signature>const STATUS_MUTATED: StringName = &amp;"mutated"</signature>
+			<description>候选 sections 已应用并持久化。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_RECONCILED">
+			<signature>const STATUS_RECONCILED: StringName = &amp;"reconciled"</signature>
+			<description>outcome_unknown 已通过显式重新读取完成对账。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_PROFILE">
+			<signature>const STATUS_INVALID_PROFILE: StringName = &amp;"invalid_profile"</signature>
+			<description>Profile ID、Provider topology 或事务身份无效。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_REQUEST">
+			<signature>const STATUS_INVALID_REQUEST: StringName = &amp;"invalid_request"</signature>
+			<description>一次性请求无效、已被 claim 或含不支持的数据。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_LEASE">
+			<signature>const STATUS_INVALID_LEASE: StringName = &amp;"invalid_lease"</signature>
+			<description>Recovery/Reconcile Lease 无效、已消费或绑定已经过期。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INACTIVE">
+			<signature>const STATUS_INACTIVE: StringName = &amp;"inactive"</signature>
+			<description>请求要求活跃 Profile，但当前 Provider domain 未激活。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_ALREADY_ACTIVE">
+			<signature>const STATUS_ALREADY_ACTIVE: StringName = &amp;"already_active"</signature>
+			<description>activate/bootstrap/adopt 的目标 domain 已有活跃 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_BUSY">
+			<signature>const STATUS_BUSY: StringName = &amp;"busy"</signature>
+			<description>Provider domain 正在执行互斥事务或发生不安全回调重入。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_UNSUPPORTED_OPERATION">
+			<signature>const STATUS_UNSUPPORTED_OPERATION: StringName = &amp;"unsupported_operation"</signature>
+			<description>Profile 配置不支持请求的读取或写入阶段。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_RECOVERY_REQUIRED">
+			<signature>const STATUS_RECOVERY_REQUIRED: StringName = &amp;"recovery_required"</signature>
+			<description>activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_SOURCE_FLUSH_FAILED">
+			<signature>const STATUS_SOURCE_FLUSH_FAILED: StringName = &amp;"source_flush_failed"</signature>
+			<description>switch 无法把来源 Profile flush 到调用时 generation barrier。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_TARGET_LOAD_FAILED">
+			<signature>const STATUS_TARGET_LOAD_FAILED: StringName = &amp;"target_load_failed"</signature>
+			<description>switch 已 flush 来源，但无法读取或应用目标 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_SNAPSHOT_FAILED">
+			<signature>const STATUS_SNAPSHOT_FAILED: StringName = &amp;"snapshot_failed"</signature>
+			<description>Provider 回滚或候选应用前的快照采集失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_APPLY_FAILED">
+			<signature>const STATUS_APPLY_FAILED: StringName = &amp;"apply_failed"</signature>
+			<description>至少一个候选 section 应用失败，且内存回滚成功。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_ROLLBACK_FAILED">
+			<signature>const STATUS_ROLLBACK_FAILED: StringName = &amp;"rollback_failed"</signature>
+			<description>恢复来源或候选内存状态时至少一个 Provider 回滚失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_PERSIST_FAILED">
+			<signature>const STATUS_PERSIST_FAILED: StringName = &amp;"persist_failed"</signature>
+			<description>候选持久化确定失败，且内存回滚已成功。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_OUTCOME_UNKNOWN">
+			<signature>const STATUS_OUTCOME_UNKNOWN: StringName = &amp;"outcome_unknown"</signature>
+			<description>写请求已进入底层，但其最终物理副作用无法确认。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_RECONCILE_PENDING">
+			<signature>const STATUS_RECONCILE_PENDING: StringName = &amp;"reconcile_pending"</signature>
+			<description>Reconcile Lease 仍在等待 late settlement evidence。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_RECONCILE_FAILED">
+			<signature>const STATUS_RECONCILE_FAILED: StringName = &amp;"reconcile_failed"</signature>
+			<description>显式重新读取或证据校验未能完成对账。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_DISPOSED">
+			<signature>const STATUS_DISPOSED: StringName = &amp;"disposed"</signature>
+			<description>Utility 释放时事务仍未完成。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>检查事务是否成功。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">终态属于成功状态时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; StringName:</signature>
+			<description>获取稳定终态状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATUS_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_operation">
+			<signature>func get_operation() -&gt; StringName:</signature>
+			<description>获取事务类型。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`GFSaveProfileTransactionOperation.OPERATION_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_transaction_id">
+			<signature>func get_transaction_id() -&gt; int:</signature>
+			<description>获取 Utility 生命周期内唯一的事务 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数事务 ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_profile_id">
+			<signature>func get_source_profile_id() -&gt; StringName:</signature>
+			<description>获取事务来源 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">来源 Profile ID；不适用时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_target_profile_id">
+			<signature>func get_target_profile_id() -&gt; StringName:</signature>
+			<description>获取事务目标 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">目标 Profile ID；不适用时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_active_profile_before">
+			<signature>func get_active_profile_before() -&gt; StringName:</signature>
+			<description>获取事务开始前的活跃 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">开始前活跃身份；domain 未激活时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_active_profile_after">
+			<signature>func get_active_profile_after() -&gt; StringName:</signature>
+			<description>获取事务终态后的活跃 Profile ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">终态活跃身份；未激活或身份未知时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_phase">
+			<signature>func get_phase() -&gt; StringName:</signature>
+			<description>获取失败或成功发生的稳定阶段名。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">协调器定义的 payload-free 阶段名。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_code">
+			<signature>func get_error_code() -&gt; Error:</signature>
+			<description>获取 Godot Error 码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时为 OK。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error">
+			<signature>func get_error() -&gt; String:</signature>
+			<description>获取稳定错误描述。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时为空；失败说明最多 2048 个字符。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_failed_section_id">
+			<signature>func get_failed_section_id() -&gt; StringName:</signature>
+			<description>获取首个失败 section ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非 section 失败时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_rollback_errors">
+			<signature>func get_rollback_errors() -&gt; Array[GFSaveRollbackFailure]:</signature>
+			<description>获取类型化 Provider 回滚失败证据。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">按回滚顺序排列的隔离副本。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_stage_evidence">
+			<signature>func get_stage_evidence() -&gt; Dictionary:</signature>
+			<description>获取不含文档、section 或 Provider payload 的阶段证据。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">有界 evidence 副本。</tag>
+				<tag name="schema">return: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_recovery_lease">
+			<signature>func get_recovery_lease() -&gt; GFSaveProfileRecoveryLease:</signature>
+			<description>获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">recovery_required 结果中的 Lease；其他结果通常为 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_reconcile_lease">
+			<signature>func get_reconcile_lease() -&gt; GFSaveProfileReconcileLease:</signature>
+			<description>获取持续围栏 outcome_unknown 的同一身份 Reconcile Lease。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">需要或正在对账时的 Lease；不适用时为 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_metadata">
+			<signature>func get_metadata() -&gt; Dictionary:</signature>
+			<description>获取调用方结果元数据副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">调用方在一次性请求中移交的结果元数据。</tag>
+				<tag name="schema">return: Dictionary with caller-defined result metadata.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_started_at_msec">
+			<signature>func get_started_at_msec() -&gt; int:</signature>
+			<description>获取事务开始时间。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非负单调毫秒时间。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_completed_at_msec">
+			<signature>func get_completed_at_msec() -&gt; int:</signature>
+			<description>获取事务完成时间。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">不早于开始时间的单调毫秒时间。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_duration_msec">
+			<signature>func get_duration_msec() -&gt; int:</signature>
+			<description>获取事务耗时。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">非负单调毫秒耗时。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_result">
+			<signature>func duplicate_result() -&gt; GFSaveProfileTransactionResult:</signature>
+			<description>创建隔离结果副本。
+Recovery/Reconcile Lease 不复制，以维持原始恢复授权和持续对账生命周期。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新结果对象。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为不包含持久化 payload 或 Lease 对象的报告字典。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">事务身份、终态、阶段证据、Lease 摘要、错误与时间信息。</tag>
+				<tag name="schema">return: Payload-free Dictionary with transaction identity, status, active identities, phase, rollback failures, evidence, lease summaries, metadata, errors, and timing.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSaveSectionMutation.xml
+++ b/docs/api_catalog/classes/GFSaveSectionMutation.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSaveSectionMutation" path="addons/gf/extensions/save/profile/gf_save_section_mutation.gd" module="extensions/save" extends="RefCounted" classDigest="c547da33f3c8a05912405234d882c127f5bcb233ba8aafd788a0ca9f6014efdd">
+	<description>GFSaveSectionMutation: 单个 Save section 的一次性候选替换句柄。
+Mutation 只描述完整候选 section，不接受可执行 Callable 或增量 patch。
+`take_ownership()` 成功后，调用方必须永久放弃 payload、metadata 及其全部
+嵌套集合 alias；框架 claim 后句柄会立即清空载荷。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATE_AVAILABLE">
+			<signature>const STATE_AVAILABLE: StringName = &amp;"available"</signature>
+			<description>Mutation 尚未被框架接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_CLAIMED">
+			<signature>const STATE_CLAIMED: StringName = &amp;"claimed"</signature>
+			<description>Mutation 已被框架接管，候选载荷不再可用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATE_DISCARDED">
+			<signature>const STATE_DISCARDED: StringName = &amp;"discarded"</signature>
+			<description>Mutation 已被框架丢弃，候选载荷不再可用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="take_ownership">
+			<signature>static func take_ownership( section_id: StringName, schema_version: int, payload: Variant, metadata: Dictionary = {} ) -&gt; GFSaveSectionMutation:</signature>
+			<description>接管一个完整候选 section 的逻辑唯一所有权。
+该方法不会深复制 payload 或 metadata。成功返回后，调用方不得继续读取、
+修改或复用原集合及其嵌套 alias。输入必须满足 Save persisted-value 契约；
+Callable、Object、Signal、RID、循环集合和非有限数会被拒绝。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">section_id: 稳定 section ID。</tag>
+				<tag name="param">schema_version: 候选 section 的正整数 schema 版本。</tag>
+				<tag name="param">payload: 完整候选 section 载荷，不是 patch 或回调。</tag>
+				<tag name="param">metadata: 候选 section 持久化元数据。</tag>
+				<tag name="return">可用 Mutation；身份或候选数据无效时返回 null。</tag>
+				<tag name="schema">payload: Variant accepted by the Save persisted-value contract.</tag>
+				<tag name="schema">metadata: Dictionary accepted by the Save persisted-value contract.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_section_id">
+			<signature>func get_section_id() -&gt; StringName:</signature>
+			<description>获取稳定 section ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">section ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_schema_version">
+			<signature>func get_schema_version() -&gt; int:</signature>
+			<description>获取候选 section schema 版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">正整数 schema 版本；无效句柄为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_state">
+			<signature>func get_state() -&gt; StringName:</signature>
+			<description>获取当前所有权状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATE_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_available">
+			<signature>func is_available() -&gt; bool:</signature>
+			<description>检查 Mutation 是否仍可被请求或框架接管。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未 claim 或 discard 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="55d4090dc63ad9a240ade0c73a8aafd9f194d60f4259e4610c28a6d714102db2" classCount="794" methodCount="7201">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="64a5352766a4740db7d147a74d23e0d911a664091176fbddf23d8cac74a01cc5" classCount="802" methodCount="7289">
 	<module id="kernel" label="Kernel" classCount="74" methodCount="792">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -763,7 +763,7 @@
 		<class name="GFGravityField3D" path="classes/GFGravityField3D.xml" sourcePath="addons/gf/extensions/physics/nodes/gf_gravity_field_3d.gd" extends="Node3D" />
 		<class name="GFGravityProbe3D" path="classes/GFGravityProbe3D.xml" sourcePath="addons/gf/extensions/physics/nodes/gf_gravity_probe_3d.gd" extends="Node3D" />
 	</module>
-	<module id="extensions/save" label="Save" classCount="44" methodCount="325">
+	<module id="extensions/save" label="Save" classCount="52" methodCount="413">
 		<class name="GFNodeAnimationPlayerSerializer" path="classes/GFNodeAnimationPlayerSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_animation_player_serializer.gd" extends="GFNodeSerializer" />
 		<class name="GFNodeAudioStreamPlayerSerializer" path="classes/GFNodeAudioStreamPlayerSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_audio_stream_player_serializer.gd" extends="GFNodeSerializer" />
 		<class name="GFNodeCanvasItemSerializer" path="classes/GFNodeCanvasItemSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_canvas_item_serializer.gd" extends="GFNodeSerializer" />
@@ -790,14 +790,22 @@
 		<class name="GFSavePipelineEvent" path="classes/GFSavePipelineEvent.xml" sourcePath="addons/gf/extensions/save/pipeline/gf_save_pipeline_event.gd" extends="RefCounted" />
 		<class name="GFSavePipelineStep" path="classes/GFSavePipelineStep.xml" sourcePath="addons/gf/extensions/save/pipeline/gf_save_pipeline_step.gd" extends="Resource" />
 		<class name="GFSaveProfile" path="classes/GFSaveProfile.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile.gd" extends="Resource" />
+		<class name="GFSaveProfileMutationRequest" path="classes/GFSaveProfileMutationRequest.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd" extends="RefCounted" />
 		<class name="GFSaveProfileOperation" path="classes/GFSaveProfileOperation.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_operation.gd" extends="RefCounted" />
+		<class name="GFSaveProfileReconcileLease" path="classes/GFSaveProfileReconcileLease.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd" extends="RefCounted" />
+		<class name="GFSaveProfileReconcileRequest" path="classes/GFSaveProfileReconcileRequest.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd" extends="RefCounted" />
+		<class name="GFSaveProfileRecoveryLease" path="classes/GFSaveProfileRecoveryLease.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd" extends="RefCounted" />
 		<class name="GFSaveProfileRequest" path="classes/GFSaveProfileRequest.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_request.gd" extends="RefCounted" />
 		<class name="GFSaveProfileResult" path="classes/GFSaveProfileResult.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_result.gd" extends="RefCounted" />
+		<class name="GFSaveProfileTransactionCoordinator" path="classes/GFSaveProfileTransactionCoordinator.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd" extends="GFUtility" />
+		<class name="GFSaveProfileTransactionOperation" path="classes/GFSaveProfileTransactionOperation.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd" extends="RefCounted" />
+		<class name="GFSaveProfileTransactionResult" path="classes/GFSaveProfileTransactionResult.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd" extends="RefCounted" />
 		<class name="GFSaveProfileUtility" path="classes/GFSaveProfileUtility.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_profile_utility.gd" extends="GFUtility" />
 		<class name="GFSaveRecoveryPolicy" path="classes/GFSaveRecoveryPolicy.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_recovery_policy.gd" extends="Resource" />
 		<class name="GFSaveRollbackFailure" path="classes/GFSaveRollbackFailure.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_rollback_failure.gd" extends="RefCounted" />
 		<class name="GFSaveScope" path="classes/GFSaveScope.xml" sourcePath="addons/gf/extensions/save/core/gf_save_scope.gd" extends="Node" />
 		<class name="GFSaveSection" path="classes/GFSaveSection.xml" sourcePath="addons/gf/extensions/save/document/gf_save_section.gd" extends="RefCounted" />
+		<class name="GFSaveSectionMutation" path="classes/GFSaveSectionMutation.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_section_mutation.gd" extends="RefCounted" />
 		<class name="GFSaveSectionProvider" path="classes/GFSaveSectionProvider.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_section_provider.gd" extends="Resource" />
 		<class name="GFSaveSectionSnapshot" path="classes/GFSaveSectionSnapshot.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_section_snapshot.gd" extends="RefCounted" />
 		<class name="GFSaveSectionSnapshotOperation" path="classes/GFSaveSectionSnapshotOperation.xml" sourcePath="addons/gf/extensions/save/profile/gf_save_section_snapshot_operation.gd" extends="RefCounted" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -24,7 +24,7 @@
 
 ## [未发布]
 
-**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，补充 Save Profile bootstrap、Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；框架只提供可验证的通用机制，不内置项目启动政策、部署协议、环境业务模型或轮询式音频模拟。
+**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，为 Save Profile 增加精确 provider domain、活动身份与显式恢复/对账事务，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；框架只提供可验证的通用机制，不内置项目启动、存档业务、部署协议、环境模型或轮询式音频模拟。
 
 ### 🚀 新增特性 (Added)
 
@@ -45,6 +45,15 @@
 - Save Profile 新增 `GFSaveSectionSnapshot` 与 `GFSaveSectionSnapshotOperation`：Provider 通过 `begin_save_snapshot()` / `_begin_save_snapshot()` 在主线程按 work unit 分片生成不可变 section Snapshot；固定且很小的载荷可用 `make_completed_snapshot()`，大型载荷必须实现有界 Operation。
 - Storage 新增 `GFStoragePayloadTransfer` 与 `save_payload_request_async()`：以 opaque 单所有者句柄逻辑移交纯 Variant 载荷，并允许同一冻结绑定上的 timeout-detached attempt 与有界重试共享只读 Snapshot。
 - `GFSaveProfileUtility` 新增全局准备 work budget、单 profile slice budget 和软时间 budget；`GFSaveProfileResult` 新增准备耗时、Storage attempt 累计耗时与准备 work units 诊断。
+- 新增 `GFSaveProfileTransactionCoordinator`、`GFSaveProfileTransactionOperation` 与
+  `GFSaveProfileTransactionResult`：在单 Profile 原语之上按精确有序 Provider 身份管理
+  domain、活动 Profile、严格 activate/switch、显式 bootstrap/adopt、类型化 mutation
+  和 reconcile，并以独立不可变终态报告跨 Profile 事务。
+- 新增 `GFSaveProfileRecoveryLease`、`GFSaveProfileReconcileLease` 与
+  `GFSaveProfileReconcileRequest`：missing/corrupt 只能通过匹配的一次性恢复能力继续，
+  写入结果未知时冻结 domain，等待底层证据 settled 后通过显式严格重读收敛。
+- 新增 `GFSaveSectionMutation` 与 `GFSaveProfileMutationRequest`：用 move-only 候选 section
+  清单替代事务内任意回调，固定 Provider 顺序并在确定失败时逆序恢复。
 - `GFStorageAsyncResult` 新增 `WriteFailureKind` 与隔离的 worker 载荷预检报告，区分非法请求、不可持久化载荷、编码、线程、生命周期和 IO 故障。
 
 ### 🔄 机制更改 (Changed)
@@ -72,6 +81,16 @@
 - 保存 Provider 从后续 `tick()` 开始按全局预算公平轮转，软时间预算只阻止启动下一个 slice，不伪装成可抢占执行。准备完成后文档逻辑 move 到 `GFStoragePayloadTransfer`；Storage worker 在本次新写入的编码与 temp、marker、final 事务提交前执行有界纯 Variant 图预检和物化，既有事务 recovery 与目录初始化仍是独立前置生命周期。Save 终态不再保留完整文档副本，完整文档只由 load 结果返回。
 - Storage 首次 claim transfer 时冻结 Storage 实例、规范文件名、canonical target file-family identity 和 codec options；每个物理 attempt 取得独立只读 lease，最后一个 lease 结束且 Profile 释放 generation 后才清空载荷，重试不再重新采集 Provider 或复制完整文档。
 - Storage worker 载荷预检现在同时限制 128 层深度、1,000,000 个值和 64 MiB 估算原始字节，拒绝 Object/Script typed container 元数据；诊断只保留结构索引、类型与预算计数，Save 通过隔离 Adapter 映射 section，不输出 key/value 或 key 派生摘要。
+- Coordinator 管理的 Profile 只在 domain 稳定且该 Profile 活动时开放直接 save/flush；
+  直接 load、非活动 Profile 写入以及事务或 reconcile fence 期间的直接操作均失败关闭。
+  activate/switch 始终采用严格读取，不把 `ACTION_USE_CURRENT_STATE` 隐式提升为活动身份；strict load 绑定 manager capability，撤权后的迟到读取不会在事务终态之后应用 Provider。
+- Switch 先 flush 调用时源 generation，再快照并加载目标，已知失败逆序恢复且保留源活动
+  身份。Bootstrap/Adopt 只消费各自 missing/corrupt Recovery Lease，并在写确认后激活；
+  mutation 的已知 Storage 失败已证明未提交，因此恢复内存但不发起扩大风险的补偿保存。
+- 事务写入返回 `outcome_unknown` 时，Coordinator 保持 Provider 状态与 domain fence，
+  不自动回滚、重试、补偿或猜测迟到终态；Reconcile Lease 等待底层 generation 证据
+  settled，随后仍须由项目提交 `GFSaveProfileReconcileRequest`，严格重读 lease 指定
+  Profile 并完整应用后才解锁。Request 不接受项目布尔结论或可执行恢复策略。
 
 ### 🐛 Bug 修复 (Fixed)
 
@@ -90,6 +109,11 @@
 - 修复场景树先释放 root-owned BGM 播放器后，`GFAudioUtility.dispose()` 在有效性检查前构造 typed array 而触发 freed-instance 转换错误的问题；两条 BGM 清理路径与重复 dispose 都收敛到幂等终态。
 - 修复场景切换完成帧立即启动邻居预载时与活动 Asset warmup 重叠，可能导致 `.tscn` 间歇解析失败的问题；邻居请求现在必须经过目标场景确认、稳定帧和共享 Broker idle 边界。
 - 修复 `save_profile()` 在提交调用栈内同步遍历大型 Provider、可造成超过 100ms 主线程停顿的问题；请求现在先返回句柄，再由生命周期 tick 在显式预算内推进准备。
+- 修复共享 Provider 的 Profile 切换由项目拼接 flush/load 时缺少原子活动身份、目标失败后
+  可能遗留部分应用状态的问题；新 Coordinator 在精确 domain 锁内完成源屏障、逆序恢复
+  与单次身份提交。
+- 修复 section 修改与保存分离时，已知写入失败、未知提交和生命周期关闭之间没有统一
+  所有权的问题；类型化 mutation 现在区分可逆确定失败与必须 fence 的未知结果。
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
@@ -117,7 +141,16 @@
 - `GFSaveProfileUtility.STATE_PREPARING` 替代 `STATE_GATHERING`，`GFSaveProfileResult.STATUS_PREPARATION_FAILED` 替代 `STATUS_GATHER_FAILED`，并新增 `save_preparation_work_budget_per_tick`、`save_preparation_slice_budget` 与 `save_preparation_time_budget_usec`。
 - `GFSaveProfileResult.get_preparation_duration_msec()`、`get_storage_duration_msec()` 与 `get_preparation_work_units()` 分开暴露阶段诊断；Save 结果的 `get_document()` 固定返回 `null`，只有 load 结果携带文档。
 - `GFStoragePayloadTransfer.take_ownership()`、`release()`、`GFStorageUtility.save_payload_request_async()`、`GFStorageAsyncOperation.reclaim_failed_payload()`、`GFStorageAsyncResult.get_write_failure_kind()` 与 `get_write_validation_report()` 构成新的显式 move / retry 契约。`gf.save` 的 `extension_version` 因此提升到 `6.0.0`。
-- Save 扩展 Installer 现在先确保 `GFStorageUtility` 存在，再装配 Save Graph/Profile；项目 Installer 不再重复拥有 Storage 注册。
+- `GFSaveProfileTransactionCoordinator.register_profile()` / `unregister_profile()`、
+  `activate_profile()`、`switch_profile()`、`bootstrap_profile()`、`adopt_profile()`、
+  `mutate_and_persist()`、`reconcile_profile()`、`get_active_profile_id()` 与
+  `get_domain_state_snapshot()` 是新的活动 Profile 事务 API。
+- `GFSaveProfileTransactionOperation` / `GFSaveProfileTransactionResult`、
+  `GFSaveProfileRecoveryLease`、`GFSaveProfileReconcileLease` /
+  `GFSaveProfileReconcileRequest`、`GFSaveSectionMutation` 与
+  `GFSaveProfileMutationRequest` 是新的公开 operation、result、lease 和 move-only request
+  类型；它们不与普通 `GFSaveProfileOperation` / `GFSaveProfileResult` 混用。`gf.save` 因新增可选活动身份事务层并收紧受管 Profile 准入，`extension_version` 从 `6.0.0` 提升到 `6.1.0`。
+- Save 扩展 Installer 现在先确保 `GFStorageUtility` 存在，再装配 Save Graph、Profile 与 Profile Transaction Coordinator；项目 Installer 不再重复拥有 Storage 注册。
 - `GFModel`、`GFSystem`、`GFUtility` 新增 `begin_activation(GFAsyncScope) -> GFAsyncCompletion` 与 `begin_quiesce(GFAsyncScope) -> GFAsyncCompletion`。
 - `GFArchitecture.init(cancellation_token = null)` 保留无参数调用形状并新增显式取消输入；新增 `activation_timeout_seconds`、`shutdown_timeout_seconds`、`is_activating()`、`is_quiescing()`、`is_accepting_runtime_work()`、`is_module_active()`、`shutdown_async()`、`get_last_shutdown_result()` 与 `shutdown_finished`。`module_async_init_timeout_seconds` 与两个新增 timeout 属性统一为有限 `0..86400` 契约，`0` 禁用 deadline；并发 init/shutdown 都由首个调用拥有共享流程策略，后续 init token 只取消自身等待，后续 shutdown 调用只复制同一终态。父级 required module/factory 由 child generation 弱租约保护；模块租约冻结相关父级模块拓扑，任一外部依赖租约都使父级正常关闭以 `ERR_BUSY` 失败。`create_instance()` 现在属于 READY 运行时准入，在 activation、热拓扑事务或 quiesce 期间不会调用 provider。依赖诊断固定复用四类 typed Hook 与真实父级解析语义，不再提供 `include_parent_lookup` / `include_factories` 行为开关。
 - `GFArchitecture.unregister_model()`、`unregister_system()`、`unregister_utility()` 及 classless Autoload facade `Gf.unregister_*()` 均改为必须 `await` 且返回 `bool` 的拓扑事务；旧同步 fire-and-forget 调用不再受支持。
@@ -145,6 +178,22 @@
 18. 将 `Gf.unregister_model()`、`Gf.unregister_system()` 与 `Gf.unregister_utility()` 的调用改为 `await` 并检查 `bool`；不要依赖旧的同步注销时序。
 19. 启用 Save 扩展的项目删除项目 Installer 中重复的 `GFStorageUtility` 注册；需要调整参数时取回扩展已安装实例并配置，需要替换实现时显式调用 `replace_utility()`。
 20. 不再在 Installer、`init()`、`ready()` 或 activation 中调用 `create_instance()` 触发工厂副作用；装配期改用 `has_factory()` / `get_required_factories()` 校验，只有 Architecture 提交 READY 且无热拓扑事务后才创建运行时对象。
+21. 需要活动槽位或账号身份的项目，把 Profile 注册从 `GFSaveProfileUtility` 迁移到
+    `GFSaveProfileTransactionCoordinator.register_profile()`；只让完全相同且顺序一致的
+    Provider 实例共享一个 domain，消除部分重叠和重排拓扑。
+22. 把 activation 中直接 `load_profile()` 的恢复改为 `activate_profile()`。收到 missing
+    Recovery Lease 后由项目确认再调用 `bootstrap_profile()`；收到 corrupt Lease 后先执行
+    项目备份/确认政策，再调用 `adopt_profile()`。不要用 `ACTION_USE_CURRENT_STATE` 发布身份。
+23. 把项目手写的 flush-source/load-target 切换改为 `switch_profile()`，并以
+    `GFSaveProfileTransactionResult` 判断 source flush、target load、rollback 和活动身份终态。
+24. 需要“修改后必须持久化”的 section 流程改为构造 `GFSaveSectionMutation` 清单，通过
+    `GFSaveProfileMutationRequest` 提交 `mutate_and_persist()`；成功 claim 后放弃请求与候选
+    payload 的全部 alias，不再在写失败后自行追加补偿保存。
+25. 事务返回 `outcome_unknown` 时停止该 domain 的后续工作，并以结果中的
+    `GFSaveProfileReconcileLease` 调用 `reconcile_profile()`；waiting 状态会返回
+    `reconcile_pending` 且不 claim Request。lease ready 后用同一 lease 与
+    `GFSaveProfileReconcileRequest` 重试，等待严格重读和应用成功；不要用直接 load/save
+    绕过 fence，也不要把迟到成功当成原 switch 会自动继续目标。
 
 ### 📁 核心受影响文件 (Affected Files)
 
@@ -188,6 +237,14 @@
 - `addons/gf/extensions/save/profile/gf_save_section_snapshot_operation.gd`
 - `addons/gf/extensions/save/profile/gf_save_profile_utility.gd`
 - `addons/gf/extensions/save/profile/gf_save_profile_result.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd`
+- `addons/gf/extensions/save/profile/gf_save_section_mutation.gd`
+- `addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd`
 - `addons/gf/extensions/save/gf_extension.json`
 - `packages/standard/gf.standard.storage.json`
 - `addons/gf/extensions/network/backends/gf_network_backend.gd`
@@ -207,6 +264,7 @@
 - `docs/zh/kernel/lifecycle/module-lifecycle/dynamic-registration.md`
 - `docs/zh/kernel/architecture/assembly-diagnostics/dependency-diagnostics.md`
 - `docs/zh/extensions/save-graph/save-profile-adr.md`
+- `docs/zh/extensions/save-graph/save-profile-transactions.md`
 - `docs/zh/extensions/network-turnbased/network-transport/backend-session.md`
 - `docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md`
 - `docs/zh/standard/utilities/io/assets-jobs-warmup/resource-broker.md`

--- a/docs/zh/extensions/save-graph/index.md
+++ b/docs/zh/extensions/save-graph/index.md
@@ -9,6 +9,7 @@ GF Save 扩展负责把场景树节点状态组织成可采集、可校验、可
 - [节点序列化器与槽位](serializers-slots.md)：默认节点状态片段、`GFSaveIdentity`、`GFSaveSlotWorkflow`、槽位元数据和卡片 DTO。
 - [Pipeline Trace](pipeline-trace.md)：`GFSavePipelineContext`、流程事件和采集/应用诊断日志。
 - [Save Profile 运行时](save-profile-runtime.md)：多 section 所有权、异步 generation 合并、flush 屏障、迁移和恢复政策。
+- [Save Profile 会话与事务](save-profile-transactions.md)：精确 provider domain、活动身份、严格切换、显式恢复、类型化修改和未知结果对账。
 - [Save Profile 架构决策](save-profile-adr.md)：状态机、不变量、失败矩阵和故障注入策略。
 
 ## 使用边界

--- a/docs/zh/extensions/save-graph/save-profile-adr.md
+++ b/docs/zh/extensions/save-graph/save-profile-adr.md
@@ -15,6 +15,9 @@ GF 已经具备版本化 `GFSaveDocument`、独立 section、迁移注册表、�
 - 保存请求如何只入队，并把大型 Provider 的主线程准备限制在可配置预算内；
 - 异步读取、迁移、校验、应用和回滚如何形成一个可观察终态；
 - 缺失、损坏、未来版本和临时 IO 故障如何被明确区分；
+- 共享同一组 Provider 的多个 Profile 如何只有一个可证明的活动身份；
+- Profile 切换、显式恢复和 section 修改如何跨多次底层操作保持原子边界；
+- 写入结果未知时如何冻结冲突工作，等待 generation 证据并显式严格重读；
 - 测试如何确定性地注入失败，而不依赖真实磁盘竞争或计时。
 
 这些责任不属于具体游戏业务，也不应由 UI、场景或单个 section 承担。
@@ -37,6 +40,14 @@ GF 已经具备版本化 `GFSaveDocument`、独立 section、迁移注册表、�
   分开记录准备与 Storage 耗时，完整文档只存在于 load 结果。
 - `GFSaveRecoveryPolicy` 只允许显式、可审计的恢复和有界重试。
 - `GFStorageAsyncOperation` 为每次底层 IO 提供独立 request ID 和类型化终态。
+- `GFSaveProfileTransactionCoordinator` 在上述原语之上编译精确 provider domain，管理
+  活动 Profile 身份，并串行推进 activate、switch、bootstrap、adopt、mutation 和 reconcile。
+- `GFSaveProfileTransactionOperation` / `GFSaveProfileTransactionResult` 为跨 Profile 流程
+  提供独立类型化句柄与不可变终态，不扩张普通 `GFSaveProfileResult` 的单 Profile 语义。
+- `GFSaveProfileRecoveryLease` 把已知 missing/corrupt 恢复选择变成一次性显式能力；
+  `GFSaveProfileReconcileLease` 与 `GFSaveProfileReconcileRequest` 负责未知写入的受控重读收敛。
+- `GFSaveSectionMutation` 与一次性 `GFSaveProfileMutationRequest` 提交候选 section，
+  不接受可在事务中执行任意副作用的 Callable。
 
 Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽位 UI、云同步或平台 SDK。
 
@@ -48,7 +59,7 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 4. `flush_profile()` 捕获调用时的目标 generation，不把“已入队”等同于“已持久化”。
 5. 文档在全部迁移和校验成功前不得触碰运行时状态。
 6. 应用前先采集所有可加载 provider 的回滚快照；任一应用失败后按逆序回滚。
-7. 缺失或损坏数据默认失败并保留现状；使用当前状态恢复必须显式配置。
+7. 缺失或损坏数据默认失败并保留现状；非 managed 普通读取使用当前状态必须显式配置。
 8. 未来 schema 永不进入重置或使用当前状态分支，必须升级代码后再读取。
 9. 重试只适用于策略声明的临时错误，并受有限延迟序列约束。
 10. 终态结果必须保留操作类型、generation、失败 section、底层读取结果和恢复信息。
@@ -68,7 +79,18 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 24. Worker 只能处理已移交的纯 Variant 图；图预算或可持久化性预检失败必须在本次新写入的编码以及 temp、marker、final 事务提交副作用前结束。既有事务 recovery 与目录初始化是独立前置生命周期。
 25. 保存终态不得为了诊断保留完整文档副本；只有读取终态可通过 `get_document()` 返回文档，准备耗时与 Storage attempt 累计耗时必须分开报告；同时活跃的 attempt 分别累计，重叠区间不折叠。
 26. worker 失败报告只允许携带有界结构索引、Variant 类型和预算计数；Save 只能用文档构造时记录的 entry index 映射 section，不得复制 key/value 或可离线关联的 key 摘要。
-26. Save Operation 只持有对应请求的 result metadata；document metadata 与 Provider context 由最新 generation 状态直接接管，开始准备时通过 assignment 移入当前状态，不得深复制。
+27. Save Operation 只持有对应请求的 result metadata；document metadata 与 Provider context 由最新 generation 状态直接接管，开始准备时通过 assignment 移入当前状态，不得深复制。
+28. Provider domain 只由完全相同的有序 Provider 对象身份构成；任何部分重叠或顺序不同的拓扑都不得共享活动身份或锁域。
+29. 每个 domain 最多有一个活动 Profile；只有严格加载或显式恢复写入获得确定成功后才可原子发布或切换活动身份。
+30. Coordinator 管理的 Profile 只允许稳定活动身份执行直接 save/flush；直接 load、非活动 Profile 操作和事务/fence 期间的全部直接操作必须失败关闭。
+31. Switch 必须先 flush 调用时源 generation，再采集完整 Provider 快照并严格加载目标；已知失败按逆序恢复且不改变源活动身份。
+32. 首次 activate 的 missing 只能产生 Bootstrap Recovery Lease，corrupt 只能产生 Adopt Recovery Lease；两类一次性能力不得互换、复用或跨 domain generation 使用；switch 目标的同类失败保留源身份并以 target load failure 结束。
+33. Bootstrap 与 Adopt 只有在候选写入确定成功后才激活目标；普通恢复政策不得隐式发布活动身份。
+34. Mutation 必须先固定 Provider 顺序并采集回滚快照，再应用类型化候选并等待保存终态；已知 Storage 失败证明未提交，因此逆序恢复内存且不得自动补偿写入。
+35. 任何无法证明提交与否的写入都必须冻结整个 domain 并返回 Reconcile Lease；不得自动回滚、补偿、重试、激活或接受冲突工作。
+36. Reconcile Lease 在底层 generation 证据 settled 前保持 waiting，pending 调用不 claim Request；ready 后只能严格重读 lease 指定 Profile，完整应用成功才解锁并重建活动身份。
+37. Quiesce 必须先关闭 Coordinator 的新业务准入，再等待已接纳事务、底层 Profile 操作和路径所有权收敛；只允许既有 ready Reconcile Lease 作为 closure continuation 严格重读，不能借此创建其他事务；同步 dispose 不得把未知写入伪装成确定失败或已回滚。
+38. 受管 strict load 必须绑定 manager capability，并在文档应用前及每次 Provider 回调后复核；dispose 撤权后的迟到读取不得提交 Provider 状态，已开始应用时必须逆序恢复并显式报告恢复失败。
 
 ## 状态机
 
@@ -92,6 +114,19 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 应用过程中不接受保存，以免基于旧内存状态覆盖新读取的数据。`retry_wait -> idle` 表示
 等待期间 detached 写入迟到成功，计划重试随逻辑保存完成而取消。
 
+Coordinator 在 primitive 状态机之外为每个 provider domain 维护以下状态：
+
+| Domain 状态 | 含义 | 公开准入 |
+| --- | --- | --- |
+| `inactive` | 尚无活动 Profile | activate；匹配 lease 的 bootstrap/adopt |
+| `active` | 一个 Profile 拥有当前 Provider 状态 | switch、mutation；活动 Profile save/flush |
+| `transacting` | 已接纳事务正在推进 | 拒绝并发 domain 操作与直接原语 |
+| `reconciliation_required` | 写入结果未知并持有 fence | 仅匹配 lease 的 reconcile 与诊断查询 |
+| `disposed` | 强制释放终态 | 无 |
+
+Quiesce 是 Coordinator 的全局准入阶段，不伪装成额外 domain 状态；诊断快照通过
+`quiescing` 字段独立报告它。
+
 ## 失败矩阵
 
 | 阶段/故障 | 默认结果 | 可恢复行为 | 必须保留的证据 |
@@ -107,8 +142,19 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 | 写入永久失败 | `storage_failed` | 无自动恢复 | generation、错误码 |
 | 读取 IO 超时 | `storage_failed` | 可由上层重新读取 | request ID、尝试次数、超时 |
 | 写入超时或写入中释放 | `outcome_unknown` | 先重读/对账，再决定重试 | request ID、generation、超时/释放原因 |
-| 文件不存在 | `missing` | 显式 `use_current_state` | 原始 `GFStorageReadResult` |
-| 文档损坏或完整性失败 | `corrupt` | 显式 `use_current_state`，不立即覆盖原文件 | 原始读取结果、恢复动作 |
+| 非 managed 普通读取文件不存在 | `missing` | 显式 `use_current_state` | 原始 `GFStorageReadResult` |
+| 非 managed 普通读取文档损坏 | `corrupt` | 显式 `use_current_state`，不立即覆盖原文件 | 原始读取结果、恢复动作 |
+| Managed activate 文件不存在 | `recovery_required` | 只签发 Bootstrap Recovery Lease | profile/domain/generation、读取结果 |
+| Managed activate 文档损坏 | `recovery_required` | 只签发 Adopt Recovery Lease | profile/domain/generation、读取结果 |
+| Switch 目标文件缺失或损坏 | `target_load_failed` | 恢复 Provider 并保留源身份 | 目标读取结果、回滚错误 |
+| Managed Profile 直接 load 或非活动 save/flush | `busy` | 改用 Coordinator，或等待活动稳定 | profile/domain/活动身份 |
+| Switch 的源 flush 失败 | `source_flush_failed` | 保留源活动身份 | 源 generation 与底层终态 |
+| Switch 目标已知失败 | `target_load_failed` / 应用失败 | 逆序恢复并保留源身份 | 目标读取结果、回滚错误 |
+| Mutation 已知持久化失败 | `persist_failed` | 逆序恢复；不发补偿写 | generation、底层确定失败 |
+| 事务写入结果未知 | `outcome_unknown` | 冻结 domain，签发 Reconcile Lease | domain generation、request IDs |
+| Lease 无效、过期或重复消费 | `invalid_lease` | 重新取得当前状态证据 | lease kind、domain generation |
+| generation 证据仍为 unknown | `reconcile_pending` | 保持 fence，等待底层证据 settled；不 claim Request | bounded reconcile snapshot |
+| ready lease 的严格重读失败 | `reconcile_failed` | 保持 fence，由项目稍后重新对账 | 读取结果、失败 section、回滚错误 |
 | schema id 不匹配 | `schema_mismatch` | 无 | 实际/目标 schema |
 | 旧版本缺少迁移链 | `migration_failed` | 注册完整迁移链后重试 | 迁移结果 |
 | 迁移步骤失败 | `migration_failed` | 修复步骤后重试 | 迁移结果、步骤 id |
@@ -123,8 +169,10 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 ## 恢复与重试政策
 
 - `missing` 与 `corrupt` 默认动作均为 `fail`。
-- `use_current_state` 只表示保留内存中的当前/default 状态并返回显式 recovered
-  终态；读取操作本身不写盘，也不删除、替换或修补原文件。
+- `use_current_state` 只适用于非 managed 普通读取，表示保留内存中的当前/default 状态并
+  返回显式 recovered 终态；读取本身不写盘，也不删除、替换或修补原文件。
+- Coordinator 的 strict load 忽略 `use_current_state`：missing/corrupt 必须分别经过
+  Bootstrap/Adopt Recovery Lease，写确认后才能发布活动身份。
 - 未来 schema、schema id 不匹配和迁移失败不属于损坏恢复。
 - 重试延迟是有限的毫秒序列；序列耗尽后必须返回失败，禁止无限循环。
 - 时间判断只使用注入的 `GFClock` 单调时间，测试使用 `GFManualClock`。
@@ -167,6 +215,16 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 - Save 结果的 `get_document()` 返回 `null`，load 结果仍返回文档；准备耗时、准备 work
   units 与 Storage attempt 累计耗时分别可观察；
 - 真实 `GFStorageUtility` 往返测试覆盖异步句柄集成，不只依赖测试替身。
+- 精确相同的有序 Provider 身份共享 domain，重排和部分重叠注册失败关闭；不相交 domain
+  可独立推进；
+- activate/switch 只在严格成功后发布活动身份；首次 activate 的 missing/corrupt 分别
+  只能由匹配的 bootstrap/adopt lease 继续，switch 目标失败则保留源身份；
+- 活动 managed Profile 只开放稳定期 save/flush，直接 load、非活动写入和事务期重入均被拒绝；
+- switch 源 flush、目标读取、应用和逆序恢复的每个故障点都保持可证明身份；
+- typed mutation 的无效请求不被消费，已知持久化失败逆序恢复且不产生补偿写；
+- outcome-unknown 冻结整个 domain；waiting reconcile 不 claim Request，底层证据 settled
+  后仍需匹配 lease 严格重读指定 Profile并完整应用，才可解锁并重建活动身份；
+- quiesce 等待已接纳事务和路径所有权，forced dispose 保留未知终态证据。
 
 ## 后果
 
@@ -177,3 +235,8 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 保持在明确上界，并在逻辑 move 后主动放弃全部源 alias。注册后身份与能力被冻结。无法
 回滚的外部副作用必须留在更高层事务参与者中，不能伪装成普通 section 应用。写入结果
 未知时，上层还必须采用重读、版本戳或业务对账策略，而不能盲目重复提交。
+
+Coordinator 进一步把活动身份和跨 Profile 流程变成框架级可测试契约。代价是 managed
+Profile 必须通过精确 Provider 拓扑共享 domain，并遵循一次性 Recovery/Reconcile Lease
+与 Mutation Request；项目仍需拥有账号到 Profile 的映射、恢复确认、损坏备份、云端冲突、
+业务 schema 和对账重试时机，框架不会替这些政策选择默认答案。

--- a/docs/zh/extensions/save-graph/save-profile-runtime.md
+++ b/docs/zh/extensions/save-graph/save-profile-runtime.md
@@ -111,84 +111,17 @@ if not GFVariantData.get_option_bool(registration, "registered"):
 `GFSaveMigrationRegistry` 仍是唯一迁移引擎。Profile 不提供字段级兼容回退；文档或
 section 版本落后时必须存在完整迁移链，未来版本始终拒绝读取。
 
-## 与 Architecture Activation 组合
+## 与活动 Profile 事务组合
 
-需要在首个运行场景开放前恢复存档或确认既有 generation 已落盘时，由项目
-`GFSystem` 声明 `GFSaveProfileUtility` 为必需依赖，并在
-`begin_activation(scope)` 中把 `load_profile()` 或 `flush_profile()` 的类型化终态
-桥接到 `GFAsyncCompletion`。不要把项目 slot、账号选择或恢复决策写入框架 Utility，
-也不要在 System 中手动轮询 `architecture.tick()`：
+`load_profile()` 与 `flush_profile()` 是单 Profile 原语，不负责活动槽位、账号身份或
+跨 Profile 切换。需要在 Architecture activation 中严格恢复既有存档，或需要原子切换、
+显式创建/接管、类型化修改和未知写入对账时，使用
+`GFSaveProfileTransactionCoordinator`。完整拓扑、恢复 lease、managed gate 和生命周期
+组合见 [Save Profile 会话与事务](save-profile-transactions.md)。
 
-```gdscript
-extends GFSystem
-
-const BOOTSTRAP_PROFILE_ID: StringName = &"project.player"
-
-var _save_profiles: GFSaveProfileUtility = null
-var _bootstrap_operation: GFSaveProfileOperation = null
-
-func get_required_utilities() -> Array[Script]:
-	return [GFSaveProfileUtility]
-
-func ready() -> void:
-	var value: Variant = get_utility(GFSaveProfileUtility, true)
-	if value is GFSaveProfileUtility:
-		_save_profiles = value
-	# 在这里注册项目自己的 GFSaveProfile，并检查 registered 报告。
-
-func begin_activation(scope: GFAsyncScope) -> GFAsyncCompletion:
-	var completion: GFAsyncCompletion = GFAsyncCompletion.new()
-	var _bound: bool = completion.bind_cancel_token(scope)
-	if not completion.is_pending():
-		return completion
-	if _save_profiles == null:
-		var _failed: bool = completion.fail("Save Profile dependency is unavailable.")
-		return completion
-
-	# 恢复启动状态时等待 load；若职责是确认已排队 generation 落盘，
-	# 则用 flush_profile(BOOTSTRAP_PROFILE_ID) 并复用同一桥接方法。
-	_bootstrap_operation = _save_profiles.load_profile(BOOTSTRAP_PROFILE_ID)
-	_bridge_bootstrap_operation(_bootstrap_operation, completion)
-	return completion
-
-func _bridge_bootstrap_operation(
-	operation: GFSaveProfileOperation,
-	completion: GFAsyncCompletion
-) -> void:
-	if operation == null:
-		var _failed: bool = completion.fail("Save Profile bootstrap returned no operation.")
-		return
-	if operation.is_completed():
-		_finish_bootstrap(operation.get_result(), completion)
-		return
-	var connected: Error = operation.completed.connect(
-		Callable(self, &"_finish_bootstrap").bind(completion),
-		CONNECT_ONE_SHOT
-	)
-	if connected != OK:
-		var _failed_connect: bool = completion.fail("Bootstrap completion is unavailable.")
-
-func _finish_bootstrap(result: GFSaveProfileResult, completion: GFAsyncCompletion) -> void:
-	_bootstrap_operation = null
-	if not completion.is_pending():
-		return
-	if result != null and result.is_successful():
-		var _succeeded: bool = completion.succeed()
-		return
-	var error_message: String = result.get_error() if result != null else "No result."
-	var _failed: bool = completion.fail(error_message)
-```
-
-依赖 DAG 会先激活 `GFStorageUtility`，再激活 `GFSaveProfileUtility`，最后执行项目
-System 的 activation。等待上述 Operation 时，Architecture 只推进当前 System 的
-本地依赖闭包，因此 Profile 与 Storage 的 tick-driven 状态机会继续运行，但命令、
-事件、普通 tick 和其他外部运行时工作仍保持关闭。Operation 失败、scope 取消或超过
-`activation_timeout_seconds` 时，项目 System 必须让 completion 进入非成功终态；
-Architecture 随即拒绝 READY，并由 lifecycle generation 防止迟到回调写回。
-
-`load_profile()` 适合恢复并应用启动状态；`flush_profile()` 只保证调用时捕获的
-generation 或更新 generation 已经持久化，不能替代读取。是否在 load 后安排一次
-save/flush 取决于项目恢复政策，框架不隐式改写文件。
+直接使用原语的非 managed Profile 仍可把 Operation 终态桥接到
+`GFAsyncCompletion`。`load_profile()` 恢复并应用状态；`flush_profile()` 只保证调用时
+捕获的 generation 或更新 generation 已持久化，不能替代读取，也不能发布活动身份。
 
 ## 保存、flush 与读取屏障
 
@@ -272,9 +205,9 @@ Profile 层使用 `GFStorageAsyncOperation` 的 request ID 观察自己的底层
 
 ## 恢复政策
 
-`GFSaveRecoveryPolicy` 默认对缺失和损坏文件返回失败。项目可以显式选择
-`ACTION_USE_CURRENT_STATE`，此时读取成功终态会标记 recovered，但只保留当前内存
-状态，不删除、替换或自动覆盖原文件。
+`GFSaveRecoveryPolicy` 默认对缺失和损坏文件返回失败。直接管理非 managed Profile 的
+项目可以显式选择 `ACTION_USE_CURRENT_STATE`，此时普通读取成功终态会标记 recovered，
+但只保留当前内存状态，不删除、替换或自动覆盖原文件。
 
 ```gdscript
 var policy := GFSaveRecoveryPolicy.new()
@@ -292,6 +225,11 @@ schema ID 不匹配、迁移失败和 provider 应用失败不进入损坏恢复
 迟到的完成回调不会改变已经进入终态的操作句柄；如果同一逻辑保存仍在等待或执行重试，
 任一覆盖其 generation 的物理写入成功会立即完成该句柄并取消尚未启动的重试。已经启动的
 其他写请求继续由 Profile 保有路径直到物理终态，但其后续失败不会翻转已确认的保存成功。
+
+Coordinator 管理的 Profile 不把 `ACTION_USE_CURRENT_STATE` 当成激活授权：严格 activate
+会把 missing/corrupt 分别转换为受约束的 Recovery Lease，项目必须显式调用
+bootstrap/adopt，且只有写确认后才发布活动身份。Switch 的目标缺失或损坏会恢复并保留
+源活动身份，不会隐式创建或覆盖目标存档。
 
 未知 section 默认采用 `GFSaveProfile.UNKNOWN_SECTION_REJECT`，避免旧客户端读取后保存时
 静默删除新客户端数据。只有明确拥有向前兼容要求时才选择 `UNKNOWN_SECTION_PRESERVE`；

--- a/docs/zh/extensions/save-graph/save-profile-transactions.md
+++ b/docs/zh/extensions/save-graph/save-profile-transactions.md
@@ -1,0 +1,134 @@
+# Save Profile 会话与事务
+
+`GFSaveProfileTransactionCoordinator` 在 `GFSaveProfileUtility` 的单 Profile 保存、读取、
+flush 原语之上，提供跨 Profile 的活动身份、切换、恢复、类型化修改和未知结果对账。
+项目需要管理槽位、账号或角色存档时使用 Coordinator；只读写一个没有活动身份语义的
+独立文档时，继续直接使用 Utility 原语。
+
+## 两层职责
+
+- `GFSaveProfileUtility` 负责 generation、Snapshot 准备预算、单 Profile IO 调度、迁移、
+  校验和 section 应用回滚。它不决定哪个 Profile 当前代表运行时状态。
+- `GFSaveProfileTransactionCoordinator` 负责 provider domain、活动 Profile 身份和跨原语
+  事务。它复用 Utility，不引入第二套存档格式、迁移引擎或 Storage 提交协议。
+
+Coordinator 的异步入口统一返回 `GFSaveProfileTransactionOperation`，终态由不可变的
+`GFSaveProfileTransactionResult` 表达。项目不应通过字符串错误、底层文件名或普通
+`GFSaveProfileResult` 猜测跨 Profile 事务是否提交。
+
+## Provider domain 与活动身份
+
+Coordinator 按 provider 的“完全相同对象身份、完全相同顺序”编译 domain。只有两个
+Profile 的 provider 数量、每一位置的实例身份和顺序都一致，它们才共享一个 domain；
+只重排同一组 provider 也不是同一拓扑。注册时若两个拓扑只部分重叠，Coordinator 会
+失败关闭，避免同一权威状态被两个独立锁域并发修改。
+
+每个 domain 最多有一个活动 Profile 身份，但互不相交的 domain 可以独立推进。活动身份
+不是 UI 当前选中项，而是“当前 provider 状态由哪个已确认持久化身份拥有”的框架事实。
+通过 `get_active_profile_id()` 查询它，通过 `get_domain_state_snapshot()` 取得有界诊断；
+不要在项目中维护第二份可写 active 标志。
+
+Profile 应通过 Coordinator 的 `register_profile()` / `unregister_profile()` 进入和退出该
+边界。注册后，managed gate 只允许稳定活动 Profile 直接 `save_profile()` /
+`flush_profile()`，供普通游戏状态与自动保存继续使用；直接 `load_profile()`、非活动
+Profile 的 save/flush，以及事务或 reconcile fence 期间的全部直接原语都会被拒绝。
+活动身份变更和原子 section 修改必须经 Coordinator，否则无法维持 domain 串行化。
+
+## 严格激活与切换
+
+`activate_profile()` 只在 domain 尚无活动身份时加载一份已经存在且有效的 Profile。
+读取、迁移、校验和所有 provider 应用全部成功后，活动身份才原子发布。它不会把当前
+默认状态自动解释成已存在存档。
+
+`switch_profile()` 要求目标与当前活动 Profile 属于同一精确拓扑，并按固定顺序执行：
+
+1. 捕获调用时源 Profile 的 generation 屏障，并确认源状态已 flush。
+2. 在触碰目标前采集全部 provider 的稳定回滚快照。
+3. 严格读取、迁移、校验并事务化应用目标 Profile。
+4. 全部成功后才把活动身份从源 Profile 原子切换到目标 Profile。
+
+源 flush 已知失败时不会读取目标。目标读取或应用发生已知失败时，Coordinator 按逆序
+恢复已尝试的 provider，并保留源活动身份；任一恢复失败都返回显式 rollback failure，
+不能把部分恢复状态标成仍然安全的源状态。切换不会把任意两个不同 provider 拓扑转换成
+同一业务状态，项目需要的字段映射必须留在自己的迁移或导入流程中。
+
+## 缺失与损坏的显式边界
+
+严格 activate 遇到缺失文件时返回 `recovery_required` 与一次性的
+`GFSaveProfileRecoveryLease`；遇到已知损坏文件时也返回 recovery lease，但两种原因
+不能互换。Switch 的目标缺失或损坏属于已知 target load failure，会恢复 Provider 并
+保留源活动身份，不会把源内存状态隐式写成目标存档：
+
+- `bootstrap_profile()` 只消费由 `missing` 产生且仍属于当前 domain generation 的 lease。
+- `adopt_profile()` 只消费由 `corrupt` 产生且仍属于当前 domain generation 的 lease。
+
+两者都把当前内存状态作为候选，只有 Storage 写入获得确定成功后才激活目标 Profile。
+无效、过期、重复消费或原因不匹配的 lease 会失败关闭。框架不会因为 Profile 的普通
+读取恢复政策而替项目自动创建、覆盖或接管一个活动身份；是否向用户展示“新建”或
+“接管损坏存档”，以及是否先备份损坏文件，均由项目决定。
+
+## 类型化修改并持久化
+
+`GFSaveSectionMutation` 表达一个 section 的候选替换，`GFSaveProfileMutationRequest`
+以一次性所有权句柄提交有界、类型化的 mutation 清单。`mutate_and_persist()` 只修改当前
+活动 Profile，不接受任意回调，也不允许项目绕过 provider 的 section 身份、schema 与
+应用契约。
+
+Coordinator 固定本次 provider 顺序，先采集回滚快照，再按请求应用候选 section，最后
+通过 Utility 保存并等待对应 generation 的确定终态。已知应用或 Storage 失败时，已尝试
+provider 按逆序恢复；Storage 的已知失败已经证明本次写入没有提交，因此不会再发起一笔
+“补偿保存”。这种额外写入既不能增加正确性，还会扩大新的未知提交窗口。
+
+Mutation Request 是 move-only 边界。成功提交后，调用方必须放弃请求及其候选 payload
+的全部嵌套 alias；无效或 busy 的前置拒绝不消费请求。项目仍负责业务字段含义、跨 section
+约束和候选生成，框架只保证类型、顺序、所有权与事务终态。
+
+## 结果未知与对账
+
+写入超时、释放中仍有物理写入等无法证明是否提交的情况返回 `outcome_unknown`，并交付
+一次性的 `GFSaveProfileReconcileLease`。Coordinator 此时冻结整个 provider domain：
+不发布新的活动身份，不执行反向回滚、自动重试或补偿写，也拒绝新的 activate、switch、
+bootstrap、adopt、mutation 和直接原语。否则磁盘可能已经保存候选状态，而内存又被静默
+改回旧状态。
+
+`GFSaveProfileReconcileLease` 初始为 waiting。此时调用 `reconcile_profile()` 只返回
+`reconcile_pending`，不会 claim `GFSaveProfileReconcileRequest`。底层 Utility 的
+generation 证据从 unknown 进入 persisted 或 failed 后，lease 才变为 ready；迟到证据
+本身仍不会自动提交、回滚或解除 fence。
+
+项目随后用同一 lease 和 Request 再次调用 reconcile。Coordinator 此时才 claim Request，
+严格重读 lease 记录的 reconcile Profile；读取和全部 provider 应用成功后，才解除 fence
+并从该 Profile 重建活动身份。Request 只携带本次严格读取的 context 与 result metadata，
+不接受“已提交/未提交”布尔结论、可执行 patch 或恢复回调。Switch 的源 flush 结果未知时，
+reconcile Profile 固定为源 Profile，原目标不会在迟到成功后自动继续；项目需要重新发起
+一次新的 switch。对账成功前 lease 保持 domain 所有权，错误 domain、过期或重复消费均
+返回显式失败。
+
+## Architecture 生命周期
+
+需要在首个运行场景开放前恢复存档的项目 System，应声明
+`GFSaveProfileTransactionCoordinator` 为必需 Utility，并在 `begin_activation(scope)`
+中把 activate/switch/bootstrap/adopt Operation 的唯一终态桥接到
+`GFAsyncCompletion`。不要手动轮询 `architecture.tick()`；依赖 DAG 会继续推进
+Coordinator、Save Profile 与 Storage 的本地依赖闭包。
+
+Quiesce 先关闭 Coordinator 的新事务准入，再等待已接纳事务、底层 Profile 原语和仍持有
+路径所有权的迟到写入收敛。关闭期间只保留一个窄例外：已经持有的 ready Reconcile Lease
+可作为 closure continuation 发起严格重读，从而解除既有 fence；它不能创建新业务事务，
+waiting lease 也仍须先等待物理尾部收敛。同步 `dispose()` 只用于无法等待的最终释放：未开始事务进入
+`disposed`，无法证明的写入保持 `outcome_unknown` 与诊断证据，不能伪装成已回滚。
+Dispose 会立即撤销 manager capability；已经完成 Storage 读取但尚未应用的 strict load 会
+在触碰 Provider 前终止，正在 Provider apply 回调中的读取会在回调返回后复核 capability
+并逆序恢复，避免迟到读取在 Coordinator 终态之后改写权威内存。
+项目可控退出、账号登出或运行域替换应等待 Architecture 的类型化异步关闭。
+
+## 项目责任边界
+
+框架不内置槽位数量、账号到路径映射、自动覆盖政策、损坏文件备份、云端冲突合并、
+存档选择 UI、业务字段 schema 或跨 section 业务校验。项目负责构造 Profile 与 provider、
+选择目标身份、生成 mutation、决定何时重试 reconcile，并决定何时把失败展示给用户。
+Coordinator 只提供可复用的活动身份和事务安全边界，不把任何一种游戏流程固化为默认策略。
+
+完整 primitive 状态机与失败矩阵见
+[Save Profile 运行时编排决策](save-profile-adr.md)，单 Profile 保存与读取用法见
+[Save Profile 运行时](save-profile-runtime.md)。

--- a/docs/zh/reference/api/classes/GFSaveProfileMutationRequest.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileMutationRequest.md
@@ -1,0 +1,114 @@
+# GFSaveProfileMutationRequest
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+mutate-and-persist 的一次性所有权请求。 请求在创建时原子接管每个 `GFSaveSectionMutation`，随后只允许协调器 claim 一次。调用方必须放弃传入的 Dictionary、Array 及其全部嵌套 alias；请求 不公开任何候选 payload getter，也不接受 Callable 或可执行 patch。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`take_ownership`](#member-gfsaveprofilemutationrequest-methods-take_ownership) | `static func take_ownership( mutations: Array[GFSaveSectionMutation], document_metadata: Dictionary = {}, context: Dictionary = {}, result_metadata: Dictionary = {} ) -> GFSaveProfileMutationRequest:` |
+| 方法 | [`is_available`](#member-gfsaveprofilemutationrequest-methods-is_available) | `func is_available() -> bool:` |
+| 方法 | [`is_claimed`](#member-gfsaveprofilemutationrequest-methods-is_claimed) | `func is_claimed() -> bool:` |
+| 方法 | [`get_mutation_count`](#member-gfsaveprofilemutationrequest-methods-get_mutation_count) | `func get_mutation_count() -> int:` |
+| 方法 | [`get_section_ids`](#member-gfsaveprofilemutationrequest-methods-get_section_ids) | `func get_section_ids() -> PackedStringArray:` |
+
+## 方法
+
+<a id="member-gfsaveprofilemutationrequest-methods-take_ownership"></a>
+
+### `take_ownership`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func take_ownership( mutations: Array[GFSaveSectionMutation], document_metadata: Dictionary = {}, context: Dictionary = {}, result_metadata: Dictionary = {} ) -> GFSaveProfileMutationRequest:
+```
+
+创建请求并接管全部候选 section 与元数据。 Mutation 必须非空、可用且 section ID 唯一。方法会先完成全部预检，再按输入 顺序 claim，因而校验失败不会部分消费 Mutation。输入顺序只用于所有权收集； 协调器始终按已注册 Profile 的 Provider 顺序 capture/apply。成功返回后，调用方必须永久 放弃 mutations 数组、三个 Dictionary 及其全部嵌套 alias。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `mutations` | 待接管的完整候选 sections；输入顺序不定义应用顺序。 |
+| `document_metadata` | 写入候选文档的持久化元数据。 |
+| `context` | Provider 操作使用的临时纯数据上下文。 |
+| `result_metadata` | 只写入当前事务结果的调用方纯数据元数据。 |
+
+返回：可用请求；输入无效时返回 null，且不消费任何 Mutation。
+
+结构：
+
+- `document_metadata`: Dictionary accepted by the Save persisted-value contract whose source aliases are abandoned after success.
+- `context`: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+- `result_metadata`: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+
+<a id="member-gfsaveprofilemutationrequest-methods-is_available"></a>
+
+### `is_available`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_available() -> bool:
+```
+
+检查请求是否仍可由协调器接管。
+
+返回：尚未 claim 时返回 true。
+
+<a id="member-gfsaveprofilemutationrequest-methods-is_claimed"></a>
+
+### `is_claimed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_claimed() -> bool:
+```
+
+检查请求是否已经被协调器接管。
+
+返回：已成功 claim 时返回 true。
+
+<a id="member-gfsaveprofilemutationrequest-methods-get_mutation_count"></a>
+
+### `get_mutation_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_mutation_count() -> int:
+```
+
+获取候选 section 数量。
+
+返回：尚未 claim 时返回候选数；claim 后为 0。
+
+<a id="member-gfsaveprofilemutationrequest-methods-get_section_ids"></a>
+
+### `get_section_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_section_ids() -> PackedStringArray:
+```
+
+获取候选 section ID 的隔离快照。
+
+返回：按请求收集顺序排列的 section ID；不包含候选载荷。

--- a/docs/zh/reference/api/classes/GFSaveProfileReconcileLease.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileReconcileLease.md
@@ -1,0 +1,378 @@
+# GFSaveProfileReconcileLease
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+outcome_unknown 的持续所有权与对账围栏。 Lease 保留同一对象身份，直到所有相关底层请求 late-settle 并由显式 reconcile 操作解除 domain 围栏。结果副本不会复制 Lease；因此调用方连接 `settled`、 轮询状态和提交对账时观察的是同一条生命周期。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`settled`](#member-gfsaveprofilereconcilelease-signals-settled) | `signal settled(lease: GFSaveProfileReconcileLease, state: StringName)` |
+| 常量 | [`STATE_WAITING`](#member-gfsaveprofilereconcilelease-constants-state_waiting) | `const STATE_WAITING: StringName = &"waiting"` |
+| 常量 | [`STATE_READY`](#member-gfsaveprofilereconcilelease-constants-state_ready) | `const STATE_READY: StringName = &"ready"` |
+| 常量 | [`STATE_RECONCILING`](#member-gfsaveprofilereconcilelease-constants-state_reconciling) | `const STATE_RECONCILING: StringName = &"reconciling"` |
+| 常量 | [`STATE_RESOLVED`](#member-gfsaveprofilereconcilelease-constants-state_resolved) | `const STATE_RESOLVED: StringName = &"resolved"` |
+| 常量 | [`STATE_DISPOSED_UNRESOLVED`](#member-gfsaveprofilereconcilelease-constants-state_disposed_unresolved) | `const STATE_DISPOSED_UNRESOLVED: StringName = &"disposed_unresolved"` |
+| 方法 | [`get_lease_id`](#member-gfsaveprofilereconcilelease-methods-get_lease_id) | `func get_lease_id() -> int:` |
+| 方法 | [`get_transaction_id`](#member-gfsaveprofilereconcilelease-methods-get_transaction_id) | `func get_transaction_id() -> int:` |
+| 方法 | [`get_operation`](#member-gfsaveprofilereconcilelease-methods-get_operation) | `func get_operation() -> StringName:` |
+| 方法 | [`get_reconcile_profile_id`](#member-gfsaveprofilereconcilelease-methods-get_reconcile_profile_id) | `func get_reconcile_profile_id() -> StringName:` |
+| 方法 | [`get_source_profile_id`](#member-gfsaveprofilereconcilelease-methods-get_source_profile_id) | `func get_source_profile_id() -> StringName:` |
+| 方法 | [`get_target_profile_id`](#member-gfsaveprofilereconcilelease-methods-get_target_profile_id) | `func get_target_profile_id() -> StringName:` |
+| 方法 | [`get_domain_id`](#member-gfsaveprofilereconcilelease-methods-get_domain_id) | `func get_domain_id() -> int:` |
+| 方法 | [`get_domain_generation`](#member-gfsaveprofilereconcilelease-methods-get_domain_generation) | `func get_domain_generation() -> int:` |
+| 方法 | [`get_epoch`](#member-gfsaveprofilereconcilelease-methods-get_epoch) | `func get_epoch() -> int:` |
+| 方法 | [`get_storage_request_ids`](#member-gfsaveprofilereconcilelease-methods-get_storage_request_ids) | `func get_storage_request_ids() -> PackedInt64Array:` |
+| 方法 | [`get_state`](#member-gfsaveprofilereconcilelease-methods-get_state) | `func get_state() -> StringName:` |
+| 方法 | [`is_waiting`](#member-gfsaveprofilereconcilelease-methods-is_waiting) | `func is_waiting() -> bool:` |
+| 方法 | [`is_ready`](#member-gfsaveprofilereconcilelease-methods-is_ready) | `func is_ready() -> bool:` |
+| 方法 | [`is_terminal`](#member-gfsaveprofilereconcilelease-methods-is_terminal) | `func is_terminal() -> bool:` |
+| 方法 | [`get_settlement_evidence`](#member-gfsaveprofilereconcilelease-methods-get_settlement_evidence) | `func get_settlement_evidence() -> Dictionary:` |
+| 方法 | [`get_resolution_evidence`](#member-gfsaveprofilereconcilelease-methods-get_resolution_evidence) | `func get_resolution_evidence() -> Dictionary:` |
+
+## 信号
+
+<a id="member-gfsaveprofilereconcilelease-signals-settled"></a>
+
+### `settled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal settled(lease: GFSaveProfileReconcileLease, state: StringName)
+```
+
+Lease 首次离开 waiting 时发出。 正常 late settlement 进入 ready；Utility 先释放则进入 disposed_unresolved。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `lease` | 当前同一身份 Lease。 |
+| `state` | `STATE_READY` 或 `STATE_DISPOSED_UNRESOLVED`。 |
+
+## 常量
+
+<a id="member-gfsaveprofilereconcilelease-constants-state_waiting"></a>
+
+### `STATE_WAITING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_WAITING: StringName = &"waiting"
+```
+
+仍在等待至少一个底层请求 late-settle。
+
+<a id="member-gfsaveprofilereconcilelease-constants-state_ready"></a>
+
+### `STATE_READY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_READY: StringName = &"ready"
+```
+
+已取得有界 settlement evidence，可以开始显式对账。
+
+<a id="member-gfsaveprofilereconcilelease-constants-state_reconciling"></a>
+
+### `STATE_RECONCILING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_RECONCILING: StringName = &"reconciling"
+```
+
+一个 reconcile 操作已经接管 Lease。
+
+<a id="member-gfsaveprofilereconcilelease-constants-state_resolved"></a>
+
+### `STATE_RESOLVED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_RESOLVED: StringName = &"resolved"
+```
+
+对账已经完成，Provider domain 围栏可以释放。
+
+<a id="member-gfsaveprofilereconcilelease-constants-state_disposed_unresolved"></a>
+
+### `STATE_DISPOSED_UNRESOLVED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_DISPOSED_UNRESOLVED: StringName = &"disposed_unresolved"
+```
+
+Utility 已释放，但不确定副作用尚未完成对账。
+
+## 方法
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_lease_id"></a>
+
+### `get_lease_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_lease_id() -> int:
+```
+
+获取 Utility 生命周期内唯一的 Lease ID。
+
+返回：正整数 Lease ID；未配置时为 0。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_transaction_id"></a>
+
+### `get_transaction_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_transaction_id() -> int:
+```
+
+获取产生当前 Lease 的事务 ID。
+
+返回：正整数事务 ID；未配置时为 0。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_operation"></a>
+
+### `get_operation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_operation() -> StringName:
+```
+
+获取产生 outcome_unknown 的事务类型。
+
+返回：`GFSaveProfileTransactionOperation.OPERATION_*` 常量之一。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_reconcile_profile_id"></a>
+
+### `get_reconcile_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_reconcile_profile_id() -> StringName:
+```
+
+获取显式对账应重新读取的 Profile ID。
+
+返回：非空 Profile ID。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_source_profile_id"></a>
+
+### `get_source_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_profile_id() -> StringName:
+```
+
+获取原事务来源 Profile ID。
+
+返回：来源 Profile ID；不适用时为空。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_target_profile_id"></a>
+
+### `get_target_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_target_profile_id() -> StringName:
+```
+
+获取原事务目标 Profile ID。
+
+返回：目标 Profile ID；不适用时为空。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_domain_id"></a>
+
+### `get_domain_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_domain_id() -> int:
+```
+
+获取运行时 Provider domain ID。
+
+返回：Utility 生命周期内唯一的正整数 domain ID。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_domain_generation"></a>
+
+### `get_domain_generation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_domain_generation() -> int:
+```
+
+获取 Lease 创建时的 domain generation。
+
+返回：正整数 domain generation。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_epoch"></a>
+
+### `get_epoch`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_epoch() -> int:
+```
+
+获取 Lease 创建时的 Utility lifecycle epoch。
+
+返回：正整数 lifecycle epoch。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_storage_request_ids"></a>
+
+### `get_storage_request_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_storage_request_ids() -> PackedInt64Array:
+```
+
+获取支撑 outcome_unknown 的底层 Storage 请求 ID。
+
+返回：按发起顺序排列的正整数请求 ID。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_state"></a>
+
+### `get_state`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_state() -> StringName:
+```
+
+获取当前 Lease 状态。
+
+返回：`STATE_*` 常量之一。
+
+<a id="member-gfsaveprofilereconcilelease-methods-is_waiting"></a>
+
+### `is_waiting`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_waiting() -> bool:
+```
+
+检查 Lease 是否仍等待 late settlement。
+
+返回：waiting 时返回 true。
+
+<a id="member-gfsaveprofilereconcilelease-methods-is_ready"></a>
+
+### `is_ready`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_ready() -> bool:
+```
+
+检查 Lease 是否可由 reconcile 操作接管。
+
+返回：ready 时返回 true。
+
+<a id="member-gfsaveprofilereconcilelease-methods-is_terminal"></a>
+
+### `is_terminal`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_terminal() -> bool:
+```
+
+检查 Lease 是否已进入不可再对账的终态。
+
+返回：resolved 或 disposed_unresolved 时返回 true。
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_settlement_evidence"></a>
+
+### `get_settlement_evidence`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_settlement_evidence() -> Dictionary:
+```
+
+获取不含文档或 Provider payload 的 settlement evidence。
+
+返回：有界 evidence 副本。
+
+结构：
+
+- `return`: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+
+<a id="member-gfsaveprofilereconcilelease-methods-get_resolution_evidence"></a>
+
+### `get_resolution_evidence`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_resolution_evidence() -> Dictionary:
+```
+
+获取成功对账后提交的最终证据。
+
+返回：resolved 前为空；resolved 后返回有界 evidence 副本。
+
+结构：
+
+- `return`: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.

--- a/docs/zh/reference/api/classes/GFSaveProfileReconcileRequest.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileReconcileRequest.md
@@ -1,0 +1,79 @@
+# GFSaveProfileReconcileRequest
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+uncertain 写入对账的一次性请求句柄。 请求只携带调用方纯数据上下文和结果元数据，不携带 Recovery/Reconcile Lease 身份。Lease 必须作为独立类型化参数提交，避免从 Dictionary 恢复所有权。 `take_ownership()` 成功后，调用方必须放弃两个 Dictionary 及其嵌套 alias。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`take_ownership`](#member-gfsaveprofilereconcilerequest-methods-take_ownership) | `static func take_ownership( context: Dictionary = {}, result_metadata: Dictionary = {} ) -> GFSaveProfileReconcileRequest:` |
+| 方法 | [`is_available`](#member-gfsaveprofilereconcilerequest-methods-is_available) | `func is_available() -> bool:` |
+| 方法 | [`is_claimed`](#member-gfsaveprofilereconcilerequest-methods-is_claimed) | `func is_claimed() -> bool:` |
+
+## 方法
+
+<a id="member-gfsaveprofilereconcilerequest-methods-take_ownership"></a>
+
+### `take_ownership`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func take_ownership( context: Dictionary = {}, result_metadata: Dictionary = {} ) -> GFSaveProfileReconcileRequest:
+```
+
+创建请求并接管 context 与 result_metadata 的逻辑唯一所有权。 输入必须是有界纯 Variant 数据，不能包含 Callable、Object、Signal、RID 或 循环集合。该请求不接受可执行恢复策略或 patch；项目策略应在提交前完成决策。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `context` | 对账流程使用的临时纯数据上下文。 |
+| `result_metadata` | 只写入当前对账结果的调用方纯数据元数据。 |
+
+返回：可用请求；输入无效时返回 null。
+
+结构：
+
+- `context`: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+- `result_metadata`: Bounded Dictionary without Callable, Signal, RID, Object, or circular references whose source aliases are abandoned after success.
+
+<a id="member-gfsaveprofilereconcilerequest-methods-is_available"></a>
+
+### `is_available`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_available() -> bool:
+```
+
+检查请求是否仍可由协调器接管。
+
+返回：尚未 claim 时返回 true。
+
+<a id="member-gfsaveprofilereconcilerequest-methods-is_claimed"></a>
+
+### `is_claimed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_claimed() -> bool:
+```
+
+检查请求是否已经被协调器接管。
+
+返回：已成功 claim 时返回 true。

--- a/docs/zh/reference/api/classes/GFSaveProfileRecoveryLease.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileRecoveryLease.md
@@ -1,0 +1,267 @@
+# GFSaveProfileRecoveryLease
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+缺失或损坏 Profile 的一次性恢复授权。 Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease； domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`REASON_MISSING`](#member-gfsaveprofilerecoverylease-constants-reason_missing) | `const REASON_MISSING: StringName = &"missing"` |
+| 常量 | [`REASON_CORRUPT`](#member-gfsaveprofilerecoverylease-constants-reason_corrupt) | `const REASON_CORRUPT: StringName = &"corrupt"` |
+| 常量 | [`STATE_AVAILABLE`](#member-gfsaveprofilerecoverylease-constants-state_available) | `const STATE_AVAILABLE: StringName = &"available"` |
+| 常量 | [`STATE_CLAIMED`](#member-gfsaveprofilerecoverylease-constants-state_claimed) | `const STATE_CLAIMED: StringName = &"claimed"` |
+| 常量 | [`STATE_STALE`](#member-gfsaveprofilerecoverylease-constants-state_stale) | `const STATE_STALE: StringName = &"stale"` |
+| 方法 | [`get_lease_id`](#member-gfsaveprofilerecoverylease-methods-get_lease_id) | `func get_lease_id() -> int:` |
+| 方法 | [`get_transaction_id`](#member-gfsaveprofilerecoverylease-methods-get_transaction_id) | `func get_transaction_id() -> int:` |
+| 方法 | [`get_profile_id`](#member-gfsaveprofilerecoverylease-methods-get_profile_id) | `func get_profile_id() -> StringName:` |
+| 方法 | [`get_reason`](#member-gfsaveprofilerecoverylease-methods-get_reason) | `func get_reason() -> StringName:` |
+| 方法 | [`get_domain_id`](#member-gfsaveprofilerecoverylease-methods-get_domain_id) | `func get_domain_id() -> int:` |
+| 方法 | [`get_domain_generation`](#member-gfsaveprofilerecoverylease-methods-get_domain_generation) | `func get_domain_generation() -> int:` |
+| 方法 | [`get_epoch`](#member-gfsaveprofilerecoverylease-methods-get_epoch) | `func get_epoch() -> int:` |
+| 方法 | [`get_state`](#member-gfsaveprofilerecoverylease-methods-get_state) | `func get_state() -> StringName:` |
+| 方法 | [`is_available`](#member-gfsaveprofilerecoverylease-methods-is_available) | `func is_available() -> bool:` |
+| 方法 | [`is_claimed`](#member-gfsaveprofilerecoverylease-methods-is_claimed) | `func is_claimed() -> bool:` |
+| 方法 | [`is_stale`](#member-gfsaveprofilerecoverylease-methods-is_stale) | `func is_stale() -> bool:` |
+
+## 常量
+
+<a id="member-gfsaveprofilerecoverylease-constants-reason_missing"></a>
+
+### `REASON_MISSING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_MISSING: StringName = &"missing"
+```
+
+激活目标没有持久化文档。
+
+<a id="member-gfsaveprofilerecoverylease-constants-reason_corrupt"></a>
+
+### `REASON_CORRUPT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const REASON_CORRUPT: StringName = &"corrupt"
+```
+
+激活目标文档损坏或完整性无效。
+
+<a id="member-gfsaveprofilerecoverylease-constants-state_available"></a>
+
+### `STATE_AVAILABLE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_AVAILABLE: StringName = &"available"
+```
+
+Lease 尚未被恢复操作消费。
+
+<a id="member-gfsaveprofilerecoverylease-constants-state_claimed"></a>
+
+### `STATE_CLAIMED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_CLAIMED: StringName = &"claimed"
+```
+
+Lease 已被一个恢复操作消费。
+
+<a id="member-gfsaveprofilerecoverylease-constants-state_stale"></a>
+
+### `STATE_STALE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_STALE: StringName = &"stale"
+```
+
+Lease 的 domain generation 或 lifecycle epoch 已过期。
+
+## 方法
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_lease_id"></a>
+
+### `get_lease_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_lease_id() -> int:
+```
+
+获取 Utility 生命周期内唯一的 Lease ID。
+
+返回：正整数 Lease ID；未配置时为 0。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_transaction_id"></a>
+
+### `get_transaction_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_transaction_id() -> int:
+```
+
+获取产生当前 Lease 的事务 ID。
+
+返回：正整数事务 ID；未配置时为 0。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_profile_id"></a>
+
+### `get_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_profile_id() -> StringName:
+```
+
+获取待恢复 Profile ID。
+
+返回：Profile ID。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_reason"></a>
+
+### `get_reason`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_reason() -> StringName:
+```
+
+获取恢复原因。
+
+返回：`REASON_MISSING` 或 `REASON_CORRUPT`。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_domain_id"></a>
+
+### `get_domain_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_domain_id() -> int:
+```
+
+获取运行时 Provider domain ID。
+
+返回：Utility 生命周期内唯一的正整数 domain ID。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_domain_generation"></a>
+
+### `get_domain_generation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_domain_generation() -> int:
+```
+
+获取 Lease 创建时的 domain generation。
+
+返回：正整数 domain generation。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_epoch"></a>
+
+### `get_epoch`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_epoch() -> int:
+```
+
+获取 Lease 创建时的 Utility lifecycle epoch。
+
+返回：正整数 lifecycle epoch。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_state"></a>
+
+### `get_state`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_state() -> StringName:
+```
+
+获取当前 Lease 状态。
+
+返回：`STATE_*` 常量之一。
+
+<a id="member-gfsaveprofilerecoverylease-methods-is_available"></a>
+
+### `is_available`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_available() -> bool:
+```
+
+检查 Lease 是否仍可由 bootstrap/adopt 消费。
+
+返回：可用时返回 true。
+
+<a id="member-gfsaveprofilerecoverylease-methods-is_claimed"></a>
+
+### `is_claimed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_claimed() -> bool:
+```
+
+检查 Lease 是否已经被消费。
+
+返回：已 claim 时返回 true。
+
+<a id="member-gfsaveprofilerecoverylease-methods-is_stale"></a>
+
+### `is_stale`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_stale() -> bool:
+```
+
+检查 Lease 是否已经过期。
+
+返回：已标记 stale 或从未有效配置时返回 true。

--- a/docs/zh/reference/api/classes/GFSaveProfileTransactionCoordinator.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileTransactionCoordinator.md
@@ -1,0 +1,525 @@
+# GFSaveProfileTransactionCoordinator
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd`
+- 模块：`Save`
+- 继承：`GFUtility`
+- API：`public`
+- 类别：运行时服务 (`runtime_service`)
+- 首次版本：`unreleased`
+
+活动 Profile 身份与跨 Profile 事务协调器。 Coordinator 在完全相同且同序的 Provider 实例拓扑上建立独立 domain，委托 `GFSaveProfileUtility` 完成 generation、Storage IO、重试与 detached settlement。 它不解释业务 payload，也不拥有项目的身份到路径、云同步或恢复选择。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`active_profile_changed`](#member-gfsaveprofiletransactioncoordinator-signals-active_profile_changed) | `signal active_profile_changed(` |
+| 信号 | [`transaction_completed`](#member-gfsaveprofiletransactioncoordinator-signals-transaction_completed) | `signal transaction_completed(result: GFSaveProfileTransactionResult)` |
+| 常量 | [`DOMAIN_STATE_INACTIVE`](#member-gfsaveprofiletransactioncoordinator-constants-domain_state_inactive) | `const DOMAIN_STATE_INACTIVE: StringName = &"inactive"` |
+| 常量 | [`DOMAIN_STATE_ACTIVE`](#member-gfsaveprofiletransactioncoordinator-constants-domain_state_active) | `const DOMAIN_STATE_ACTIVE: StringName = &"active"` |
+| 常量 | [`DOMAIN_STATE_TRANSACTING`](#member-gfsaveprofiletransactioncoordinator-constants-domain_state_transacting) | `const DOMAIN_STATE_TRANSACTING: StringName = &"transacting"` |
+| 常量 | [`DOMAIN_STATE_RECONCILIATION_REQUIRED`](#member-gfsaveprofiletransactioncoordinator-constants-domain_state_reconciliation_required) | `const DOMAIN_STATE_RECONCILIATION_REQUIRED: StringName = &"reconciliation_required"` |
+| 常量 | [`DOMAIN_STATE_DISPOSED`](#member-gfsaveprofiletransactioncoordinator-constants-domain_state_disposed) | `const DOMAIN_STATE_DISPOSED: StringName = &"disposed"` |
+| 方法 | [`get_required_utilities`](#member-gfsaveprofiletransactioncoordinator-methods-get_required_utilities) | `func get_required_utilities() -> Array[Script]:` |
+| 方法 | [`ready`](#member-gfsaveprofiletransactioncoordinator-methods-ready) | `func ready() -> void:` |
+| 方法 | [`begin_activation`](#member-gfsaveprofiletransactioncoordinator-methods-begin_activation) | `func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`begin_quiesce`](#member-gfsaveprofiletransactioncoordinator-methods-begin_quiesce) | `func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:` |
+| 方法 | [`tick`](#member-gfsaveprofiletransactioncoordinator-methods-tick) | `func tick(_delta: float) -> void:` |
+| 方法 | [`dispose`](#member-gfsaveprofiletransactioncoordinator-methods-dispose) | `func dispose() -> void:` |
+| 方法 | [`release_dependencies`](#member-gfsaveprofiletransactioncoordinator-methods-release_dependencies) | `func release_dependencies() -> void:` |
+| 方法 | [`setup`](#member-gfsaveprofiletransactioncoordinator-methods-setup) | `func setup( profile_utility: GFSaveProfileUtility ) -> GFSaveProfileTransactionCoordinator:` |
+| 方法 | [`register_profile`](#member-gfsaveprofiletransactioncoordinator-methods-register_profile) | `func register_profile( profile: GFSaveProfile, migrations: GFSaveMigrationRegistry = null ) -> Dictionary:` |
+| 方法 | [`unregister_profile`](#member-gfsaveprofiletransactioncoordinator-methods-unregister_profile) | `func unregister_profile(profile_id: StringName) -> bool:` |
+| 方法 | [`get_active_profile_id`](#member-gfsaveprofiletransactioncoordinator-methods-get_active_profile_id) | `func get_active_profile_id(profile_id: StringName) -> StringName:` |
+| 方法 | [`get_domain_state_snapshot`](#member-gfsaveprofiletransactioncoordinator-methods-get_domain_state_snapshot) | `func get_domain_state_snapshot(profile_id: StringName) -> Dictionary:` |
+| 方法 | [`activate_profile`](#member-gfsaveprofiletransactioncoordinator-methods-activate_profile) | `func activate_profile( profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`switch_profile`](#member-gfsaveprofiletransactioncoordinator-methods-switch_profile) | `func switch_profile( target_profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`bootstrap_profile`](#member-gfsaveprofiletransactioncoordinator-methods-bootstrap_profile) | `func bootstrap_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`adopt_profile`](#member-gfsaveprofiletransactioncoordinator-methods-adopt_profile) | `func adopt_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`mutate_and_persist`](#member-gfsaveprofiletransactioncoordinator-methods-mutate_and_persist) | `func mutate_and_persist( profile_id: StringName, request: GFSaveProfileMutationRequest ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`reconcile_profile`](#member-gfsaveprofiletransactioncoordinator-methods-reconcile_profile) | `func reconcile_profile( lease: GFSaveProfileReconcileLease, request: GFSaveProfileReconcileRequest = null ) -> GFSaveProfileTransactionOperation:` |
+
+## 信号
+
+<a id="member-gfsaveprofiletransactioncoordinator-signals-active_profile_changed"></a>
+
+### `active_profile_changed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal active_profile_changed(
+```
+
+活动 Profile 身份完成原子提交后发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `previous_profile_id` | 提交前活动 Profile；首次激活时为空。 |
+| `current_profile_id` | 提交后活动 Profile。 |
+
+<a id="member-gfsaveprofiletransactioncoordinator-signals-transaction_completed"></a>
+
+### `transaction_completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal transaction_completed(result: GFSaveProfileTransactionResult)
+```
+
+任一事务进入稳定终态时发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `result` | 不包含持久化 payload 的隔离结果。 |
+
+## 常量
+
+<a id="member-gfsaveprofiletransactioncoordinator-constants-domain_state_inactive"></a>
+
+### `DOMAIN_STATE_INACTIVE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DOMAIN_STATE_INACTIVE: StringName = &"inactive"
+```
+
+Domain 尚未建立活动身份。
+
+<a id="member-gfsaveprofiletransactioncoordinator-constants-domain_state_active"></a>
+
+### `DOMAIN_STATE_ACTIVE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DOMAIN_STATE_ACTIVE: StringName = &"active"
+```
+
+Domain 已建立一个可直接 save/flush 的活动身份。
+
+<a id="member-gfsaveprofiletransactioncoordinator-constants-domain_state_transacting"></a>
+
+### `DOMAIN_STATE_TRANSACTING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DOMAIN_STATE_TRANSACTING: StringName = &"transacting"
+```
+
+Domain 正在执行一个事务。
+
+<a id="member-gfsaveprofiletransactioncoordinator-constants-domain_state_reconciliation_required"></a>
+
+### `DOMAIN_STATE_RECONCILIATION_REQUIRED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DOMAIN_STATE_RECONCILIATION_REQUIRED: StringName = &"reconciliation_required"
+```
+
+Domain 被 outcome_unknown 或显式故障围栏占用，必须对账。
+
+<a id="member-gfsaveprofiletransactioncoordinator-constants-domain_state_disposed"></a>
+
+### `DOMAIN_STATE_DISPOSED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DOMAIN_STATE_DISPOSED: StringName = &"disposed"
+```
+
+Coordinator 已释放。
+
+## 方法
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-get_required_utilities"></a>
+
+### `get_required_utilities`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_required_utilities() -> Array[Script]:
+```
+
+声明底层 Save Profile Utility 依赖。
+
+返回：仅包含 `GFSaveProfileUtility`。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-ready"></a>
+
+### `ready`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func ready() -> void:
+```
+
+在架构 ready 阶段采用已注册的 Profile Utility。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-begin_activation"></a>
+
+### `begin_activation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+开放事务准入；底层 Utility 不可用时失败。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_scope` | 当前激活阶段的取消作用域。 |
+
+返回：一次性激活完成源。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-begin_quiesce"></a>
+
+### `begin_quiesce`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
+```
+
+关闭新事务准入，并等待已接纳事务与 reconcile fence 收敛。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `scope` | 当前静默阶段的取消作用域。 |
+
+返回：全部 domain 可安全关闭时完成的一次性完成源。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-tick"></a>
+
+### `tick`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func tick(_delta: float) -> void:
+```
+
+推进已接纳的同步 Provider mutation 阶段。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_delta` | 未使用；底层 IO 由 Profile Utility 推进。 |
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-dispose"></a>
+
+### `dispose`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func dispose() -> void:
+```
+
+强制结束未完成事务并释放全部 manager capability。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-release_dependencies"></a>
+
+### `release_dependencies`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func release_dependencies() -> void:
+```
+
+释放架构注入依赖。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-setup"></a>
+
+### `setup`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func setup( profile_utility: GFSaveProfileUtility ) -> GFSaveProfileTransactionCoordinator:
+```
+
+显式注入底层 Profile Utility，供 standalone 场景与测试使用。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile_utility` | 已配置的底层 Profile Utility。 |
+
+返回：当前 Coordinator；输入无效或已有受管 Profile 时返回 null。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-register_profile"></a>
+
+### `register_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func register_profile( profile: GFSaveProfile, migrations: GFSaveMigrationRegistry = null ) -> Dictionary:
+```
+
+注册并声明一个受管 Profile。 完全相同且同序的 Provider 实例序列共享 domain；任意部分重叠或同实例异序 会在触碰底层注册前失败。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile` | Profile 声明。 |
+| `migrations` | 可选迁移注册表。 |
+
+返回：底层注册报告，附加 managed 与 provider_domain_id 字段。
+
+结构：
+
+- `return`: GFValidationReportDictionary-compatible report with managed and provider_domain_id fields.
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-unregister_profile"></a>
+
+### `unregister_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unregister_profile(profile_id: StringName) -> bool:
+```
+
+注销一个无活动身份、事务或 fence 的受管 Profile。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile_id` | 受管 Profile ID。 |
+
+返回：安全注销成功时返回 true。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-get_active_profile_id"></a>
+
+### `get_active_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_active_profile_id(profile_id: StringName) -> StringName:
+```
+
+获取指定受管 Profile 所在 domain 的活动身份。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile_id` | 用于定位 Provider domain 的任一受管 Profile ID。 |
+
+返回：活动 Profile ID；domain 未激活或 Profile 不存在时为空。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-get_domain_state_snapshot"></a>
+
+### `get_domain_state_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_domain_state_snapshot(profile_id: StringName) -> Dictionary:
+```
+
+获取无载荷 domain 调试快照。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile_id` | 用于定位 Provider domain 的任一受管 Profile ID。 |
+
+返回：domain 状态、活动身份、generation、epoch 与事务/lease ID。
+
+结构：
+
+- `return`: Payload-free Dictionary with domain_id, state, active_profile_id, profile_ids, domain_generation, transaction_epoch, transaction_id, reconcile_lease_id, quiescing, and disposed fields.
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-activate_profile"></a>
+
+### `activate_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func activate_profile( profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation:
+```
+
+严格读取一个已存在存档并建立首次活动身份。 missing/corrupt 不会应用低层 `ACTION_USE_CURRENT_STATE`；结果分别返回只能用于 `bootstrap_profile()` 或 `adopt_profile()` 的类型化 Recovery Lease。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile_id` | 已注册受管 Profile ID。 |
+| `context` | 迁移与 Provider apply 临时上下文。 |
+| `metadata` | 仅写入外层事务结果的调用方元数据。 |
+
+返回：类型化 activate 操作。
+
+结构：
+
+- `context`: Dictionary with caller-defined ephemeral operation data.
+- `metadata`: Dictionary with caller-defined result metadata.
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-switch_profile"></a>
+
+### `switch_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func switch_profile( target_profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation:
+```
+
+从当前活动 Profile 原子切换到同一 Provider domain 的目标 Profile。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `target_profile_id` | 同一 domain 内的目标 Profile ID。 |
+| `context` | 目标读取的迁移与 Provider 临时上下文。 |
+| `metadata` | 仅写入外层事务结果的调用方元数据。 |
+
+返回：类型化 switch 操作。
+
+结构：
+
+- `context`: Dictionary with caller-defined ephemeral operation data.
+- `metadata`: Dictionary with caller-defined result metadata.
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-bootstrap_profile"></a>
+
+### `bootstrap_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func bootstrap_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:
+```
+
+使用 activate 返回的 missing lease 创建存档并首次激活。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `lease` | 尚未过期的 missing Recovery Lease。 |
+| `request` | 当前 Provider 状态的保存请求；null 表示空元数据。 |
+
+返回：类型化 bootstrap 操作；拒绝不会 claim lease 或 request。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-adopt_profile"></a>
+
+### `adopt_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func adopt_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:
+```
+
+使用 activate 返回的 corrupt lease 明确覆盖损坏存档并首次激活。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `lease` | 尚未过期的 corrupt Recovery Lease。 |
+| `request` | 当前 Provider 状态的保存请求；null 表示空元数据。 |
+
+返回：类型化 adopt 操作；拒绝不会 claim lease 或 request。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-mutate_and_persist"></a>
+
+### `mutate_and_persist`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func mutate_and_persist( profile_id: StringName, request: GFSaveProfileMutationRequest ) -> GFSaveProfileTransactionOperation:
+```
+
+事务化应用一个或多个完整 section replacement 并持久化活动 Profile。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `profile_id` | 当前 domain 的活动 Profile ID。 |
+| `request` | 一次性候选与元数据请求。 |
+
+返回：类型化 mutate-and-persist 操作；边界拒绝不会 claim request。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-reconcile_profile"></a>
+
+### `reconcile_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func reconcile_profile( lease: GFSaveProfileReconcileLease, request: GFSaveProfileReconcileRequest = null ) -> GFSaveProfileTransactionOperation:
+```
+
+在 late generation 证据收敛后严格重载 lease 指定 Profile 并解除 fence。 waiting lease 返回 `reconcile_pending`，且不 claim lease/request；调用方可在 `GFSaveProfileReconcileLease.settled` 后用同一 lease 与新请求重试。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `lease` | 当前 Coordinator 持有的 Reconcile Lease。 |
+| `request` | 一次性 reconcile context 与结果元数据。 |
+
+返回：类型化 reconcile 操作。

--- a/docs/zh/reference/api/classes/GFSaveProfileTransactionOperation.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileTransactionOperation.md
@@ -1,0 +1,255 @@
+# GFSaveProfileTransactionOperation
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+Profile 身份与持久化事务的异步句柄。 句柄由 Save Profile 事务协调器完成一次且只完成一次。调用方可在连接信号前 检查 `is_completed()`，避免同步拒绝或立即终态造成竞态。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`completed`](#member-gfsaveprofiletransactionoperation-signals-completed) | `signal completed(result: GFSaveProfileTransactionResult)` |
+| 常量 | [`OPERATION_ACTIVATE`](#member-gfsaveprofiletransactionoperation-constants-operation_activate) | `const OPERATION_ACTIVATE: StringName = &"activate"` |
+| 常量 | [`OPERATION_SWITCH`](#member-gfsaveprofiletransactionoperation-constants-operation_switch) | `const OPERATION_SWITCH: StringName = &"switch"` |
+| 常量 | [`OPERATION_BOOTSTRAP`](#member-gfsaveprofiletransactionoperation-constants-operation_bootstrap) | `const OPERATION_BOOTSTRAP: StringName = &"bootstrap"` |
+| 常量 | [`OPERATION_ADOPT`](#member-gfsaveprofiletransactionoperation-constants-operation_adopt) | `const OPERATION_ADOPT: StringName = &"adopt"` |
+| 常量 | [`OPERATION_MUTATE_AND_PERSIST`](#member-gfsaveprofiletransactionoperation-constants-operation_mutate_and_persist) | `const OPERATION_MUTATE_AND_PERSIST: StringName = &"mutate_and_persist"` |
+| 常量 | [`OPERATION_RECONCILE`](#member-gfsaveprofiletransactionoperation-constants-operation_reconcile) | `const OPERATION_RECONCILE: StringName = &"reconcile"` |
+| 方法 | [`get_operation`](#member-gfsaveprofiletransactionoperation-methods-get_operation) | `func get_operation() -> StringName:` |
+| 方法 | [`get_transaction_id`](#member-gfsaveprofiletransactionoperation-methods-get_transaction_id) | `func get_transaction_id() -> int:` |
+| 方法 | [`get_source_profile_id`](#member-gfsaveprofiletransactionoperation-methods-get_source_profile_id) | `func get_source_profile_id() -> StringName:` |
+| 方法 | [`get_target_profile_id`](#member-gfsaveprofiletransactionoperation-methods-get_target_profile_id) | `func get_target_profile_id() -> StringName:` |
+| 方法 | [`is_pending`](#member-gfsaveprofiletransactionoperation-methods-is_pending) | `func is_pending() -> bool:` |
+| 方法 | [`is_running`](#member-gfsaveprofiletransactionoperation-methods-is_running) | `func is_running() -> bool:` |
+| 方法 | [`is_completed`](#member-gfsaveprofiletransactionoperation-methods-is_completed) | `func is_completed() -> bool:` |
+| 方法 | [`get_result`](#member-gfsaveprofiletransactionoperation-methods-get_result) | `func get_result() -> GFSaveProfileTransactionResult:` |
+
+## 信号
+
+<a id="member-gfsaveprofiletransactionoperation-signals-completed"></a>
+
+### `completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal completed(result: GFSaveProfileTransactionResult)
+```
+
+事务进入终态时发出一次。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `result` | 不包含 Provider payload 的隔离终态结果。 |
+
+## 常量
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_activate"></a>
+
+### `OPERATION_ACTIVATE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_ACTIVATE: StringName = &"activate"
+```
+
+激活已存在的 Profile 存档。
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_switch"></a>
+
+### `OPERATION_SWITCH`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_SWITCH: StringName = &"switch"
+```
+
+从当前活跃 Profile 事务切换到另一个已存在 Profile。
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_bootstrap"></a>
+
+### `OPERATION_BOOTSTRAP`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_BOOTSTRAP: StringName = &"bootstrap"
+```
+
+用当前 Provider 状态显式创建缺失 Profile 并激活。
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_adopt"></a>
+
+### `OPERATION_ADOPT`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_ADOPT: StringName = &"adopt"
+```
+
+显式采用当前 Provider 状态作为恢复后的活跃 Profile。
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_mutate_and_persist"></a>
+
+### `OPERATION_MUTATE_AND_PERSIST`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_MUTATE_AND_PERSIST: StringName = &"mutate_and_persist"
+```
+
+应用完整候选 section 并持久化。
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_reconcile"></a>
+
+### `OPERATION_RECONCILE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_RECONCILE: StringName = &"reconcile"
+```
+
+对账此前 outcome_unknown 的事务。
+
+## 方法
+
+<a id="member-gfsaveprofiletransactionoperation-methods-get_operation"></a>
+
+### `get_operation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_operation() -> StringName:
+```
+
+获取事务类型。
+
+返回：`OPERATION_*` 常量之一。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-get_transaction_id"></a>
+
+### `get_transaction_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_transaction_id() -> int:
+```
+
+获取 Utility 生命周期内唯一的事务 ID。
+
+返回：正整数事务 ID；尚未配置时为 0。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-get_source_profile_id"></a>
+
+### `get_source_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_profile_id() -> StringName:
+```
+
+获取事务来源 Profile ID。 activate、bootstrap 与 adopt 没有来源身份；mutate-and-persist 和 reconcile 使用当前受管 Profile 作为来源。
+
+返回：来源 Profile ID；不适用时为空。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-get_target_profile_id"></a>
+
+### `get_target_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_target_profile_id() -> StringName:
+```
+
+获取事务目标 Profile ID。
+
+返回：目标 Profile ID；不适用时为空。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-is_pending"></a>
+
+### `is_pending`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_pending() -> bool:
+```
+
+检查事务是否等待调度。
+
+返回：尚未运行或完成时返回 true。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-is_running"></a>
+
+### `is_running`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_running() -> bool:
+```
+
+检查事务是否正在运行。
+
+返回：已启动但无终态时返回 true。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-is_completed"></a>
+
+### `is_completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_completed() -> bool:
+```
+
+检查事务是否已有终态。
+
+返回：已完成时返回 true。
+
+<a id="member-gfsaveprofiletransactionoperation-methods-get_result"></a>
+
+### `get_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_result() -> GFSaveProfileTransactionResult:
+```
+
+获取终态结果副本。 结果副本中的 Recovery/Reconcile Lease 保留原始句柄身份，其他集合均隔离复制。
+
+返回：已完成结果；等待中返回 null。

--- a/docs/zh/reference/api/classes/GFSaveProfileTransactionResult.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileTransactionResult.md
@@ -1,0 +1,721 @@
+# GFSaveProfileTransactionResult
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+Profile 事务的不可变终态快照。 结果不保留文档、section、Provider snapshot 或候选 payload，只保留有界阶段 证据、类型化回滚失败、调用方元数据和必要的 Lease。`duplicate_result()` 会 隔离复制集合，但刻意保留 Recovery/Reconcile Lease 的同一对象身份。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_ACTIVATED`](#member-gfsaveprofiletransactionresult-constants-status_activated) | `const STATUS_ACTIVATED: StringName = &"activated"` |
+| 常量 | [`STATUS_SWITCHED`](#member-gfsaveprofiletransactionresult-constants-status_switched) | `const STATUS_SWITCHED: StringName = &"switched"` |
+| 常量 | [`STATUS_BOOTSTRAPPED`](#member-gfsaveprofiletransactionresult-constants-status_bootstrapped) | `const STATUS_BOOTSTRAPPED: StringName = &"bootstrapped"` |
+| 常量 | [`STATUS_ADOPTED`](#member-gfsaveprofiletransactionresult-constants-status_adopted) | `const STATUS_ADOPTED: StringName = &"adopted"` |
+| 常量 | [`STATUS_MUTATED`](#member-gfsaveprofiletransactionresult-constants-status_mutated) | `const STATUS_MUTATED: StringName = &"mutated"` |
+| 常量 | [`STATUS_RECONCILED`](#member-gfsaveprofiletransactionresult-constants-status_reconciled) | `const STATUS_RECONCILED: StringName = &"reconciled"` |
+| 常量 | [`STATUS_INVALID_PROFILE`](#member-gfsaveprofiletransactionresult-constants-status_invalid_profile) | `const STATUS_INVALID_PROFILE: StringName = &"invalid_profile"` |
+| 常量 | [`STATUS_INVALID_REQUEST`](#member-gfsaveprofiletransactionresult-constants-status_invalid_request) | `const STATUS_INVALID_REQUEST: StringName = &"invalid_request"` |
+| 常量 | [`STATUS_INVALID_LEASE`](#member-gfsaveprofiletransactionresult-constants-status_invalid_lease) | `const STATUS_INVALID_LEASE: StringName = &"invalid_lease"` |
+| 常量 | [`STATUS_INACTIVE`](#member-gfsaveprofiletransactionresult-constants-status_inactive) | `const STATUS_INACTIVE: StringName = &"inactive"` |
+| 常量 | [`STATUS_ALREADY_ACTIVE`](#member-gfsaveprofiletransactionresult-constants-status_already_active) | `const STATUS_ALREADY_ACTIVE: StringName = &"already_active"` |
+| 常量 | [`STATUS_BUSY`](#member-gfsaveprofiletransactionresult-constants-status_busy) | `const STATUS_BUSY: StringName = &"busy"` |
+| 常量 | [`STATUS_UNSUPPORTED_OPERATION`](#member-gfsaveprofiletransactionresult-constants-status_unsupported_operation) | `const STATUS_UNSUPPORTED_OPERATION: StringName = &"unsupported_operation"` |
+| 常量 | [`STATUS_RECOVERY_REQUIRED`](#member-gfsaveprofiletransactionresult-constants-status_recovery_required) | `const STATUS_RECOVERY_REQUIRED: StringName = &"recovery_required"` |
+| 常量 | [`STATUS_SOURCE_FLUSH_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_source_flush_failed) | `const STATUS_SOURCE_FLUSH_FAILED: StringName = &"source_flush_failed"` |
+| 常量 | [`STATUS_TARGET_LOAD_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_target_load_failed) | `const STATUS_TARGET_LOAD_FAILED: StringName = &"target_load_failed"` |
+| 常量 | [`STATUS_SNAPSHOT_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_snapshot_failed) | `const STATUS_SNAPSHOT_FAILED: StringName = &"snapshot_failed"` |
+| 常量 | [`STATUS_APPLY_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_apply_failed) | `const STATUS_APPLY_FAILED: StringName = &"apply_failed"` |
+| 常量 | [`STATUS_ROLLBACK_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_rollback_failed) | `const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"` |
+| 常量 | [`STATUS_PERSIST_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_persist_failed) | `const STATUS_PERSIST_FAILED: StringName = &"persist_failed"` |
+| 常量 | [`STATUS_OUTCOME_UNKNOWN`](#member-gfsaveprofiletransactionresult-constants-status_outcome_unknown) | `const STATUS_OUTCOME_UNKNOWN: StringName = &"outcome_unknown"` |
+| 常量 | [`STATUS_RECONCILE_PENDING`](#member-gfsaveprofiletransactionresult-constants-status_reconcile_pending) | `const STATUS_RECONCILE_PENDING: StringName = &"reconcile_pending"` |
+| 常量 | [`STATUS_RECONCILE_FAILED`](#member-gfsaveprofiletransactionresult-constants-status_reconcile_failed) | `const STATUS_RECONCILE_FAILED: StringName = &"reconcile_failed"` |
+| 常量 | [`STATUS_DISPOSED`](#member-gfsaveprofiletransactionresult-constants-status_disposed) | `const STATUS_DISPOSED: StringName = &"disposed"` |
+| 方法 | [`is_successful`](#member-gfsaveprofiletransactionresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`get_status`](#member-gfsaveprofiletransactionresult-methods-get_status) | `func get_status() -> StringName:` |
+| 方法 | [`get_operation`](#member-gfsaveprofiletransactionresult-methods-get_operation) | `func get_operation() -> StringName:` |
+| 方法 | [`get_transaction_id`](#member-gfsaveprofiletransactionresult-methods-get_transaction_id) | `func get_transaction_id() -> int:` |
+| 方法 | [`get_source_profile_id`](#member-gfsaveprofiletransactionresult-methods-get_source_profile_id) | `func get_source_profile_id() -> StringName:` |
+| 方法 | [`get_target_profile_id`](#member-gfsaveprofiletransactionresult-methods-get_target_profile_id) | `func get_target_profile_id() -> StringName:` |
+| 方法 | [`get_active_profile_before`](#member-gfsaveprofiletransactionresult-methods-get_active_profile_before) | `func get_active_profile_before() -> StringName:` |
+| 方法 | [`get_active_profile_after`](#member-gfsaveprofiletransactionresult-methods-get_active_profile_after) | `func get_active_profile_after() -> StringName:` |
+| 方法 | [`get_phase`](#member-gfsaveprofiletransactionresult-methods-get_phase) | `func get_phase() -> StringName:` |
+| 方法 | [`get_error_code`](#member-gfsaveprofiletransactionresult-methods-get_error_code) | `func get_error_code() -> Error:` |
+| 方法 | [`get_error`](#member-gfsaveprofiletransactionresult-methods-get_error) | `func get_error() -> String:` |
+| 方法 | [`get_failed_section_id`](#member-gfsaveprofiletransactionresult-methods-get_failed_section_id) | `func get_failed_section_id() -> StringName:` |
+| 方法 | [`get_rollback_errors`](#member-gfsaveprofiletransactionresult-methods-get_rollback_errors) | `func get_rollback_errors() -> Array[GFSaveRollbackFailure]:` |
+| 方法 | [`get_stage_evidence`](#member-gfsaveprofiletransactionresult-methods-get_stage_evidence) | `func get_stage_evidence() -> Dictionary:` |
+| 方法 | [`get_recovery_lease`](#member-gfsaveprofiletransactionresult-methods-get_recovery_lease) | `func get_recovery_lease() -> GFSaveProfileRecoveryLease:` |
+| 方法 | [`get_reconcile_lease`](#member-gfsaveprofiletransactionresult-methods-get_reconcile_lease) | `func get_reconcile_lease() -> GFSaveProfileReconcileLease:` |
+| 方法 | [`get_metadata`](#member-gfsaveprofiletransactionresult-methods-get_metadata) | `func get_metadata() -> Dictionary:` |
+| 方法 | [`get_started_at_msec`](#member-gfsaveprofiletransactionresult-methods-get_started_at_msec) | `func get_started_at_msec() -> int:` |
+| 方法 | [`get_completed_at_msec`](#member-gfsaveprofiletransactionresult-methods-get_completed_at_msec) | `func get_completed_at_msec() -> int:` |
+| 方法 | [`get_duration_msec`](#member-gfsaveprofiletransactionresult-methods-get_duration_msec) | `func get_duration_msec() -> int:` |
+| 方法 | [`duplicate_result`](#member-gfsaveprofiletransactionresult-methods-duplicate_result) | `func duplicate_result() -> GFSaveProfileTransactionResult:` |
+| 方法 | [`to_dict`](#member-gfsaveprofiletransactionresult-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_activated"></a>
+
+### `STATUS_ACTIVATED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ACTIVATED: StringName = &"activated"
+```
+
+已存在 Profile 已成功激活。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_switched"></a>
+
+### `STATUS_SWITCHED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_SWITCHED: StringName = &"switched"
+```
+
+活跃身份已成功切换。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_bootstrapped"></a>
+
+### `STATUS_BOOTSTRAPPED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_BOOTSTRAPPED: StringName = &"bootstrapped"
+```
+
+缺失 Profile 已从当前状态显式创建并激活。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_adopted"></a>
+
+### `STATUS_ADOPTED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ADOPTED: StringName = &"adopted"
+```
+
+当前状态已被显式采用为恢复后的活跃 Profile。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_mutated"></a>
+
+### `STATUS_MUTATED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_MUTATED: StringName = &"mutated"
+```
+
+候选 sections 已应用并持久化。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_reconciled"></a>
+
+### `STATUS_RECONCILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_RECONCILED: StringName = &"reconciled"
+```
+
+outcome_unknown 已通过显式重新读取完成对账。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_invalid_profile"></a>
+
+### `STATUS_INVALID_PROFILE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_PROFILE: StringName = &"invalid_profile"
+```
+
+Profile ID、Provider topology 或事务身份无效。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_invalid_request"></a>
+
+### `STATUS_INVALID_REQUEST`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_REQUEST: StringName = &"invalid_request"
+```
+
+一次性请求无效、已被 claim 或含不支持的数据。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_invalid_lease"></a>
+
+### `STATUS_INVALID_LEASE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_LEASE: StringName = &"invalid_lease"
+```
+
+Recovery/Reconcile Lease 无效、已消费或绑定已经过期。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_inactive"></a>
+
+### `STATUS_INACTIVE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INACTIVE: StringName = &"inactive"
+```
+
+请求要求活跃 Profile，但当前 Provider domain 未激活。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_already_active"></a>
+
+### `STATUS_ALREADY_ACTIVE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ALREADY_ACTIVE: StringName = &"already_active"
+```
+
+activate/bootstrap/adopt 的目标 domain 已有活跃 Profile。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_busy"></a>
+
+### `STATUS_BUSY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_BUSY: StringName = &"busy"
+```
+
+Provider domain 正在执行互斥事务或发生不安全回调重入。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_unsupported_operation"></a>
+
+### `STATUS_UNSUPPORTED_OPERATION`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_UNSUPPORTED_OPERATION: StringName = &"unsupported_operation"
+```
+
+Profile 配置不支持请求的读取或写入阶段。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_recovery_required"></a>
+
+### `STATUS_RECOVERY_REQUIRED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_RECOVERY_REQUIRED: StringName = &"recovery_required"
+```
+
+activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_source_flush_failed"></a>
+
+### `STATUS_SOURCE_FLUSH_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_SOURCE_FLUSH_FAILED: StringName = &"source_flush_failed"
+```
+
+switch 无法把来源 Profile flush 到调用时 generation barrier。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_target_load_failed"></a>
+
+### `STATUS_TARGET_LOAD_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_TARGET_LOAD_FAILED: StringName = &"target_load_failed"
+```
+
+switch 已 flush 来源，但无法读取或应用目标 Profile。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_snapshot_failed"></a>
+
+### `STATUS_SNAPSHOT_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_SNAPSHOT_FAILED: StringName = &"snapshot_failed"
+```
+
+Provider 回滚或候选应用前的快照采集失败。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_apply_failed"></a>
+
+### `STATUS_APPLY_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_APPLY_FAILED: StringName = &"apply_failed"
+```
+
+至少一个候选 section 应用失败，且内存回滚成功。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_rollback_failed"></a>
+
+### `STATUS_ROLLBACK_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ROLLBACK_FAILED: StringName = &"rollback_failed"
+```
+
+恢复来源或候选内存状态时至少一个 Provider 回滚失败。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_persist_failed"></a>
+
+### `STATUS_PERSIST_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_PERSIST_FAILED: StringName = &"persist_failed"
+```
+
+候选持久化确定失败，且内存回滚已成功。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_outcome_unknown"></a>
+
+### `STATUS_OUTCOME_UNKNOWN`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_OUTCOME_UNKNOWN: StringName = &"outcome_unknown"
+```
+
+写请求已进入底层，但其最终物理副作用无法确认。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_reconcile_pending"></a>
+
+### `STATUS_RECONCILE_PENDING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_RECONCILE_PENDING: StringName = &"reconcile_pending"
+```
+
+Reconcile Lease 仍在等待 late settlement evidence。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_reconcile_failed"></a>
+
+### `STATUS_RECONCILE_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_RECONCILE_FAILED: StringName = &"reconcile_failed"
+```
+
+显式重新读取或证据校验未能完成对账。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_disposed"></a>
+
+### `STATUS_DISPOSED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_DISPOSED: StringName = &"disposed"
+```
+
+Utility 释放时事务仍未完成。
+
+## 方法
+
+<a id="member-gfsaveprofiletransactionresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+检查事务是否成功。
+
+返回：终态属于成功状态时返回 true。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> StringName:
+```
+
+获取稳定终态状态。
+
+返回：`STATUS_*` 常量之一。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_operation"></a>
+
+### `get_operation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_operation() -> StringName:
+```
+
+获取事务类型。
+
+返回：`GFSaveProfileTransactionOperation.OPERATION_*` 常量之一。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_transaction_id"></a>
+
+### `get_transaction_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_transaction_id() -> int:
+```
+
+获取 Utility 生命周期内唯一的事务 ID。
+
+返回：正整数事务 ID。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_source_profile_id"></a>
+
+### `get_source_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_profile_id() -> StringName:
+```
+
+获取事务来源 Profile ID。
+
+返回：来源 Profile ID；不适用时为空。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_target_profile_id"></a>
+
+### `get_target_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_target_profile_id() -> StringName:
+```
+
+获取事务目标 Profile ID。
+
+返回：目标 Profile ID；不适用时为空。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_active_profile_before"></a>
+
+### `get_active_profile_before`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_active_profile_before() -> StringName:
+```
+
+获取事务开始前的活跃 Profile ID。
+
+返回：开始前活跃身份；domain 未激活时为空。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_active_profile_after"></a>
+
+### `get_active_profile_after`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_active_profile_after() -> StringName:
+```
+
+获取事务终态后的活跃 Profile ID。
+
+返回：终态活跃身份；未激活或身份未知时为空。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_phase"></a>
+
+### `get_phase`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_phase() -> StringName:
+```
+
+获取失败或成功发生的稳定阶段名。
+
+返回：协调器定义的 payload-free 阶段名。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_error_code"></a>
+
+### `get_error_code`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_code() -> Error:
+```
+
+获取 Godot Error 码。
+
+返回：成功时为 OK。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_error"></a>
+
+### `get_error`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error() -> String:
+```
+
+获取稳定错误描述。
+
+返回：成功时为空；失败说明最多 2048 个字符。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_failed_section_id"></a>
+
+### `get_failed_section_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_failed_section_id() -> StringName:
+```
+
+获取首个失败 section ID。
+
+返回：非 section 失败时为空。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_rollback_errors"></a>
+
+### `get_rollback_errors`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_rollback_errors() -> Array[GFSaveRollbackFailure]:
+```
+
+获取类型化 Provider 回滚失败证据。
+
+返回：按回滚顺序排列的隔离副本。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_stage_evidence"></a>
+
+### `get_stage_evidence`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_stage_evidence() -> Dictionary:
+```
+
+获取不含文档、section 或 Provider payload 的阶段证据。
+
+返回：有界 evidence 副本。
+
+结构：
+
+- `return`: Payload-free bounded Dictionary containing scalar, packed-array, Array, and Dictionary evidence only.
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_recovery_lease"></a>
+
+### `get_recovery_lease`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_recovery_lease() -> GFSaveProfileRecoveryLease:
+```
+
+获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。
+
+返回：recovery_required 结果中的 Lease；其他结果通常为 null。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_reconcile_lease"></a>
+
+### `get_reconcile_lease`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_reconcile_lease() -> GFSaveProfileReconcileLease:
+```
+
+获取持续围栏 outcome_unknown 的同一身份 Reconcile Lease。
+
+返回：需要或正在对账时的 Lease；不适用时为 null。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_metadata"></a>
+
+### `get_metadata`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_metadata() -> Dictionary:
+```
+
+获取调用方结果元数据副本。
+
+返回：调用方在一次性请求中移交的结果元数据。
+
+结构：
+
+- `return`: Dictionary with caller-defined result metadata.
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_started_at_msec"></a>
+
+### `get_started_at_msec`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_started_at_msec() -> int:
+```
+
+获取事务开始时间。
+
+返回：非负单调毫秒时间。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_completed_at_msec"></a>
+
+### `get_completed_at_msec`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_completed_at_msec() -> int:
+```
+
+获取事务完成时间。
+
+返回：不早于开始时间的单调毫秒时间。
+
+<a id="member-gfsaveprofiletransactionresult-methods-get_duration_msec"></a>
+
+### `get_duration_msec`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_duration_msec() -> int:
+```
+
+获取事务耗时。
+
+返回：非负单调毫秒耗时。
+
+<a id="member-gfsaveprofiletransactionresult-methods-duplicate_result"></a>
+
+### `duplicate_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_result() -> GFSaveProfileTransactionResult:
+```
+
+创建隔离结果副本。 Recovery/Reconcile Lease 不复制，以维持原始恢复授权和持续对账生命周期。
+
+返回：新结果对象。
+
+<a id="member-gfsaveprofiletransactionresult-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为不包含持久化 payload 或 Lease 对象的报告字典。
+
+返回：事务身份、终态、阶段证据、Lease 摘要、错误与时间信息。
+
+结构：
+
+- `return`: Payload-free Dictionary with transaction identity, status, active identities, phase, rollback failures, evidence, lease summaries, metadata, errors, and timing.

--- a/docs/zh/reference/api/classes/GFSaveSectionMutation.md
+++ b/docs/zh/reference/api/classes/GFSaveSectionMutation.md
@@ -1,0 +1,157 @@
+# GFSaveSectionMutation
+
+[API Reference](../index.md) / [Save](../extensions-save.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/save/profile/gf_save_section_mutation.gd`
+- 模块：`Save`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+单个 Save section 的一次性候选替换句柄。 Mutation 只描述完整候选 section，不接受可执行 Callable 或增量 patch。 `take_ownership()` 成功后，调用方必须永久放弃 payload、metadata 及其全部 嵌套集合 alias；框架 claim 后句柄会立即清空载荷。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATE_AVAILABLE`](#member-gfsavesectionmutation-constants-state_available) | `const STATE_AVAILABLE: StringName = &"available"` |
+| 常量 | [`STATE_CLAIMED`](#member-gfsavesectionmutation-constants-state_claimed) | `const STATE_CLAIMED: StringName = &"claimed"` |
+| 常量 | [`STATE_DISCARDED`](#member-gfsavesectionmutation-constants-state_discarded) | `const STATE_DISCARDED: StringName = &"discarded"` |
+| 方法 | [`take_ownership`](#member-gfsavesectionmutation-methods-take_ownership) | `static func take_ownership( section_id: StringName, schema_version: int, payload: Variant, metadata: Dictionary = {} ) -> GFSaveSectionMutation:` |
+| 方法 | [`get_section_id`](#member-gfsavesectionmutation-methods-get_section_id) | `func get_section_id() -> StringName:` |
+| 方法 | [`get_schema_version`](#member-gfsavesectionmutation-methods-get_schema_version) | `func get_schema_version() -> int:` |
+| 方法 | [`get_state`](#member-gfsavesectionmutation-methods-get_state) | `func get_state() -> StringName:` |
+| 方法 | [`is_available`](#member-gfsavesectionmutation-methods-is_available) | `func is_available() -> bool:` |
+
+## 常量
+
+<a id="member-gfsavesectionmutation-constants-state_available"></a>
+
+### `STATE_AVAILABLE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_AVAILABLE: StringName = &"available"
+```
+
+Mutation 尚未被框架接管。
+
+<a id="member-gfsavesectionmutation-constants-state_claimed"></a>
+
+### `STATE_CLAIMED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_CLAIMED: StringName = &"claimed"
+```
+
+Mutation 已被框架接管，候选载荷不再可用。
+
+<a id="member-gfsavesectionmutation-constants-state_discarded"></a>
+
+### `STATE_DISCARDED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATE_DISCARDED: StringName = &"discarded"
+```
+
+Mutation 已被框架丢弃，候选载荷不再可用。
+
+## 方法
+
+<a id="member-gfsavesectionmutation-methods-take_ownership"></a>
+
+### `take_ownership`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func take_ownership( section_id: StringName, schema_version: int, payload: Variant, metadata: Dictionary = {} ) -> GFSaveSectionMutation:
+```
+
+接管一个完整候选 section 的逻辑唯一所有权。 该方法不会深复制 payload 或 metadata。成功返回后，调用方不得继续读取、 修改或复用原集合及其嵌套 alias。输入必须满足 Save persisted-value 契约； Callable、Object、Signal、RID、循环集合和非有限数会被拒绝。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `section_id` | 稳定 section ID。 |
+| `schema_version` | 候选 section 的正整数 schema 版本。 |
+| `payload` | 完整候选 section 载荷，不是 patch 或回调。 |
+| `metadata` | 候选 section 持久化元数据。 |
+
+返回：可用 Mutation；身份或候选数据无效时返回 null。
+
+结构：
+
+- `payload`: Variant accepted by the Save persisted-value contract.
+- `metadata`: Dictionary accepted by the Save persisted-value contract.
+
+<a id="member-gfsavesectionmutation-methods-get_section_id"></a>
+
+### `get_section_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_section_id() -> StringName:
+```
+
+获取稳定 section ID。
+
+返回：section ID。
+
+<a id="member-gfsavesectionmutation-methods-get_schema_version"></a>
+
+### `get_schema_version`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_schema_version() -> int:
+```
+
+获取候选 section schema 版本。
+
+返回：正整数 schema 版本；无效句柄为 0。
+
+<a id="member-gfsavesectionmutation-methods-get_state"></a>
+
+### `get_state`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_state() -> StringName:
+```
+
+获取当前所有权状态。
+
+返回：`STATE_*` 常量之一。
+
+<a id="member-gfsavesectionmutation-methods-is_available"></a>
+
+### `is_available`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_available() -> bool:
+```
+
+检查 Mutation 是否仍可被请求或框架接管。
+
+返回：尚未 claim 或 discard 时返回 true。

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -23,7 +23,7 @@
 | Interaction | 6 | 82 | [Interaction](#module-extensions-interaction) |
 | Network | 38 | 602 | [Network](#module-extensions-network) |
 | Physics | 4 | 50 | [Physics](#module-extensions-physics) |
-| Save | 44 | 510 | [Save](#module-extensions-save) |
+| Save | 52 | 650 | [Save](#module-extensions-save) |
 | Turn Based | 4 | 49 | [Turn Based](#module-extensions-turn_based) |
 | Tool Packages | 17 | 135 | [Tool Packages](#module-tools) |
 
@@ -886,6 +886,7 @@
 | [`GFNodeSerializerRegistry`](GFNodeSerializerRegistry.md#gfnodeserializerregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/extensions/save/serializers/gf_node_serializer_registry.gd` |
 | [`GFSaveGraphUtility`](GFSaveGraphUtility.md#gfsavegraphutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 30 | `addons/gf/extensions/save/graph/gf_save_graph_utility.gd` |
 | [`GFSaveMigrationRegistry`](GFSaveMigrationRegistry.md#gfsavemigrationregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/extensions/save/document/gf_save_migration_registry.gd` |
+| [`GFSaveProfileTransactionCoordinator`](GFSaveProfileTransactionCoordinator.md#gfsaveprofiletransactioncoordinator) | 运行时服务 (`runtime_service`) | `GFUtility` | 25 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd` |
 | [`GFSaveProfileUtility`](GFSaveProfileUtility.md#gfsaveprofileutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 26 | `addons/gf/extensions/save/profile/gf_save_profile_utility.gd` |
 | [`GFSaveSlotStorageAdapter`](GFSaveSlotStorageAdapter.md#gfsaveslotstorageadapter) | 运行时服务 (`runtime_service`) | `Resource` | 16 | `addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd` |
 | [`GFSaveSlotSyncBridge`](GFSaveSlotSyncBridge.md#gfsaveslotsyncbridge) | 运行时服务 (`runtime_service`) | `RefCounted` | 6 | `addons/gf/extensions/save/slots/gf_save_slot_sync_bridge.gd` |
@@ -912,8 +913,14 @@
 | [`GFSaveProfile`](GFSaveProfile.md#gfsaveprofile) | 资源定义 (`resource_definition`) | `Resource` | 17 | `addons/gf/extensions/save/profile/gf_save_profile.gd` |
 | [`GFSaveRecoveryPolicy`](GFSaveRecoveryPolicy.md#gfsaverecoverypolicy) | 资源定义 (`resource_definition`) | `Resource` | 10 | `addons/gf/extensions/save/profile/gf_save_recovery_policy.gd` |
 | [`GFSaveSlotWorkflow`](GFSaveSlotWorkflow.md#gfsaveslotworkflow) | 资源定义 (`resource_definition`) | `Resource` | 21 | `addons/gf/extensions/save/slots/gf_save_slot_workflow.gd` |
+| [`GFSaveProfileMutationRequest`](GFSaveProfileMutationRequest.md#gfsaveprofilemutationrequest) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 5 | `addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd` |
 | [`GFSaveProfileOperation`](GFSaveProfileOperation.md#gfsaveprofileoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 11 | `addons/gf/extensions/save/profile/gf_save_profile_operation.gd` |
+| [`GFSaveProfileReconcileLease`](GFSaveProfileReconcileLease.md#gfsaveprofilereconcilelease) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 22 | `addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd` |
+| [`GFSaveProfileReconcileRequest`](GFSaveProfileReconcileRequest.md#gfsaveprofilereconcilerequest) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 3 | `addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd` |
+| [`GFSaveProfileRecoveryLease`](GFSaveProfileRecoveryLease.md#gfsaveprofilerecoverylease) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 16 | `addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd` |
 | [`GFSaveProfileRequest`](GFSaveProfileRequest.md#gfsaveprofilerequest) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 2 | `addons/gf/extensions/save/profile/gf_save_profile_request.gd` |
+| [`GFSaveProfileTransactionOperation`](GFSaveProfileTransactionOperation.md#gfsaveprofiletransactionoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 15 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd` |
+| [`GFSaveSectionMutation`](GFSaveSectionMutation.md#gfsavesectionmutation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 8 | `addons/gf/extensions/save/profile/gf_save_section_mutation.gd` |
 | [`GFSaveSectionSnapshot`](GFSaveSectionSnapshot.md#gfsavesectionsnapshot) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 8 | `addons/gf/extensions/save/profile/gf_save_section_snapshot.gd` |
 | [`GFSaveSectionSnapshotOperation`](GFSaveSectionSnapshotOperation.md#gfsavesectionsnapshotoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 20 | `addons/gf/extensions/save/profile/gf_save_section_snapshot_operation.gd` |
 | [`GFSaveDocument`](GFSaveDocument.md#gfsavedocument) | 值对象 (`value_object`) | `RefCounted` | 17 | `addons/gf/extensions/save/document/gf_save_document.gd` |
@@ -921,6 +928,7 @@
 | [`GFSaveMigrationResult`](GFSaveMigrationResult.md#gfsavemigrationresult) | 值对象 (`value_object`) | `RefCounted` | 9 | `addons/gf/extensions/save/document/gf_save_migration_result.gd` |
 | [`GFSavePipelineContext`](GFSavePipelineContext.md#gfsavepipelinecontext) | 值对象 (`value_object`) | `RefCounted` | 21 | `addons/gf/extensions/save/pipeline/gf_save_pipeline_context.gd` |
 | [`GFSaveProfileResult`](GFSaveProfileResult.md#gfsaveprofileresult) | 值对象 (`value_object`) | `RefCounted` | 47 | `addons/gf/extensions/save/profile/gf_save_profile_result.gd` |
+| [`GFSaveProfileTransactionResult`](GFSaveProfileTransactionResult.md#gfsaveprofiletransactionresult) | 值对象 (`value_object`) | `RefCounted` | 46 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd` |
 | [`GFSaveRollbackFailure`](GFSaveRollbackFailure.md#gfsaverollbackfailure) | 值对象 (`value_object`) | `RefCounted` | 4 | `addons/gf/extensions/save/profile/gf_save_rollback_failure.gd` |
 | [`GFSaveSection`](GFSaveSection.md#gfsavesection) | 值对象 (`value_object`) | `RefCounted` | 9 | `addons/gf/extensions/save/document/gf_save_section.gd` |
 | [`GFSaveSlotCard`](GFSaveSlotCard.md#gfsaveslotcard) | 值对象 (`value_object`) | `Resource` | 14 | `addons/gf/extensions/save/slots/gf_save_slot_card.gd` |

--- a/docs/zh/reference/api/extensions-save.md
+++ b/docs/zh/reference/api/extensions-save.md
@@ -6,11 +6,11 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 6 | 92 | 66 |
+| [运行时服务](#category-runtime_service) | 7 | 117 | 84 |
 | [协议与扩展点](#category-protocol) | 10 | 114 | 69 |
 | [资源定义](#category-resource_definition) | 13 | 92 | 58 |
-| [运行时句柄](#category-runtime_handle) | 4 | 41 | 28 |
-| [值对象](#category-value_object) | 9 | 154 | 98 |
+| [运行时句柄](#category-runtime_handle) | 10 | 110 | 76 |
+| [值对象](#category-value_object) | 10 | 200 | 120 |
 | [领域模型](#category-domain_model) | 1 | 6 | 3 |
 | [事件契约](#category-event_contract) | 1 | 11 | 3 |
 
@@ -25,6 +25,7 @@
 | [`GFNodeSerializerRegistry`](classes/GFNodeSerializerRegistry.md#gfnodeserializerregistry) | `RefCounted` | `addons/gf/extensions/save/serializers/gf_node_serializer_registry.gd` |
 | [`GFSaveGraphUtility`](classes/GFSaveGraphUtility.md#gfsavegraphutility) | `GFUtility` | `addons/gf/extensions/save/graph/gf_save_graph_utility.gd` |
 | [`GFSaveMigrationRegistry`](classes/GFSaveMigrationRegistry.md#gfsavemigrationregistry) | `RefCounted` | `addons/gf/extensions/save/document/gf_save_migration_registry.gd` |
+| [`GFSaveProfileTransactionCoordinator`](classes/GFSaveProfileTransactionCoordinator.md#gfsaveprofiletransactioncoordinator) | `GFUtility` | `addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd` |
 | [`GFSaveProfileUtility`](classes/GFSaveProfileUtility.md#gfsaveprofileutility) | `GFUtility` | `addons/gf/extensions/save/profile/gf_save_profile_utility.gd` |
 | [`GFSaveSlotStorageAdapter`](classes/GFSaveSlotStorageAdapter.md#gfsaveslotstorageadapter) | `Resource` | `addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd` |
 | [`GFSaveSlotSyncBridge`](classes/GFSaveSlotSyncBridge.md#gfsaveslotsyncbridge) | `RefCounted` | `addons/gf/extensions/save/slots/gf_save_slot_sync_bridge.gd` |
@@ -72,8 +73,14 @@
 
 | 类 | 继承 | 源文件 |
 |---|---|---|
+| [`GFSaveProfileMutationRequest`](classes/GFSaveProfileMutationRequest.md#gfsaveprofilemutationrequest) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd` |
 | [`GFSaveProfileOperation`](classes/GFSaveProfileOperation.md#gfsaveprofileoperation) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_operation.gd` |
+| [`GFSaveProfileReconcileLease`](classes/GFSaveProfileReconcileLease.md#gfsaveprofilereconcilelease) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd` |
+| [`GFSaveProfileReconcileRequest`](classes/GFSaveProfileReconcileRequest.md#gfsaveprofilereconcilerequest) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd` |
+| [`GFSaveProfileRecoveryLease`](classes/GFSaveProfileRecoveryLease.md#gfsaveprofilerecoverylease) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd` |
 | [`GFSaveProfileRequest`](classes/GFSaveProfileRequest.md#gfsaveprofilerequest) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_request.gd` |
+| [`GFSaveProfileTransactionOperation`](classes/GFSaveProfileTransactionOperation.md#gfsaveprofiletransactionoperation) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd` |
+| [`GFSaveSectionMutation`](classes/GFSaveSectionMutation.md#gfsavesectionmutation) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_section_mutation.gd` |
 | [`GFSaveSectionSnapshot`](classes/GFSaveSectionSnapshot.md#gfsavesectionsnapshot) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_section_snapshot.gd` |
 | [`GFSaveSectionSnapshotOperation`](classes/GFSaveSectionSnapshotOperation.md#gfsavesectionsnapshotoperation) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_section_snapshot_operation.gd` |
 
@@ -88,6 +95,7 @@
 | [`GFSaveMigrationResult`](classes/GFSaveMigrationResult.md#gfsavemigrationresult) | `RefCounted` | `addons/gf/extensions/save/document/gf_save_migration_result.gd` |
 | [`GFSavePipelineContext`](classes/GFSavePipelineContext.md#gfsavepipelinecontext) | `RefCounted` | `addons/gf/extensions/save/pipeline/gf_save_pipeline_context.gd` |
 | [`GFSaveProfileResult`](classes/GFSaveProfileResult.md#gfsaveprofileresult) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_result.gd` |
+| [`GFSaveProfileTransactionResult`](classes/GFSaveProfileTransactionResult.md#gfsaveprofiletransactionresult) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd` |
 | [`GFSaveRollbackFailure`](classes/GFSaveRollbackFailure.md#gfsaverollbackfailure) | `RefCounted` | `addons/gf/extensions/save/profile/gf_save_rollback_failure.gd` |
 | [`GFSaveSection`](classes/GFSaveSection.md#gfsavesection) | `RefCounted` | `addons/gf/extensions/save/document/gf_save_section.gd` |
 | [`GFSaveSlotCard`](classes/GFSaveSlotCard.md#gfsaveslotcard) | `Resource` | `addons/gf/extensions/save/slots/gf_save_slot_card.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,9 +5,9 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`794`
-- 公开成员：`11671`
-- 公开方法：`7201`
+- 公开类：`802`
+- 公开成员：`11811`
+- 公开方法：`7289`
 
 ## 模块
 
@@ -30,7 +30,7 @@
 | Interaction | 6 | 82 | 29 | [extensions-interaction.md](extensions-interaction.md) |
 | Network | 38 | 602 | 323 | [extensions-network.md](extensions-network.md) |
 | Physics | 4 | 50 | 23 | [extensions-physics.md](extensions-physics.md) |
-| Save | 44 | 510 | 325 | [extensions-save.md](extensions-save.md) |
+| Save | 52 | 650 | 413 | [extensions-save.md](extensions-save.md) |
 | Turn Based | 4 | 49 | 24 | [extensions-turn-based.md](extensions-turn-based.md) |
 | Tool Packages | 17 | 135 | 86 | [tools.md](tools.md) |
 

--- a/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd
+++ b/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd
@@ -1,0 +1,309 @@
+## GFSaveProfileTransactionTestSupport: Save Profile 事务测试的受控存储与内存 Provider 夹具。
+class_name GFSaveProfileTransactionTestSupport
+extends RefCounted
+
+
+# --- 公共方法 ---
+
+static func make_provider(
+	section_id: StringName,
+	initial_value: int,
+	shared_events: Array[String] = []
+) -> MemorySectionProvider:
+	var provider: MemorySectionProvider = MemorySectionProvider.new()
+	provider.section_id = section_id
+	provider.schema_version = 1
+	provider.required_on_load = true
+	provider.value = initial_value
+	provider.shared_events = shared_events
+	return provider
+
+
+static func make_profile(
+	profile_id: StringName,
+	providers: Array[GFSaveSectionProvider],
+	io_timeout_msec: int = 30_000
+) -> GFSaveProfile:
+	var profile: GFSaveProfile = GFSaveProfile.new()
+	profile.profile_id = profile_id
+	profile.file_name = "%s.sav" % String(profile_id)
+	profile.schema_version = 1
+	profile.providers = providers
+	profile.recovery_policy.io_timeout_msec = io_timeout_msec
+	return profile
+
+
+static func make_document(profile: GFSaveProfile, payloads: Dictionary) -> GFSaveDocument:
+	var document: GFSaveDocument = GFSaveDocument.new().configure(
+		profile.get_effective_schema_id(),
+		profile.schema_version
+	)
+	for provider: GFSaveSectionProvider in profile.providers:
+		var payload: Variant = GFVariantData.get_option_value(payloads, provider.section_id)
+		var _section_set: bool = document.set_section(GFSaveSection.new().configure(
+			provider.section_id,
+			provider.schema_version,
+			payload
+		))
+	return document
+
+
+static func read_success(document: GFSaveDocument) -> GFStorageReadResult:
+	return GFStorageReadResult.new().configure_success(document.to_dict())
+
+
+static func read_failure(
+	error_code: Error,
+	error_message: String,
+	failure_kind: GFStorageReadResult.FailureKind
+) -> GFStorageReadResult:
+	return GFStorageReadResult.new().configure_failure(
+		error_message,
+		error_code,
+		{},
+		GFStorageReadResult.IntegrityStatus.NOT_CHECKED,
+		0,
+		failure_kind
+	)
+
+
+static func get_saved_value(save_call: Dictionary, section_id: StringName) -> int:
+	var data: Dictionary = GFVariantData.get_option_dictionary(save_call, "data")
+	var document: GFSaveDocument = GFSaveDocument.from_dict(data)
+	if document == null:
+		return -1
+	var section: GFSaveSection = document.get_section(section_id)
+	if section == null:
+		return -1
+	var payload: Variant = section.get_payload()
+	if not payload is Dictionary:
+		return -1
+	var payload_dictionary: Dictionary = payload
+	return GFVariantData.get_option_int(payload_dictionary, "value", -1)
+
+
+# --- 内部类 ---
+
+class ControlledStorage extends GFStorageUtility:
+	var save_calls: Array[Dictionary] = []
+	var load_calls: PackedStringArray = PackedStringArray()
+	var events: Array[String] = []
+	var active_io_count: int = 0
+	var max_active_io_count: int = 0
+	var driver: GFSaveProfileUtility = null
+	var _next_request_id: int = 1
+	var _pending_save_operations: Array[GFStorageAsyncOperation] = []
+	var _pending_load_operations: Array[GFStorageAsyncOperation] = []
+
+	func save_data_request_async(file_name: String, data: Dictionary) -> GFStorageAsyncOperation:
+		var operation: GFStorageAsyncOperation = _make_operation(
+			GFStorageAsyncOperation.OPERATION_SAVE,
+			file_name
+		)
+		_record_save(file_name, data, operation.get_request_id())
+		_pending_save_operations.append(operation)
+		_begin_io()
+		return operation
+
+	func save_payload_request_async(
+		file_name: String,
+		transfer: GFStoragePayloadTransfer
+	) -> GFStorageAsyncOperation:
+		var operation: GFStorageAsyncOperation = _make_operation(
+			GFStorageAsyncOperation.OPERATION_SAVE,
+			file_name
+		)
+		var attempt: Dictionary = (
+			transfer.begin_attempt_for_framework(
+				get_instance_id(),
+				file_name,
+				_get_async_file_key(file_name),
+				_get_codec_options()
+			)
+			if transfer != null
+			else {}
+		)
+		if not GFVariantData.get_option_bool(attempt, "ok"):
+			_complete_operation(
+				operation,
+				ERR_INVALID_PARAMETER,
+				null,
+				GFStorageAsyncResult.WriteFailureKind.INVALID_REQUEST
+			)
+			return operation
+		var attempt_id: int = GFVariantData.get_option_int(attempt, "attempt_id")
+		var _configured_transfer: bool = operation.configure_payload_attempt_for_framework(
+			transfer,
+			attempt_id
+		)
+		_record_save(
+			file_name,
+			GFVariantData.get_option_dictionary(attempt, "payload"),
+			operation.get_request_id()
+		)
+		_pending_save_operations.append(operation)
+		_begin_io()
+		return operation
+
+	func load_data_request_async(file_name: String) -> GFStorageAsyncOperation:
+		var operation: GFStorageAsyncOperation = _make_operation(
+			GFStorageAsyncOperation.OPERATION_LOAD,
+			file_name
+		)
+		var _appended_load: bool = load_calls.append(file_name)
+		events.append("load:%s" % file_name)
+		_pending_load_operations.append(operation)
+		_begin_io()
+		return operation
+
+	func complete_next_save(error_code: Error = OK) -> void:
+		complete_save_at(0, error_code)
+
+	func complete_save_at(index: int, error_code: Error = OK) -> void:
+		if index < 0 or index >= _pending_save_operations.size():
+			return
+		var operation: GFStorageAsyncOperation = _pending_save_operations[index]
+		_pending_save_operations.remove_at(index)
+		_end_io()
+		_complete_operation(operation, error_code, null)
+		_tick_driver()
+
+	func complete_next_load(result: GFStorageReadResult) -> void:
+		complete_load_at(0, result)
+
+	func complete_load_at(index: int, result: GFStorageReadResult) -> void:
+		if index < 0 or index >= _pending_load_operations.size() or result == null:
+			return
+		var operation: GFStorageAsyncOperation = _pending_load_operations[index]
+		_pending_load_operations.remove_at(index)
+		_end_io()
+		_complete_operation(operation, result.error_code, result)
+		_tick_driver()
+
+	func complete_load_for_file(file_name: String, result: GFStorageReadResult) -> void:
+		for index: int in range(_pending_load_operations.size()):
+			var operation: GFStorageAsyncOperation = _pending_load_operations[index]
+			if operation.get_file_name() == file_name:
+				complete_load_at(index, result)
+				return
+
+	func get_pending_save_count() -> int:
+		return _pending_save_operations.size()
+
+	func get_pending_load_count() -> int:
+		return _pending_load_operations.size()
+
+	func get_pending_save_file_name(index: int = 0) -> String:
+		if index < 0 or index >= _pending_save_operations.size():
+			return ""
+		return _pending_save_operations[index].get_file_name()
+
+	func get_pending_load_file_name(index: int = 0) -> String:
+		if index < 0 or index >= _pending_load_operations.size():
+			return ""
+		return _pending_load_operations[index].get_file_name()
+
+	func _record_save(file_name: String, data: Dictionary, request_id: int) -> void:
+		save_calls.append({
+			"file_name": file_name,
+			"data": data.duplicate(true),
+			"request_id": request_id,
+		})
+		events.append("save:%s" % file_name)
+
+	func _begin_io() -> void:
+		active_io_count += 1
+		max_active_io_count = maxi(max_active_io_count, active_io_count)
+
+	func _end_io() -> void:
+		active_io_count = maxi(active_io_count - 1, 0)
+
+	func _tick_driver() -> void:
+		if driver != null:
+			driver.tick(0.0)
+
+	func _make_operation(
+		operation_kind: StringName,
+		file_name: String
+	) -> GFStorageAsyncOperation:
+		var operation: GFStorageAsyncOperation = GFStorageAsyncOperation.new()
+		var _configured: bool = operation.configure_for_framework(
+			_next_request_id,
+			operation_kind,
+			file_name
+		)
+		_next_request_id += 1
+		return operation
+
+	func _complete_operation(
+		operation: GFStorageAsyncOperation,
+		error_code: Error,
+		read_result: GFStorageReadResult,
+		write_failure_kind: GFStorageAsyncResult.WriteFailureKind = (
+			GFStorageAsyncResult.WriteFailureKind.NONE
+		)
+	) -> void:
+		var _finished_transfer: bool = operation.finish_payload_attempt_for_framework()
+		var successful: bool = error_code == OK
+		if operation.get_operation() == GFStorageAsyncOperation.OPERATION_LOAD:
+			successful = read_result != null and read_result.ok
+		var async_result: GFStorageAsyncResult = GFStorageAsyncResult.new()
+		var _configured: bool = async_result.configure_for_framework(
+			operation.get_request_id(),
+			operation.get_operation(),
+			operation.get_file_name(),
+			successful,
+			error_code,
+			read_result,
+			write_failure_kind,
+			{}
+		)
+		var _completed: bool = operation.complete_for_framework(async_result)
+
+
+class MemorySectionProvider extends GFSaveSectionProvider:
+	var value: int = 0
+	var fail_apply: bool = false
+	var fail_rollback: bool = false
+	var apply_count: int = 0
+	var rollback_count: int = 0
+	var shared_events: Array[String] = []
+	var save_snapshot_callback: Callable = Callable()
+	var apply_callback: Callable = Callable()
+	var rollback_callback: Callable = Callable()
+
+	func _begin_save_snapshot(
+		_context: Dictionary = {}
+	) -> GFSaveSectionSnapshotOperation:
+		shared_events.append("prepare:%s" % String(section_id))
+		if save_snapshot_callback.is_valid():
+			save_snapshot_callback.call()
+		return make_completed_snapshot({ "value": value })
+
+	func _capture_section(_context: Dictionary = {}) -> GFSaveSection:
+		shared_events.append("capture:%s" % String(section_id))
+		return make_section({ "value": value })
+
+	func _apply_section(section: GFSaveSection, _context: Dictionary = {}) -> Error:
+		shared_events.append("apply:%s" % String(section_id))
+		apply_count += 1
+		var payload: Variant = section.get_payload()
+		if fail_apply or not payload is Dictionary:
+			return ERR_INVALID_DATA
+		var payload_dictionary: Dictionary = payload
+		value = GFVariantData.get_option_int(payload_dictionary, "value")
+		if apply_callback.is_valid():
+			apply_callback.call()
+		return OK
+
+	func _rollback_section(section: GFSaveSection, _context: Dictionary = {}) -> Error:
+		shared_events.append("rollback:%s" % String(section_id))
+		rollback_count += 1
+		var payload: Variant = section.get_payload()
+		if fail_rollback or not payload is Dictionary:
+			return ERR_CANT_RESOLVE
+		var payload_dictionary: Dictionary = payload
+		value = GFVariantData.get_option_int(payload_dictionary, "value")
+		if rollback_callback.is_valid():
+			rollback_callback.call()
+		return OK

--- a/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd.uid
+++ b/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd.uid
@@ -1,0 +1,1 @@
+uid://bfrjo2jd4j38l

--- a/tests/gf_core/extensions/save/test_gf_save_profile_mutation_transactions.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_mutation_transactions.gd
@@ -1,0 +1,727 @@
+# 测试 Save Profile 类型化 section mutation、回滚与 outcome-unknown 对账。
+extends GutTest
+
+
+# --- 私有变量 ---
+
+var _clock: GFManualClock
+var _storage: GFSaveProfileTransactionTestSupport.ControlledStorage
+var _profile_utility: GFSaveProfileUtility
+var _coordinator: GFSaveProfileTransactionCoordinator
+
+
+# --- Godot 生命周期方法 ---
+
+func before_each() -> void:
+	_clock = GFManualClock.new(1_000_000, 1_700_000_000_000)
+	_storage = GFSaveProfileTransactionTestSupport.ControlledStorage.new()
+	_profile_utility = GFSaveProfileUtility.new().setup(_storage, _clock)
+	_storage.driver = _profile_utility
+	_coordinator = GFSaveProfileTransactionCoordinator.new().setup(_profile_utility)
+
+
+func after_each() -> void:
+	if _coordinator != null:
+		_coordinator.dispose()
+	_coordinator = null
+	if _profile_utility != null:
+		_profile_utility.dispose()
+	_profile_utility = null
+	if _storage != null:
+		_storage.driver = null
+		_storage.dispose()
+	_storage = null
+	_clock = null
+
+
+# --- 公共方法 ---
+
+func test_mutation_uses_registered_provider_order_and_persists_candidate() -> void:
+	var events: Array[String] = []
+	var first: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 1, events)
+	)
+	var second: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 2, events)
+	)
+	var providers: Array[GFSaveSectionProvider] = [first, second]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.success",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, {
+		&"first": { "value": 1 },
+		&"second": { "value": 2 },
+	})
+	events.clear()
+	var first_mutation: GFSaveSectionMutation = GFSaveSectionMutation.take_ownership(
+		&"first",
+		1,
+		{ "value": 10 }
+	)
+	var second_mutation: GFSaveSectionMutation = GFSaveSectionMutation.take_ownership(
+		&"second",
+		1,
+		{ "value": 20 }
+	)
+	var mutations: Array[GFSaveSectionMutation] = [second_mutation, first_mutation]
+	var request: GFSaveProfileMutationRequest = GFSaveProfileMutationRequest.take_ownership(
+		mutations,
+		{ "source": "test" },
+		{ "reason": "stable-order" },
+		{ "trace": 1 }
+	)
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	_tick_queued_mutation()
+	assert_true(request.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_lt(events.find("capture:first"), events.find("capture:second"))
+	assert_lt(events.find("apply:first"), events.find("apply:second"))
+	_storage.complete_next_save(OK)
+
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_true(result.is_successful())
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_MUTATED)
+	assert_eq(first.value, 10)
+	assert_eq(second.value, 20)
+	assert_eq(
+		GFSaveProfileTransactionTestSupport.get_saved_value(_storage.save_calls[0], &"first"),
+		10
+	)
+	assert_eq(
+		GFSaveProfileTransactionTestSupport.get_saved_value(_storage.save_calls[0], &"second"),
+		20
+	)
+
+
+func test_apply_failure_rolls_back_attempted_providers_in_reverse_order() -> void:
+	var events: Array[String] = []
+	var first: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 3, events)
+	)
+	var second: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 4, events)
+	)
+	var providers: Array[GFSaveSectionProvider] = [first, second]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.apply_failure",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, {
+		&"first": { "value": 3 },
+		&"second": { "value": 4 },
+	})
+	events.clear()
+	second.fail_apply = true
+	var request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"first", 30),
+		_make_mutation(&"second", 40),
+	])
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	_tick_queued_mutation()
+
+	assert_true(operation.is_completed())
+	assert_false(operation.get_result().is_successful())
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(first.value, 3)
+	assert_eq(second.value, 4)
+	assert_true(events.has("rollback:second"))
+	assert_true(events.has("rollback:first"))
+	assert_lt(events.find("rollback:second"), events.find("rollback:first"))
+
+
+func test_known_save_failure_rollback_dispose_keeps_persist_failed_once() -> void:
+	var events: Array[String] = []
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 6, events)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.save_failure",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 6 } })
+	events.clear()
+	var request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 60),
+	])
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	var terminal_statuses: Array[StringName] = []
+	var _connected: Error = operation.completed.connect(
+		func(terminal_result: GFSaveProfileTransactionResult) -> void:
+			terminal_statuses.append(terminal_result.get_status())
+	) as Error
+	_tick_queued_mutation()
+	assert_eq(provider.value, 60)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	provider.rollback_callback = func() -> void:
+		_coordinator.dispose()
+	_storage.complete_next_save(ERR_FILE_CANT_WRITE)
+	provider.rollback_callback = Callable()
+
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_false(result.is_successful())
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED)
+	assert_eq(terminal_statuses, [GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED])
+	assert_eq(provider.value, 6)
+	assert_true(events.has("rollback:state"))
+	assert_eq(_storage.save_calls.size(), 1, "已知未提交失败不应扩大为补偿写窗口。")
+	assert_true(result.get_rollback_errors().is_empty())
+	_coordinator.dispose()
+	assert_eq(terminal_statuses.size(), 1)
+
+
+func test_known_save_failure_reports_provider_rollback_failure() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 9)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.rollback_failure",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 9 } })
+	provider.fail_rollback = true
+	var request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 90),
+	])
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	_tick_queued_mutation()
+	_storage.complete_next_save(ERR_FILE_CANT_WRITE)
+
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_false(result.is_successful())
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_ROLLBACK_FAILED)
+	assert_false(result.get_rollback_errors().is_empty())
+	assert_eq(provider.value, 90, "回滚失败不得伪装成旧内存状态。")
+
+
+func test_non_active_profile_rejects_mutation_without_claiming_request() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 1)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.inactive",
+		providers
+	)
+	assert_true(_register(profile))
+	var request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 2),
+	])
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	_profile_utility.tick(0.0)
+
+	assert_true(operation.is_completed())
+	assert_false(operation.get_result().is_successful())
+	assert_false(request.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 0)
+
+
+func test_unknown_write_fences_domain_until_late_evidence_is_reloaded() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 7)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.reconcile",
+		providers,
+		10
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 7 } })
+	var request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 70),
+	])
+	var mutation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	_tick_queued_mutation()
+	assert_eq(_storage.get_pending_save_count(), 1)
+	var _advanced: bool = _clock.advance_msec(11)
+	_profile_utility.tick(0.0)
+
+	var unknown_result: GFSaveProfileTransactionResult = mutation.get_result()
+	var reconcile_lease: GFSaveProfileReconcileLease = unknown_result.get_reconcile_lease()
+	assert_eq(unknown_result.get_status(), GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN)
+	assert_not_null(reconcile_lease)
+	assert_true(reconcile_lease.is_waiting())
+	assert_eq(
+		GFVariantData.get_option_string_name(
+			_coordinator.get_domain_state_snapshot(profile.profile_id),
+			"state"
+		),
+		GFSaveProfileTransactionCoordinator.DOMAIN_STATE_RECONCILIATION_REQUIRED
+	)
+	var blocked_request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 71),
+	])
+	var blocked: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		blocked_request
+	)
+	assert_true(blocked.is_completed())
+	assert_false(blocked_request.is_claimed(), "fence 拒绝必须发生在 move-only claim 之前。")
+
+	var reconcile_request: GFSaveProfileReconcileRequest = (
+		GFSaveProfileReconcileRequest.take_ownership(
+			{ "evidence": "pending" },
+			{ "trace": 9 }
+		)
+	)
+	var pending_operation: GFSaveProfileTransactionOperation = _coordinator.reconcile_profile(
+		reconcile_lease,
+		reconcile_request
+	)
+	assert_true(pending_operation.is_completed())
+	assert_eq(
+		pending_operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECONCILE_PENDING
+	)
+	assert_false(reconcile_request.is_claimed())
+	assert_true(reconcile_lease.is_waiting())
+
+	var settled_reconcile_operations: Array[GFSaveProfileTransactionOperation] = []
+	var settled_request_availability: Array[bool] = []
+	var _settled_connected: Error = reconcile_lease.settled.connect(
+		func(
+			settled_lease: GFSaveProfileReconcileLease,
+			_state: StringName
+		) -> void:
+			settled_reconcile_operations.append(
+				_coordinator.reconcile_profile(settled_lease, reconcile_request)
+			)
+			settled_request_availability.append(reconcile_request.is_available())
+	) as Error
+	_storage.complete_next_save(OK)
+	assert_true(reconcile_lease.is_ready(), "迟到成功只能开放显式 reconcile，不能自动解锁。")
+	assert_eq(settled_reconcile_operations.size(), 1)
+	assert_eq(settled_request_availability, [true])
+	assert_true(settled_reconcile_operations[0].is_completed())
+	assert_eq(
+		settled_reconcile_operations[0].get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BUSY
+	)
+	assert_false(reconcile_request.is_claimed(), "settled 回调内 BUSY 拒绝必须先于 request claim。")
+	assert_eq(
+		mutation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+		"原终态必须保持不可变。"
+	)
+	var reconcile: GFSaveProfileTransactionOperation = _coordinator.reconcile_profile(
+		reconcile_lease,
+		reconcile_request
+	)
+	_profile_utility.tick(0.0)
+	assert_true(reconcile_request.is_claimed())
+	assert_eq(_storage.get_pending_load_file_name(), profile.file_name)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			profile,
+			{ &"state": { "value": 70 } }
+		)
+	))
+
+	assert_true(reconcile.get_result().is_successful())
+	assert_eq(reconcile.get_result().get_status(), GFSaveProfileTransactionResult.STATUS_RECONCILED)
+	assert_true(reconcile_lease.is_terminal())
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), profile.profile_id)
+	assert_eq(
+		GFVariantData.get_option_string_name(
+			_coordinator.get_domain_state_snapshot(profile.profile_id),
+			"state"
+		),
+		GFSaveProfileTransactionCoordinator.DOMAIN_STATE_ACTIVE
+	)
+	assert_eq(provider.value, 70)
+
+
+func test_coordinator_dispose_abandons_inflight_write_until_late_settlement() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 4)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.dispose_inflight",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 4 } })
+	var request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 40),
+	])
+	var operation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		request
+	)
+	var terminal_statuses: Array[StringName] = []
+	var _connected: Error = operation.completed.connect(
+		func(terminal_result: GFSaveProfileTransactionResult) -> void:
+			terminal_statuses.append(terminal_result.get_status())
+	) as Error
+	_tick_queued_mutation()
+	assert_true(request.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(provider.value, 40)
+
+	_coordinator.dispose()
+	assert_true(operation.is_completed())
+	if not operation.is_completed():
+		return
+	assert_eq(terminal_statuses, [GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN])
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN)
+	assert_not_null(result.get_reconcile_lease())
+	assert_true(result.get_reconcile_lease().is_terminal())
+	var direct_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "source": "after-abandon" }
+	)
+	var rejected_direct: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		direct_request
+	)
+	assert_true(rejected_direct.is_completed())
+	assert_eq(rejected_direct.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_false(direct_request.is_claimed())
+	assert_false(_profile_utility.unregister_profile(profile.profile_id))
+
+	_storage.complete_next_save(OK)
+	assert_eq(terminal_statuses.size(), 1, "迟到低层写终态不得重写外层 disposal 结果。")
+	assert_eq(operation.get_result().get_status(), GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN)
+	assert_true(_profile_utility.unregister_profile(profile.profile_id))
+	assert_true(_profile_utility.get_profile_state_snapshot(profile.profile_id).is_empty())
+
+
+func test_reconcile_load_dispose_ignores_late_document() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 7)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.reconcile_dispose",
+		providers,
+		10
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 7 } })
+	var mutation: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		_make_request([_make_mutation(&"state", 70)])
+	)
+	_tick_queued_mutation()
+	assert_eq(_storage.get_pending_save_count(), 1)
+	var _advanced: bool = _clock.advance_msec(11)
+	_profile_utility.tick(0.0)
+	var unknown_result: GFSaveProfileTransactionResult = mutation.get_result()
+	assert_eq(unknown_result.get_status(), GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN)
+	var lease: GFSaveProfileReconcileLease = unknown_result.get_reconcile_lease()
+	assert_not_null(lease)
+	assert_true(lease.is_waiting())
+	_storage.complete_next_save(OK)
+	assert_true(lease.is_ready())
+
+	var reconcile: GFSaveProfileTransactionOperation = _coordinator.reconcile_profile(lease)
+	var terminal_statuses: Array[StringName] = []
+	var _connected: Error = reconcile.completed.connect(
+		func(terminal_result: GFSaveProfileTransactionResult) -> void:
+			terminal_statuses.append(terminal_result.get_status())
+	) as Error
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_file_name(), profile.file_name)
+	_coordinator.dispose()
+	assert_true(reconcile.is_completed())
+	var disposed_result: GFSaveProfileTransactionResult = reconcile.get_result()
+	assert_eq(disposed_result.get_status(), GFSaveProfileTransactionResult.STATUS_DISPOSED)
+	assert_same(disposed_result.get_reconcile_lease(), lease)
+	assert_true(lease.is_terminal())
+	assert_eq(terminal_statuses, [GFSaveProfileTransactionResult.STATUS_DISPOSED])
+	assert_eq(provider.value, 70)
+
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			profile,
+			{ &"state": { "value": 99 } }
+		)
+	))
+	assert_eq(provider.value, 70, "关闭后的 reconcile 严格读取不得迟到应用。")
+	assert_eq(terminal_statuses.size(), 1)
+
+
+func test_generation_evidence_signal_observes_stabilized_unknown_and_late_state() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 2)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.generation_evidence",
+		providers,
+		10
+	)
+	assert_true(GFVariantData.get_option_bool(
+		_profile_utility.register_profile(profile),
+		"registered"
+	))
+	var observed_evidence: Array[Dictionary] = []
+	var observed_snapshots: Array[Dictionary] = []
+	var observed_generations: Array[int] = []
+	var _connected: Error = _profile_utility.profile_generation_evidence_changed.connect(
+		func(changed_profile_id: StringName, changed_generation: int) -> void:
+			if changed_profile_id != profile.profile_id:
+				return
+			observed_generations.append(changed_generation)
+			observed_evidence.append(
+				_profile_utility.get_generation_evidence_for_framework(
+					changed_profile_id,
+					changed_generation
+				)
+			)
+			observed_snapshots.append(
+				_profile_utility.get_profile_state_snapshot(changed_profile_id)
+			)
+	) as Error
+	var operation: GFSaveProfileOperation = _profile_utility.save_profile(profile.profile_id)
+	_profile_utility.tick(0.0)
+	var generation: int = operation.get_requested_generation()
+	var _advanced: bool = _clock.advance_msec(11)
+	_profile_utility.tick(0.0)
+
+	assert_eq(operation.get_result().get_status(), GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN)
+	assert_eq(observed_evidence.size(), 1)
+	if observed_evidence.size() != 1:
+		return
+	var unknown_evidence: Dictionary = observed_evidence[0]
+	var unknown_snapshot: Dictionary = observed_snapshots[0]
+	assert_eq(observed_generations[0], generation)
+	assert_eq(
+		GFVariantData.get_option_string_name(unknown_evidence, "state"),
+		&"outcome_unknown"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(unknown_evidence, "status"),
+		GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN
+	)
+	assert_true(GFVariantData.get_option_bool(unknown_snapshot, "write_outcome_unknown"))
+	assert_eq(GFVariantData.get_option_int(unknown_snapshot, "detached_write_count"), 1)
+	assert_eq(
+		_get_packed_int64_array(unknown_evidence, "storage_request_ids"),
+		_get_packed_int64_array(unknown_snapshot, "detached_storage_request_ids")
+	)
+	assert_eq(
+		_get_packed_int64_array(unknown_snapshot, "unknown_write_generations"),
+		PackedInt64Array([generation])
+	)
+
+	_storage.complete_next_save(OK)
+	assert_eq(observed_evidence.size(), 2)
+	if observed_evidence.size() != 2:
+		return
+	var persisted_evidence: Dictionary = observed_evidence[1]
+	var persisted_snapshot: Dictionary = observed_snapshots[1]
+	assert_eq(observed_generations[1], generation)
+	assert_eq(
+		GFVariantData.get_option_string_name(persisted_evidence, "state"),
+		&"persisted"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(persisted_evidence, "persisted_generation"),
+		generation
+	)
+	assert_eq(
+		_get_packed_int64_array(persisted_evidence, "storage_request_ids"),
+		PackedInt64Array()
+	)
+	assert_false(GFVariantData.get_option_bool(persisted_snapshot, "write_outcome_unknown"))
+	assert_eq(GFVariantData.get_option_int(persisted_snapshot, "detached_write_count"), 0)
+	assert_eq(
+		_get_packed_int64_array(persisted_snapshot, "detached_storage_request_ids"),
+		PackedInt64Array()
+	)
+
+
+func test_manager_owner_dispose_inside_apply_rechecks_permit_and_rolls_back() -> void:
+	var events: Array[String] = []
+	var first: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 1, events)
+	)
+	var second: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 2, events)
+	)
+	var providers: Array[GFSaveSectionProvider] = [first, second]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.owner_dispose_apply",
+		providers
+	)
+	assert_true(GFVariantData.get_option_bool(
+		_profile_utility.register_profile(profile),
+		"registered"
+	))
+	var manager_owner: Node = Node.new()
+	var permit: RefCounted = _profile_utility.claim_profile_management_for_framework(
+		profile.profile_id,
+		manager_owner
+	)
+	assert_not_null(permit)
+	var candidates: Array[GFSaveSection] = [
+		first.make_section({ "value": 10 }),
+		second.make_section({ "value": 20 }),
+	]
+	second.apply_callback = func() -> void:
+		manager_owner.free()
+	var apply_result: Dictionary = (
+		_profile_utility.apply_profile_candidates_for_manager_for_framework(
+			profile.profile_id,
+			candidates,
+			{},
+			permit
+		)
+	)
+	second.apply_callback = Callable()
+
+	assert_false(GFVariantData.get_option_bool(apply_result, "ok"))
+	assert_eq(
+		GFVariantData.get_option_string_name(apply_result, "failure_stage"),
+		&"apply"
+	)
+	assert_eq(GFVariantData.get_option_int(apply_result, "error_code"), int(ERR_UNAUTHORIZED))
+	assert_eq(first.value, 1)
+	assert_eq(second.value, 2)
+	assert_lt(events.find("rollback:second"), events.find("rollback:first"))
+	assert_true(
+		GFVariantData.get_option_array(apply_result, "rollback_errors").is_empty()
+	)
+	assert_true(_profile_utility.unregister_profile(profile.profile_id))
+
+
+func test_mutation_callback_reentry_and_coordinator_dispose_restore_once() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 5)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"mutation.callback_dispose",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 5 } })
+	var nested_request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 51),
+	])
+	var nested_operations: Array[GFSaveProfileTransactionOperation] = []
+	provider.apply_callback = func() -> void:
+		nested_operations.append(_coordinator.mutate_and_persist(
+			profile.profile_id,
+			nested_request
+		))
+		_coordinator.dispose()
+	var outer_request: GFSaveProfileMutationRequest = _make_request([
+		_make_mutation(&"state", 50),
+	])
+	var outer: GFSaveProfileTransactionOperation = _coordinator.mutate_and_persist(
+		profile.profile_id,
+		outer_request
+	)
+	var terminal_statuses: Array[StringName] = []
+	var _connected: Error = outer.completed.connect(
+		func(result: GFSaveProfileTransactionResult) -> void:
+			terminal_statuses.append(result.get_status())
+	) as Error
+	_tick_queued_mutation()
+	provider.apply_callback = Callable()
+
+	assert_true(outer_request.is_claimed())
+	assert_eq(nested_operations.size(), 1)
+	assert_true(nested_operations[0].is_completed())
+	assert_eq(
+		nested_operations[0].get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BUSY
+	)
+	assert_false(nested_request.is_claimed(), "重入准入拒绝不得消费 mutation request。")
+	assert_true(outer.is_completed(), "回调内 dispose 不得遗留 pending 外层事务。")
+	assert_eq(provider.value, 5, "物理写入前的关闭必须恢复已 apply 的内存状态。")
+	assert_eq(provider.rollback_count, 1)
+	assert_eq(_storage.get_pending_save_count(), 0)
+	if not outer.is_completed():
+		return
+	assert_eq(outer.get_result().get_status(), GFSaveProfileTransactionResult.STATUS_DISPOSED)
+	assert_eq(terminal_statuses, [GFSaveProfileTransactionResult.STATUS_DISPOSED])
+	_coordinator.dispose()
+	assert_eq(terminal_statuses.size(), 1)
+
+
+# --- 私有/辅助方法 ---
+
+func _register(profile: GFSaveProfile) -> bool:
+	return GFVariantData.get_option_bool(
+		_coordinator.register_profile(profile),
+		"registered"
+	)
+
+
+func _activate_existing(profile: GFSaveProfile, payloads: Dictionary) -> void:
+	var operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_load_for_file(
+		profile.file_name,
+		GFSaveProfileTransactionTestSupport.read_success(
+			GFSaveProfileTransactionTestSupport.make_document(profile, payloads)
+		)
+	)
+	assert_true(operation.is_completed())
+	assert_true(operation.get_result().is_successful())
+
+
+func _make_mutation(section_id: StringName, value: int) -> GFSaveSectionMutation:
+	return GFSaveSectionMutation.take_ownership(
+		section_id,
+		1,
+		{ "value": value }
+	)
+
+
+func _make_request(
+	mutations: Array[GFSaveSectionMutation]
+) -> GFSaveProfileMutationRequest:
+	return GFSaveProfileMutationRequest.take_ownership(mutations, {}, {}, {})
+
+
+func _get_packed_int64_array(source: Dictionary, key: String) -> PackedInt64Array:
+	var value: Variant = GFVariantData.get_option_value(source, key)
+	if value is PackedInt64Array:
+		var values: PackedInt64Array = value
+		return values
+	return PackedInt64Array()
+
+
+func _tick_queued_mutation() -> void:
+	_profile_utility.tick(0.0)
+	_coordinator.tick(0.0)
+	_profile_utility.tick(0.0)

--- a/tests/gf_core/extensions/save/test_gf_save_profile_mutation_transactions.gd.uid
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_mutation_transactions.gd.uid
@@ -1,0 +1,1 @@
+uid://bdq22t7ya2xqg

--- a/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
@@ -1,0 +1,921 @@
+# 测试 Save Profile 活动身份、恢复与切换事务。
+extends GutTest
+
+
+# --- 私有变量 ---
+
+var _clock: GFManualClock
+var _storage: GFSaveProfileTransactionTestSupport.ControlledStorage
+var _profile_utility: GFSaveProfileUtility
+var _coordinator: GFSaveProfileTransactionCoordinator
+var _terminal_count: int = 0
+
+
+# --- Godot 生命周期方法 ---
+
+func before_each() -> void:
+	_clock = GFManualClock.new(1_000_000, 1_700_000_000_000)
+	_storage = GFSaveProfileTransactionTestSupport.ControlledStorage.new()
+	_profile_utility = GFSaveProfileUtility.new().setup(_storage, _clock)
+	_storage.driver = _profile_utility
+	_coordinator = GFSaveProfileTransactionCoordinator.new().setup(_profile_utility)
+	_terminal_count = 0
+
+
+func after_each() -> void:
+	if _coordinator != null:
+		_coordinator.dispose()
+	_coordinator = null
+	if _profile_utility != null:
+		_profile_utility.dispose()
+	_profile_utility = null
+	if _storage != null:
+		_storage.driver = null
+		_storage.dispose()
+	_storage = null
+	_clock = null
+
+
+# --- 公共方法 ---
+
+func test_registration_uses_exact_ordered_provider_topology_and_rejects_overlap() -> void:
+	var first: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 1)
+	)
+	var second: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 2)
+	)
+	var third: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"third", 3)
+	)
+	var exact_providers: Array[GFSaveSectionProvider] = [first, second]
+	var reversed_providers: Array[GFSaveSectionProvider] = [second, first]
+	var partial_providers: Array[GFSaveSectionProvider] = [first, third]
+	var first_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.topology.first",
+		exact_providers
+	)
+	var second_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.topology.second",
+		exact_providers
+	)
+	var reversed_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.topology.reversed",
+		reversed_providers
+	)
+	var partial_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.topology.partial",
+		partial_providers
+	)
+
+	assert_true(_register(first_profile))
+	assert_true(_register(second_profile), "完全相同且顺序一致的 Provider 应共享 domain。")
+	var first_snapshot: Dictionary = _coordinator.get_domain_state_snapshot(
+		first_profile.profile_id
+	)
+	var second_snapshot: Dictionary = _coordinator.get_domain_state_snapshot(
+		second_profile.profile_id
+	)
+	assert_eq(
+		GFVariantData.get_option_int(first_snapshot, "domain_id"),
+		GFVariantData.get_option_int(second_snapshot, "domain_id")
+	)
+	var reversed_report: Dictionary = _coordinator.register_profile(reversed_profile)
+	assert_false(
+		GFVariantData.get_option_bool(reversed_report, "registered"),
+		(
+			"同一 Provider 的重排不得伪装成相同 topology；provider ids=%s/%s，report=%s。"
+			% [first.get_instance_id(), second.get_instance_id(), reversed_report]
+		)
+	)
+	var partial_report: Dictionary = _coordinator.register_profile(partial_profile)
+	assert_false(
+		GFVariantData.get_option_bool(partial_report, "registered"),
+		"部分重叠必须失败关闭，避免双重权威锁域；report=%s。" % partial_report
+	)
+	assert_true(
+		_profile_utility.get_profile_state_snapshot(reversed_profile.profile_id).is_empty(),
+		"Coordinator 注册回滚不得留下低层孤儿 Profile。"
+	)
+	assert_true(_profile_utility.get_profile_state_snapshot(partial_profile.profile_id).is_empty())
+
+
+func test_disjoint_provider_domains_activate_concurrently() -> void:
+	var first_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 0)
+	)
+	var second_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 0)
+	)
+	var first_providers: Array[GFSaveSectionProvider] = [first_provider]
+	var second_providers: Array[GFSaveSectionProvider] = [second_provider]
+	var first_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.concurrent.first",
+		first_providers
+	)
+	var second_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.concurrent.second",
+		second_providers
+	)
+	assert_true(_register(first_profile))
+	assert_true(_register(second_profile))
+	var first_snapshot: Dictionary = _coordinator.get_domain_state_snapshot(
+		first_profile.profile_id
+	)
+	var second_snapshot: Dictionary = _coordinator.get_domain_state_snapshot(
+		second_profile.profile_id
+	)
+	assert_ne(
+		GFVariantData.get_option_int(first_snapshot, "domain_id"),
+		GFVariantData.get_option_int(second_snapshot, "domain_id")
+	)
+
+	var first_operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		first_profile.profile_id
+	)
+	var second_operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		second_profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+
+	assert_eq(_storage.get_pending_load_count(), 2)
+	assert_eq(_storage.max_active_io_count, 2, "不相交 domain 不应被全局串行锁阻塞。")
+	_storage.complete_load_for_file(
+		first_profile.file_name,
+		GFSaveProfileTransactionTestSupport.read_success(
+			GFSaveProfileTransactionTestSupport.make_document(
+				first_profile,
+				{ &"first": { "value": 11 } }
+			)
+		)
+	)
+	_storage.complete_load_for_file(
+		second_profile.file_name,
+		GFSaveProfileTransactionTestSupport.read_success(
+			GFSaveProfileTransactionTestSupport.make_document(
+				second_profile,
+				{ &"second": { "value": 22 } }
+			)
+		)
+	)
+
+	assert_true(first_operation.get_result().is_successful())
+	assert_true(second_operation.get_result().is_successful())
+	assert_eq(first_provider.value, 11)
+	assert_eq(second_provider.value, 22)
+
+
+func test_activate_strictly_loads_existing_profile_before_publishing_identity() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 3)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.activate",
+		providers
+	)
+	assert_true(_register(profile))
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id,
+		{ "source": "test" },
+		{ "trace": 17 }
+	)
+	_profile_utility.tick(0.0)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), &"")
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			profile,
+			{ &"state": { "value": 41 } }
+		)
+	))
+
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_true(result.is_successful())
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_ACTIVATED)
+	assert_eq(result.get_active_profile_before(), &"")
+	assert_eq(result.get_active_profile_after(), profile.profile_id)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), profile.profile_id)
+	assert_eq(provider.value, 41)
+
+
+func test_missing_activate_requires_lease_before_bootstrap_can_activate() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 7)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap",
+		providers
+	)
+	profile.recovery_policy.missing_file_action = GFSaveRecoveryPolicy.ACTION_USE_CURRENT_STATE
+	assert_true(_register(profile))
+
+	var activation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_failure(
+		ERR_FILE_NOT_FOUND,
+		"Injected missing profile.",
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	))
+	var activation_result: GFSaveProfileTransactionResult = activation.get_result()
+	var recovery_lease: GFSaveProfileRecoveryLease = activation_result.get_recovery_lease()
+	assert_eq(
+		activation_result.get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED
+	)
+	assert_not_null(recovery_lease, "严格激活不得走 use-current-state 隐式恢复。")
+	assert_eq(recovery_lease.get_reason(), GFSaveProfileRecoveryLease.REASON_MISSING)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), &"")
+	var epoch_before_invalid_request: int = GFVariantData.get_option_int(
+		_coordinator.get_domain_state_snapshot(profile.profile_id),
+		"transaction_epoch"
+	)
+	var uninitialized_request: GFSaveProfileRequest = GFSaveProfileRequest.new()
+	var rejected_bootstrap: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_profile(recovery_lease, uninitialized_request)
+	)
+	assert_eq(
+		rejected_bootstrap.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST
+	)
+	assert_false(uninitialized_request.is_claimed())
+	assert_true(recovery_lease.is_available())
+	assert_eq(
+		GFVariantData.get_option_int(
+			_coordinator.get_domain_state_snapshot(profile.profile_id),
+			"transaction_epoch"
+		),
+		epoch_before_invalid_request,
+		"无效 request 必须在 lease claim 与 domain epoch 推进前失败。"
+	)
+
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{ "reason": "bootstrap" },
+		{},
+		{ "trace": 1 }
+	)
+	var bootstrap: GFSaveProfileTransactionOperation = _coordinator.bootstrap_profile(
+		recovery_lease,
+		request
+	)
+	_profile_utility.tick(0.0)
+	assert_true(request.is_claimed())
+	assert_true(recovery_lease.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), &"")
+	_storage.complete_next_save(OK)
+
+	assert_true(bootstrap.get_result().is_successful())
+	assert_eq(
+		bootstrap.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BOOTSTRAPPED
+	)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), profile.profile_id)
+	assert_eq(
+		GFSaveProfileTransactionTestSupport.get_saved_value(_storage.save_calls[0], &"state"),
+		7
+	)
+	var retained_activation_result: GFSaveProfileTransactionResult = activation.get_result()
+	assert_eq(
+		retained_activation_result.get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED
+	)
+	assert_same(retained_activation_result.get_recovery_lease(), recovery_lease)
+	assert_true(retained_activation_result.get_recovery_lease().is_claimed())
+
+
+func test_recovery_result_remains_copyable_after_later_transaction_stales_lease() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 8)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.recovery_stale_copy",
+		providers
+	)
+	assert_true(_register(profile))
+	var first_activation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_failure(
+		ERR_FILE_NOT_FOUND,
+		"Injected first missing profile.",
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	))
+	var first_result: GFSaveProfileTransactionResult = first_activation.get_result()
+	var first_lease: GFSaveProfileRecoveryLease = first_result.get_recovery_lease()
+	assert_not_null(first_lease)
+	assert_true(first_lease.is_available())
+
+	var second_activation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	assert_true(first_lease.is_stale(), "后续 domain 事务必须使旧恢复能力失效。")
+	var copied_after_stale: GFSaveProfileTransactionResult = first_activation.get_result()
+	assert_not_null(copied_after_stale)
+	assert_eq(
+		copied_after_stale.get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED
+	)
+	assert_same(copied_after_stale.get_recovery_lease(), first_lease)
+	assert_true(copied_after_stale.get_recovery_lease().is_stale())
+	_profile_utility.tick(0.0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_failure(
+		ERR_FILE_NOT_FOUND,
+		"Injected second missing profile.",
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	))
+	assert_eq(
+		second_activation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED
+	)
+
+
+func test_corrupt_activate_requires_lease_before_adopt_can_activate() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 13)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.adopt",
+		providers
+	)
+	profile.recovery_policy.corrupt_file_action = GFSaveRecoveryPolicy.ACTION_USE_CURRENT_STATE
+	assert_true(_register(profile))
+
+	var activation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_failure(
+		ERR_FILE_CORRUPT,
+		"Injected corrupt profile.",
+		GFStorageReadResult.FailureKind.CORRUPT
+	))
+	var activation_result: GFSaveProfileTransactionResult = activation.get_result()
+	var recovery_lease: GFSaveProfileRecoveryLease = activation_result.get_recovery_lease()
+	assert_eq(
+		activation_result.get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED
+	)
+	assert_not_null(recovery_lease)
+	assert_eq(recovery_lease.get_reason(), GFSaveProfileRecoveryLease.REASON_CORRUPT)
+	var epoch_before_invalid_request: int = GFVariantData.get_option_int(
+		_coordinator.get_domain_state_snapshot(profile.profile_id),
+		"transaction_epoch"
+	)
+	var uninitialized_request: GFSaveProfileRequest = GFSaveProfileRequest.new()
+	var rejected_adopt: GFSaveProfileTransactionOperation = _coordinator.adopt_profile(
+		recovery_lease,
+		uninitialized_request
+	)
+	assert_eq(
+		rejected_adopt.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST
+	)
+	assert_false(uninitialized_request.is_claimed())
+	assert_true(recovery_lease.is_available())
+	assert_eq(
+		GFVariantData.get_option_int(
+			_coordinator.get_domain_state_snapshot(profile.profile_id),
+			"transaction_epoch"
+		),
+		epoch_before_invalid_request
+	)
+
+	var adopt: GFSaveProfileTransactionOperation = _coordinator.adopt_profile(recovery_lease)
+	_profile_utility.tick(0.0)
+	assert_true(recovery_lease.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), &"")
+	_storage.complete_next_save(OK)
+
+	assert_true(adopt.get_result().is_successful())
+	assert_eq(adopt.get_result().get_status(), GFSaveProfileTransactionResult.STATUS_ADOPTED)
+	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), profile.profile_id)
+
+
+func test_switch_waits_for_source_generation_before_loading_target() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 0)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 5 } })
+
+	provider.value = 8
+	var save_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership({}, {}, {})
+	var source_save: GFSaveProfileOperation = _profile_utility.save_profile(
+		source.profile_id,
+		save_request
+	)
+	_profile_utility.tick(0.0)
+	assert_true(
+		save_request.is_claimed(),
+		"活动 Profile 的直接 save 应获准；result=%s。" % source_save.get_result()
+	)
+	assert_eq(_storage.get_pending_save_count(), 1)
+
+	var switch_operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_count(), 0, "源 generation 未确认前不得读取目标。")
+	_storage.complete_next_save(OK)
+	_profile_utility.tick(0.0)
+	assert_true(source_save.is_completed())
+	assert_eq(_storage.get_pending_load_file_name(), target.file_name)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			target,
+			{ &"state": { "value": 21 } }
+		)
+	))
+
+	var result: GFSaveProfileTransactionResult = switch_operation.get_result()
+	assert_true(result.is_successful())
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_SWITCHED)
+	assert_eq(result.get_source_profile_id(), source.profile_id)
+	assert_eq(result.get_target_profile_id(), target.profile_id)
+	assert_eq(result.get_active_profile_after(), target.profile_id)
+	assert_eq(provider.value, 21)
+
+
+func test_switch_apply_failure_restores_source_state_and_identity() -> void:
+	var events: Array[String] = []
+	var first: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 0, events)
+	)
+	var second: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 0, events)
+	)
+	var providers: Array[GFSaveSectionProvider] = [first, second]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.rollback.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.rollback.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, {
+		&"first": { "value": 10 },
+		&"second": { "value": 11 },
+	})
+	events.clear()
+	second.fail_apply = true
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			target,
+			{
+				&"first": { "value": 20 },
+				&"second": { "value": 21 },
+			}
+		)
+	))
+
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_false(result.is_successful())
+	assert_eq(_coordinator.get_active_profile_id(source.profile_id), source.profile_id)
+	assert_eq(first.value, 10)
+	assert_eq(second.value, 11)
+	assert_lt(events.find("rollback:second"), events.find("rollback:first"))
+
+
+func test_switch_target_load_dispose_ignores_late_document() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 0)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_dispose.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_dispose.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 10 } })
+	var operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var terminal_statuses: Array[StringName] = []
+	var _connected: Error = operation.completed.connect(
+		func(terminal_result: GFSaveProfileTransactionResult) -> void:
+			terminal_statuses.append(terminal_result.get_status())
+	) as Error
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_file_name(), target.file_name)
+
+	_coordinator.dispose()
+	assert_true(operation.is_completed())
+	var disposed_result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_eq(disposed_result.get_status(), GFSaveProfileTransactionResult.STATUS_DISPOSED)
+	assert_not_null(disposed_result.get_reconcile_lease())
+	assert_true(disposed_result.get_reconcile_lease().is_terminal())
+	assert_eq(terminal_statuses, [GFSaveProfileTransactionResult.STATUS_DISPOSED])
+	assert_eq(provider.value, 10)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			target,
+			{ &"state": { "value": 99 } }
+		)
+	))
+	assert_eq(provider.value, 10, "关闭后的目标读取不得迟到应用到共享 Provider。")
+	assert_eq(terminal_statuses.size(), 1)
+
+
+func test_inactive_managed_profile_rejects_direct_bypass_without_claiming_request() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 1)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.managed_gate",
+		providers
+	)
+	assert_true(_register(profile))
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{ "document": 1 },
+		{ "context": 2 },
+		{ "result": 3 }
+	)
+
+	var save_operation: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		request
+	)
+	var load_operation: GFSaveProfileOperation = _profile_utility.load_profile(
+		profile.profile_id
+	)
+	var flush_operation: GFSaveProfileOperation = _profile_utility.flush_profile(
+		profile.profile_id
+	)
+
+	assert_true(save_operation.is_completed())
+	assert_true(load_operation.is_completed())
+	assert_true(flush_operation.is_completed())
+	assert_false(request.is_claimed(), "前置 managed gate 必须先于 move-only request claim。")
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_storage.get_pending_load_count(), 0)
+
+
+func test_utility_quiesce_rejects_manager_operations_before_claiming_save_request() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 1)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.manager_quiesce",
+		providers
+	)
+	assert_true(GFVariantData.get_option_bool(
+		_profile_utility.register_profile(profile),
+		"registered"
+	))
+	var manager_owner: RefCounted = RefCounted.new()
+	var permit: RefCounted = _profile_utility.claim_profile_management_for_framework(
+		profile.profile_id,
+		manager_owner
+	)
+	assert_not_null(permit)
+	var _quiesce: GFAsyncCompletion = _profile_utility.begin_quiesce(GFAsyncScope.new())
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{ "document": 1 },
+		{ "context": 2 },
+		{ "result": 3 }
+	)
+
+	var save_operation: GFSaveProfileOperation = (
+		_profile_utility.save_profile_for_manager_for_framework(
+			profile.profile_id,
+			request,
+			permit
+		)
+	)
+	var load_operation: GFSaveProfileOperation = (
+		_profile_utility.load_profile_strict_for_manager_for_framework(
+			profile.profile_id,
+			{},
+			{},
+			permit
+		)
+	)
+	var flush_operation: GFSaveProfileOperation = (
+		_profile_utility.flush_profile_for_manager_for_framework(
+			profile.profile_id,
+			{},
+			permit
+		)
+	)
+
+	assert_true(save_operation.is_completed())
+	assert_true(load_operation.is_completed())
+	assert_true(flush_operation.is_completed())
+	assert_eq(save_operation.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_eq(load_operation.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_eq(flush_operation.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_false(request.is_claimed(), "quiesce 准入门禁必须先于 manager request claim。")
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_storage.get_pending_load_count(), 0)
+
+
+func test_provider_capture_quiesce_revokes_active_direct_save_access_immediately() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 1)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.capture_quiesce",
+		providers
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 1 } })
+	var completions: Array[GFAsyncCompletion] = []
+	provider.save_snapshot_callback = func() -> void:
+		completions.append(_coordinator.begin_quiesce(GFAsyncScope.new()))
+	provider.value = 2
+	var accepted_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "source": "accepted" }
+	)
+	var accepted: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		accepted_request
+	)
+
+	_profile_utility.tick(0.0)
+
+	assert_true(accepted_request.is_claimed())
+	assert_eq(completions.size(), 1)
+	assert_false(completions[0].is_completed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	var blocked_during_request: GFSaveProfileRequest = (
+		GFSaveProfileRequest.take_ownership({}, {}, { "source": "during" })
+	)
+	var blocked_during: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		blocked_during_request
+	)
+	assert_true(blocked_during.is_completed())
+	assert_eq(blocked_during.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_false(
+		blocked_during_request.is_claimed(),
+		"capture 回调返回后，单调撤权必须先于 direct save request claim。"
+	)
+
+	_storage.complete_next_save(OK)
+
+	assert_true(accepted.get_result().is_successful())
+	assert_true(completions[0].is_successful())
+	var blocked_after_request: GFSaveProfileRequest = (
+		GFSaveProfileRequest.take_ownership({}, {}, { "source": "after" })
+	)
+	var blocked_after: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		blocked_after_request
+	)
+	assert_true(blocked_after.is_completed())
+	assert_eq(blocked_after.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_false(
+		blocked_after_request.is_claimed(),
+		"Coordinator quiesce 收敛后不得重新放宽 active Profile 的 direct save。"
+	)
+
+
+func test_coordinator_quiesce_blocks_direct_save_and_waits_for_detached_tail() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 1)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.quiesce_direct_tail",
+		providers,
+		10
+	)
+	assert_true(_register(profile))
+	_activate_existing(profile, { &"state": { "value": 1 } })
+	provider.value = 2
+	var accepted_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "source": "accepted" }
+	)
+	var accepted: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		accepted_request
+	)
+	_profile_utility.tick(0.0)
+	assert_true(accepted_request.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+
+	var completion: GFAsyncCompletion = _coordinator.begin_quiesce(GFAsyncScope.new())
+	assert_false(completion.is_completed())
+	var blocked_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "source": "blocked" }
+	)
+	var blocked: GFSaveProfileOperation = _profile_utility.save_profile(
+		profile.profile_id,
+		blocked_request
+	)
+	assert_true(blocked.is_completed())
+	assert_eq(blocked.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	assert_false(blocked_request.is_claimed())
+
+	var _advanced: bool = _clock.advance_msec(11)
+	_profile_utility.tick(0.0)
+	assert_eq(accepted.get_result().get_status(), GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN)
+	assert_false(completion.is_completed(), "逻辑超时后仍须等待 detached 物理写尾部。")
+	assert_eq(
+		GFVariantData.get_option_int(
+			_profile_utility.get_profile_state_snapshot(profile.profile_id),
+			"detached_write_count"
+		),
+		1
+	)
+
+	_storage.complete_next_save(OK)
+	assert_true(completion.is_successful())
+	assert_eq(
+		GFVariantData.get_option_int(
+			_profile_utility.get_profile_state_snapshot(profile.profile_id),
+			"detached_write_count"
+		),
+		0
+	)
+
+
+func test_managed_strict_load_owner_dispose_maps_rollback_failure_once() -> void:
+	var events: Array[String] = []
+	var first: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"first", 1, events)
+	)
+	var second: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"second", 2, events)
+	)
+	var providers: Array[GFSaveSectionProvider] = [first, second]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.strict_load_owner_dispose",
+		providers
+	)
+	assert_true(GFVariantData.get_option_bool(
+		_profile_utility.register_profile(profile),
+		"registered"
+	))
+	var manager_owner: Node = Node.new()
+	var permit: RefCounted = _profile_utility.claim_profile_management_for_framework(
+		profile.profile_id,
+		manager_owner
+	)
+	assert_not_null(permit)
+	first.fail_rollback = true
+	first.apply_callback = func() -> void:
+		manager_owner.free()
+	var operation: GFSaveProfileOperation = (
+		_profile_utility.load_profile_strict_for_manager_for_framework(
+			profile.profile_id,
+			{},
+			{},
+			permit
+		)
+	)
+	var terminal_statuses: Array[StringName] = []
+	var _connected: Error = operation.completed.connect(
+		func(terminal_result: GFSaveProfileResult) -> void:
+			terminal_statuses.append(terminal_result.get_status())
+	) as Error
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_count(), 1)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			profile,
+			{
+				&"first": { "value": 10 },
+				&"second": { "value": 20 },
+			}
+		)
+	))
+	first.apply_callback = Callable()
+
+	assert_true(operation.is_completed())
+	assert_eq(operation.get_result().get_status(), GFSaveProfileResult.STATUS_ROLLBACK_FAILED)
+	assert_eq(terminal_statuses, [GFSaveProfileResult.STATUS_ROLLBACK_FAILED])
+	assert_eq(operation.get_result().get_failed_section_id(), &"first")
+	assert_eq(operation.get_result().get_rollback_errors().size(), 1)
+	assert_eq(first.value, 10, "rollback failure 必须显式保留不确定的已应用 section。")
+	assert_eq(second.value, 2, "permit 撤销后不得继续应用后续 section。")
+	assert_eq(first.apply_count, 1)
+	assert_eq(second.apply_count, 0)
+	assert_eq(first.rollback_count, 1)
+	assert_eq(events, [
+		"capture:first",
+		"capture:second",
+		"apply:first",
+		"rollback:first",
+	])
+	assert_eq(_storage.load_calls.size(), 1)
+	assert_eq(_storage.save_calls.size(), 0)
+	assert_eq(_storage.get_pending_load_count(), 0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			profile,
+			{
+				&"first": { "value": 99 },
+				&"second": { "value": 99 },
+			}
+		)
+	))
+	assert_eq(first.value, 10)
+	assert_eq(second.value, 2)
+	assert_eq(terminal_statuses.size(), 1)
+	assert_true(_profile_utility.unregister_profile(profile.profile_id))
+
+
+func test_dispose_keeps_inflight_operation_at_one_terminal_completion() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 0)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.dispose",
+		providers
+	)
+	assert_true(_register(profile))
+	var operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	var _connected: Error = operation.completed.connect(_on_transaction_completed) as Error
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_count(), 1)
+
+	_coordinator.dispose()
+	assert_true(operation.is_completed())
+	assert_eq(_terminal_count, 1)
+	var disposed_result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_eq(disposed_result.get_status(), GFSaveProfileTransactionResult.STATUS_DISPOSED)
+	assert_not_null(disposed_result.get_reconcile_lease())
+	assert_true(disposed_result.get_reconcile_lease().is_terminal())
+	assert_eq(provider.value, 0)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			profile,
+			{ &"state": { "value": 99 } }
+		)
+	))
+	assert_eq(_terminal_count, 1, "迟到低层终态不得再次完成已释放事务。")
+	assert_eq(provider.value, 0, "关闭后的严格读取不得迟到应用 Provider 文档。")
+
+
+# --- 私有/辅助方法 ---
+
+func _register(profile: GFSaveProfile) -> bool:
+	return GFVariantData.get_option_bool(
+		_coordinator.register_profile(profile),
+		"registered"
+	)
+
+
+func _activate_existing(profile: GFSaveProfile, payloads: Dictionary) -> void:
+	var operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_load_for_file(
+		profile.file_name,
+		GFSaveProfileTransactionTestSupport.read_success(
+			GFSaveProfileTransactionTestSupport.make_document(profile, payloads)
+		)
+	)
+	assert_true(operation.is_completed())
+	assert_true(operation.get_result().is_successful())
+
+
+# --- 信号处理函数 ---
+
+func _on_transaction_completed(_result: GFSaveProfileTransactionResult) -> void:
+	_terminal_count += 1

--- a/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd.uid
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd.uid
@@ -1,0 +1,1 @@
+uid://c8e1byf1snh5n

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -65,8 +65,10 @@
       "res://tests/gf_core/extensions/save/test_gf_save_payload_validation_adapter.gd",
       "res://tests/gf_core/extensions/save/test_gf_save_document.gd",
       "res://tests/gf_core/extensions/save/test_gf_save_graph_utility.gd",
+      "res://tests/gf_core/extensions/save/test_gf_save_profile_mutation_transactions.gd",
       "res://tests/gf_core/extensions/save/test_gf_save_profile_preparation.gd",
       "res://tests/gf_core/extensions/save/test_gf_save_profile_scheduler.gd",
+      "res://tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd",
       "res://tests/gf_core/extensions/save/test_gf_save_profile_utility.gd",
       "res://tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd"
     ],


### PR DESCRIPTION
## Summary

- add `GFSaveProfileTransactionCoordinator` to own exact ordered-provider domains and active Profile identity
- add strict activate/switch transactions plus independent typed Bootstrap and Adopt recovery operations
- add typed mutate-and-persist section transactions with stable provider order and reverse rollback
- fence unknown physical write outcomes behind typed Reconcile leases and an explicit strict reload
- harden managed Profile admission, late load authorization, quiesce, dispose, and detached I/O settlement
- update Save extension registration/version, guides, ADRs, changelog, generated API references, AI knowledge, and focused mappings

## Design notes

- Missing and corrupt storage never cause an implicit write. A matching one-shot Recovery lease must be consumed by `bootstrap_profile()` or `adopt_profile()`.
- Known persistence failure restores memory without issuing a speculative compensation write.
- Unknown persistence outcome keeps the provider domain fenced until storage evidence settles and the application explicitly reconciles.
- Managed direct save/flush is allowed only for the stable active Profile; managed direct load and inactive writes fail closed.
- The implementation intentionally adds no compatibility shim or application-specific identity/recovery policy.

## Validation

- `python tools/gf_maintenance.py check --suite full --jobs 3 --suite-timeout 3600 --failed-only` — 41/41 checks passed
- Save Profile Utility focused GUT — 46/46
- Session transaction focused GUT — 15/15
- Mutation transaction focused GUT — 11/11
- API Surface — 28/28
- GDScript Layout — 9/9
- LSP diagnostics — 0
- implementation, API/docs, and strict layout audits — P0/P1/P2 cleared

Closes #65
Closes #66