### PR TITLE
Add lifecycle-bound routes, policy-aware accessors, and owned input pulses

### DIFF
--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -45,6 +45,35 @@ signal shutdown_finished(result: GFArchitectureShutdownResult)
 signal project_installers_finished
 
 
+# --- 枚举 ---
+
+## 可由架构访问策略解析的模块类型。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum ModuleKind {
+	## Model 模块。
+	MODEL,
+	## System 模块。
+	SYSTEM,
+	## Utility 模块。
+	UTILITY,
+}
+
+## 模块访问的架构作用域。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum ModuleLookupScope {
+	## 按当前架构的父级回退与 strict_dependency_lookup 规则解析。
+	INHERITED,
+	## 只解析当前架构，不回退父级。
+	LOCAL,
+}
+
+
 # --- 常量 ---
 
 ## 依赖绑定记录脚本。
@@ -2010,6 +2039,60 @@ func unregister_utility(script_cls: Script) -> bool:
 
 # --- 公共方法（获取） ---
 
+## 按冻结的作用域、必需性和 ready 策略解析已注册模块。
+## 该入口供生成访问器与其他声明式依赖边界复用；required 只控制严格依赖缺失诊断，
+## 不改变 strict_dependency_lookup 对父级回退的限制。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param module_kind: 要解析的 Model、System 或 Utility 类型。
+## [br]
+## @param script_cls: 模块脚本类。
+## [br]
+## @param lookup_scope: 父级可见或仅当前架构的查询作用域。
+## [br]
+## @param required: 为 true 时，严格查询模式下缺失模块会输出 required miss。
+## [br]
+## @param require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。
+## [br]
+## @return: 符合全部冻结策略的模块实例；未命中时返回 null。
+func resolve_module_access(
+	module_kind: ModuleKind,
+	script_cls: Script,
+	lookup_scope: ModuleLookupScope = ModuleLookupScope.INHERITED,
+	required: bool = true,
+	require_ready: bool = false
+) -> Object:
+	var module_registry: ModuleRegistry = _get_module_registry_for_access_kind(module_kind)
+	if module_registry == null:
+		push_error("[GFArchitecture] resolve_module_access 失败：module_kind 无效。")
+		return null
+	if script_cls == null:
+		push_error("[GFArchitecture] resolve_module_access 失败：script_cls 为空。")
+		return null
+
+	match lookup_scope:
+		ModuleLookupScope.INHERITED:
+			return _get_registered_instance_with_parent_lookup(
+				module_registry._label_key(),
+				script_cls,
+				require_ready,
+				required
+			)
+		ModuleLookupScope.LOCAL:
+			var instance: Object = _get_local_registered_instance(module_registry, script_cls)
+			if instance == null:
+				if required and strict_dependency_lookup:
+					_report_strict_lookup_miss(script_cls, module_registry.label)
+				return null
+			return instance if not require_ready or _is_module_ready_for_lookup(instance) else null
+		_:
+			push_error("[GFArchitecture] resolve_module_access 失败：lookup_scope 无效。")
+			return null
+
+
 ## 通过脚本类获取 System 实例。
 ## [br]
 ## @api public
@@ -2020,7 +2103,13 @@ func unregister_utility(script_cls: Script) -> bool:
 ## [br]
 ## @return 系统实例，如果未找到则返回 null。
 func get_system(script_cls: Script, require_ready: bool = false) -> Object:
-	return _get_registered_instance_with_parent_lookup("system", script_cls, require_ready)
+	return resolve_module_access(
+		ModuleKind.SYSTEM,
+		script_cls,
+		ModuleLookupScope.INHERITED,
+		true,
+		require_ready
+	)
 
 
 ## 通过脚本类获取 Model 实例。
@@ -2033,7 +2122,13 @@ func get_system(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 模型实例，如果未找到则返回 null。
 func get_model(script_cls: Script, require_ready: bool = false) -> Object:
-	return _get_registered_instance_with_parent_lookup("model", script_cls, require_ready)
+	return resolve_module_access(
+		ModuleKind.MODEL,
+		script_cls,
+		ModuleLookupScope.INHERITED,
+		true,
+		require_ready
+	)
 
 
 ## 通过脚本类获取 Utility 实例。
@@ -2046,7 +2141,13 @@ func get_model(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 工具实例，如果未找到则返回 null。
 func get_utility(script_cls: Script, require_ready: bool = false) -> Object:
-	return _get_registered_instance_with_parent_lookup("utility", script_cls, require_ready)
+	return resolve_module_access(
+		ModuleKind.UTILITY,
+		script_cls,
+		ModuleLookupScope.INHERITED,
+		true,
+		require_ready
+	)
 
 
 ## 可选查找 System 实例，未找到时不输出严格依赖缺失错误。
@@ -2062,11 +2163,12 @@ func get_utility(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 系统实例；可选依赖不存在或尚未 ready 时返回 null。
 func find_system(script_cls: Script, require_ready: bool = false) -> Object:
-	return _get_registered_instance_with_parent_lookup(
-		"system",
+	return resolve_module_access(
+		ModuleKind.SYSTEM,
 		script_cls,
-		require_ready,
-		false
+		ModuleLookupScope.INHERITED,
+		false,
+		require_ready
 	)
 
 
@@ -2083,11 +2185,12 @@ func find_system(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 模型实例；可选依赖不存在或尚未 ready 时返回 null。
 func find_model(script_cls: Script, require_ready: bool = false) -> Object:
-	return _get_registered_instance_with_parent_lookup(
-		"model",
+	return resolve_module_access(
+		ModuleKind.MODEL,
 		script_cls,
-		require_ready,
-		false
+		ModuleLookupScope.INHERITED,
+		false,
+		require_ready
 	)
 
 
@@ -2104,11 +2207,12 @@ func find_model(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 工具实例；可选依赖不存在或尚未 ready 时返回 null。
 func find_utility(script_cls: Script, require_ready: bool = false) -> Object:
-	return _get_registered_instance_with_parent_lookup(
-		"utility",
+	return resolve_module_access(
+		ModuleKind.UTILITY,
 		script_cls,
-		require_ready,
-		false
+		ModuleLookupScope.INHERITED,
+		false,
+		require_ready
 	)
 
 
@@ -2122,8 +2226,13 @@ func find_utility(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 当前架构中的系统实例，如果未找到则返回 null。
 func get_local_system(script_cls: Script, require_ready: bool = false) -> Object:
-	var instance: Object = _get_local_registered_instance(_system_registry, script_cls)
-	return instance if not require_ready or _is_module_ready_for_lookup(instance) else null
+	return resolve_module_access(
+		ModuleKind.SYSTEM,
+		script_cls,
+		ModuleLookupScope.LOCAL,
+		false,
+		require_ready
+	)
 
 
 ## 仅从当前架构获取 Model，不回退父级架构。
@@ -2136,8 +2245,13 @@ func get_local_system(script_cls: Script, require_ready: bool = false) -> Object
 ## [br]
 ## @return 当前架构中的模型实例，如果未找到则返回 null。
 func get_local_model(script_cls: Script, require_ready: bool = false) -> Object:
-	var instance: Object = _get_local_registered_instance(_model_registry, script_cls)
-	return instance if not require_ready or _is_module_ready_for_lookup(instance) else null
+	return resolve_module_access(
+		ModuleKind.MODEL,
+		script_cls,
+		ModuleLookupScope.LOCAL,
+		false,
+		require_ready
+	)
 
 
 ## 仅从当前架构获取 Utility，不回退父级架构。
@@ -2150,8 +2264,13 @@ func get_local_model(script_cls: Script, require_ready: bool = false) -> Object:
 ## [br]
 ## @return 当前架构中的工具实例，如果未找到则返回 null。
 func get_local_utility(script_cls: Script, require_ready: bool = false) -> Object:
-	var instance: Object = _get_local_registered_instance(_utility_registry, script_cls)
-	return instance if not require_ready or _is_module_ready_for_lookup(instance) else null
+	return resolve_module_access(
+		ModuleKind.UTILITY,
+		script_cls,
+		ModuleLookupScope.LOCAL,
+		false,
+		require_ready
+	)
 
 
 ## 通过已注册工厂创建短生命周期对象。
@@ -3105,6 +3224,18 @@ func _get_module_registry_by_kind(registry_kind: String) -> ModuleRegistry:
 		"system", "systems":
 			return _system_registry
 		"utility", "utilities":
+			return _utility_registry
+		_:
+			return null
+
+
+func _get_module_registry_for_access_kind(module_kind: ModuleKind) -> ModuleRegistry:
+	match module_kind:
+		ModuleKind.MODEL:
+			return _model_registry
+		ModuleKind.SYSTEM:
+			return _system_registry
+		ModuleKind.UTILITY:
 			return _utility_registry
 		_:
 			return null

--- a/addons/gf/kernel/editor/gf_access_generator.gd
+++ b/addons/gf/kernel/editor/gf_access_generator.gd
@@ -54,6 +54,28 @@ const DEFAULT_OUTPUT_PATH: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.ACCESS_OUT
 ## [br]
 ## @since 9.0.0
 const DEFAULT_PROJECT_OUTPUT_PATH: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.PROJECT_ACCESS_OUTPUT_PATH
+
+## 访问器按父级回退规则解析模块。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ACCESS_SCOPE_INHERITED: StringName = &"inherited"
+
+## 访问器只解析传入架构的本地模块。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ACCESS_SCOPE_LOCAL: StringName = &"local"
+
+## 每个生成类型的冻结访问策略 ProjectSettings 键。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ACCESS_POLICIES_SETTING: String = "gf/codegen/access_policies"
+const _ACCESS_POLICY_KEYS: Array[String] = ["scope", "required", "require_ready"]
 const _BASE_MODEL_SCRIPT = preload("res://addons/gf/kernel/base/gf_model.gd")
 const _BASE_SYSTEM_SCRIPT = preload("res://addons/gf/kernel/base/gf_system.gd")
 const _BASE_UTILITY_SCRIPT = preload("res://addons/gf/kernel/base/gf_utility.gd")
@@ -72,6 +94,7 @@ const _LAYER_TYPES: Dictionary = {
 }
 const _KNOWN_GF_PROJECT_SETTINGS: Array[String] = [
 	"gf/codegen/access_output_path",
+	"gf/codegen/access_policies",
 	"gf/codegen/project_access_output_path",
 	"gf/extensions/auto_install_enabled_installers",
 	"gf/extensions/enabled",
@@ -118,8 +141,25 @@ func generate(output_path: String = DEFAULT_OUTPUT_PATH, overwrite_existing: boo
 ## [br]
 ## @schema return: Dictionary，包含 success、path、status、error_code、error、written、changed、dry_run、size_bytes 和 metadata。
 func generate_with_report(output_path: String = DEFAULT_OUTPUT_PATH, options: Dictionary = {}) -> Dictionary:
-	var records: Array[Dictionary] = collect_records()
+	var collection: Dictionary = _collect_records_with_validation()
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(collection, "valid"):
+		return _make_access_policy_generation_failure(
+			output_path,
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+				collection,
+				"error",
+				"访问策略验证失败。"
+			),
+			options
+		)
+	var records: Array[Dictionary] = _get_record_dictionary_array(collection.get("records"))
 	var source: String = build_source(records)
+	if source.is_empty():
+		return _make_access_policy_generation_failure(
+			output_path,
+			"访问器源码准备失败。",
+			options
+		)
 	return save_source_with_report(output_path, source, options)
 
 
@@ -167,34 +207,16 @@ func generate_project_access_with_report(
 ## [br]
 ## @api public
 ## [br]
-## @return 类型记录列表。
+## @since 3.17.0
 ## [br]
-## @schema return: Array of Dictionary type records with class_name, path, script, kind, and access metadata.
+## @return: 类型记录列表；访问策略配置无效时返回空数组且不会返回部分冻结结果。
+## [br]
+## @schema return: Array of Dictionary type records with class_name, path, and kind; Model/System/Utility records additionally contain scope, required, and require_ready.
 func collect_records() -> Array[Dictionary]:
-	var records: Array[Dictionary] = []
-	for global_class: Dictionary in ProjectSettings.get_global_class_list():
-		var class_name_value: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(global_class, "class")
-		var path: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(global_class, "path")
-		if class_name_value.is_empty() or path.is_empty():
-			continue
-
-		var script: Script = _variant_to_script(load(path))
-		if script == null:
-			continue
-
-		var kind: int = _resolve_kind(script)
-		if kind == -1:
-			continue
-
-		records.append({
-			"class_name": class_name_value,
-			"path": path,
-			"kind": kind,
-		})
-
-	_append_access_generator_extension_records(records)
-	_sort_records(records)
-	return records
+	var collection: Dictionary = _collect_records_with_validation()
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(collection, "valid"):
+		return []
+	return _get_record_dictionary_array(collection.get("records"))
 
 
 ## 收集项目层常量记录，包括命名层、InputMap 动作和 GF ProjectSettings。
@@ -216,21 +238,41 @@ func collect_project_records() -> Dictionary:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param records: 生成访问器时使用的类型记录列表。
 ## [br]
-## @schema records: Array of Dictionary type records containing class_name, path, and kind.
+## @schema records: Array of Dictionary type records containing class_name, path, and kind; Model/System/Utility records may additionally contain scope, required, and require_ready.
 ## [br]
-## @return GDScript 源码。
+## @return: 完整 GDScript 源码；任一记录或模块访问策略无效时整批失败并返回空字符串。
 func build_source(records: Array) -> String:
+	var preparation: Dictionary = _prepare_records_for_source(records)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(preparation, "valid"):
+		push_error(
+			"[GFAccessGenerator] %s" % _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+				preparation,
+				"error",
+				"访问器记录验证失败，整批生成已中止。"
+			)
+		)
+		return ""
+	var prepared_records: Array[Dictionary] = _get_record_dictionary_array(
+		preparation.get("records")
+	)
 	var builder: GFSourceBuilder = GFSourceBuilder.new()
-	var has_capability_records: bool = _records_include_kind(records, TargetKind.CAPABILITY)
+	var has_capability_records: bool = _records_include_kind(
+		prepared_records,
+		TargetKind.CAPABILITY
+	)
 	builder.doc("GFAccess: 自动生成的强类型 GF 访问器。")
 	builder.doc()
 	builder.doc("该文件由 GFAccessGenerator 生成，可以提交到版本库；请不要手动编辑。")
 	builder.line("class_name GFAccess")
 	builder.line("extends RefCounted")
 	if has_capability_records:
-		var capability_utility_script_path: String = _get_capability_utility_script_path(records)
+		var capability_utility_script_path: String = _get_capability_utility_script_path(
+			prepared_records
+		)
 		builder.blank(2)
 		builder.section("常量")
 		builder.line("const _CAPABILITY_UTILITY_SCRIPT_PATH: String = \"%s\"" % capability_utility_script_path)
@@ -248,10 +290,10 @@ func build_source(records: Array) -> String:
 	builder.blank()
 
 	var used_names: Dictionary = {}
-	for record: Dictionary in records:
+	for record: Dictionary in prepared_records:
 		_append_record_function(builder, record, used_names)
 
-	_append_access_generator_extensions(builder, records)
+	_append_access_generator_extensions(builder, prepared_records)
 
 	builder.blank()
 	builder.section("私有/辅助方法")
@@ -412,6 +454,137 @@ func save_source_with_report(output_path: String, source: String, options: Dicti
 
 
 # --- 私有/辅助方法 ---
+
+func _collect_records_with_validation() -> Dictionary:
+	var configured_result: Dictionary = _get_configured_access_policies()
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(configured_result, "valid"):
+		return configured_result
+	var records: Array[Dictionary] = []
+	for global_class: Dictionary in ProjectSettings.get_global_class_list():
+		var class_name_value: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(global_class, "class")
+		var path: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(global_class, "path")
+		if class_name_value.is_empty() or path.is_empty():
+			continue
+
+		var script: Script = _variant_to_script(load(path))
+		if script == null:
+			continue
+
+		var kind: int = _resolve_kind(script)
+		if kind == -1:
+			continue
+
+		records.append({
+			"class_name": class_name_value,
+			"path": path,
+			"kind": kind,
+		})
+
+	_append_access_generator_extension_records(records)
+	var policy_result: Dictionary = _apply_access_policies_with_config(
+		records,
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(configured_result, "policies")
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(policy_result, "valid"):
+		return policy_result
+	var frozen_records: Array[Dictionary] = _get_record_dictionary_array(
+		policy_result.get("records")
+	)
+	_sort_records(frozen_records)
+	return {
+		"valid": true,
+		"error": "",
+		"records": frozen_records,
+	}
+
+
+func _make_access_policy_generation_failure(
+	output_path: String,
+	message: String,
+	options: Dictionary
+) -> Dictionary:
+	var report_options: Dictionary = {
+		"written": false,
+		"changed": false,
+		"dry_run": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(options, "dry_run"),
+		"size_bytes": 0,
+		"artifact_owner": _GF_VARIANT_ACCESS_SCRIPT.get_option_value(
+			options,
+			"artifact_owner",
+			_GENERATED_ARTIFACT_REPORT_SCRIPT.OWNER_GENERATED
+		),
+		"generator_id": "GFAccessGenerator",
+		"source_id": _GF_VARIANT_ACCESS_SCRIPT.get_option_string(options, "source_id"),
+		"content_sha256": "",
+		"previous_sha256": "",
+		"encoding": "utf-8",
+		"metadata": _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+			options,
+			"metadata"
+		).duplicate(true),
+	}
+	return _GENERATED_ARTIFACT_REPORT_SCRIPT.make_report(
+		output_path,
+		_GENERATED_ARTIFACT_REPORT_SCRIPT.STATUS_FAILED,
+		ERR_INVALID_DATA,
+		message,
+		report_options
+	)
+
+
+func _duplicate_record_dictionaries(records: Array) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for record_value: Variant in records:
+		if record_value is Dictionary:
+			var record: Dictionary = record_value
+			result.append(record.duplicate(true))
+	return result
+
+
+func _get_record_dictionary_array(value: Variant) -> Array[Dictionary]:
+	if value is Array:
+		var records: Array = value
+		return _duplicate_record_dictionaries(records)
+	return []
+
+
+func _prepare_records_for_source(records: Array) -> Dictionary:
+	var prepared_records: Array[Dictionary] = []
+	for record_value: Variant in records:
+		if not (record_value is Dictionary):
+			return {
+				"valid": false,
+				"error": "访问器记录必须是 Dictionary，整批生成已中止。",
+				"records": [],
+			}
+		var source_record: Dictionary = record_value
+		var prepared_record: Dictionary = source_record.duplicate(true)
+		var kind: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(
+			prepared_record,
+			"kind",
+			-1
+		)
+		if _is_module_target_kind(kind):
+			var normalized_policy: Dictionary = _normalize_access_policy(prepared_record)
+			if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(normalized_policy, "valid"):
+				return {
+					"valid": false,
+					"error": "access policy 无效，整批生成已中止：%s" % (
+						_GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+							prepared_record,
+							"class_name"
+						)
+					),
+					"records": [],
+				}
+			_write_normalized_access_policy(prepared_record, normalized_policy)
+		prepared_records.append(prepared_record)
+	return {
+		"valid": true,
+		"error": "",
+		"records": prepared_records,
+	}
+
 
 func _collect_layer_records() -> Array[Dictionary]:
 	var records: Array[Dictionary] = []
@@ -581,6 +754,273 @@ func _get_capability_utility_script_path(records: Array) -> String:
 	return ""
 
 
+func _apply_access_policies(records: Array[Dictionary]) -> Dictionary:
+	var configured_result: Dictionary = _get_configured_access_policies()
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(configured_result, "valid"):
+		return configured_result
+	var configured_policies: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+		configured_result,
+		"policies"
+	)
+	return _apply_access_policies_with_config(records, configured_policies)
+
+
+func _apply_access_policies_with_config(
+	records: Array[Dictionary],
+	configured_policies: Dictionary
+) -> Dictionary:
+	var frozen_records: Array[Dictionary] = _duplicate_record_dictionaries(records)
+	var configured_validation: Dictionary = _validate_configured_access_policies(
+		frozen_records,
+		configured_policies
+	)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(configured_validation, "valid"):
+		return configured_validation
+	configured_policies = _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+		configured_validation,
+		"policies"
+	)
+
+	for record: Dictionary in frozen_records:
+		var kind: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(record, "kind", -1)
+		if not _is_module_target_kind(kind):
+			continue
+		var class_name_value: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+			record,
+			"class_name"
+		)
+		var normalized_policy: Dictionary = _normalize_access_policy(record)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(normalized_policy, "valid"):
+			return _fail_access_policy_validation(
+				"access policy 无效：%s" % class_name_value
+			)
+		var script_path: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(record, "path")
+		if configured_policies.has(script_path):
+			var configured_policy: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.as_dictionary(
+				configured_policies.get(script_path)
+			)
+			for policy_key: String in _ACCESS_POLICY_KEYS:
+				if configured_policy.has(policy_key):
+					normalized_policy[policy_key] = configured_policy.get(policy_key)
+
+		normalized_policy = _normalize_access_policy(normalized_policy)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(normalized_policy, "valid"):
+			return _fail_access_policy_validation(
+				"access policy 无效：%s" % class_name_value
+			)
+		_write_normalized_access_policy(record, normalized_policy)
+	return {
+		"valid": true,
+		"error": "",
+		"records": frozen_records,
+	}
+
+
+func _get_configured_access_policies() -> Dictionary:
+	var value: Variant = ProjectSettings.get_setting(ACCESS_POLICIES_SETTING, {})
+	if not (value is Dictionary):
+		return _fail_access_policy_validation(
+			"gf/codegen/access_policies 必须是 Dictionary。"
+		)
+	var policies: Dictionary = value
+	return {
+		"valid": true,
+		"error": "",
+		"policies": policies.duplicate(true),
+	}
+
+
+func _validate_configured_access_policies(
+	records: Array[Dictionary],
+	configured_policies: Dictionary
+) -> Dictionary:
+	var eligible_paths: Dictionary = {}
+	for record: Dictionary in records:
+		if not _is_module_target_kind(
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_int(record, "kind", -1)
+		):
+			continue
+		var record_path: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(record, "path")
+		if not record_path.is_empty():
+			eligible_paths[record_path] = true
+
+	var normalized_paths: Dictionary = {}
+	var normalized_policies: Dictionary = {}
+	for raw_path: Variant in configured_policies:
+		if not (raw_path is String or raw_path is StringName):
+			return _fail_access_policy_validation(
+				"access policy 路径键必须是 String 或 StringName。"
+			)
+		var script_path: String = _GF_VARIANT_ACCESS_SCRIPT.to_text(raw_path)
+		if (
+			script_path.is_empty()
+			or not script_path.begins_with("res://")
+			or not eligible_paths.has(script_path)
+		):
+			return _fail_access_policy_validation(
+				"access policy 路径未匹配可生成模块：%s" % script_path
+			)
+		if normalized_paths.has(script_path):
+			return _fail_access_policy_validation(
+				"access policy 路径重复：%s" % script_path
+			)
+		normalized_paths[script_path] = true
+		var configured_value: Variant = configured_policies.get(raw_path)
+		if not (configured_value is Dictionary):
+			return _fail_access_policy_validation(
+				"access policy 必须是 Dictionary：%s" % script_path
+			)
+		var configured_policy: Dictionary = configured_value
+		var field_normalization: Dictionary = _normalize_access_policy_fields(
+			configured_policy,
+			false
+		)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(field_normalization, "valid"):
+			var error_kind: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(
+				field_normalization,
+				"error_kind"
+			)
+			if error_kind == "duplicate_field":
+				return _fail_access_policy_validation(
+					"access policy 包含等价重复字段：%s" % script_path
+				)
+			return _fail_access_policy_validation(
+				"access policy 包含未知字段：%s" % script_path
+			)
+		var normalized_configured_policy: Dictionary = (
+			_GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+				field_normalization,
+				"policy"
+			)
+		)
+		if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			_normalize_access_policy(normalized_configured_policy),
+			"valid"
+		):
+			return _fail_access_policy_validation(
+				"access policy 值无效：%s" % script_path
+			)
+		normalized_policies[script_path] = normalized_configured_policy.duplicate(true)
+	return {
+		"valid": true,
+		"error": "",
+		"policies": normalized_policies,
+	}
+
+
+func _fail_access_policy_validation(message: String) -> Dictionary:
+	push_error("[GFAccessGenerator] %s" % message)
+	return {
+		"valid": false,
+		"error": message,
+		"records": [],
+	}
+
+
+func _normalize_access_policy(record: Dictionary) -> Dictionary:
+	if _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(record, "access_policy_valid", true) == false:
+		return { "valid": false }
+	var field_normalization: Dictionary = _normalize_access_policy_fields(record, true)
+	if not _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(field_normalization, "valid"):
+		return { "valid": false }
+	var policy: Dictionary = _GF_VARIANT_ACCESS_SCRIPT.get_option_dictionary(
+		field_normalization,
+		"policy"
+	)
+
+	var scope: StringName = ACCESS_SCOPE_INHERITED
+	if policy.has("scope"):
+		var raw_scope: Variant = policy.get("scope")
+		if not (raw_scope is String or raw_scope is StringName):
+			return { "valid": false }
+		scope = StringName(_GF_VARIANT_ACCESS_SCRIPT.to_text(raw_scope).strip_edges().to_lower())
+	if scope not in [ACCESS_SCOPE_INHERITED, ACCESS_SCOPE_LOCAL]:
+		return { "valid": false }
+
+	if policy.has("required") and not (policy.get("required") is bool):
+		return { "valid": false }
+	if policy.has("require_ready") and not (policy.get("require_ready") is bool):
+		return { "valid": false }
+	return {
+		"valid": true,
+		"scope": scope,
+		"required": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(policy, "required", true),
+		"require_ready": _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+			policy,
+			"require_ready",
+			false
+		),
+	}
+
+
+func _normalize_access_policy_fields(
+	source: Dictionary,
+	allow_other_fields: bool
+) -> Dictionary:
+	var normalized_policy: Dictionary = {}
+	for raw_key: Variant in source:
+		if not (raw_key is String or raw_key is StringName):
+			if allow_other_fields:
+				continue
+			return {
+				"valid": false,
+				"error_kind": "unknown_field",
+				"policy": {},
+			}
+		var policy_key: String = _GF_VARIANT_ACCESS_SCRIPT.to_text(raw_key)
+		if not _ACCESS_POLICY_KEYS.has(policy_key):
+			if allow_other_fields:
+				continue
+			return {
+				"valid": false,
+				"error_kind": "unknown_field",
+				"policy": {},
+			}
+		if normalized_policy.has(policy_key):
+			return {
+				"valid": false,
+				"error_kind": "duplicate_field",
+				"policy": {},
+			}
+		normalized_policy[policy_key] = source.get(raw_key)
+	return {
+		"valid": true,
+		"error_kind": "",
+		"policy": normalized_policy,
+	}
+
+
+func _write_normalized_access_policy(record: Dictionary, policy: Dictionary) -> void:
+	var policy_keys_to_erase: Array = []
+	for raw_key: Variant in record:
+		if not (raw_key is String or raw_key is StringName):
+			continue
+		if _ACCESS_POLICY_KEYS.has(_GF_VARIANT_ACCESS_SCRIPT.to_text(raw_key)):
+			policy_keys_to_erase.append(raw_key)
+	for raw_key: Variant in policy_keys_to_erase:
+		var _erased_policy_key: bool = record.erase(raw_key)
+
+	record["access_policy_valid"] = true
+	record["scope"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+		policy,
+		"scope",
+		ACCESS_SCOPE_INHERITED
+	)
+	record["required"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		policy,
+		"required",
+		true
+	)
+	record["require_ready"] = _GF_VARIANT_ACCESS_SCRIPT.get_option_bool(
+		policy,
+		"require_ready"
+	)
+
+
+func _is_module_target_kind(kind: int) -> bool:
+	return kind in [TargetKind.MODEL, TargetKind.SYSTEM, TargetKind.UTILITY]
+
+
 func _append_access_generator_extension_records(records: Array[Dictionary]) -> void:
 	for extension_path: String in GFExtensionSettings.get_enabled_access_generator_extension_paths():
 		var extension: Object = _load_access_generator_extension(extension_path)
@@ -675,6 +1115,7 @@ func _append_source_section(builder: GFSourceBuilder, source: String) -> void:
 func _append_record_function(builder: GFSourceBuilder, record: Dictionary, used_names: Dictionary) -> void:
 	var class_name_value: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(record, "class_name")
 	var kind: int = _GF_VARIANT_ACCESS_SCRIPT.get_option_int(record, "kind")
+	var access_policy: Dictionary = _normalize_access_policy(record)
 	var function_name: String = _get_function_name(class_name_value, kind)
 	if used_names.has(function_name):
 		push_warning("[GFAccessGenerator] 函数名重复，已跳过：%s" % function_name)
@@ -686,18 +1127,7 @@ func _append_record_function(builder: GFSourceBuilder, record: Dictionary, used_
 			builder.doc("获取 %s Model。" % class_name_value)
 			builder.line("static func %s(architecture: GFArchitecture = null) -> %s:" % [function_name, class_name_value])
 			builder.indent()
-			builder.line("var resolved_architecture: GFArchitecture = architecture_or_null(architecture)")
-			builder.line("if resolved_architecture == null:")
-			builder.indent()
-			builder.line("return null")
-			builder.dedent()
-			builder.line("var model_value: Variant = resolved_architecture.get_model(%s)" % class_name_value)
-			builder.line("if model_value is %s:" % class_name_value)
-			builder.indent()
-			builder.line("var model: %s = model_value" % class_name_value)
-			builder.line("return model")
-			builder.dedent()
-			builder.line("return null")
+			_append_module_access_body(builder, record, access_policy, "model", "MODEL")
 			builder.dedent()
 			builder.blank(2)
 
@@ -705,18 +1135,7 @@ func _append_record_function(builder: GFSourceBuilder, record: Dictionary, used_
 			builder.doc("获取 %s System。" % class_name_value)
 			builder.line("static func %s(architecture: GFArchitecture = null) -> %s:" % [function_name, class_name_value])
 			builder.indent()
-			builder.line("var resolved_architecture: GFArchitecture = architecture_or_null(architecture)")
-			builder.line("if resolved_architecture == null:")
-			builder.indent()
-			builder.line("return null")
-			builder.dedent()
-			builder.line("var system_value: Variant = resolved_architecture.get_system(%s)" % class_name_value)
-			builder.line("if system_value is %s:" % class_name_value)
-			builder.indent()
-			builder.line("var system: %s = system_value" % class_name_value)
-			builder.line("return system")
-			builder.dedent()
-			builder.line("return null")
+			_append_module_access_body(builder, record, access_policy, "system", "SYSTEM")
 			builder.dedent()
 			builder.blank(2)
 
@@ -724,18 +1143,7 @@ func _append_record_function(builder: GFSourceBuilder, record: Dictionary, used_
 			builder.doc("获取 %s Utility。" % class_name_value)
 			builder.line("static func %s(architecture: GFArchitecture = null) -> %s:" % [function_name, class_name_value])
 			builder.indent()
-			builder.line("var resolved_architecture: GFArchitecture = architecture_or_null(architecture)")
-			builder.line("if resolved_architecture == null:")
-			builder.indent()
-			builder.line("return null")
-			builder.dedent()
-			builder.line("var utility_value: Variant = resolved_architecture.get_utility(%s)" % class_name_value)
-			builder.line("if utility_value is %s:" % class_name_value)
-			builder.indent()
-			builder.line("var utility: %s = utility_value" % class_name_value)
-			builder.line("return utility")
-			builder.dedent()
-			builder.line("return null")
+			_append_module_access_body(builder, record, access_policy, "utility", "UTILITY")
 			builder.dedent()
 			builder.blank(2)
 
@@ -821,6 +1229,48 @@ func _append_record_function(builder: GFSourceBuilder, record: Dictionary, used_
 			builder.line("return callback.call(capability)")
 			builder.dedent()
 			builder.blank(2)
+
+
+func _append_module_access_body(
+	builder: GFSourceBuilder,
+	record: Dictionary,
+	access_policy: Dictionary,
+	value_name: String,
+	module_kind_name: String
+) -> void:
+	var class_name_value: String = _GF_VARIANT_ACCESS_SCRIPT.get_option_string(record, "class_name")
+	var scope: StringName = _GF_VARIANT_ACCESS_SCRIPT.get_option_string_name(
+		access_policy,
+		"scope",
+		ACCESS_SCOPE_INHERITED
+	)
+	var scope_name: String = "LOCAL" if scope == ACCESS_SCOPE_LOCAL else "INHERITED"
+	var required_text: String = str(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(access_policy, "required", true)
+	).to_lower()
+	var require_ready_text: String = str(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_bool(access_policy, "require_ready", false)
+	).to_lower()
+	builder.line("var resolved_architecture: GFArchitecture = architecture_or_null(architecture)")
+	builder.line("if resolved_architecture == null:")
+	builder.indent()
+	builder.line("return null")
+	builder.dedent()
+	builder.line("var %s_value: Variant = resolved_architecture.resolve_module_access(" % value_name)
+	builder.indent()
+	builder.line("GFArchitecture.ModuleKind.%s," % module_kind_name)
+	builder.line("%s," % class_name_value)
+	builder.line("GFArchitecture.ModuleLookupScope.%s," % scope_name)
+	builder.line("%s," % required_text)
+	builder.line(require_ready_text)
+	builder.dedent()
+	builder.line(")")
+	builder.line("if %s_value is %s:" % [value_name, class_name_value])
+	builder.indent()
+	builder.line("var %s: %s = %s_value" % [value_name, class_name_value, value_name])
+	builder.line("return %s" % value_name)
+	builder.dedent()
+	builder.line("return null")
 
 
 func _get_function_name(class_name_value: String, kind: int) -> String:

--- a/addons/gf/kernel/editor/gf_plugin_project_settings.gd
+++ b/addons/gf/kernel/editor/gf_plugin_project_settings.gd
@@ -67,6 +67,22 @@ const ACCESS_OUTPUT_SETTING: String = "gf/codegen/access_output_path"
 ## @layer kernel/editor
 const ACCESS_OUTPUT_DEFAULT: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.ACCESS_OUTPUT_PATH
 
+## GF 访问器类型策略设置。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/editor
+const ACCESS_POLICIES_SETTING: String = "gf/codegen/access_policies"
+
+## GF 访问器类型策略默认值。
+## [br]
+## @api framework_internal
+## [br]
+## @layer kernel/editor
+## [br]
+## @schema ACCESS_POLICIES_DEFAULT: 空 Dictionary；项目按稳定 res:// 模块脚本路径声明访问策略。
+const ACCESS_POLICIES_DEFAULT: Dictionary = {}
+
 ## 项目访问器输出路径设置。
 ## [br]
 ## @api framework_internal
@@ -117,6 +133,10 @@ static func ensure_all(project_setting_records: Array[Dictionary] = []) -> void:
 	var _access_output_ensured: bool = _ensure_default(
 		ACCESS_OUTPUT_SETTING,
 		ACCESS_OUTPUT_DEFAULT
+	)
+	var _access_policies_ensured: bool = _ensure_default(
+		ACCESS_POLICIES_SETTING,
+		ACCESS_POLICIES_DEFAULT
 	)
 	var _project_access_output_ensured: bool = _ensure_default(
 		PROJECT_ACCESS_OUTPUT_SETTING,
@@ -192,6 +212,9 @@ static func _register_property_info() -> void:
 	_GF_PROJECT_SETTINGS_TOOLS.register_property_info(ACCESS_OUTPUT_SETTING, TYPE_STRING, {
 		"hint": PROPERTY_HINT_SAVE_FILE,
 		"hint_string": "*.gd",
+		"basic": true,
+	})
+	_GF_PROJECT_SETTINGS_TOOLS.register_property_info(ACCESS_POLICIES_SETTING, TYPE_DICTIONARY, {
 		"basic": true,
 	})
 	_GF_PROJECT_SETTINGS_TOOLS.register_property_info(PROJECT_ACCESS_OUTPUT_SETTING, TYPE_STRING, {

--- a/addons/gf/kernel/editor/gf_project_setting_presentation_catalog.gd
+++ b/addons/gf/kernel/editor/gf_project_setting_presentation_catalog.gd
@@ -334,8 +334,8 @@ func _get_builtin_section_records() -> Array[Dictionary]:
 				"zh_CN": "代码生成",
 			},
 			"editor_descriptions": {
-				"en": "Output locations used by GF code generators.",
-				"zh_CN": "GF 代码生成器使用的输出位置。",
+				"en": "Output locations and generation-time policies used by GF code generators.",
+				"zh_CN": "GF 代码生成器使用的输出位置与生成期策略。",
 			},
 		},
 		{
@@ -396,6 +396,17 @@ func _get_builtin_records() -> Array[Dictionary]:
 			"editor_descriptions": {
 				"en": "Output script path used when generating accessors for GF framework types.",
 				"zh_CN": "生成 GF 框架类型访问器时写入的脚本路径。",
+			},
+		},
+		{
+			"name": _GF_PLUGIN_PROJECT_SETTINGS_SCRIPT.ACCESS_POLICIES_SETTING,
+			"editor_labels": {
+				"en": "Framework Access Policies",
+				"zh_CN": "框架访问策略",
+			},
+			"editor_descriptions": {
+				"en": "Per-script accessor policies keyed by stable resource path; each record freezes scope, required, and require_ready into generated code.",
+				"zh_CN": "按稳定资源路径配置访问器策略；每条记录会把 scope、required 与 require_ready 冻结到生成代码中。",
 			},
 		},
 		{

--- a/addons/gf/standard/input/runtime/gf_input_mapping_utility.gd
+++ b/addons/gf/standard/input/runtime/gf_input_mapping_utility.gd
@@ -168,6 +168,10 @@ var _router_attach_serial: int = 0
 var _input_devices: GFInputDeviceUtility = null
 var _clear_transient_input_state_queued: bool = false
 var _transient_input_state_mark_frame: int = -1
+var _virtual_pulse_leases: Dictionary = {}
+var _virtual_pulse_mutation_keys: Dictionary = {}
+var _virtual_pulse_bulk_mutation_depth: int = 0
+var _next_virtual_pulse_lease_id: int = 1
 
 
 # --- GF 生命周期方法 ---
@@ -178,7 +182,7 @@ var _transient_input_state_mark_frame: int = -1
 func init() -> void:
 	ignore_pause = true
 	ignore_time_scale = true
-	_clear_runtime_state()
+	_clear_runtime_state(false, &"mapping_initialized")
 	_ensure_router()
 
 
@@ -199,7 +203,7 @@ func dispose() -> void:
 	_unbind_input_device_utility()
 	_active_contexts.clear()
 	_effective_entries.clear()
-	_clear_runtime_state()
+	_clear_runtime_state(false, &"mapping_disposed")
 	if is_instance_valid(_router):
 		_router.queue_free()
 	_router = null
@@ -212,6 +216,7 @@ func dispose() -> void:
 ## @param delta: 本帧时间增量（秒）。
 func tick(delta: float) -> void:
 	_bind_input_device_utility()
+	_prune_virtual_pulse_leases()
 	_clear_transient_input_state_if_queued()
 	_advance_active_durations(delta)
 	_refresh_triggered_action_states(delta)
@@ -367,14 +372,19 @@ func handle_input_event(event: InputEvent) -> void:
 ## [br]
 ## @param player_index: 玩家索引；小于 0 时只写入全局动作状态。
 ## [br]
-## @return 虚拟输入源。
+## @param timer_utility: 可选的虚拟脉冲定时器注入。
+## [br]
+## @return: 虚拟输入源。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 func create_virtual_source(
 	source_id: StringName = &"virtual",
-	player_index: int = -1
+	player_index: int = -1,
+	timer_utility: GFTimerUtility = null
 ) -> GFVirtualInputSource:
-	return GFVirtualInputSource.new(self, source_id, player_index)
+	return GFVirtualInputSource.new(self, source_id, player_index, timer_utility)
 
 
 ## 写入虚拟动作值。
@@ -387,9 +397,11 @@ func create_virtual_source(
 ## [br]
 ## @param player_index: 玩家索引；小于 0 时只写入全局动作状态。
 ## [br]
-## @return 写入成功返回 true。
+## @return: 写入成功返回 true。
 ## [br]
 ## @api public
+## [br]
+## @since 2.6.0
 ## [br]
 ## @schema value: Variant，要转换为动作运行时向量贡献的 bool、float、Vector2 或 Vector3 值。
 func set_virtual_action_value(
@@ -398,29 +410,45 @@ func set_virtual_action_value(
 	source_id: StringName = &"virtual",
 	player_index: int = -1
 ) -> bool:
-	var action: GFInputAction = _get_registered_action(action_id)
-	if action == null:
-		return false
-
 	var source_key: StringName = source_id if source_id != &"" else &"virtual"
-	var contribution: Vector3 = _coerce_virtual_value_to_vector(value, action.value_type)
 	var binding_key: String = _make_virtual_binding_key(source_key, action_id, player_index)
-	_binding_values[binding_key] = contribution
-	_binding_to_action[binding_key] = action_id
-	if player_index >= 0:
-		_binding_player_indices[binding_key] = player_index
-	else:
-		_erase_dictionary_key(_binding_player_indices, binding_key)
-	_refresh_action_state(action_id, action)
-
-	if player_index >= 0:
-		var player_binding_key: String = _make_player_binding_key(player_index, binding_key)
-		_register_player_binding_metadata(player_binding_key, player_index, binding_key)
-		_player_binding_values[player_binding_key] = contribution
-		_player_binding_to_action[player_binding_key] = action_id
-		_refresh_player_action_state(player_index, action_id, action)
-
-	return true
+	if (
+		_get_registered_action(action_id) == null
+		or _virtual_pulse_bulk_mutation_depth > 0
+		or _virtual_pulse_mutation_keys.has(binding_key)
+	):
+		return false
+	_virtual_pulse_mutation_keys[binding_key] = true
+	var lease_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+	var operation: GFVirtualInputPulseOperation = _get_virtual_pulse_operation(lease_record)
+	var lease_removed: bool = lease_record.is_empty()
+	if not lease_record.is_empty():
+		lease_removed = _remove_virtual_pulse_lease_record(binding_key, lease_record)
+	if not lease_removed:
+		_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+		return false
+	var written: bool = _set_virtual_action_value_raw(
+		action_id,
+		value,
+		source_key,
+		player_index
+	)
+	var released_after_failure: bool = false
+	if not written and not lease_record.is_empty():
+		var _cleared_failed_override: bool = _clear_virtual_action_raw(
+			action_id,
+			source_key,
+			player_index
+		)
+		released_after_failure = true
+	if operation != null and operation.is_pending():
+		var _finished_overridden_pulse: bool = operation.finish_from_mapping_for_framework(
+			GFVirtualInputPulseOperation.Status.CANCELLED,
+			&"manual_write" if written else &"manual_write_failed",
+			released_after_failure
+		)
+	_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+	return written
 
 
 ## 清除虚拟动作值。
@@ -439,27 +467,21 @@ func clear_virtual_action(
 	source_id: StringName = &"virtual",
 	player_index: int = -1
 ) -> bool:
-	var action: GFInputAction = _get_registered_action(action_id)
-	if action == null:
-		return false
-
 	var source_key: StringName = source_id if source_id != &"" else &"virtual"
 	var binding_key: String = _make_virtual_binding_key(source_key, action_id, player_index)
-	var changed: bool = _binding_values.has(binding_key)
-	_erase_dictionary_key(_binding_values, binding_key)
-	_erase_dictionary_key(_binding_to_action, binding_key)
-	_erase_dictionary_key(_binding_player_indices, binding_key)
-	_refresh_action_state(action_id, action)
-
-	if player_index >= 0:
-		var player_binding_key: String = _make_player_binding_key(player_index, binding_key)
-		changed = _player_binding_values.has(player_binding_key) or changed
-		_erase_dictionary_key(_player_binding_values, player_binding_key)
-		_erase_dictionary_key(_player_binding_to_action, player_binding_key)
-		_erase_dictionary_key(_player_binding_metadata, player_binding_key)
-		_refresh_player_action_state(player_index, action_id, action)
-
-	return changed
+	if _virtual_pulse_bulk_mutation_depth > 0 or _virtual_pulse_mutation_keys.has(binding_key):
+		return false
+	_virtual_pulse_mutation_keys[binding_key] = true
+	var terminated_pulse: bool = _terminate_virtual_pulse_lease_by_key(
+		binding_key,
+		GFVirtualInputPulseOperation.Status.CANCELLED,
+		&"manual_clear"
+	)
+	var changed: bool = false
+	if not terminated_pulse:
+		changed = _clear_virtual_action_raw(action_id, source_key, player_index)
+	_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+	return terminated_pulse or changed
 
 
 ## 清除指定虚拟输入源的所有动作贡献。
@@ -469,6 +491,8 @@ func clear_virtual_action(
 ## @param source_id: 虚拟输入源标识。
 func clear_virtual_source(source_id: StringName = &"virtual") -> void:
 	var source_key: StringName = source_id if source_id != &"" else &"virtual"
+	_virtual_pulse_bulk_mutation_depth += 1
+	_terminate_virtual_pulse_leases_for_source(source_key, &"source_cleared")
 	var affected_actions: Dictionary = {}
 	var affected_player_actions: Dictionary = {}
 
@@ -505,6 +529,7 @@ func clear_virtual_source(source_id: StringName = &"virtual") -> void:
 		var action: GFInputAction = _get_registered_action(action_id)
 		if action != null:
 			_refresh_player_action_state(_get_entry_player_index(entry), action_id, action)
+	_virtual_pulse_bulk_mutation_depth = maxi(_virtual_pulse_bulk_mutation_depth - 1, 0)
 
 
 ## 获取虚拟输入源状态快照。
@@ -850,7 +875,7 @@ func get_remappable_items(
 ## [br]
 ## @api public
 func clear_input_state() -> void:
-	_clear_runtime_state(true)
+	_clear_runtime_state(true, &"input_state_cleared")
 
 
 ## 清空指定玩家动作运行时状态。
@@ -860,6 +885,167 @@ func clear_input_state() -> void:
 ## @param player_index: 玩家索引。
 func clear_player_input_state(player_index: int) -> void:
 	_clear_player_runtime_state(player_index, true)
+
+
+# --- 框架内部方法 ---
+
+## 为类型化虚拟输入脉冲取得稳定输入键的权威 lease 并写入脉冲值。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param operation: 已冻结身份且仍在等待的脉冲句柄。
+## [br]
+## @param value: 脉冲期间的动作值。
+## [br]
+## @param replacement_policy: GFVirtualInputSource.PulseReplacementPolicy 枚举值。
+## [br]
+## @schema value: Variant，动作接受的 bool、float、Vector2 或 Vector3 值。
+## [br]
+## @return: 当前操作取得 lease 时返回 true；拒绝或失败时返回 false。
+func begin_virtual_pulse_lease_for_framework(
+	operation: GFVirtualInputPulseOperation,
+	value: Variant,
+	replacement_policy: GFVirtualInputSource.PulseReplacementPolicy
+) -> bool:
+	if (
+		operation == null
+		or not operation.is_pending()
+		or not operation.matches_mapping_for_framework(self)
+	):
+		return false
+	var action_id: StringName = operation.get_action_id()
+	var source_id: StringName = operation.get_source_id()
+	var player_index: int = operation.get_player_index()
+	if _get_registered_action(action_id) == null:
+		var _failed_action: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"action_not_registered"
+		)
+		return false
+	var binding_key: String = _make_virtual_binding_key(source_id, action_id, player_index)
+	if _virtual_pulse_bulk_mutation_depth > 0 or _virtual_pulse_mutation_keys.has(binding_key):
+		var _rejected_mutation: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.REJECTED,
+			&"input_state_mutation"
+		)
+		return false
+
+	var previous_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+	var previous_operation: GFVirtualInputPulseOperation = _get_virtual_pulse_operation(previous_record)
+	if (
+		previous_operation != null
+		and previous_operation.is_pending()
+		and replacement_policy == GFVirtualInputSource.PulseReplacementPolicy.REJECT_NEW
+	):
+		var _rejected_existing: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.REJECTED,
+			&"pulse_already_active"
+		)
+		return false
+
+	_virtual_pulse_mutation_keys[binding_key] = true
+	var previous_removed: bool = previous_record.is_empty()
+	if not previous_record.is_empty():
+		previous_removed = _remove_virtual_pulse_lease_record(binding_key, previous_record)
+	if not previous_removed:
+		_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+		var _failed_conflict: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"pulse_lease_conflict"
+		)
+		return false
+
+	var lease_record: Dictionary = _make_virtual_pulse_lease_record(operation)
+	_virtual_pulse_leases[binding_key] = lease_record
+	if not operation.mark_lease_acquired_for_framework():
+		var _removed_unclaimed_lease: bool = _erase_virtual_pulse_lease_if_current(
+			binding_key,
+			lease_record
+		)
+		if previous_operation != null and previous_operation.is_pending():
+			_virtual_pulse_leases[binding_key] = previous_record
+		elif not previous_record.is_empty():
+			var _cleared_stale_contribution: bool = _clear_virtual_action_raw(
+				action_id,
+				source_id,
+				player_index
+			)
+		_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+		return false
+	var written: bool = _set_virtual_action_value_raw(action_id, value, source_id, player_index)
+	if not written:
+		var released_failed_lease: bool = _release_virtual_pulse_lease_record(
+			binding_key,
+			lease_record
+		)
+		var _failed_write: bool = operation.finish_from_mapping_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"pulse_write_failed",
+			released_failed_lease
+		)
+		if previous_operation != null and previous_operation.is_pending():
+			var _finished_previous_after_failure: bool = previous_operation.finish_from_mapping_for_framework(
+				GFVirtualInputPulseOperation.Status.REPLACED,
+				&"replaced",
+				false
+			)
+		_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+		return false
+
+	if previous_operation != null and previous_operation.is_pending():
+		var _finished_previous: bool = previous_operation.finish_from_mapping_for_framework(
+			GFVirtualInputPulseOperation.Status.REPLACED,
+			&"replaced",
+			false
+		)
+	var lease_is_current: bool = (
+		operation.is_pending()
+		and _virtual_pulse_lease_matches_operation(binding_key, operation)
+	)
+	_erase_dictionary_key(_virtual_pulse_mutation_keys, binding_key)
+	return lease_is_current
+
+
+## 结束指定操作仍持有的权威 lease，并只释放匹配 generation 的贡献。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param operation: 请求进入终态的脉冲句柄。
+## [br]
+## @param status: COMPLETED、CANCELLED、REPLACED 或 FAILED 终态。
+## [br]
+## @param reason: 稳定终态原因。
+## [br]
+## @return: 当前句柄仍持有匹配 lease 且已完成释放时返回 true。
+func finish_virtual_pulse_lease_for_framework(
+	operation: GFVirtualInputPulseOperation,
+	status: GFVirtualInputPulseOperation.Status,
+	reason: StringName
+) -> bool:
+	if operation == null or status in [
+		GFVirtualInputPulseOperation.Status.PENDING,
+		GFVirtualInputPulseOperation.Status.REJECTED,
+	]:
+		return false
+	var binding_key: String = _make_virtual_binding_key(
+		operation.get_source_id(),
+		operation.get_action_id(),
+		operation.get_player_index()
+	)
+	var lease_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+	if not _virtual_pulse_lease_record_matches_operation(lease_record, operation):
+		return false
+	var released: bool = _release_virtual_pulse_lease_record(binding_key, lease_record)
+	var _finished: bool = operation.finish_from_mapping_for_framework(status, reason, released)
+	return true
 
 
 # --- 私有/辅助方法 ---
@@ -872,6 +1058,229 @@ func _erase_dictionary_key(target: Dictionary, key: Variant) -> void:
 
 func _append_array_value(target: Array, value: Variant) -> void:
 	target.append(value)
+
+
+func _set_virtual_action_value_raw(
+	action_id: StringName,
+	value: Variant,
+	source_id: StringName,
+	player_index: int
+) -> bool:
+	var action: GFInputAction = _get_registered_action(action_id)
+	if action == null:
+		return false
+	var contribution: Vector3 = _coerce_virtual_value_to_vector(value, action.value_type)
+	var binding_key: String = _make_virtual_binding_key(source_id, action_id, player_index)
+	_binding_values[binding_key] = contribution
+	_binding_to_action[binding_key] = action_id
+	if player_index >= 0:
+		_binding_player_indices[binding_key] = player_index
+	else:
+		_erase_dictionary_key(_binding_player_indices, binding_key)
+	if player_index >= 0:
+		var player_binding_key: String = _make_player_binding_key(player_index, binding_key)
+		_register_player_binding_metadata(player_binding_key, player_index, binding_key)
+		_player_binding_values[player_binding_key] = contribution
+		_player_binding_to_action[player_binding_key] = action_id
+
+	_refresh_action_state(action_id, action)
+	if player_index >= 0:
+		_refresh_player_action_state(player_index, action_id, action)
+	return true
+
+
+func _clear_virtual_action_raw(
+	action_id: StringName,
+	source_id: StringName,
+	player_index: int
+) -> bool:
+	var binding_key: String = _make_virtual_binding_key(source_id, action_id, player_index)
+	var changed: bool = _binding_values.has(binding_key)
+	_erase_dictionary_key(_binding_values, binding_key)
+	_erase_dictionary_key(_binding_to_action, binding_key)
+	_erase_dictionary_key(_binding_player_indices, binding_key)
+	if player_index >= 0:
+		var player_binding_key: String = _make_player_binding_key(player_index, binding_key)
+		changed = _player_binding_values.has(player_binding_key) or changed
+		_erase_dictionary_key(_player_binding_values, player_binding_key)
+		_erase_dictionary_key(_player_binding_to_action, player_binding_key)
+		_erase_dictionary_key(_player_binding_metadata, player_binding_key)
+
+	var action: GFInputAction = _get_registered_action(action_id)
+	if action != null:
+		_refresh_action_state(action_id, action)
+		if player_index >= 0:
+			_refresh_player_action_state(player_index, action_id, action)
+	return changed
+
+
+func _make_virtual_pulse_lease_record(operation: GFVirtualInputPulseOperation) -> Dictionary:
+	return {
+		"lease_id": _take_next_virtual_pulse_lease_id(),
+		"operation_ref": weakref(operation),
+		"operation_id": operation.get_instance_id(),
+		"generation": operation.get_generation(),
+		"source_id": operation.get_source_id(),
+		"player_index": operation.get_player_index(),
+		"action_id": operation.get_action_id(),
+	}
+
+
+func _get_virtual_pulse_lease(binding_key: String) -> Dictionary:
+	var record_value: Variant = GFVariantData.get_option_value(_virtual_pulse_leases, binding_key)
+	if record_value is Dictionary:
+		var lease_record: Dictionary = record_value
+		return lease_record
+	return {}
+
+
+func _get_virtual_pulse_operation(lease_record: Dictionary) -> GFVirtualInputPulseOperation:
+	var operation_ref_value: Variant = GFVariantData.get_option_value(lease_record, "operation_ref")
+	if not (operation_ref_value is WeakRef):
+		return null
+	var operation_ref: WeakRef = operation_ref_value
+	var operation_value: Variant = operation_ref.get_ref()
+	if not (operation_value is GFVirtualInputPulseOperation):
+		return null
+	var operation: GFVirtualInputPulseOperation = operation_value
+	if (
+		operation.get_instance_id() != GFVariantData.get_option_int(lease_record, "operation_id", 0)
+		or operation.get_generation() != GFVariantData.get_option_int(lease_record, "generation", 0)
+	):
+		return null
+	return operation
+
+
+func _virtual_pulse_lease_matches_operation(
+	binding_key: String,
+	operation: GFVirtualInputPulseOperation
+) -> bool:
+	return _virtual_pulse_lease_record_matches_operation(
+		_get_virtual_pulse_lease(binding_key),
+		operation
+	)
+
+
+func _virtual_pulse_lease_record_matches_operation(
+	lease_record: Dictionary,
+	operation: GFVirtualInputPulseOperation
+) -> bool:
+	return (
+		not lease_record.is_empty()
+		and operation != null
+		and _get_virtual_pulse_operation(lease_record) == operation
+	)
+
+
+func _erase_virtual_pulse_lease_if_current(binding_key: String, lease_record: Dictionary) -> bool:
+	var current_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+	var current_ref: Variant = GFVariantData.get_option_value(current_record, "operation_ref")
+	var expected_ref: Variant = GFVariantData.get_option_value(lease_record, "operation_ref")
+	if (
+		GFVariantData.get_option_int(current_record, "lease_id", 0) <= 0
+		or GFVariantData.get_option_int(current_record, "lease_id", 0)
+		!= GFVariantData.get_option_int(lease_record, "lease_id", 0)
+		or not (current_ref is WeakRef)
+		or not (expected_ref is WeakRef)
+	):
+		return false
+	var current_operation_ref: WeakRef = current_ref
+	var expected_operation_ref: WeakRef = expected_ref
+	if current_operation_ref.get_ref() != expected_operation_ref.get_ref():
+		return false
+	_erase_dictionary_key(_virtual_pulse_leases, binding_key)
+	return true
+
+
+func _take_next_virtual_pulse_lease_id() -> int:
+	var lease_id: int = _next_virtual_pulse_lease_id
+	_next_virtual_pulse_lease_id += 1
+	if _next_virtual_pulse_lease_id <= 0:
+		_next_virtual_pulse_lease_id = 1
+	return lease_id
+
+
+func _remove_virtual_pulse_lease_record(binding_key: String, lease_record: Dictionary) -> bool:
+	return _erase_virtual_pulse_lease_if_current(binding_key, lease_record)
+
+
+func _release_virtual_pulse_lease_record(binding_key: String, lease_record: Dictionary) -> bool:
+	if not _remove_virtual_pulse_lease_record(binding_key, lease_record):
+		return false
+	var action_id: StringName = GFVariantData.get_option_string_name(lease_record, "action_id")
+	var source_id: StringName = GFVariantData.get_option_string_name(lease_record, "source_id")
+	var player_index: int = GFVariantData.get_option_int(lease_record, "player_index", -1)
+	var _released_value: bool = _clear_virtual_action_raw(action_id, source_id, player_index)
+	return true
+
+
+func _terminate_virtual_pulse_lease_by_key(
+	binding_key: String,
+	status: GFVirtualInputPulseOperation.Status,
+	reason: StringName
+) -> bool:
+	var lease_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+	if lease_record.is_empty():
+		return false
+	var operation: GFVirtualInputPulseOperation = _get_virtual_pulse_operation(lease_record)
+	var released: bool = _release_virtual_pulse_lease_record(binding_key, lease_record)
+	if operation != null and operation.is_pending():
+		var _finished: bool = operation.finish_from_mapping_for_framework(status, reason, released)
+	return released
+
+
+func _terminate_virtual_pulse_leases_for_source(source_id: StringName, reason: StringName) -> void:
+	var binding_keys: Array = _virtual_pulse_leases.keys()
+	for binding_key_value: Variant in binding_keys:
+		var binding_key: String = GFVariantData.to_text(binding_key_value)
+		var lease_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+		if GFVariantData.get_option_string_name(lease_record, "source_id") != source_id:
+			continue
+		var _terminated: bool = _terminate_virtual_pulse_lease_by_key(
+			binding_key,
+			GFVirtualInputPulseOperation.Status.CANCELLED,
+			reason
+		)
+
+
+func _terminate_virtual_pulse_leases_for_player(player_index: int, reason: StringName) -> void:
+	var binding_keys: Array = _virtual_pulse_leases.keys()
+	for binding_key_value: Variant in binding_keys:
+		var binding_key: String = GFVariantData.to_text(binding_key_value)
+		var lease_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+		if GFVariantData.get_option_int(lease_record, "player_index", -1) != player_index:
+			continue
+		var _terminated: bool = _terminate_virtual_pulse_lease_by_key(
+			binding_key,
+			GFVirtualInputPulseOperation.Status.CANCELLED,
+			reason
+		)
+
+
+func _terminate_all_virtual_pulse_leases(reason: StringName) -> void:
+	var binding_keys: Array = _virtual_pulse_leases.keys()
+	for binding_key_value: Variant in binding_keys:
+		var binding_key: String = GFVariantData.to_text(binding_key_value)
+		var _terminated: bool = _terminate_virtual_pulse_lease_by_key(
+			binding_key,
+			GFVirtualInputPulseOperation.Status.CANCELLED,
+			reason
+		)
+	_virtual_pulse_leases.clear()
+
+
+func _prune_virtual_pulse_leases() -> void:
+	var binding_keys: Array = _virtual_pulse_leases.keys()
+	for binding_key_value: Variant in binding_keys:
+		var binding_key: String = GFVariantData.to_text(binding_key_value)
+		var lease_record: Dictionary = _get_virtual_pulse_lease(binding_key)
+		if lease_record.is_empty():
+			continue
+		var operation: GFVirtualInputPulseOperation = _get_virtual_pulse_operation(lease_record)
+		if operation == null or operation.is_completed():
+			var _released_stale: bool = _release_virtual_pulse_lease_record(binding_key, lease_record)
+			continue
+		var _still_pending: bool = operation.poll_lifecycle_for_framework()
 
 
 func _get_node_value(value: Variant) -> Node:
@@ -1073,7 +1482,7 @@ func _attach_router_to_root(router_variant: Variant, attach_serial: int) -> void
 
 
 func _rebuild_effective_entries() -> void:
-	_clear_runtime_state(true)
+	_clear_runtime_state(true, &"mapping_rebuilt")
 	_effective_entries.clear()
 	_actions.clear()
 	_action_modifiers.clear()
@@ -1349,7 +1758,12 @@ func _clear_transient_input_state_if_queued() -> void:
 	_transient_input_state_mark_frame = -1
 
 
-func _clear_runtime_state(emit_completed: bool = false) -> void:
+func _clear_runtime_state(
+	emit_completed: bool = false,
+	pulse_reason: StringName = &"input_state_cleared"
+) -> void:
+	_virtual_pulse_bulk_mutation_depth += 1
+	_terminate_all_virtual_pulse_leases(pulse_reason)
 	if emit_completed:
 		for action_id: StringName in _action_active.keys():
 			if _get_action_active(action_id) and _actions.has(action_id):
@@ -1391,9 +1805,12 @@ func _clear_runtime_state(emit_completed: bool = false) -> void:
 	_clear_transient_input_state_queued = false
 	_transient_input_state_mark_frame = -1
 	_reset_all_trigger_states()
+	_virtual_pulse_bulk_mutation_depth = maxi(_virtual_pulse_bulk_mutation_depth - 1, 0)
 
 
 func _clear_player_runtime_state(player_index: int, emit_completed: bool = false) -> void:
+	_virtual_pulse_bulk_mutation_depth += 1
+	_terminate_virtual_pulse_leases_for_player(player_index, &"player_state_cleared")
 	var affected_actions: Dictionary = {}
 	if emit_completed:
 		for player_action_key: String in _player_action_active.keys():
@@ -1439,6 +1856,7 @@ func _clear_player_runtime_state(player_index: int, emit_completed: bool = false
 		var action: GFInputAction = _get_registered_action(action_id)
 		if action != null:
 			_refresh_action_state(action_id, action)
+	_virtual_pulse_bulk_mutation_depth = maxi(_virtual_pulse_bulk_mutation_depth - 1, 0)
 
 
 func _get_effective_event(

--- a/addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd
+++ b/addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd
@@ -374,6 +374,10 @@ func finish_from_mapping_for_framework(
 func poll_lifecycle_for_framework() -> bool:
 	if not is_pending():
 		return false
+	var cancellation_scope_completed: bool = false
+	if _cancel_token is GFAsyncScope:
+		var async_scope: GFAsyncScope = _cancel_token
+		cancellation_scope_completed = async_scope.is_completed()
 	if _owner_lifetime != null and _owner_lifetime.owner_is_released():
 		var _cancelled_for_owner: bool = _request_terminal(Status.CANCELLED, &"owner_released")
 	elif _cancel_token != null and _cancel_token.is_cancel_requested():
@@ -381,6 +385,11 @@ func poll_lifecycle_for_framework() -> bool:
 		var _cancelled_for_token: bool = _request_terminal(
 			Status.CANCELLED,
 			reason if reason != &"" else &"cancellation_requested"
+		)
+	elif cancellation_scope_completed:
+		var _cancelled_for_scope: bool = _request_terminal(
+			Status.CANCELLED,
+			&"cancellation_scope_completed"
 		)
 	elif _lease_acquired and _duration_seconds > 0.0:
 		var timer_utility: GFTimerUtility = _get_timer_utility()

--- a/addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd
+++ b/addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd
@@ -1,0 +1,591 @@
+## GFVirtualInputPulseOperation: 单次虚拟输入脉冲的类型化运行时句柄。
+##
+## 句柄冻结创建时的 Mapping、source_id、player_index 与 action_id，并由
+## GFInputMappingUtility 的权威 lease 保证旧定时器不会释放后续脉冲。owner 与
+## cancellation_token 均为可选锚点；同时提供时，任一先结束都会取消脉冲。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFVirtualInputPulseOperation
+extends RefCounted
+
+
+# --- 信号 ---
+
+## 脉冲首次进入终态时发出一次。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param operation: 已进入终态的当前句柄。
+signal completed(operation: GFVirtualInputPulseOperation)
+
+
+# --- 枚举 ---
+
+## 脉冲操作状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum Status {
+	## 等待定时、生命周期或显式终止。
+	PENDING,
+	## 到达脉冲时长并完成匹配释放。
+	COMPLETED,
+	## 被调用方、owner、token 或状态清理取消。
+	CANCELLED,
+	## 被同一稳定输入键上的新脉冲替换。
+	REPLACED,
+	## 因同一稳定输入键已有脉冲而拒绝启动。
+	REJECTED,
+	## 输入或运行时依赖无效，未能启动。
+	FAILED,
+}
+
+
+# --- 私有变量 ---
+
+var _status: Status = Status.PENDING
+var _terminal_reason: StringName = &""
+var _generation: int = 0
+var _source_id: StringName = &""
+var _player_index: int = -1
+var _action_id: StringName = &""
+var _duration_seconds: float = 0.0
+var _started_at_msec: int = 0
+var _completed_at_msec: int = 0
+var _release_count: int = 0
+var _lease_acquired: bool = false
+var _mapping_ref: WeakRef = null
+var _source_completion_invocation: GFWeakMethodInvocation = null
+var _timer_ref: WeakRef = null
+var _timer_handle: int = 0
+var _owner_lifetime: GFLifetimeSubscription = null
+var _cancel_token: GFCancellationToken = null
+var _cancel_token_callback: Callable = Callable()
+
+
+# --- 公共方法 ---
+
+## 取消仍在等待的脉冲。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param reason: 稳定取消原因；空值会规范化为 cancelled。
+## [br]
+## @return: 本次调用是否首次使操作进入终态。
+func cancel(reason: StringName = &"cancelled") -> bool:
+	return _request_terminal(Status.CANCELLED, reason if reason != &"" else &"cancelled")
+
+
+## 获取 Source 分配的单调 generation。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 大于零的 generation；配置失败前可能为 0。
+func get_generation() -> int:
+	return _generation
+
+
+## 获取冻结的虚拟输入源标识。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 创建脉冲时的 source_id。
+func get_source_id() -> StringName:
+	return _source_id
+
+
+## 获取冻结的玩家索引。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 创建脉冲时的 player_index。
+func get_player_index() -> int:
+	return _player_index
+
+
+## 获取冻结的动作标识。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 创建脉冲时的 action_id。
+func get_action_id() -> StringName:
+	return _action_id
+
+
+## 获取规范化脉冲时长。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 秒数。
+func get_duration_seconds() -> float:
+	return _duration_seconds
+
+
+## 获取当前状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: Status 枚举值。
+func get_status() -> Status:
+	return _status
+
+
+## 获取终态原因。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 等待中为空 StringName；终态时为稳定原因。
+func get_terminal_reason() -> StringName:
+	return _terminal_reason
+
+
+## 返回操作是否仍在等待。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 等待中返回 true。
+func is_pending() -> bool:
+	return _status == Status.PENDING
+
+
+## 返回操作是否已经进入任意终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 已完成、取消、替换、拒绝或失败时返回 true。
+func is_completed() -> bool:
+	return _status != Status.PENDING
+
+
+## 获取该脉冲完成的匹配释放次数。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 仅当前 lease 实际清除动作贡献时为 1；无释放交接、未取得 lease 或未释放时为 0。
+func get_release_count() -> int:
+	return _release_count
+
+
+## 获取稳定调试快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 冻结身份、状态、时长、时间戳与释放证明。
+## [br]
+## @schema return: Dictionary，包含 generation、source_id、player_index、action_id、duration_seconds、status、status_name、terminal_reason、pending、completed、started_at_msec、completed_at_msec、release_count、lease_acquired 和 timer_handle。
+func get_debug_snapshot() -> Dictionary:
+	return {
+		"generation": _generation,
+		"source_id": _source_id,
+		"player_index": _player_index,
+		"action_id": _action_id,
+		"duration_seconds": _duration_seconds,
+		"status": _status,
+		"status_name": Status.keys()[_status],
+		"terminal_reason": _terminal_reason,
+		"pending": is_pending(),
+		"completed": is_completed(),
+		"started_at_msec": _started_at_msec,
+		"completed_at_msec": _completed_at_msec,
+		"release_count": _release_count,
+		"lease_acquired": _lease_acquired,
+		"timer_handle": _timer_handle,
+	}
+
+
+# --- 框架内部方法 ---
+
+## 由 GFVirtualInputSource 冻结操作身份并绑定可选生命周期锚点。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param input_mapping: 创建时的输入映射工具。
+## [br]
+## @param source: 创建当前 generation 的虚拟输入源。
+## [br]
+## @param generation: Source 分配的单调 generation。
+## [br]
+## @param source_id: 冻结的虚拟输入源标识。
+## [br]
+## @param player_index: 冻结的玩家索引。
+## [br]
+## @param action_id: 冻结的动作标识。
+## [br]
+## @param duration_seconds: 有界脉冲时长。
+## [br]
+## @param owner: 可选生命周期 owner。
+## [br]
+## @param cancellation_token: 可选取消 token。
+## [br]
+## @return: 首次配置成功返回 true。
+func configure_for_framework(
+	input_mapping: GFInputMappingUtility,
+	source: GFVirtualInputSource,
+	generation: int,
+	source_id: StringName,
+	player_index: int,
+	action_id: StringName,
+	duration_seconds: float,
+	owner: Object,
+	cancellation_token: GFCancellationToken
+) -> bool:
+	if _generation != 0 or generation <= 0:
+		return false
+	_generation = generation
+	_source_id = source_id
+	_player_index = player_index
+	_action_id = action_id
+	_duration_seconds = duration_seconds
+	_started_at_msec = Time.get_ticks_msec()
+	_mapping_ref = weakref(input_mapping) if input_mapping != null else null
+	_source_completion_invocation = GFWeakMethodInvocation.new(
+		source,
+		&"notify_pulse_operation_completed_for_framework"
+	)
+	if not _bind_owner(owner):
+		var _failed_owner: bool = _finish(Status.FAILED, &"invalid_owner_lifecycle", false)
+		return true
+	if (
+		cancellation_token != null
+		and not cancellation_token.is_cancel_requested()
+		and cancellation_token is GFAsyncScope
+	):
+		var async_scope: GFAsyncScope = cancellation_token
+		if async_scope.is_completed():
+			var _failed_scope: bool = _finish(
+				Status.FAILED,
+				&"cancellation_scope_completed",
+				false
+			)
+			return true
+	if not _bind_cancellation_token(cancellation_token):
+		var _failed_token: bool = _finish(Status.FAILED, &"cancellation_token_bind_failed", false)
+	return true
+
+
+## 由 GFVirtualInputSource 使用注入的 GFTimerUtility 启动有界计时。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param timer_utility: Source 注入的定时器工具。
+## [br]
+## @return: 已排队、同步完成或已进入其他终态时返回 true。
+func arm_timer_for_framework(timer_utility: GFTimerUtility) -> bool:
+	if not is_pending() or timer_utility == null:
+		return not is_pending()
+	_timer_ref = weakref(timer_utility)
+	var timer_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+		self,
+		&"_on_pulse_timer_elapsed"
+	)
+	var timer_callback: Callable = func() -> void:
+		var _invoke_result: Dictionary = timer_invocation.invoke()
+	_timer_handle = timer_utility.execute_after_owned(self, _duration_seconds, timer_callback)
+	return not is_pending() or _duration_seconds > 0.0 and _timer_handle > 0
+
+
+## 由 Mapping 在发布 lease 后冻结已取得状态。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @return: 当前操作首次取得 lease 时返回 true。
+func mark_lease_acquired_for_framework() -> bool:
+	if not is_pending() or _lease_acquired:
+		return false
+	_lease_acquired = true
+	return true
+
+
+## 由 Mapping 提交唯一终态并记录是否执行了匹配释放。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param status: 非 PENDING 终态。
+## [br]
+## @param reason: 稳定终态原因。
+## [br]
+## @param release_performed: Mapping 是否为当前 lease 执行了匹配释放。
+## [br]
+## @return: 首次进入终态返回 true。
+func finish_from_mapping_for_framework(
+	status: Status,
+	reason: StringName,
+	release_performed: bool
+) -> bool:
+	return _finish(status, reason, release_performed)
+
+
+## 由 Mapping tick 检查普通 Object owner 的弱生命周期。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @return: 检查后操作是否仍在等待。
+func poll_lifecycle_for_framework() -> bool:
+	if not is_pending():
+		return false
+	if _owner_lifetime != null and _owner_lifetime.owner_is_released():
+		var _cancelled_for_owner: bool = _request_terminal(Status.CANCELLED, &"owner_released")
+	elif _cancel_token != null and _cancel_token.is_cancel_requested():
+		var reason: StringName = _cancel_token.get_cancel_reason()
+		var _cancelled_for_token: bool = _request_terminal(
+			Status.CANCELLED,
+			reason if reason != &"" else &"cancellation_requested"
+		)
+	elif _lease_acquired and _duration_seconds > 0.0:
+		var timer_utility: GFTimerUtility = _get_timer_utility()
+		if (
+			timer_utility == null
+			or not timer_utility.has_owned_timer_for_framework(_timer_handle, self)
+		):
+			var _failed_for_timer: bool = _request_terminal(
+				Status.FAILED,
+				&"timer_schedule_lost"
+			)
+	return is_pending()
+
+
+## 检查当前操作是否由指定 Mapping 创建。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param input_mapping: 待验证的输入映射工具。
+## [br]
+## @return: 冻结 Mapping 仍存活且身份一致时返回 true。
+func matches_mapping_for_framework(input_mapping: GFInputMappingUtility) -> bool:
+	return input_mapping != null and _get_input_mapping() == input_mapping
+
+
+## 在尚未取得 Mapping lease 时提交拒绝或失败终态。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param status: REJECTED、FAILED 或 CANCELLED。
+## [br]
+## @param reason: 稳定终态原因。
+## [br]
+## @return: 首次进入终态返回 true。
+func finish_without_lease_for_framework(status: Status, reason: StringName) -> bool:
+	if status not in [Status.REJECTED, Status.FAILED, Status.CANCELLED]:
+		return false
+	return _finish(status, reason, false)
+
+
+# --- 私有/辅助方法 ---
+
+func _request_terminal(status: Status, reason: StringName) -> bool:
+	if not is_pending():
+		return false
+	var input_mapping: GFInputMappingUtility = _get_input_mapping()
+	if input_mapping != null:
+		var finished_by_mapping: bool = input_mapping.finish_virtual_pulse_lease_for_framework(
+			self,
+			status,
+			reason
+		)
+		if finished_by_mapping:
+			return true
+		if _lease_acquired:
+			return false
+	return _finish(status, reason, false)
+
+
+func _finish(status: Status, reason: StringName, release_performed: bool) -> bool:
+	if not is_pending() or status == Status.PENDING:
+		return false
+	_status = status
+	_terminal_reason = reason if reason != &"" else _default_reason_for_status(status)
+	_completed_at_msec = Time.get_ticks_msec()
+	_release_count = 1 if release_performed else 0
+	_disconnect_runtime_anchors()
+	if _source_completion_invocation != null:
+		var _source_result: Dictionary = _source_completion_invocation.invoke([_generation, self])
+	completed.emit(self)
+	return true
+
+
+func _bind_owner(owner: Object) -> bool:
+	if owner == null:
+		return true
+	if not is_instance_valid(owner):
+		return false
+	if owner is Node:
+		var owner_node: Node = owner
+		if not owner_node.is_inside_tree():
+			return false
+	var owner_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+		self,
+		&"_on_pulse_owner_released"
+	)
+	var cancel_callback: Callable = func() -> void:
+		var _invoke_result: Dictionary = owner_invocation.invoke()
+	_owner_lifetime = GFLifetimeSubscription.new(
+		owner,
+		cancel_callback,
+		"virtual_input_pulse:%s:%s" % [_source_id, _action_id]
+	)
+	return _owner_lifetime.is_active()
+
+
+func _bind_cancellation_token(cancellation_token: GFCancellationToken) -> bool:
+	if cancellation_token == null:
+		return true
+	_cancel_token = cancellation_token
+	if cancellation_token.is_cancel_requested():
+		var reason: StringName = cancellation_token.get_cancel_reason()
+		var _cancelled_immediately: bool = _finish(
+			Status.CANCELLED,
+			reason if reason != &"" else &"cancellation_requested",
+			false
+		)
+		return true
+	if cancellation_token is GFAsyncScope:
+		var async_scope: GFAsyncScope = cancellation_token
+		if async_scope.is_completed():
+			_cancel_token = null
+			return false
+	var token_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+		self,
+		&"_on_pulse_token_cancelled"
+	)
+	_cancel_token_callback = func(reason: StringName) -> void:
+		var _invoke_result: Dictionary = token_invocation.invoke([reason])
+	var connect_error: Error = cancellation_token.cancel_requested.connect(
+		_cancel_token_callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	if connect_error != OK:
+		_cancel_token = null
+		_cancel_token_callback = Callable()
+		return false
+	if cancellation_token.is_cancel_requested():
+		var reason: StringName = cancellation_token.get_cancel_reason()
+		_on_pulse_token_cancelled(reason)
+	return true
+
+
+func _disconnect_runtime_anchors() -> void:
+	var timer_utility: GFTimerUtility = _get_timer_utility()
+	if timer_utility != null and _timer_handle > 0:
+		var _cancelled_timer_count: int = timer_utility.cancel_owner(self)
+	_timer_handle = 0
+	_timer_ref = null
+	if _owner_lifetime != null and _owner_lifetime.is_active():
+		var _owner_cancelled: bool = _owner_lifetime.cancel()
+	_owner_lifetime = null
+	if (
+		_cancel_token != null
+		and _cancel_token_callback.is_valid()
+		and _cancel_token.cancel_requested.is_connected(_cancel_token_callback)
+	):
+		_cancel_token.cancel_requested.disconnect(_cancel_token_callback)
+	_cancel_token = null
+	_cancel_token_callback = Callable()
+
+
+func _get_input_mapping() -> GFInputMappingUtility:
+	if _mapping_ref == null:
+		return null
+	var mapping_value: Variant = _mapping_ref.get_ref()
+	if mapping_value is GFInputMappingUtility:
+		var input_mapping: GFInputMappingUtility = mapping_value
+		return input_mapping
+	return null
+
+
+func _get_timer_utility() -> GFTimerUtility:
+	if _timer_ref == null:
+		return null
+	var timer_value: Variant = _timer_ref.get_ref()
+	if timer_value is GFTimerUtility:
+		var timer_utility: GFTimerUtility = timer_value
+		return timer_utility
+	return null
+
+
+func _default_reason_for_status(status: Status) -> StringName:
+	match status:
+		Status.COMPLETED:
+			return &"duration_elapsed"
+		Status.CANCELLED:
+			return &"cancelled"
+		Status.REPLACED:
+			return &"replaced"
+		Status.REJECTED:
+			return &"rejected"
+		Status.FAILED:
+			return &"failed"
+	return &""
+
+
+func _on_pulse_timer_elapsed() -> void:
+	var _completed_now: bool = _request_terminal(Status.COMPLETED, &"duration_elapsed")
+
+
+func _on_pulse_owner_released() -> void:
+	var _cancelled_now: bool = _request_terminal(Status.CANCELLED, &"owner_released")
+
+
+func _on_pulse_token_cancelled(reason: StringName) -> void:
+	var _cancelled_now: bool = _request_terminal(
+		Status.CANCELLED,
+		reason if reason != &"" else &"cancellation_requested"
+	)

--- a/addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd.uid
+++ b/addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd.uid
@@ -1,0 +1,1 @@
+uid://c30y5dhbkwt4k

--- a/addons/gf/standard/input/sources/gf_virtual_input_source.gd
+++ b/addons/gf/standard/input/sources/gf_virtual_input_source.gd
@@ -12,6 +12,21 @@ class_name GFVirtualInputSource
 extends RefCounted
 
 
+# --- 枚举 ---
+
+## 同一 source_id、player_index 与 action_id 已存在脉冲时的处理策略。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum PulseReplacementPolicy {
+	## 原子交接同一动作贡献，不产生中间释放。
+	REPLACE,
+	## 保留旧脉冲，并让新句柄立即进入 REJECTED 终态。
+	REJECT_NEW,
+}
+
+
 # --- 公共变量 ---
 
 ## 虚拟输入源标识。
@@ -28,6 +43,10 @@ var player_index: int = -1
 # --- 私有变量 ---
 
 var _input_mapping_ref: WeakRef = null
+var _timer_utility_ref: WeakRef = null
+var _active_pulses: Dictionary = {}
+var _next_pulse_generation: int = 1
+var _disposed: bool = false
 
 
 # --- Godot 生命周期方法 ---
@@ -35,9 +54,15 @@ var _input_mapping_ref: WeakRef = null
 func _init(
 	input_mapping: GFInputMappingUtility = null,
 	p_source_id: StringName = &"virtual",
-	p_player_index: int = -1
+	p_player_index: int = -1,
+	timer_utility: GFTimerUtility = null
 ) -> void:
-	var _configure_result_40: Variant = configure(input_mapping, p_source_id, p_player_index)
+	var _configure_result: GFVirtualInputSource = configure(
+		input_mapping,
+		p_source_id,
+		p_player_index,
+		timer_utility
+	)
 
 
 # --- 公共方法 ---
@@ -46,22 +71,188 @@ func _init(
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param input_mapping: 输入映射工具。
 ## [br]
 ## @param p_source_id: 虚拟输入源标识。
 ## [br]
 ## @param p_player_index: 玩家索引。
 ## [br]
-## @return 当前输入源。
+## @param timer_utility: 可选的脉冲定时器注入。
+## [br]
+## @return: 当前输入源；dispose 后返回同一终态实例且不修改配置。
 func configure(
 	input_mapping: GFInputMappingUtility,
 	p_source_id: StringName = &"virtual",
-	p_player_index: int = -1
+	p_player_index: int = -1,
+	timer_utility: GFTimerUtility = null
 ) -> GFVirtualInputSource:
+	if _disposed:
+		return self
+	if _input_mapping_ref != null:
+		clear_all()
 	_input_mapping_ref = weakref(input_mapping) if input_mapping != null else null
+	_timer_utility_ref = weakref(timer_utility) if timer_utility != null else null
 	source_id = p_source_id if p_source_id != &"" else &"virtual"
 	player_index = p_player_index
 	return self
+
+
+## 替换后续脉冲使用的定时器工具。
+## 已启动操作会继续使用其创建时冻结的定时器，不受本次替换影响。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param timer_utility: 可注入的定时器工具；null 会禁用后续 pulse_action()。
+## [br]
+## @return: 当前输入源；dispose 后返回同一终态实例且不修改配置。
+func set_timer_utility(timer_utility: GFTimerUtility) -> GFVirtualInputSource:
+	if _disposed:
+		return self
+	_timer_utility_ref = weakref(timer_utility) if timer_utility != null else null
+	return self
+
+
+## 获取后续脉冲使用的定时器工具。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 当前注入且仍存活的 GFTimerUtility。
+func get_timer_utility() -> GFTimerUtility:
+	return _get_timer_utility()
+
+
+## 启动一次有界虚拟动作脉冲。
+##
+## owner 与 cancellation_token 均可省略；同时提供时采用 OR 语义。返回句柄冻结
+## 当前 Mapping、source_id、player_index 和 action_id，Source 后续重配不会改写旧操作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param action_id: 已注册的抽象动作标识。
+## [br]
+## @param value: 脉冲期间的动作值。
+## [br]
+## @param duration_seconds: 非负且有限的脉冲时长；0 会同步释放。
+## [br]
+## @param owner: 可选生命周期 owner；Node 离树或普通 Object 释放后取消。
+## [br]
+## @param cancellation_token: 可选取消 token。
+## [br]
+## @param replacement_policy: 同一稳定输入键已有脉冲时的策略。
+## [br]
+## @schema value: Variant，GFInputMappingUtility 接受的 bool、float、Vector2 或 Vector3 动作值。
+## [br]
+## @schema owner: Variant，null 或仍有效的 Object；无效及已释放对象会在写入前失败。
+## [br]
+## @return: 类型化脉冲句柄；输入无效时返回立即 FAILED 的句柄。
+func pulse_action(
+	action_id: StringName,
+	value: Variant = true,
+	duration_seconds: float = 0.1,
+	owner: Variant = null,
+	cancellation_token: GFCancellationToken = null,
+	replacement_policy: PulseReplacementPolicy = PulseReplacementPolicy.REPLACE
+) -> GFVirtualInputPulseOperation:
+	var generation: int = _take_next_pulse_generation()
+	var input_mapping: GFInputMappingUtility = _get_input_mapping()
+	var frozen_source_id: StringName = source_id if source_id != &"" else &"virtual"
+	var operation: GFVirtualInputPulseOperation = GFVirtualInputPulseOperation.new()
+	_active_pulses[generation] = operation
+	var owner_object: Object = null
+	var owner_invalid: bool = false
+	if typeof(owner) != TYPE_NIL:
+		if not is_instance_valid(owner):
+			owner_invalid = true
+		elif owner is Object:
+			owner_object = owner
+		else:
+			owner_invalid = true
+	if owner_invalid:
+		owner_object = self
+	var token_for_configuration: GFCancellationToken = (
+		null if owner_invalid else cancellation_token
+	)
+	var configured: bool = operation.configure_for_framework(
+		input_mapping,
+		self,
+		generation,
+		frozen_source_id,
+		player_index,
+		action_id,
+		duration_seconds,
+		owner_object,
+		token_for_configuration
+	)
+	if not configured:
+		var _removed_unconfigured: bool = _active_pulses.erase(generation)
+		return operation
+	if owner_invalid and operation.is_pending():
+		var _failed_owner: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"invalid_owner_lifecycle"
+		)
+	if not operation.is_pending():
+		return operation
+	if _disposed:
+		var _failed_disposed: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"source_disposed"
+		)
+		return operation
+	if input_mapping == null:
+		var _failed_mapping: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"mapping_unavailable"
+		)
+		return operation
+	if action_id == &"":
+		var _failed_action: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"invalid_action_id"
+		)
+		return operation
+	if duration_seconds < 0.0 or is_nan(duration_seconds) or is_inf(duration_seconds):
+		var _failed_duration: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"invalid_duration"
+		)
+		return operation
+	if replacement_policy not in [PulseReplacementPolicy.REPLACE, PulseReplacementPolicy.REJECT_NEW]:
+		var _failed_policy: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"invalid_replacement_policy"
+		)
+		return operation
+	var timer_utility: GFTimerUtility = _get_timer_utility()
+	if timer_utility == null:
+		var _failed_timer: bool = operation.finish_without_lease_for_framework(
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"timer_unavailable"
+		)
+		return operation
+
+	var lease_acquired: bool = input_mapping.begin_virtual_pulse_lease_for_framework(
+		operation,
+		value,
+		replacement_policy
+	)
+	if not lease_acquired or not operation.is_pending():
+		return operation
+	if not operation.arm_timer_for_framework(timer_utility):
+		var _failed_schedule: bool = input_mapping.finish_virtual_pulse_lease_for_framework(
+			operation,
+			GFVirtualInputPulseOperation.Status.FAILED,
+			&"timer_schedule_failed"
+		)
+	return operation
 
 
 ## 写入动作值。
@@ -199,9 +390,27 @@ func clear_action_for_player(action_id: StringName, next_player_index: int) -> b
 ## [br]
 ## @api public
 func clear_all() -> void:
+	_cancel_active_pulses(&"source_cleared")
 	var input_mapping: GFInputMappingUtility = _get_input_mapping()
 	if input_mapping != null:
 		input_mapping.call("clear_virtual_source", source_id)
+
+
+## 取消全部 Source-owned 脉冲、清除当前 source_id 贡献并释放依赖引用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func dispose() -> void:
+	if _disposed:
+		return
+	_disposed = true
+	_cancel_active_pulses(&"source_disposed")
+	var input_mapping: GFInputMappingUtility = _get_input_mapping()
+	if input_mapping != null:
+		input_mapping.clear_virtual_source(source_id)
+	_input_mapping_ref = null
+	_timer_utility_ref = null
 
 
 ## 获取当前虚拟源快照。
@@ -223,6 +432,28 @@ func get_snapshot() -> Dictionary:
 	return GFVariantData.to_dictionary(snapshot)
 
 
+# --- 框架内部方法 ---
+
+## 由 GFVirtualInputPulseOperation 在首次终态后移除 Source 强引用。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/input
+## [br]
+## @param generation: 操作创建时的 Source generation。
+## [br]
+## @param operation: 已完成操作。
+func notify_pulse_operation_completed_for_framework(
+	generation: int,
+	operation: GFVirtualInputPulseOperation
+) -> void:
+	var current: GFVirtualInputPulseOperation = _get_pulse_operation(generation)
+	if current == operation:
+		var _removed: bool = _active_pulses.erase(generation)
+
+
 # --- 私有/辅助方法 ---
 
 func _get_input_mapping() -> GFInputMappingUtility:
@@ -231,4 +462,42 @@ func _get_input_mapping() -> GFInputMappingUtility:
 	var input_mapping: Variant = _input_mapping_ref.get_ref()
 	if input_mapping is GFInputMappingUtility:
 		return input_mapping
+	return null
+
+
+func _get_timer_utility() -> GFTimerUtility:
+	if _timer_utility_ref == null:
+		return null
+	var timer_value: Variant = _timer_utility_ref.get_ref()
+	if timer_value is GFTimerUtility:
+		var timer_utility: GFTimerUtility = timer_value
+		return timer_utility
+	return null
+
+
+func _take_next_pulse_generation() -> int:
+	var generation: int = _next_pulse_generation
+	_next_pulse_generation += 1
+	if _next_pulse_generation <= 0:
+		_next_pulse_generation = 1
+	return generation
+
+
+func _cancel_active_pulses(reason: StringName) -> void:
+	var operations: Array = _active_pulses.values()
+	for operation_value: Variant in operations:
+		var operation: GFVirtualInputPulseOperation = _variant_to_pulse_operation(operation_value)
+		if operation != null and operation.is_pending():
+			var _cancelled: bool = operation.cancel(reason)
+	_active_pulses.clear()
+
+
+func _get_pulse_operation(generation: int) -> GFVirtualInputPulseOperation:
+	return _variant_to_pulse_operation(GFVariantData.get_option_value(_active_pulses, generation))
+
+
+func _variant_to_pulse_operation(value: Variant) -> GFVirtualInputPulseOperation:
+	if value is GFVirtualInputPulseOperation:
+		var operation: GFVirtualInputPulseOperation = value
+		return operation
 	return null

--- a/addons/gf/standard/utilities/time/gf_timer_utility.gd
+++ b/addons/gf/standard/utilities/time/gf_timer_utility.gd
@@ -250,6 +250,30 @@ func cancel_owner(owner: Object) -> int:
 	return removed
 
 
+## 检查指定 handle 是否仍属于给定 owner 的待执行或执行中 timer。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @layer standard/utilities
+## [br]
+## @param handle: execute_after_owned() 返回的 timer handle。
+## [br]
+## @param owner: 创建 owner-bound timer 时使用的 owner。
+## [br]
+## @return: handle 与 owner 身份均匹配时返回 true。
+func has_owned_timer_for_framework(handle: int, owner: Object) -> bool:
+	if handle <= 0 or owner == null or not is_instance_valid(owner):
+		return false
+	for timer_data: Dictionary in _pending_timers:
+		if _get_timer_id(timer_data) == handle and _timer_is_owned_by(timer_data, owner):
+			return true
+	if _executing_handles.has(handle):
+		return _timer_is_owned_by(_get_executing_timer(handle), owner)
+	return false
+
+
 ## 获取定时器工具诊断快照。
 ## [br]
 ## @api public
@@ -387,6 +411,15 @@ func _get_timer_owner_ref(timer_data: Dictionary) -> WeakRef:
 
 func _timer_has_owner_ref(timer_data: Dictionary) -> bool:
 	return GFVariantData.get_option_value(timer_data, "owner_ref") != null
+
+
+func _timer_is_owned_by(timer_data: Dictionary, owner: Object) -> bool:
+	if timer_data.is_empty() or owner == null or not is_instance_valid(owner):
+		return false
+	if _get_timer_owner_id(timer_data) != owner.get_instance_id():
+		return false
+	var owner_ref: WeakRef = _get_timer_owner_ref(timer_data)
+	return owner_ref != null and owner_ref.get_ref() == owner
 
 
 func _variant_to_callable(value: Variant) -> Callable:

--- a/addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd
+++ b/addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd
@@ -1,0 +1,241 @@
+## GFUIPanelAsyncOperation: 单次异步 UI 面板请求的可观察句柄。
+##
+## 句柄冻结 UI 分配的请求序号、路径、层级与操作类型，并且只接受一个终态。
+## 成功面板仅以弱引用保存，句柄不会延长面板节点的生命周期。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFUIPanelAsyncOperation
+extends RefCounted
+
+
+# --- 信号 ---
+
+## 请求进入终态时发出一次。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param handle: 已完成的当前句柄。
+signal completed(handle: GFUIPanelAsyncOperation)
+
+
+# --- 常量 ---
+
+## 请求尚未进入终态时由 get_status() 返回的状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_PENDING: int = -1
+
+## 压入面板操作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_PUSH: StringName = &"push"
+
+## 替换层级操作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_REPLACE: StringName = &"replace"
+const _STATUS_OPENED: int = 0
+const _STATUS_FAILED: int = 1
+const _STATUS_CANCELLED: int = 2
+
+
+# --- 私有变量 ---
+
+var _serial: int = 0
+var _path: String = ""
+var _layer: int = -1
+var _operation: StringName = &""
+var _status: int = STATUS_PENDING
+var _panel_reference: WeakRef = null
+var _configured: bool = false
+
+
+# --- 公共方法 ---
+
+## 获取 UI 分配的请求序号。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 配置后为大于零的请求序号；未配置时为 0。
+func get_serial() -> int:
+	return _serial
+
+
+## 获取面板场景路径。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 请求创建时冻结的场景路径。
+func get_path() -> String:
+	return _path
+
+
+## 获取目标 UI 层级。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 请求创建时冻结的逻辑层 ID。
+func get_layer() -> int:
+	return _layer
+
+
+## 获取 push 或 replace 操作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: `OPERATION_*` 常量之一。
+func get_operation() -> StringName:
+	return _operation
+
+
+## 检查请求是否仍在等待终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 已配置且尚未完成时返回 true。
+func is_pending() -> bool:
+	return _configured and _status == STATUS_PENDING
+
+
+## 检查请求是否已有终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 已完成时返回 true。
+func is_completed() -> bool:
+	return _configured and _status != STATUS_PENDING
+
+
+## 获取请求状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 等待中返回 STATUS_PENDING；完成后返回 GFUIUtility.AsyncPanelLoadStatus。
+func get_status() -> int:
+	return _status
+
+
+## 获取成功打开的面板。
+##
+## 句柄只保存弱引用；面板已释放、请求失败或请求取消时返回 null。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 当前仍有效的成功面板；否则返回 null。
+func get_panel() -> Node:
+	if _panel_reference == null:
+		return null
+	var panel_value: Variant = _panel_reference.get_ref()
+	if panel_value is Node:
+		var panel: Node = panel_value
+		return panel
+	return null
+
+
+## 获取稳定调试快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 请求身份与终态摘要。
+## [br]
+## @schema return: Dictionary，包含 serial、path、layer、operation、pending、completed、status、has_panel 和 panel_instance_id。
+func get_debug_snapshot() -> Dictionary:
+	var panel: Node = get_panel()
+	return {
+		"serial": _serial,
+		"path": _path,
+		"layer": _layer,
+		"operation": String(_operation),
+		"pending": is_pending(),
+		"completed": is_completed(),
+		"status": _status,
+		"has_panel": panel != null,
+		"panel_instance_id": panel.get_instance_id() if panel != null else 0,
+	}
+
+
+# --- 框架内部方法 ---
+
+## 由 GFUIUtility 初始化请求身份。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param serial: 同一 GFUIUtility 实例内全局单调的请求序号。
+## [br]
+## @param path: 面板场景路径。
+## [br]
+## @param layer: 目标逻辑层 ID。
+## [br]
+## @param operation: push 或 replace。
+## [br]
+## @return: 首次配置且输入有效时返回 true。
+func configure_for_framework(
+	serial: int,
+	path: String,
+	layer: int,
+	operation: StringName
+) -> bool:
+	if _configured or serial <= 0:
+		return false
+	if operation not in [OPERATION_PUSH, OPERATION_REPLACE]:
+		return false
+	_serial = serial
+	_path = path
+	_layer = layer
+	_operation = operation
+	_configured = true
+	return true
+
+
+## 由 GFUIUtility 写入并发出唯一终态。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param status: GFUIUtility.AsyncPanelLoadStatus 终态。
+## [br]
+## @param panel: 成功打开的面板；失败或取消时为 null。
+## [br]
+## @return: 首次完成成功返回 true。
+func complete_for_framework(status: int, panel: Node) -> bool:
+	if not is_pending() or status not in [_STATUS_OPENED, _STATUS_FAILED, _STATUS_CANCELLED]:
+		return false
+	if status == _STATUS_OPENED and not is_instance_valid(panel):
+		return false
+	_status = status
+	_panel_reference = weakref(panel) if status == _STATUS_OPENED else null
+	completed.emit(self)
+	return true

--- a/addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd.uid
@@ -1,0 +1,1 @@
+uid://db4oklkncr1t8

--- a/addons/gf/standard/utilities/ui/gf_ui_route_result.gd
+++ b/addons/gf/standard/utilities/ui/gf_ui_route_result.gd
@@ -63,6 +63,13 @@ const STATUS_ASYNC_CONFLICT: StringName = &"async_conflict"
 ## @since 10.0.0
 const STATUS_INVALID_PRELOAD_POLICY: StringName = &"invalid_preload_policy"
 
+## 请求 owner 或异步作用域不满足生命周期契约。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_LIFECYCLE: StringName = &"invalid_lifecycle"
+
 ## 预加载策略需要 Asset Utility，但当前架构未提供。
 ## [br]
 ## @api public
@@ -91,7 +98,7 @@ const STATUS_PRELOAD_FAILED: StringName = &"preload_failed"
 ## @since 10.0.0
 const STATUS_PANEL_FAILED: StringName = &"panel_failed"
 
-## 底层 UI 请求在完成前被取消。
+## 请求在面板提交前因 owner/scope 结束，或在提交后被底层 UI 取消。
 ## [br]
 ## @api public
 ## [br]
@@ -488,6 +495,7 @@ static func _is_valid_status(status: StringName) -> bool:
 		STATUS_MISSING_UI_LAYER,
 		STATUS_ASYNC_CONFLICT,
 		STATUS_INVALID_PRELOAD_POLICY,
+		STATUS_INVALID_LIFECYCLE,
 		STATUS_MISSING_ASSET_UTILITY,
 		STATUS_PRELOAD_PLAN_FAILED,
 		STATUS_PRELOAD_FAILED,

--- a/addons/gf/standard/utilities/ui/gf_ui_router_utility.gd
+++ b/addons/gf/standard/utilities/ui/gf_ui_router_utility.gd
@@ -117,7 +117,6 @@ var max_history: int = 64
 
 var _routes: Dictionary = {}
 var _ui_utility_ref: WeakRef = null
-var _connected_ui_utility_ref: WeakRef = null
 var _history: Array[Dictionary] = []
 var _pending_async_routes: Dictionary = {}
 var _next_async_request_id: int = 1
@@ -127,16 +126,20 @@ var _disposed: bool = false
 # --- GF 生命周期方法 ---
 
 ## 初始化路由表、UI 工具引用和历史记录。
+## 重复初始化会先以 dispose 语义终结旧 pending 请求；请求 ID 在同一实例内保持单调，
+## 避免旧异步回调或临时预加载组与新生命周期串线。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 func init() -> void:
-	_disconnect_connected_ui_utility()
+	_disposed = true
+	if not _pending_async_routes.is_empty():
+		_finish_pending_routes_for_dispose()
 	_routes.clear()
 	_ui_utility_ref = null
-	_connected_ui_utility_ref = null
 	_history.clear()
 	_pending_async_routes.clear()
-	_next_async_request_id = 1
 	_disposed = false
 
 
@@ -146,12 +149,22 @@ func init() -> void:
 func dispose() -> void:
 	_disposed = true
 	_finish_pending_routes_for_dispose()
-	_disconnect_connected_ui_utility()
 	_routes.clear()
 	_ui_utility_ref = null
-	_connected_ui_utility_ref = null
 	_history.clear()
 	_pending_async_routes.clear()
+
+
+## 清理普通 Object owner 已释放的提交前路由请求。
+## Node owner 和 GFAsyncScope 会通过信号即时取消；普通 Object 依赖本帧弱引用检查。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param _delta: 本帧时间增量；生命周期清理不依赖具体数值。
+func tick(_delta: float) -> void:
+	_prune_pending_route_lifecycles()
 
 
 # --- 公共方法 ---
@@ -184,10 +197,6 @@ func set_ui_utility(ui_utility: GFUIUtility) -> void:
 		push_warning("[GFUIRouterUtility] 存在异步路由请求时不能更换 GFUIUtility。")
 		return
 	_ui_utility_ref = weakref(ui_utility) if ui_utility != null else null
-	if ui_utility != null:
-		_ensure_ui_async_signal_connected(ui_utility)
-	else:
-		_disconnect_connected_ui_utility()
 
 
 ## 注册一个路由。
@@ -375,7 +384,7 @@ func replace_route(
 ## [br]
 ## @schema option_overrides: Dictionary，字段同 GFUIUtility 打开面板 options，会覆盖路由 default_options。
 ## [br]
-## @schema async_options: Dictionary，可包含 preload_policy、preload_plan_options 和 metadata；preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
+## @schema async_options: Dictionary，可包含 preload_policy、preload_plan_options、metadata、owner: Object 和 scope: GFAsyncScope；owner 与 scope 使用 OR 取消语义且只约束面板提交前，preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
 ## [br]
 ## @return 可观察的异步路由句柄；相同 pending 请求返回同一句柄。
 func push_route_async(
@@ -415,7 +424,7 @@ func push_route_async(
 ## [br]
 ## @schema option_overrides: Dictionary，字段同 GFUIUtility 打开面板 options，会覆盖路由 default_options。
 ## [br]
-## @schema async_options: Dictionary，可包含 preload_policy、preload_plan_options 和 metadata；preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
+## @schema async_options: Dictionary，可包含 preload_policy、preload_plan_options、metadata、owner: Object 和 scope: GFAsyncScope；owner 与 scope 使用 OR 取消语义且只约束面板提交前，preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
 ## [br]
 ## @return 可观察的异步路由句柄；相同 pending 请求返回同一句柄。
 func replace_route_async(
@@ -514,7 +523,7 @@ func clear_history() -> void:
 ## [br]
 ## @return 诊断快照。
 ## [br]
-## @schema return: Dictionary，包含 route_count、history_count、pending_async_route_count、pending_async_routes、current_route_id、has_ui_utility 和 disposed。
+## @schema return: Dictionary，包含 route_count、history_count、pending_async_route_count、current_route_id、has_ui_utility、disposed，以及 pending_async_routes；其中每个 pending 条目额外包含 panel_submitted、has_owner、has_scope 与 lifecycle_cancellation_open。
 func get_debug_snapshot() -> Dictionary:
 	_prune_history()
 	return {
@@ -538,6 +547,9 @@ func _open_route(
 	config_callback: Callable
 ) -> Node:
 	var normalized_route_id: StringName = _normalize_route_id(route_id)
+	if _disposed:
+		_fail_route(normalized_route_id, "router_disposed")
+		return null
 	var route: GFUIRoute = _resolve_route_or_fail(normalized_route_id)
 	if route == null:
 		return null
@@ -610,6 +622,34 @@ func _open_route_async(
 			false
 		)
 		return operation_handle
+	var lifecycle: Dictionary = _parse_route_lifecycle_options(async_options)
+	if not GFVariantData.get_option_bool(lifecycle, "valid"):
+		_finish_route_entry(
+			immediate_entry,
+			GFUIRouteResult.STATUS_INVALID_LIFECYCLE,
+			GFVariantData.get_option_string_name(
+				lifecycle,
+				"reason",
+				&"invalid_lifecycle"
+			),
+			null,
+			true
+		)
+		return operation_handle
+	if GFVariantData.get_option_bool(lifecycle, "cancelled"):
+		_finish_route_entry(
+			immediate_entry,
+			GFUIRouteResult.STATUS_CANCELLED,
+			GFVariantData.get_option_string_name(
+				lifecycle,
+				"reason",
+				&"scope_cancelled"
+			),
+			null,
+			false
+		)
+		return operation_handle
+	_apply_route_lifecycle_to_entry(immediate_entry, lifecycle)
 
 	var route: GFUIRoute = get_route(normalized_route_id)
 	if route == null:
@@ -662,6 +702,7 @@ func _open_route_async(
 		)
 		return operation_handle
 
+	_prune_pending_route_lifecycles()
 	var pending_route: Dictionary = _find_pending_async_route(route.scene_path, route.layer, operation)
 	if not pending_route.is_empty():
 		if _pending_route_matches_request(
@@ -672,7 +713,9 @@ func _open_route_async(
 			config_callback,
 			preload_policy,
 			GFVariantData.get_option_dictionary(async_options, "preload_plan_options"),
-			metadata
+			metadata,
+			GFVariantData.get_option_int(lifecycle, "owner_id"),
+			GFVariantData.get_option_int(lifecycle, "scope_id")
 		):
 			var pending_handle: GFUIRouteOperation = _get_route_operation_value(
 				pending_route.get("operation_handle")
@@ -689,8 +732,9 @@ func _open_route_async(
 		return operation_handle
 
 	var pending_key: String = _make_pending_async_route_key(route.scene_path, route.layer, operation)
-	_ensure_ui_async_signal_connected(ui_utility)
-	_pending_async_routes[pending_key] = {
+	var request_id: int = operation_handle.get_request_id()
+	var pending_entry: Dictionary = immediate_entry.duplicate(true)
+	pending_entry.merge({
 		"route_id": normalized_route_id,
 		"route": route,
 		"path": route.scene_path,
@@ -712,15 +756,25 @@ func _open_route_async(
 		"preload_successful": false,
 		"preload_degradation_reason": &"",
 		"owns_preload_group": false,
+		"preload_started": false,
 		"panel_submitted": false,
-	}
+	}, true)
+	_pending_async_routes[pending_key] = pending_entry
+	_bind_pending_route_lifecycle(
+		pending_key,
+		request_id,
+		_get_object_value(lifecycle.get("owner")),
+		_get_async_scope_value(lifecycle.get("scope"))
+	)
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return operation_handle
 	route_open_requested.emit(normalized_route_id, operation, params.duplicate(true))
-	if not _pending_async_routes.has(pending_key):
+	if not _pending_route_has_request_id(pending_key, request_id):
 		return operation_handle
 	if preload_policy == PRELOAD_NONE:
-		_submit_pending_panel_open(pending_key)
+		_submit_pending_panel_open(pending_key, request_id)
 	else:
-		_start_pending_route_preload(pending_key)
+		_start_pending_route_preload(pending_key, request_id)
 	return operation_handle
 
 
@@ -770,6 +824,7 @@ func _make_route_operation_entry(
 		"route_id": operation_handle.get_route_id(),
 		"layer": -1,
 		"operation": operation,
+		"request_id": operation_handle.get_request_id(),
 		"operation_handle": operation_handle,
 		"preload_policy": preload_policy,
 		"preload_plan_report": {},
@@ -779,6 +834,14 @@ func _make_route_operation_entry(
 		"preload_degradation_reason": &"",
 		"owns_preload_group": false,
 		"panel_submitted": false,
+		"ui_operation": null,
+		"ui_completion_callback": Callable(),
+		"owner_ref": null,
+		"owner_id": 0,
+		"owner_lifetime": null,
+		"scope": null,
+		"scope_id": 0,
+		"scope_callback": Callable(),
 		"metadata": metadata.duplicate(true),
 	}
 
@@ -806,7 +869,9 @@ func _pending_route_matches_request(
 	config_callback: Callable,
 	preload_policy: StringName,
 	preload_plan_options: Dictionary,
-	metadata: Dictionary
+	metadata: Dictionary,
+	owner_id: int,
+	scope_id: int
 ) -> bool:
 	return (
 		GFVariantData.get_option_string_name(entry, "route_id", &"") == route_id
@@ -816,18 +881,276 @@ func _pending_route_matches_request(
 		and GFVariantData.get_option_string_name(entry, "preload_policy", PRELOAD_NONE) == preload_policy
 		and GFVariantData.get_option_dictionary(entry, "preload_plan_options") == preload_plan_options
 		and GFVariantData.get_option_dictionary(entry, "metadata") == metadata
+		and GFVariantData.get_option_int(entry, "owner_id") == owner_id
+		and GFVariantData.get_option_int(entry, "scope_id") == scope_id
 	)
 
 
-func _start_pending_route_preload(pending_key: String) -> void:
+func _parse_route_lifecycle_options(async_options: Dictionary) -> Dictionary:
+	var owner: Object = null
+	if async_options.has("owner"):
+		var raw_owner: Variant = async_options.get("owner")
+		if raw_owner != null:
+			if not (raw_owner is Object):
+				return {"valid": false, "reason": &"invalid_owner"}
+			owner = raw_owner
+			if not is_instance_valid(owner):
+				return {"valid": false, "reason": &"invalid_owner"}
+			if owner is Node:
+				var owner_node: Node = owner
+				if not owner_node.is_inside_tree():
+					return {"valid": false, "reason": &"owner_not_in_tree"}
+
+	var scope: GFAsyncScope = null
+	if async_options.has("scope"):
+		var raw_scope: Variant = async_options.get("scope")
+		if raw_scope != null:
+			if not (raw_scope is GFAsyncScope):
+				return {"valid": false, "reason": &"invalid_scope"}
+			scope = raw_scope
+			if scope.is_completed():
+				return {"valid": false, "reason": &"scope_completed"}
+			if scope.is_cancel_requested():
+				return {
+					"valid": true,
+					"cancelled": true,
+					"reason": _get_scope_cancel_reason(scope),
+				}
+
+	return {
+		"valid": true,
+		"cancelled": false,
+		"owner": owner,
+		"owner_id": owner.get_instance_id() if owner != null else 0,
+		"scope": scope,
+		"scope_id": scope.get_instance_id() if scope != null else 0,
+	}
+
+
+func _apply_route_lifecycle_to_entry(entry: Dictionary, lifecycle: Dictionary) -> void:
+	var owner: Object = _get_object_value(lifecycle.get("owner"))
+	var scope: GFAsyncScope = _get_async_scope_value(lifecycle.get("scope"))
+	entry["owner_ref"] = weakref(owner) if owner != null else null
+	entry["owner_id"] = owner.get_instance_id() if owner != null else 0
+	entry["scope"] = scope
+	entry["scope_id"] = scope.get_instance_id() if scope != null else 0
+
+
+func _bind_pending_route_lifecycle(
+	pending_key: String,
+	request_id: int,
+	owner: Object,
+	scope: GFAsyncScope
+) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
 	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 	if entry.is_empty():
 		return
-	var route_id: StringName = GFVariantData.get_option_string_name(entry, "route_id", &"")
 	var operation_handle: GFUIRouteOperation = _get_route_operation_value(entry.get("operation_handle"))
 	if operation_handle == null:
+		var _missing_handle_finished: bool = _finish_pending_route_before_submit(
+			pending_key,
+			request_id,
+			GFUIRouteResult.STATUS_INVALID_LIFECYCLE,
+			&"missing_route_operation",
+			true
+		)
+		return
+	if owner != null:
+		var owner_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+			self,
+			&"_on_pending_route_lifecycle_cancelled"
+		)
+		var owner_reason: StringName = &"owner_tree_exited" if owner is Node else &"owner_released"
+		var owner_callback: Callable = func() -> void:
+			var _invocation_result: Dictionary = owner_invocation.invoke([
+				pending_key,
+				request_id,
+				owner_reason,
+			])
+		var owner_lifetime: GFLifetimeSubscription = GFLifetimeSubscription.new(
+			owner,
+			owner_callback,
+			"ui_route:%d" % request_id
+		)
+		if not owner_lifetime.is_active():
+			var _invalid_owner_finished: bool = _finish_pending_route_before_submit(
+				pending_key,
+				request_id,
+				GFUIRouteResult.STATUS_INVALID_LIFECYCLE,
+				&"owner_binding_failed",
+				true
+			)
+			return
+		entry["owner_lifetime"] = owner_lifetime
+
+	if scope != null:
+		var scope_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+			self,
+			&"_on_pending_route_lifecycle_cancelled"
+		)
+		var scope_callback: Callable = func(reason: StringName) -> void:
+			var _invocation_result: Dictionary = scope_invocation.invoke([
+				pending_key,
+				request_id,
+				reason if reason != &"" else &"scope_cancelled",
+			])
+		entry["scope_callback"] = scope_callback
+		var connect_error: Error = scope.cancel_requested.connect(scope_callback) as Error
+		if connect_error != OK:
+			_pending_async_routes[pending_key] = entry
+			var _scope_connect_finished: bool = _finish_pending_route_before_submit(
+				pending_key,
+				request_id,
+				GFUIRouteResult.STATUS_INVALID_LIFECYCLE,
+				&"scope_connect_failed",
+				true
+			)
+			return
+
+	_pending_async_routes[pending_key] = entry
+	if scope != null and scope.is_cancel_requested():
+		_on_pending_route_lifecycle_cancelled(
+			pending_key,
+			request_id,
+			_get_scope_cancel_reason(scope)
+		)
+
+
+func _on_pending_route_lifecycle_cancelled(
+	pending_key: String,
+	request_id: int,
+	reason: StringName
+) -> void:
+	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	var operation_handle: GFUIRouteOperation = _get_route_operation_value(entry.get("operation_handle"))
+	if operation_handle == null or operation_handle.get_request_id() != request_id:
+		return
+	if GFVariantData.get_option_bool(entry, "panel_submitted"):
+		return
+	var final_reason: StringName = reason if reason != &"" else &"lifecycle_cancelled"
+	var _cancelled: bool = _finish_pending_route_before_submit(
+		pending_key,
+		request_id,
+		GFUIRouteResult.STATUS_CANCELLED,
+		final_reason,
+		false
+	)
+
+
+func _prune_pending_route_lifecycles() -> void:
+	if _pending_async_routes.is_empty():
+		return
+	var pending_keys: Array = _pending_async_routes.keys()
+	for pending_key_value: Variant in pending_keys:
+		var pending_key: String = GFVariantData.to_text(pending_key_value)
+		var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+		if entry.is_empty() or GFVariantData.get_option_bool(entry, "panel_submitted"):
+			continue
+		var expired_reason: StringName = _get_route_lifecycle_expired_reason(entry)
+		if expired_reason == &"":
+			continue
+		var operation_handle: GFUIRouteOperation = _get_route_operation_value(
+			entry.get("operation_handle")
+		)
+		if operation_handle != null:
+			_on_pending_route_lifecycle_cancelled(
+				pending_key,
+				operation_handle.get_request_id(),
+				expired_reason
+			)
+
+
+func _get_route_lifecycle_expired_reason(entry: Dictionary) -> StringName:
+	var owner_id: int = GFVariantData.get_option_int(entry, "owner_id")
+	if owner_id != 0:
+		var owner_ref: WeakRef = _get_weak_ref_value(entry.get("owner_ref"))
+		var owner: Object = _get_live_object_from_ref(owner_ref)
+		if owner == null or owner.get_instance_id() != owner_id:
+			return &"owner_released"
+		if owner is Node:
+			var owner_node: Node = owner
+			if not owner_node.is_inside_tree():
+				return &"owner_tree_exited"
+
+	var scope: GFAsyncScope = _get_async_scope_value(entry.get("scope"))
+	if scope != null:
+		if scope.is_cancel_requested():
+			return _get_scope_cancel_reason(scope)
+		if scope.is_completed():
+			return &"scope_completed"
+	return &""
+
+
+func _finish_pending_route_before_submit(
+	pending_key: String,
+	request_id: int,
+	status: StringName,
+	reason: StringName,
+	emit_legacy_failure: bool
+) -> bool:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return false
+	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	if entry.is_empty() or GFVariantData.get_option_bool(entry, "panel_submitted"):
+		return false
+	var _erased: bool = _pending_async_routes.erase(pending_key)
+	_disconnect_entry_lifecycle(entry)
+	_disconnect_entry_preload_callback(entry)
+	var session: GFAssetLoadSession = _get_asset_load_session_value(entry.get("preload_session"))
+	if session != null and not session.is_completed():
+		var _rolled_back: bool = session.rollback(reason)
+	_finish_route_entry(entry, status, reason, null, emit_legacy_failure)
+	return true
+
+
+func _get_scope_cancel_reason(scope: GFAsyncScope) -> StringName:
+	if scope == null:
+		return &"scope_cancelled"
+	var reason: StringName = scope.get_cancel_reason()
+	return reason if reason != &"" else &"scope_cancelled"
+
+
+func _cancel_pending_route_if_lifecycle_expired(pending_key: String, request_id: int) -> bool:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return false
+	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	if entry.is_empty() or GFVariantData.get_option_bool(entry, "panel_submitted"):
+		return false
+	var expired_reason: StringName = _get_route_lifecycle_expired_reason(entry)
+	if expired_reason == &"":
+		return false
+	return _finish_pending_route_before_submit(
+		pending_key,
+		request_id,
+		GFUIRouteResult.STATUS_CANCELLED,
+		expired_reason,
+		false
+	)
+
+
+func _pending_route_has_request_id(pending_key: String, request_id: int) -> bool:
+	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	return GFVariantData.get_option_int(entry, "request_id") == request_id
+
+
+func _start_pending_route_preload(pending_key: String, request_id: int) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	if _cancel_pending_route_if_lifecycle_expired(pending_key, request_id):
+		return
+	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	if entry.is_empty() or GFVariantData.get_option_bool(entry, "preload_started"):
+		return
+	entry["preload_started"] = true
+	_pending_async_routes[pending_key] = entry
+	var route_id: StringName = GFVariantData.get_option_string_name(entry, "route_id", &"")
+	var operation_handle: GFUIRouteOperation = _get_route_operation_value(entry.get("operation_handle"))
+	if operation_handle == null or operation_handle.get_request_id() != request_id:
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_PRELOAD_PLAN_FAILED,
 			&"missing_route_operation",
 			null,
@@ -849,8 +1172,14 @@ func _start_pending_route_preload(pending_key: String) -> void:
 	plan_metadata["_gf_route_request_id"] = operation_handle.get_request_id()
 	plan_metadata["_gf_route_id"] = route_id
 	plan_options["metadata"] = plan_metadata
+	_pending_async_routes[pending_key] = entry
 
 	var raw_plan_report: Dictionary = build_preload_plan(route_id, plan_options)
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	if _cancel_pending_route_if_lifecycle_expired(pending_key, request_id):
+		return
+	entry = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 	var asset_plan: GFAssetPreloadPlan = _get_asset_preload_plan_value(raw_plan_report.get("asset_plan"))
 	entry["preload_plan_report"] = _make_json_safe_preload_plan_report(raw_plan_report, asset_plan)
 	_pending_async_routes[pending_key] = entry
@@ -871,6 +1200,7 @@ func _start_pending_route_preload(pending_key: String) -> void:
 			plan_reason = &"preload_plan_empty"
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_PRELOAD_PLAN_FAILED,
 			plan_reason,
 			null,
@@ -878,25 +1208,38 @@ func _start_pending_route_preload(pending_key: String) -> void:
 		)
 		return
 	if not plan_usable:
-		_set_pending_preload_degradation(pending_key, &"preload_plan_failed_continued")
-		_submit_pending_panel_open(pending_key)
+		_set_pending_preload_degradation(
+			pending_key,
+			request_id,
+			&"preload_plan_failed_continued"
+		)
+		_submit_pending_panel_open(pending_key, request_id)
 		return
 	if not plan_healthy:
-		_set_pending_preload_degradation(pending_key, &"preload_plan_degraded_continued")
+		_set_pending_preload_degradation(
+			pending_key,
+			request_id,
+			&"preload_plan_degraded_continued"
+		)
 
 	var asset_utility: GFAssetUtility = _get_asset_utility()
 	if asset_utility == null:
 		if preload_policy == PRELOAD_REQUIRED:
 			_complete_pending_route(
 				pending_key,
+				request_id,
 				GFUIRouteResult.STATUS_MISSING_ASSET_UTILITY,
 				&"missing_asset_utility",
 				null,
 				true
 			)
 		else:
-			_set_pending_preload_degradation(pending_key, &"missing_asset_utility_continued")
-			_submit_pending_panel_open(pending_key)
+			_set_pending_preload_degradation(
+				pending_key,
+				request_id,
+				&"missing_asset_utility_continued"
+			)
+			_submit_pending_panel_open(pending_key, request_id)
 		return
 
 	var session_metadata: Dictionary = GFVariantData.get_option_dictionary(entry, "metadata")
@@ -909,7 +1252,29 @@ func _start_pending_route_preload(pending_key: String) -> void:
 			"metadata": session_metadata,
 		}
 	)
-	var _attached: bool = operation_handle.attach_preload_session_for_framework(session)
+	if not _pending_route_has_request_id(pending_key, request_id):
+		if session != null and not session.is_completed():
+			var _orphaned_session_rolled_back: bool = session.rollback(&"route_request_gone")
+		return
+	if _cancel_pending_route_if_lifecycle_expired(pending_key, request_id):
+		if session != null and not session.is_completed():
+			var _expired_session_rolled_back: bool = session.rollback(&"route_lifecycle_expired")
+		return
+	var attached: bool = operation_handle.attach_preload_session_for_framework(session)
+	if not attached:
+		if session != null and not session.is_completed():
+			var _unattached_session_rolled_back: bool = session.rollback(
+				&"preload_session_attach_failed"
+			)
+		_complete_pending_route(
+			pending_key,
+			request_id,
+			GFUIRouteResult.STATUS_PRELOAD_FAILED,
+			&"preload_session_attach_failed",
+			null,
+			true
+		)
+		return
 	entry = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 	if entry.is_empty():
 		if session != null and not session.is_completed():
@@ -919,12 +1284,15 @@ func _start_pending_route_preload(pending_key: String) -> void:
 	entry["preload_attempted"] = true
 	_pending_async_routes[pending_key] = entry
 	if session == null:
-		_on_pending_route_preload_completed(null, pending_key)
+		_on_pending_route_preload_completed(null, pending_key, request_id)
 		return
 	if session.is_completed():
-		_on_pending_route_preload_completed(session.get_result(), pending_key)
+		_on_pending_route_preload_completed(session.get_result(), pending_key, request_id)
 		return
-	var preload_callback: Callable = _on_pending_route_preload_completed.bind(pending_key)
+	var preload_callback: Callable = _on_pending_route_preload_completed.bind(
+		pending_key,
+		request_id
+	)
 	var connect_error: Error = session.completed.connect(
 		preload_callback,
 		CONNECT_ONE_SHOT as Object.ConnectFlags
@@ -934,25 +1302,36 @@ func _start_pending_route_preload(pending_key: String) -> void:
 		if preload_policy == PRELOAD_REQUIRED:
 			_complete_pending_route(
 				pending_key,
+				request_id,
 				GFUIRouteResult.STATUS_PRELOAD_FAILED,
 				&"preload_completion_signal_failed",
 				null,
 				true
 			)
 		else:
-			_set_pending_preload_degradation(pending_key, &"preload_completion_signal_failed_continued")
-			_submit_pending_panel_open(pending_key)
+			_set_pending_preload_degradation(
+				pending_key,
+				request_id,
+				&"preload_completion_signal_failed_continued"
+			)
+			_submit_pending_panel_open(pending_key, request_id)
 		return
 	entry = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
-	if not entry.is_empty():
+	if _pending_route_has_request_id(pending_key, request_id):
+		entry = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 		entry["preload_callback"] = preload_callback
 		_pending_async_routes[pending_key] = entry
 
 
 func _on_pending_route_preload_completed(
 	preload_result: GFAssetLoadSessionResult,
-	pending_key: String
+	pending_key: String,
+	request_id: int
 ) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	if _cancel_pending_route_if_lifecycle_expired(pending_key, request_id):
+		return
 	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 	if entry.is_empty():
 		return
@@ -961,7 +1340,7 @@ func _on_pending_route_preload_completed(
 	entry["preload_successful"] = preload_result != null and preload_result.is_successful()
 	_pending_async_routes[pending_key] = entry
 	if preload_result != null and preload_result.is_successful():
-		_submit_pending_panel_open(pending_key)
+		_submit_pending_panel_open(pending_key, request_id)
 		return
 	var preload_policy: StringName = GFVariantData.get_option_string_name(
 		entry,
@@ -971,17 +1350,28 @@ func _on_pending_route_preload_completed(
 	if preload_policy == PRELOAD_REQUIRED:
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_PRELOAD_FAILED,
 			&"preload_failed",
 			null,
 			true
 		)
 		return
-	_set_pending_preload_degradation(pending_key, &"preload_failed_continued")
-	_submit_pending_panel_open(pending_key)
+	_set_pending_preload_degradation(
+		pending_key,
+		request_id,
+		&"preload_failed_continued"
+	)
+	_submit_pending_panel_open(pending_key, request_id)
 
 
-func _set_pending_preload_degradation(pending_key: String, reason: StringName) -> void:
+func _set_pending_preload_degradation(
+	pending_key: String,
+	request_id: int,
+	reason: StringName
+) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
 	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 	if entry.is_empty():
 		return
@@ -989,13 +1379,18 @@ func _set_pending_preload_degradation(pending_key: String, reason: StringName) -
 	_pending_async_routes[pending_key] = entry
 
 
-func _submit_pending_panel_open(pending_key: String) -> void:
+func _submit_pending_panel_open(pending_key: String, request_id: int) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	if _cancel_pending_route_if_lifecycle_expired(pending_key, request_id):
+		return
 	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
-	if entry.is_empty():
+	if entry.is_empty() or GFVariantData.get_option_bool(entry, "panel_submitted"):
 		return
 	if _disposed:
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_DISPOSED,
 			&"router_disposed_before_panel_submit",
 			null,
@@ -1006,6 +1401,7 @@ func _submit_pending_panel_open(pending_key: String) -> void:
 	if route == null:
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_INVALID_ROUTE,
 			&"route_unavailable_before_panel_submit",
 			null,
@@ -1016,6 +1412,7 @@ func _submit_pending_panel_open(pending_key: String) -> void:
 	if ui_utility == null:
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_MISSING_UI_UTILITY,
 			&"missing_ui_utility",
 			null,
@@ -1026,6 +1423,7 @@ func _submit_pending_panel_open(pending_key: String) -> void:
 	if not ui_utility.has_layer(route_layer):
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_MISSING_UI_LAYER,
 			&"missing_ui_layer",
 			null,
@@ -1036,6 +1434,7 @@ func _submit_pending_panel_open(pending_key: String) -> void:
 	if _ui_has_matching_pending_request(ui_utility, route.scene_path, route_layer, operation):
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_ASYNC_CONFLICT,
 			&"ui_async_request_conflict",
 			null,
@@ -1051,23 +1450,79 @@ func _submit_pending_panel_open(pending_key: String) -> void:
 		params,
 		config_callback
 	)
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	if _cancel_pending_route_if_lifecycle_expired(pending_key, request_id):
+		return
+	entry = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	if entry.is_empty():
+		return
 	entry["panel_submitted"] = true
 	_pending_async_routes[pending_key] = entry
-	_ensure_ui_async_signal_connected(ui_utility)
+	_disconnect_entry_lifecycle(entry)
+	_pending_async_routes[pending_key] = entry
+	var completion_invocation: GFWeakMethodInvocation = GFWeakMethodInvocation.new(
+		self,
+		&"_on_ui_panel_async_operation_completed"
+	)
+	var completion_callback: Callable = func(
+		completed_ui_operation: GFUIPanelAsyncOperation
+	) -> void:
+		var _invocation_result: Dictionary = completion_invocation.invoke([
+			completed_ui_operation,
+			pending_key,
+			request_id,
+		])
+	var ui_operation: GFUIPanelAsyncOperation = null
 	if operation == Operation.REPLACE:
-		ui_utility.replace_layer_async_with_options(
+		ui_operation = ui_utility.replace_layer_async_with_options(
 			route.scene_path,
 			route_layer,
 			options,
-			wrapped_callback
+			wrapped_callback,
+			completion_callback
 		)
 	else:
-		ui_utility.push_panel_async_with_options(
+		ui_operation = ui_utility.push_panel_async_with_options(
 			route.scene_path,
 			route_layer,
 			options,
-			wrapped_callback
+			wrapped_callback,
+			completion_callback
 		)
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	if ui_operation == null:
+		_complete_pending_route(
+			pending_key,
+			request_id,
+			GFUIRouteResult.STATUS_PANEL_FAILED,
+			&"panel_async_request_rejected",
+			null,
+			true
+		)
+		return
+	entry = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
+	if entry.is_empty():
+		return
+	var latched_ui_operation: GFUIPanelAsyncOperation = _get_ui_panel_async_operation_value(
+		entry.get("ui_operation")
+	)
+	if latched_ui_operation != null and latched_ui_operation != ui_operation:
+		_complete_pending_route(
+			pending_key,
+			request_id,
+			GFUIRouteResult.STATUS_PANEL_FAILED,
+			&"panel_async_identity_mismatch",
+			null,
+			true
+		)
+		return
+	entry["ui_operation"] = ui_operation
+	entry["ui_completion_callback"] = completion_callback
+	_pending_async_routes[pending_key] = entry
+	if ui_operation.is_completed():
+		_on_ui_panel_async_operation_completed(ui_operation, pending_key, request_id)
 
 
 func _ui_has_matching_pending_request(
@@ -1088,16 +1543,52 @@ func _ui_has_matching_pending_request(
 
 func _complete_pending_route(
 	pending_key: String,
+	request_id: int,
 	status: StringName,
 	reason: StringName,
 	panel: Node,
 	emit_legacy_failure: bool
 ) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
 	var entry: Dictionary = GFVariantData.get_option_dictionary(_pending_async_routes, pending_key)
 	if entry.is_empty():
 		return
 	var _erased: bool = _pending_async_routes.erase(pending_key)
 	_finish_route_entry(entry, status, reason, panel, emit_legacy_failure)
+
+
+func _complete_pending_route_opened(
+	pending_key: String,
+	request_id: int,
+	route: GFUIRoute,
+	route_operation: Operation,
+	panel: Node
+) -> void:
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
+	var entry: Dictionary = GFVariantData.get_option_dictionary(
+		_pending_async_routes,
+		pending_key
+	)
+	if entry.is_empty():
+		return
+	var _erased: bool = _pending_async_routes.erase(pending_key)
+	if route_operation == Operation.REPLACE:
+		_remove_history_for_layer(route.layer)
+	_record_route_open(
+		route,
+		panel,
+		GFVariantData.get_option_dictionary(entry, "params"),
+		route_operation
+	)
+	_finish_route_entry(
+		entry,
+		GFUIRouteResult.STATUS_OPENED,
+		&"",
+		panel,
+		false
+	)
 
 
 func _finish_route_entry(
@@ -1107,6 +1598,8 @@ func _finish_route_entry(
 	panel: Node,
 	emit_legacy_failure: bool
 ) -> void:
+	_disconnect_entry_lifecycle(entry)
+	_disconnect_entry_ui_completion_callback(entry)
 	var operation_handle: GFUIRouteOperation = _get_route_operation_value(entry.get("operation_handle"))
 	if operation_handle == null or operation_handle.is_completed():
 		return
@@ -1163,6 +1656,7 @@ func _finish_pending_routes_for_dispose() -> void:
 			pending_entries.append(entry)
 	_pending_async_routes.clear()
 	for entry: Dictionary in pending_entries:
+		_disconnect_entry_lifecycle(entry)
 		_disconnect_entry_preload_callback(entry)
 		var panel_submitted: bool = GFVariantData.get_option_bool(entry, "panel_submitted")
 		var session: GFAssetLoadSession = _get_asset_load_session_value(entry.get("preload_session"))
@@ -1182,6 +1676,38 @@ func _disconnect_entry_preload_callback(entry: Dictionary) -> void:
 	var callback: Callable = _get_callable_value(entry.get("preload_callback"))
 	if session != null and callback.is_valid() and session.completed.is_connected(callback):
 		session.completed.disconnect(callback)
+
+
+func _disconnect_entry_lifecycle(entry: Dictionary) -> void:
+	var owner_lifetime: GFLifetimeSubscription = _get_lifetime_subscription_value(
+		entry.get("owner_lifetime")
+	)
+	if owner_lifetime != null and owner_lifetime.is_active():
+		var _cancelled_subscription: bool = owner_lifetime.cancel()
+	var scope: GFAsyncScope = _get_async_scope_value(entry.get("scope"))
+	var scope_callback: Callable = _get_callable_value(entry.get("scope_callback"))
+	if scope != null and scope_callback.is_valid() and scope.cancel_requested.is_connected(scope_callback):
+		scope.cancel_requested.disconnect(scope_callback)
+	entry["owner_lifetime"] = null
+	entry["scope"] = null
+	entry["scope_callback"] = Callable()
+
+
+func _disconnect_entry_ui_completion_callback(entry: Dictionary) -> void:
+	var ui_operation: GFUIPanelAsyncOperation = _get_ui_panel_async_operation_value(
+		entry.get("ui_operation")
+	)
+	var completion_callback: Callable = _get_callable_value(
+		entry.get("ui_completion_callback")
+	)
+	if (
+		ui_operation != null
+		and completion_callback.is_valid()
+		and ui_operation.completed.is_connected(completion_callback)
+	):
+		ui_operation.completed.disconnect(completion_callback)
+	entry["ui_operation"] = null
+	entry["ui_completion_callback"] = Callable()
 
 
 func _release_owned_preload_group(
@@ -1230,36 +1756,17 @@ func _get_pending_route_snapshots() -> Array[Dictionary]:
 		if operation_handle != null:
 			var snapshot: Dictionary = operation_handle.get_debug_snapshot()
 			snapshot["panel_submitted"] = GFVariantData.get_option_bool(entry, "panel_submitted")
+			snapshot["has_owner"] = GFVariantData.get_option_int(entry, "owner_id") != 0
+			snapshot["has_scope"] = GFVariantData.get_option_int(entry, "scope_id") != 0
+			snapshot["lifecycle_cancellation_open"] = not GFVariantData.get_option_bool(
+				entry,
+				"panel_submitted"
+			)
 			snapshots.append(snapshot)
 	snapshots.sort_custom(func(left: Dictionary, right: Dictionary) -> bool:
 		return GFVariantData.get_option_int(left, "request_id") < GFVariantData.get_option_int(right, "request_id")
 	)
 	return snapshots
-
-
-func _ensure_ui_async_signal_connected(ui_utility: GFUIUtility) -> void:
-	if ui_utility == null:
-		return
-	var connected_ui_utility: GFUIUtility = _get_connected_ui_utility()
-	if connected_ui_utility == ui_utility:
-		return
-	_disconnect_connected_ui_utility()
-	if not ui_utility.panel_async_load_finished.is_connected(_on_ui_panel_async_load_finished):
-		var _connect_error: Error = ui_utility.panel_async_load_finished.connect(_on_ui_panel_async_load_finished) as Error
-	_connected_ui_utility_ref = weakref(ui_utility)
-
-
-func _disconnect_connected_ui_utility() -> void:
-	var ui_utility: GFUIUtility = _get_connected_ui_utility()
-	if ui_utility != null and ui_utility.panel_async_load_finished.is_connected(_on_ui_panel_async_load_finished):
-		ui_utility.panel_async_load_finished.disconnect(_on_ui_panel_async_load_finished)
-	_connected_ui_utility_ref = null
-
-
-func _get_connected_ui_utility() -> GFUIUtility:
-	if _connected_ui_utility_ref == null:
-		return null
-	return _get_ui_utility_value(_connected_ui_utility_ref.get_ref())
 
 
 func _make_pending_async_route_key(path: String, layer: int, operation: Operation) -> String:
@@ -1269,12 +1776,6 @@ func _make_pending_async_route_key(path: String, layer: int, operation: Operatio
 func _find_pending_async_route(path: String, layer: int, operation: Operation) -> Dictionary:
 	var key: String = _make_pending_async_route_key(path, layer, operation)
 	return GFVariantData.get_option_dictionary(_pending_async_routes, key)
-
-
-func _operation_name_to_operation(operation: StringName) -> Operation:
-	if operation == &"replace":
-		return Operation.REPLACE
-	return Operation.PUSH
 
 
 func _operation_to_name(operation: Operation) -> StringName:
@@ -1435,6 +1936,13 @@ func _get_route_operation_value(value: Variant) -> GFUIRouteOperation:
 	return null
 
 
+func _get_ui_panel_async_operation_value(value: Variant) -> GFUIPanelAsyncOperation:
+	if value is GFUIPanelAsyncOperation:
+		var operation_handle: GFUIPanelAsyncOperation = value
+		return operation_handle
+	return null
+
+
 func _get_asset_preload_plan_value(value: Variant) -> GFAssetPreloadPlan:
 	if value is GFAssetPreloadPlan:
 		var asset_plan: GFAssetPreloadPlan = value
@@ -1463,6 +1971,34 @@ func _get_callable_value(value: Variant) -> Callable:
 	return Callable()
 
 
+func _get_object_value(value: Variant) -> Object:
+	if value is Object:
+		var object_value: Object = value
+		if is_instance_valid(object_value):
+			return object_value
+	return null
+
+
+func _get_live_object_from_ref(object_ref: WeakRef) -> Object:
+	if object_ref == null:
+		return null
+	return _get_object_value(object_ref.get_ref())
+
+
+func _get_async_scope_value(value: Variant) -> GFAsyncScope:
+	if value is GFAsyncScope:
+		var scope: GFAsyncScope = value
+		return scope
+	return null
+
+
+func _get_lifetime_subscription_value(value: Variant) -> GFLifetimeSubscription:
+	if value is GFLifetimeSubscription:
+		var subscription: GFLifetimeSubscription = value
+		return subscription
+	return null
+
+
 func _get_weak_ref_value(value: Variant) -> WeakRef:
 	if value is WeakRef:
 		var object_ref: WeakRef = value
@@ -1477,43 +2013,61 @@ func _get_ui_layer(value: Variant, fallback: int = GFUIUtility.DEFAULT_LAYER_ID)
 
 # --- 信号处理函数 ---
 
-func _on_ui_panel_async_load_finished(
-	path: String,
-	layer: int,
-	operation: StringName,
-	status: int,
-	panel: Node
+func _on_ui_panel_async_operation_completed(
+	ui_operation: GFUIPanelAsyncOperation,
+	pending_key: String,
+	request_id: int
 ) -> void:
-	var route_operation: Operation = _operation_name_to_operation(operation)
-	var pending_key: String = _make_pending_async_route_key(path, layer, route_operation)
+	if ui_operation == null or not ui_operation.is_completed():
+		return
+	if not _pending_route_has_request_id(pending_key, request_id):
+		return
 	var route_entry: Dictionary = GFVariantData.get_option_dictionary(
 		_pending_async_routes,
 		pending_key
 	)
 	if route_entry.is_empty() or not GFVariantData.get_option_bool(route_entry, "panel_submitted"):
 		return
-	if status == GFUIUtility.AsyncPanelLoadStatus.OPENED and is_instance_valid(panel):
-		var route: GFUIRoute = _get_route_value(route_entry.get("route"))
-		if route != null:
-			if route_operation == Operation.REPLACE:
-				_remove_history_for_layer(route.layer)
-			_record_route_open(
-				route,
-				panel,
-				GFVariantData.get_option_dictionary(route_entry, "params"),
-				route_operation
-			)
+	var latched_ui_operation: GFUIPanelAsyncOperation = _get_ui_panel_async_operation_value(
+		route_entry.get("ui_operation")
+	)
+	if latched_ui_operation != null and latched_ui_operation != ui_operation:
+		return
+	var route: GFUIRoute = _get_route_value(route_entry.get("route"))
+	var route_operation: Operation = _get_route_operation(route_entry)
+	if (
+		route == null
+		or ui_operation.get_path() != route.scene_path
+		or ui_operation.get_layer() != _get_ui_layer(route.layer)
+		or ui_operation.get_operation() != _operation_to_name(route_operation)
+	):
 		_complete_pending_route(
 			pending_key,
-			GFUIRouteResult.STATUS_OPENED,
-			&"",
-			panel,
-			false
+			request_id,
+			GFUIRouteResult.STATUS_PANEL_FAILED,
+			&"panel_async_identity_mismatch",
+			null,
+			true
+		)
+		return
+	if latched_ui_operation == null:
+		route_entry["ui_operation"] = ui_operation
+		_pending_async_routes[pending_key] = route_entry
+	var status: int = ui_operation.get_status()
+	var panel: Node = ui_operation.get_panel()
+	if status == GFUIUtility.AsyncPanelLoadStatus.OPENED and is_instance_valid(panel):
+		_complete_pending_route_opened(
+			pending_key,
+			request_id,
+			route,
+			route_operation,
+			panel
 		)
 		return
 	if status == GFUIUtility.AsyncPanelLoadStatus.CANCELLED:
 		_complete_pending_route(
 			pending_key,
+			request_id,
 			GFUIRouteResult.STATUS_CANCELLED,
 			&"panel_async_cancelled",
 			null,
@@ -1522,6 +2076,7 @@ func _on_ui_panel_async_load_finished(
 		return
 	_complete_pending_route(
 		pending_key,
+		request_id,
 		GFUIRouteResult.STATUS_PANEL_FAILED,
 		&"panel_async_failed",
 		null,

--- a/addons/gf/standard/utilities/ui/gf_ui_utility.gd
+++ b/addons/gf/standard/utilities/ui/gf_ui_utility.gd
@@ -1302,6 +1302,16 @@ func _finish_async_panel_request(request_key: String, status: int, panel: Node) 
 		return
 
 	var request: Dictionary = _get_pending_async_panel_request(request_key)
+	var terminal_status: int = status
+	var terminal_panel: Node = panel
+	if terminal_status == AsyncPanelLoadStatus.OPENED:
+		var panel_is_open: bool = _get_valid_panel_from_variant(terminal_panel) != null
+		if panel_is_open:
+			var request_layer: int = GFVariantData.get_option_int(request, "layer", -1)
+			panel_is_open = _get_layer_stack(request_layer).has(terminal_panel)
+		if not panel_is_open:
+			terminal_status = AsyncPanelLoadStatus.FAILED
+			terminal_panel = null
 	var operation_handle: GFUIPanelAsyncOperation = _get_ui_panel_async_operation_value(
 		request.get("operation_handle")
 	)
@@ -1317,15 +1327,18 @@ func _finish_async_panel_request(request_key: String, status: int, panel: Node) 
 			GFVariantData.get_option_int(request, "serial", -1)
 		)
 	var _erased: bool = _pending_async_panel_requests.erase(request_key)
-	if operation_handle == null or not operation_handle.complete_for_framework(status, panel):
+	if (
+		operation_handle == null
+		or not operation_handle.complete_for_framework(terminal_status, terminal_panel)
+	):
 		push_error("[GFUIUtility] 异步面板请求句柄无法进入终态。")
 		return
 	panel_async_load_finished.emit(
 		GFVariantData.get_option_string(request, "path", ""),
 		GFVariantData.get_option_int(request, "layer", -1),
 		GFVariantData.get_option_string_name(request, "operation", &""),
-		status,
-		panel
+		terminal_status,
+		terminal_panel
 	)
 
 
@@ -1464,8 +1477,10 @@ func _add_panel_instance(
 	_apply_open_focus_policy(panel, normalized_options)
 	_sync_layer_visibility(layer)
 	panel_opened.emit(panel, layer)
+	if not _get_layer_stack(layer).has(panel):
+		return false
 	_emit_navigation_changed(layer)
-	return true
+	return _get_valid_panel_from_variant(panel) != null and _get_layer_stack(layer).has(panel)
 
 
 func _prune_all_layer_stacks() -> void:
@@ -1485,11 +1500,20 @@ func _get_valid_panel_from_variant(value: Variant) -> Node:
 func _prune_layer_stack(layer: int) -> void:
 	var stack: Array = _get_layer_stack(layer)
 	var removed_any: bool = false
+	var queued_panels: Array[Node] = []
 	for index: int in range(stack.size() - 1, -1, -1):
-		var panel: Node = _get_valid_panel_from_variant(stack[index])
+		var panel: Node = _get_live_node(stack[index])
 		if panel == null:
 			removed_any = true
 			stack.remove_at(index)
+			continue
+		if panel.is_queued_for_deletion():
+			removed_any = true
+			stack.remove_at(index)
+			queued_panels.append(panel)
+	for panel: Node in queued_panels:
+		_handle_panel_closed(panel)
+		panel_closed.emit(panel, layer)
 	if removed_any:
 		_sync_layer_visibility(layer)
 

--- a/addons/gf/standard/utilities/ui/gf_ui_utility.gd
+++ b/addons/gf/standard/utilities/ui/gf_ui_utility.gd
@@ -161,6 +161,9 @@ var _previous_focus_by_panel_id: Dictionary = {}
 # 每个层级的结构性变更序号，用于阻止迟到异步回调污染新状态。
 var _layer_request_serials: Dictionary = {}
 
+# 跨 init/dispose 单调递增的异步请求序号，避免旧资源回调与新请求身份碰撞。
+var _next_async_panel_request_serial: int = 1
+
 # 同一层级、同一路径的异步 push 请求序号，避免连点造成重复面板实例。
 var _pending_async_push_serials: Dictionary = {}
 
@@ -201,7 +204,6 @@ func dispose() -> void:
 		stack.clear()
 	_panel_options.clear()
 	_previous_focus_by_panel_id.clear()
-	_layer_request_serials.clear()
 	_pending_async_push_serials.clear()
 	_pending_async_panel_requests.clear()
 
@@ -334,8 +336,23 @@ func set_layer_auto_hide_under(layer: int, auto_hide_under: bool) -> bool:
 ## @param layer: 目标层级。
 ## [br]
 ## @param config_callback: 实例化后、入栈前的可选配置回调。
-func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void:
-	push_panel_async_with_options(path, layer, {}, config_callback)
+## [br]
+## @param completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。
+## [br]
+## @return: 已接受请求的类型化句柄；路径无效时返回 null。
+func push_panel_async(
+	path: String,
+	layer: int = Layer.POPUP,
+	config_callback: Callable = Callable(),
+	completion_callback: Callable = Callable()
+) -> GFUIPanelAsyncOperation:
+	return push_panel_async_with_options(
+		path,
+		layer,
+		{},
+		config_callback,
+		completion_callback
+	)
 
 
 ## 异步压入一个带策略选项的面板场景。
@@ -352,26 +369,80 @@ func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: C
 ## [br]
 ## @param config_callback: 实例化后、入栈前的可选配置回调。
 ## [br]
+## @param completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。
+## [br]
+## @return: 已接受请求的类型化句柄；同步回退可能返回已完成句柄，路径无效时返回 null。
+## [br]
 ## @schema options: Dictionary，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close 和 metadata。
 func push_panel_async_with_options(
 	path: String,
 	layer: int = Layer.POPUP,
 	options: Dictionary = {},
-	config_callback: Callable = Callable()
-) -> void:
+	config_callback: Callable = Callable(),
+	completion_callback: Callable = Callable()
+) -> GFUIPanelAsyncOperation:
+	if not _is_active:
+		push_error("[GFUIUtility] UI 管理器尚未初始化或已释放。")
+		return null
 	if path.is_empty():
 		push_error("[GFUIUtility] 面板场景路径不能为空。")
-		return
+		return null
 
 	var request_key: String = _make_async_push_key(path, layer)
 	if _pending_async_push_serials.has(request_key):
-		return
+		var pending_serial: int = GFVariantData.get_option_int(
+			_pending_async_push_serials,
+			request_key,
+			-1
+		)
+		var pending_request_key: String = _make_async_panel_request_key(
+			GFUIPanelAsyncOperation.OPERATION_PUSH,
+			path,
+			layer,
+			pending_serial
+		)
+		var pending_operation: GFUIPanelAsyncOperation = (
+			_get_async_panel_operation_from_request(pending_request_key)
+		)
+		if pending_operation != null:
+			if not _connect_async_panel_completion_callback(
+				pending_operation,
+				completion_callback
+			):
+				push_error("[GFUIUtility] 无法连接异步面板请求终态回调。")
+			return pending_operation
+		var _stale_push_erased: bool = _pending_async_push_serials.erase(request_key)
 
+	var previous_layer_serial: int = _get_layer_request_serial(layer)
 	var request_serial: int = _reserve_layer_request_serial(layer)
-	_cancel_pending_async_replace_requests_for_layer(layer)
 	_pending_async_push_serials[request_key] = request_serial
-	var async_request_key: String = _make_async_panel_request_key(&"push", path, layer, request_serial)
-	_track_async_panel_request(async_request_key, path, layer, &"push", request_serial)
+	var async_request_key: String = _make_async_panel_request_key(
+		GFUIPanelAsyncOperation.OPERATION_PUSH,
+		path,
+		layer,
+		request_serial
+	)
+	var operation_handle: GFUIPanelAsyncOperation = _track_async_panel_request(
+		async_request_key,
+		path,
+		layer,
+		GFUIPanelAsyncOperation.OPERATION_PUSH,
+		request_serial,
+		completion_callback
+	)
+	if operation_handle == null:
+		_clear_pending_async_push(request_key, request_serial)
+		_restore_layer_request_serial_after_rejection(
+			layer,
+			request_serial,
+			previous_layer_serial
+		)
+		return null
+	if not operation_handle.is_pending():
+		return operation_handle
+	_cancel_pending_async_replace_requests_for_layer(layer)
+	if not operation_handle.is_pending():
+		return operation_handle
 
 	var asset_util: GFAssetUtility = _get_asset_util()
 	if asset_util == null:
@@ -383,7 +454,7 @@ func push_panel_async_with_options(
 			AsyncPanelLoadStatus.OPENED if fallback_panel != null else AsyncPanelLoadStatus.FAILED,
 			fallback_panel
 		)
-		return
+		return operation_handle
 
 	var on_loaded: Callable = func(res: Resource) -> void:
 		_clear_pending_async_push(request_key, request_serial)
@@ -405,6 +476,7 @@ func push_panel_async_with_options(
 				panel_instance.queue_free()
 
 	asset_util.load_async(path, on_loaded, "PackedScene")
+	return operation_handle
 
 
 ## 同步压入一个面板场景。
@@ -515,8 +587,23 @@ func replace_layer_with_options(
 ## @param layer: 目标层级。
 ## [br]
 ## @param config_callback: 实例化后、入栈前的可选配置回调。
-func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void:
-	replace_layer_async_with_options(path, layer, {}, config_callback)
+## [br]
+## @param completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。
+## [br]
+## @return: 已接受请求的类型化句柄；路径无效时返回 null。
+func replace_layer_async(
+	path: String,
+	layer: int = Layer.POPUP,
+	config_callback: Callable = Callable(),
+	completion_callback: Callable = Callable()
+) -> GFUIPanelAsyncOperation:
+	return replace_layer_async_with_options(
+		path,
+		layer,
+		{},
+		config_callback,
+		completion_callback
+	)
 
 
 ## 异步替换指定层级为带策略选项的面板。
@@ -533,20 +620,60 @@ func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback
 ## [br]
 ## @param config_callback: 实例化后、入栈前的可选配置回调。
 ## [br]
+## @param completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。
+## [br]
+## @return: 已接受请求的类型化句柄；同步回退可能返回已完成句柄，路径无效时返回 null。
+## [br]
 ## @schema options: Dictionary，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close 和 metadata。
 func replace_layer_async_with_options(
 	path: String,
 	layer: int = Layer.POPUP,
 	options: Dictionary = {},
-	config_callback: Callable = Callable()
-) -> void:
+	config_callback: Callable = Callable(),
+	completion_callback: Callable = Callable()
+) -> GFUIPanelAsyncOperation:
+	if not _is_active:
+		push_error("[GFUIUtility] UI 管理器尚未初始化或已释放。")
+		return null
 	if path.is_empty():
 		push_error("[GFUIUtility] 面板场景路径不能为空。")
-		return
+		return null
 
-	var request_serial: int = _next_layer_request_serial(layer)
-	var async_request_key: String = _make_async_panel_request_key(&"replace", path, layer, request_serial)
-	_track_async_panel_request(async_request_key, path, layer, &"replace", request_serial)
+	var previous_layer_serial: int = _get_layer_request_serial(layer)
+	var request_serial: int = _reserve_layer_request_serial(layer)
+	var async_request_key: String = _make_async_panel_request_key(
+		GFUIPanelAsyncOperation.OPERATION_REPLACE,
+		path,
+		layer,
+		request_serial
+	)
+	var operation_handle: GFUIPanelAsyncOperation = _track_async_panel_request(
+		async_request_key,
+		path,
+		layer,
+		GFUIPanelAsyncOperation.OPERATION_REPLACE,
+		request_serial,
+		completion_callback
+	)
+	if operation_handle == null:
+		_restore_layer_request_serial_after_rejection(
+			layer,
+			request_serial,
+			previous_layer_serial
+		)
+		return null
+	if not operation_handle.is_pending():
+		return operation_handle
+	_cancel_pending_async_panel_requests_for_layer(layer, async_request_key)
+	if not operation_handle.is_pending():
+		return operation_handle
+	if not _is_layer_request_serial_current(layer, request_serial):
+		_finish_async_panel_request(
+			async_request_key,
+			AsyncPanelLoadStatus.CANCELLED,
+			null
+		)
+		return operation_handle
 	var asset_util: GFAssetUtility = _get_asset_util()
 	if asset_util == null:
 		push_warning("[GFUIUtility] GFAssetUtility 未注册，回退为同步加载。")
@@ -562,7 +689,7 @@ func replace_layer_async_with_options(
 			AsyncPanelLoadStatus.OPENED if fallback_panel != null else AsyncPanelLoadStatus.FAILED,
 			fallback_panel
 		)
-		return
+		return operation_handle
 
 	var on_loaded: Callable = func(res: Resource) -> void:
 		if not _is_active or not _is_layer_request_serial_current(layer, request_serial):
@@ -584,6 +711,7 @@ func replace_layer_async_with_options(
 				panel_instance.queue_free()
 
 	asset_util.load_async(path, on_loaded, "PackedScene")
+	return operation_handle
 
 
 ## 压入一个已实例化的面板节点。
@@ -965,11 +1093,13 @@ func has_pending_async_panel(layer: int = -1, path: String = "") -> bool:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.15.0
+## [br]
 ## @param layer: 指定层级；小于 0 时返回所有层级。
 ## [br]
-## @return 请求快照数组，每项包含 path、layer、operation 和 serial。
+## @return: 请求快照数组，每项包含 path、layer、operation、serial 和 operation_handle。
 ## [br]
-## @schema return: Array，元素为 Dictionary，包含 path、layer、operation 和 serial。
+## @schema return: Array，元素为 Dictionary，包含 path、layer、operation、serial 和 GFUIPanelAsyncOperation operation_handle。
 func get_pending_async_panel_requests(layer: int = -1) -> Array[Dictionary]:
 	var result: Array[Dictionary] = []
 	for request: Dictionary in _pending_async_panel_requests.values():
@@ -1087,14 +1217,27 @@ func _detach_node_from_tree(node: Node) -> void:
 func _next_layer_request_serial(layer: int) -> int:
 	var next_serial: int = _reserve_layer_request_serial(layer)
 	_cancel_pending_async_panel_requests_for_layer(layer)
-	_clear_pending_async_pushes_for_layer(layer)
 	return next_serial
 
 
 func _reserve_layer_request_serial(layer: int) -> int:
-	var next_serial: int = _get_layer_request_serial(layer) + 1
+	var next_serial: int = _next_async_panel_request_serial
+	_next_async_panel_request_serial += 1
 	_layer_request_serials[layer] = next_serial
 	return next_serial
+
+
+func _restore_layer_request_serial_after_rejection(
+	layer: int,
+	rejected_serial: int,
+	previous_serial: int
+) -> void:
+	if not _is_layer_request_serial_current(layer, rejected_serial):
+		return
+	if previous_serial > 0:
+		_layer_request_serials[layer] = previous_serial
+	else:
+		var _erased: bool = _layer_request_serials.erase(layer)
 
 
 func _get_layer_request_serial(layer: int) -> int:
@@ -1118,15 +1261,40 @@ func _track_async_panel_request(
 	path: String,
 	layer: int,
 	operation: StringName,
-	request_serial: int
-) -> void:
+	request_serial: int,
+	completion_callback: Callable
+) -> GFUIPanelAsyncOperation:
+	var operation_handle: GFUIPanelAsyncOperation = GFUIPanelAsyncOperation.new()
+	if not operation_handle.configure_for_framework(request_serial, path, layer, operation):
+		push_error("[GFUIUtility] 无法配置异步面板请求句柄。")
+		return null
+	if not _connect_async_panel_completion_callback(operation_handle, completion_callback):
+		push_error("[GFUIUtility] 无法连接异步面板请求终态回调。")
+		return null
 	_pending_async_panel_requests[request_key] = {
 		"path": path,
 		"layer": layer,
 		"operation": operation,
 		"serial": request_serial,
+		"operation_handle": operation_handle,
 	}
 	panel_async_load_started.emit(path, layer, operation)
+	return operation_handle
+
+
+func _connect_async_panel_completion_callback(
+	operation_handle: GFUIPanelAsyncOperation,
+	completion_callback: Callable
+) -> bool:
+	if not completion_callback.is_valid():
+		return true
+	if operation_handle.completed.is_connected(completion_callback):
+		return true
+	var connection_error: Error = operation_handle.completed.connect(
+		completion_callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	return connection_error == OK
 
 
 func _finish_async_panel_request(request_key: String, status: int, panel: Node) -> void:
@@ -1134,7 +1302,24 @@ func _finish_async_panel_request(request_key: String, status: int, panel: Node) 
 		return
 
 	var request: Dictionary = _get_pending_async_panel_request(request_key)
+	var operation_handle: GFUIPanelAsyncOperation = _get_ui_panel_async_operation_value(
+		request.get("operation_handle")
+	)
+	if (
+		GFVariantData.get_option_string_name(request, "operation", &"")
+		== GFUIPanelAsyncOperation.OPERATION_PUSH
+	):
+		_clear_pending_async_push(
+			_make_async_push_key(
+				GFVariantData.get_option_string(request, "path", ""),
+				GFVariantData.get_option_int(request, "layer", -1)
+			),
+			GFVariantData.get_option_int(request, "serial", -1)
+		)
 	var _erased: bool = _pending_async_panel_requests.erase(request_key)
+	if operation_handle == null or not operation_handle.complete_for_framework(status, panel):
+		push_error("[GFUIUtility] 异步面板请求句柄无法进入终态。")
+		return
 	panel_async_load_finished.emit(
 		GFVariantData.get_option_string(request, "path", ""),
 		GFVariantData.get_option_int(request, "layer", -1),
@@ -1149,15 +1334,13 @@ func _clear_pending_async_push(request_key: String, request_serial: int) -> void
 		var _erased: bool = _pending_async_push_serials.erase(request_key)
 
 
-func _clear_pending_async_pushes_for_layer(layer: int) -> void:
-	var prefix: String = "%d:" % layer
-	for request_key: String in _pending_async_push_serials.keys():
-		if request_key.begins_with(prefix):
-			var _erased: bool = _pending_async_push_serials.erase(request_key)
-
-
-func _cancel_pending_async_panel_requests_for_layer(layer: int) -> void:
+func _cancel_pending_async_panel_requests_for_layer(
+	layer: int,
+	excluded_request_key: String = ""
+) -> void:
 	for request_key: String in _pending_async_panel_requests.keys():
+		if request_key == excluded_request_key:
+			continue
 		var request: Dictionary = _get_pending_async_panel_request(request_key)
 		if GFVariantData.get_option_int(request, "layer", -1) == layer:
 			_finish_async_panel_request(request_key, AsyncPanelLoadStatus.CANCELLED, null)
@@ -1168,7 +1351,10 @@ func _cancel_pending_async_replace_requests_for_layer(layer: int) -> void:
 		var request: Dictionary = _get_pending_async_panel_request(request_key)
 		if GFVariantData.get_option_int(request, "layer", -1) != layer:
 			continue
-		if GFVariantData.get_option_string_name(request, "operation", &"") != &"replace":
+		if (
+			GFVariantData.get_option_string_name(request, "operation", &"")
+			!= GFUIPanelAsyncOperation.OPERATION_REPLACE
+		):
 			continue
 		_finish_async_panel_request(request_key, AsyncPanelLoadStatus.CANCELLED, null)
 
@@ -1505,6 +1691,18 @@ func _get_panel_options_for_id(panel_id: int) -> Dictionary:
 
 func _get_pending_async_panel_request(request_key: String) -> Dictionary:
 	return GFVariantData.as_dictionary(GFVariantData.get_option_value(_pending_async_panel_requests, request_key, {}))
+
+
+func _get_async_panel_operation_from_request(request_key: String) -> GFUIPanelAsyncOperation:
+	var request: Dictionary = _get_pending_async_panel_request(request_key)
+	return _get_ui_panel_async_operation_value(request.get("operation_handle"))
+
+
+static func _get_ui_panel_async_operation_value(value: Variant) -> GFUIPanelAsyncOperation:
+	if value is GFUIPanelAsyncOperation:
+		var operation_handle: GFUIPanelAsyncOperation = value
+		return operation_handle
+	return null
 
 
 func _get_live_node(value: Variant) -> Node:

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "9b4189282f86bd884d49d2a120c9d469fe831115d3db565c7f1820b8a50216cf",
-  "class_count": 778,
+  "source_digest": "de285031e86ff6421bf561a34dcc42fa84fa2a2b45644b040a7823faf02875b6",
+  "class_count": 780,
   "package_count": 52,
   "packages": [
     {
@@ -598,6 +598,27 @@
           "name": "DEFAULT_PROJECT_OUTPUT_PATH",
           "signature": "const DEFAULT_PROJECT_OUTPUT_PATH: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.PROJECT_ACCESS_OUTPUT_PATH",
           "summary": "默认项目常量访问器输出路径。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ACCESS_SCOPE_INHERITED",
+          "signature": "const ACCESS_SCOPE_INHERITED: StringName = &\"inherited\"",
+          "summary": "访问器按父级回退规则解析模块。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ACCESS_SCOPE_LOCAL",
+          "signature": "const ACCESS_SCOPE_LOCAL: StringName = &\"local\"",
+          "summary": "访问器只解析传入架构的本地模块。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ACCESS_POLICIES_SETTING",
+          "signature": "const ACCESS_POLICIES_SETTING: String = \"gf/codegen/access_policies\"",
+          "summary": "每个生成类型的冻结访问策略 ProjectSettings 键。",
           "visibility": "public"
         },
         {
@@ -1986,6 +2007,20 @@
           "visibility": "public"
         },
         {
+          "kind": "enum",
+          "name": "ModuleKind",
+          "signature": "enum ModuleKind {\n\t## Model 模块。\n\tMODEL,\n\t## System 模块。\n\tSYSTEM,\n\t## Utility 模块。\n\tUTILITY,\n}",
+          "summary": "可由架构访问策略解析的模块类型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "ModuleLookupScope",
+          "signature": "enum ModuleLookupScope {\n\t## 按当前架构的父级回退与 strict_dependency_lookup 规则解析。\n\tINHERITED,\n\t## 只解析当前架构，不回退父级。\n\tLOCAL,\n}",
+          "summary": "模块访问的架构作用域。",
+          "visibility": "public"
+        },
+        {
           "kind": "const",
           "name": "SERVICE_COMMAND_HISTORY_STORE",
           "signature": "const SERVICE_COMMAND_HISTORY_STORE: StringName = &\"gf.kernel.command_history_store\"",
@@ -2627,6 +2662,13 @@
           "name": "unregister_utility",
           "signature": "func unregister_utility(script_cls: Script) -> bool",
           "summary": "注销 Utility 实例。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "resolve_module_access",
+          "signature": "func resolve_module_access( module_kind: ModuleKind, script_cls: Script, lookup_scope: ModuleLookupScope = ModuleLookupScope.INHERITED, required: bool = true, require_ready: bool = false ) -> Object",
+          "summary": "按冻结的作用域、必需性和 ready 策略解析已注册模块。",
           "visibility": "public"
         },
         {
@@ -40286,7 +40328,7 @@
         {
           "kind": "func",
           "name": "create_virtual_source",
-          "signature": "func create_virtual_source( source_id: StringName = &\"virtual\", player_index: int = -1 ) -> GFVirtualInputSource",
+          "signature": "func create_virtual_source( source_id: StringName = &\"virtual\", player_index: int = -1, timer_utility: GFTimerUtility = null ) -> GFVirtualInputSource",
           "summary": "创建可编程虚拟输入源。",
           "visibility": "public"
         },
@@ -86993,6 +87035,109 @@
         }
       ]
     },
+    "GFUIPanelAsyncOperation": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui.navigation",
+      "path": "addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd",
+      "summary": "GFUIPanelAsyncOperation: 单次异步 UI 面板请求的可观察句柄。 句柄冻结 UI 分配的请求序号、路径、层级与操作类型，并且只接受一个终态。 成功面板仅以弱引用保存，句柄不会延长面板节点的生命周期。",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "completed",
+          "signature": "signal completed(handle: GFUIPanelAsyncOperation)",
+          "summary": "请求进入终态时发出一次。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_PENDING",
+          "signature": "const STATUS_PENDING: int = -1",
+          "summary": "请求尚未进入终态时由 get_status() 返回的状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_PUSH",
+          "signature": "const OPERATION_PUSH: StringName = &\"push\"",
+          "summary": "压入面板操作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_REPLACE",
+          "signature": "const OPERATION_REPLACE: StringName = &\"replace\"",
+          "summary": "替换层级操作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_serial",
+          "signature": "func get_serial() -> int",
+          "summary": "获取 UI 分配的请求序号。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_path",
+          "signature": "func get_path() -> String",
+          "summary": "获取面板场景路径。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_layer",
+          "signature": "func get_layer() -> int",
+          "summary": "获取目标 UI 层级。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_operation",
+          "signature": "func get_operation() -> StringName",
+          "summary": "获取 push 或 replace 操作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_pending",
+          "signature": "func is_pending() -> bool",
+          "summary": "检查请求是否仍在等待终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_completed",
+          "signature": "func is_completed() -> bool",
+          "summary": "检查请求是否已有终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> int",
+          "summary": "获取请求状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_panel",
+          "signature": "func get_panel() -> Node",
+          "summary": "获取成功打开的面板。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_debug_snapshot",
+          "signature": "func get_debug_snapshot() -> Dictionary",
+          "summary": "获取稳定调试快照。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFUIRoute": {
       "extends": "Resource",
       "module": "standard",
@@ -87293,6 +87438,13 @@
         },
         {
           "kind": "const",
+          "name": "STATUS_INVALID_LIFECYCLE",
+          "signature": "const STATUS_INVALID_LIFECYCLE: StringName = &\"invalid_lifecycle\"",
+          "summary": "请求 owner 或异步作用域不满足生命周期契约。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
           "name": "STATUS_MISSING_ASSET_UTILITY",
           "signature": "const STATUS_MISSING_ASSET_UTILITY: StringName = &\"missing_asset_utility\"",
           "summary": "预加载策略需要 Asset Utility，但当前架构未提供。",
@@ -87323,7 +87475,7 @@
           "kind": "const",
           "name": "STATUS_CANCELLED",
           "signature": "const STATUS_CANCELLED: StringName = &\"cancelled\"",
-          "summary": "底层 UI 请求在完成前被取消。",
+          "summary": "请求在面板提交前因 owner/scope 结束，或在提交后被底层 UI 取消。",
           "visibility": "public"
         },
         {
@@ -87567,6 +87719,13 @@
           "name": "dispose",
           "signature": "func dispose() -> void",
           "summary": "释放路由表、UI 工具引用和历史记录。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "tick",
+          "signature": "func tick(_delta: float) -> void",
+          "summary": "清理普通 Object owner 已释放的提交前路由请求。",
           "visibility": "public"
         },
         {
@@ -87843,14 +88002,14 @@
         {
           "kind": "func",
           "name": "push_panel_async",
-          "signature": "func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void",
+          "signature": "func push_panel_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation",
           "summary": "异步压入一个面板场景。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "push_panel_async_with_options",
-          "signature": "func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void",
+          "signature": "func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation",
           "summary": "异步压入一个带策略选项的面板场景。",
           "visibility": "public"
         },
@@ -87885,14 +88044,14 @@
         {
           "kind": "func",
           "name": "replace_layer_async",
-          "signature": "func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void",
+          "signature": "func replace_layer_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation",
           "summary": "异步替换指定层级的面板栈。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "replace_layer_async_with_options",
-          "signature": "func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void",
+          "signature": "func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation",
           "summary": "异步替换指定层级为带策略选项的面板。",
           "visibility": "public"
         },
@@ -90534,6 +90693,116 @@
         }
       ]
     },
+    "GFVirtualInputPulseOperation": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.input",
+      "path": "addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd",
+      "summary": "GFVirtualInputPulseOperation: 单次虚拟输入脉冲的类型化运行时句柄。 句柄冻结创建时的 Mapping、source_id、player_index 与 action_id，并由 GFInputMappingUtility 的权威 lease 保证旧定时器不会释放后续脉冲。owner 与",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "completed",
+          "signature": "signal completed(operation: GFVirtualInputPulseOperation)",
+          "summary": "脉冲首次进入终态时发出一次。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "Status",
+          "signature": "enum Status {\n\t## 等待定时、生命周期或显式终止。\n\tPENDING,\n\t## 到达脉冲时长并完成匹配释放。\n\tCOMPLETED,\n\t## 被调用方、owner、token 或状态清理取消。\n\tCANCELLED,\n\t## 被同一稳定输入键上的新脉冲替换。\n\tREPLACED,\n\t## 因同一稳定输入键已有脉冲而拒绝启动。\n\tREJECTED,\n\t## 输入或运行时依赖无效，未能启动。\n\tFAILED,\n}",
+          "summary": "脉冲操作状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "cancel",
+          "signature": "func cancel(reason: StringName = &\"cancelled\") -> bool",
+          "summary": "取消仍在等待的脉冲。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_generation",
+          "signature": "func get_generation() -> int",
+          "summary": "获取 Source 分配的单调 generation。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_id",
+          "signature": "func get_source_id() -> StringName",
+          "summary": "获取冻结的虚拟输入源标识。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_player_index",
+          "signature": "func get_player_index() -> int",
+          "summary": "获取冻结的玩家索引。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_action_id",
+          "signature": "func get_action_id() -> StringName",
+          "summary": "获取冻结的动作标识。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_duration_seconds",
+          "signature": "func get_duration_seconds() -> float",
+          "summary": "获取规范化脉冲时长。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> Status",
+          "summary": "获取当前状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_terminal_reason",
+          "signature": "func get_terminal_reason() -> StringName",
+          "summary": "获取终态原因。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_pending",
+          "signature": "func is_pending() -> bool",
+          "summary": "返回操作是否仍在等待。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_completed",
+          "signature": "func is_completed() -> bool",
+          "summary": "返回操作是否已经进入任意终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_release_count",
+          "signature": "func get_release_count() -> int",
+          "summary": "获取该脉冲完成的匹配释放次数。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_debug_snapshot",
+          "signature": "func get_debug_snapshot() -> Dictionary",
+          "summary": "获取稳定调试快照。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFVirtualInputSource": {
       "extends": "RefCounted",
       "module": "standard",
@@ -90544,6 +90813,13 @@
       "category": "runtime_handle",
       "since": "3.17.0",
       "members": [
+        {
+          "kind": "enum",
+          "name": "PulseReplacementPolicy",
+          "signature": "enum PulseReplacementPolicy {\n\t## 原子交接同一动作贡献，不产生中间释放。\n\tREPLACE,\n\t## 保留旧脉冲，并让新句柄立即进入 REJECTED 终态。\n\tREJECT_NEW,\n}",
+          "summary": "同一 source_id、player_index 与 action_id 已存在脉冲时的处理策略。",
+          "visibility": "public"
+        },
         {
           "kind": "var",
           "name": "source_id",
@@ -90561,8 +90837,29 @@
         {
           "kind": "func",
           "name": "configure",
-          "signature": "func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &\"virtual\", p_player_index: int = -1 ) -> GFVirtualInputSource",
+          "signature": "func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &\"virtual\", p_player_index: int = -1, timer_utility: GFTimerUtility = null ) -> GFVirtualInputSource",
           "summary": "配置虚拟输入源。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_timer_utility",
+          "signature": "func set_timer_utility(timer_utility: GFTimerUtility) -> GFVirtualInputSource",
+          "summary": "替换后续脉冲使用的定时器工具。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_timer_utility",
+          "signature": "func get_timer_utility() -> GFTimerUtility",
+          "summary": "获取后续脉冲使用的定时器工具。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "pulse_action",
+          "signature": "func pulse_action( action_id: StringName, value: Variant = true, duration_seconds: float = 0.1, owner: Variant = null, cancellation_token: GFCancellationToken = null, replacement_policy: PulseReplacementPolicy = PulseReplacementPolicy.REPLACE ) -> GFVirtualInputPulseOperation",
+          "summary": "启动一次有界虚拟动作脉冲。",
           "visibility": "public"
         },
         {
@@ -90633,6 +90930,13 @@
           "name": "clear_all",
           "signature": "func clear_all() -> void",
           "summary": "清除当前虚拟源的所有动作贡献。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "dispose",
+          "signature": "func dispose() -> void",
+          "summary": "取消全部 Source-owned 脉冲、清除当前 source_id 贡献并释放依赖引用。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFAccessGenerator.xml
+++ b/docs/api_catalog/classes/GFAccessGenerator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFAccessGenerator" path="addons/gf/kernel/editor/gf_access_generator.gd" module="kernel" extends="RefCounted" classDigest="23ecb1147121b2d8d04152cddd67f06e28a39cc4068a49c407b2234e8d584422">
+<class name="GFAccessGenerator" path="addons/gf/kernel/editor/gf_access_generator.gd" module="kernel" extends="RefCounted" classDigest="a35307fe93216b31b9c23048ed70f9856e31e2e168d74343140f5810c8c20eb4">
 	<description>GFAccessGenerator: 生成强类型 GF 访问器脚本。
 生成结果用于减少 `Gf.get_model(Type) as Type` 这类重复样板，
 并为 Model / System / Utility / Command / Query 提供稳定的 IDE 补全入口。</description>
@@ -47,6 +47,30 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">9.0.0</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ACCESS_SCOPE_INHERITED">
+			<signature>const ACCESS_SCOPE_INHERITED: StringName = &amp;"inherited"</signature>
+			<description>访问器按父级回退规则解析模块。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ACCESS_SCOPE_LOCAL">
+			<signature>const ACCESS_SCOPE_LOCAL: StringName = &amp;"local"</signature>
+			<description>访问器只解析传入架构的本地模块。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ACCESS_POLICIES_SETTING">
+			<signature>const ACCESS_POLICIES_SETTING: String = "gf/codegen/access_policies"</signature>
+			<description>每个生成类型的冻结访问策略 ProjectSettings 键。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 	</constants>
@@ -103,8 +127,9 @@
 			<description>收集当前项目中可生成访问器的 GF 类型记录。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">类型记录列表。</tag>
-				<tag name="schema">return: Array of Dictionary type records with class_name, path, script, kind, and access metadata.</tag>
+				<tag name="return">类型记录列表；访问策略配置无效时返回空数组且不会返回部分冻结结果。</tag>
+				<tag name="schema">return: Array of Dictionary type records with class_name, path, and kind; Model/System/Utility records additionally contain scope, required, and require_ready.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="collect_project_records">
@@ -122,8 +147,9 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">records: 生成访问器时使用的类型记录列表。</tag>
-				<tag name="return">GDScript 源码。</tag>
-				<tag name="schema">records: Array of Dictionary type records containing class_name, path, and kind.</tag>
+				<tag name="return">完整 GDScript 源码；任一记录或模块访问策略无效时整批失败并返回空字符串。</tag>
+				<tag name="schema">records: Array of Dictionary type records containing class_name, path, and kind; Model/System/Utility records may additionally contain scope, required, and require_ready.</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="build_project_source">

--- a/docs/api_catalog/classes/GFArchitecture.xml
+++ b/docs/api_catalog/classes/GFArchitecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="ffe58eee8a9758a10073a0edd610bb27e453ff53cf67b105870c134027253e69">
+<class name="GFArchitecture" path="addons/gf/kernel/core/gf_architecture.gd" module="kernel" extends="Object" classDigest="bd4d808e88eda4140998b1849041ba5e9396779f810b6b0fece24e7e185c1030">
 	<description>GFArchitecture: 管理 Model、System 和 Utility 的注册与生命周期的容器。
 生命周期遵循四阶段初始化协议：
 阶段一 (init)       ：各模块按声明依赖 DAG 执行自身内部变量初始化。
@@ -45,7 +45,36 @@
 			</tags>
 		</member>
 	</signals>
-	<enums />
+	<enums>
+		<member kind="enum" name="ModuleKind">
+			<signature>enum ModuleKind {
+	## Model 模块。
+	MODEL,
+	## System 模块。
+	SYSTEM,
+	## Utility 模块。
+	UTILITY,
+}</signature>
+			<description>可由架构访问策略解析的模块类型。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="enum" name="ModuleLookupScope">
+			<signature>enum ModuleLookupScope {
+	## 按当前架构的父级回退与 strict_dependency_lookup 规则解析。
+	INHERITED,
+	## 只解析当前架构，不回退父级。
+	LOCAL,
+}</signature>
+			<description>模块访问的架构作用域。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
 	<constants>
 		<member kind="const" name="SERVICE_COMMAND_HISTORY_STORE">
 			<signature>const SERVICE_COMMAND_HISTORY_STORE: StringName = &amp;"gf.kernel.command_history_store"</signature>
@@ -981,6 +1010,22 @@ listener 携带 owner 时返回的句柄会绑定该 owner 生命周期。`once`
 				<tag name="param">script_cls: 工具的脚本类。</tag>
 				<tag name="return">模块完成 quiesce 并从活动拓扑移除时返回 true。</tag>
 				<tag name="since">11.0.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="resolve_module_access">
+			<signature>func resolve_module_access( module_kind: ModuleKind, script_cls: Script, lookup_scope: ModuleLookupScope = ModuleLookupScope.INHERITED, required: bool = true, require_ready: bool = false ) -&gt; Object:</signature>
+			<description>按冻结的作用域、必需性和 ready 策略解析已注册模块。
+该入口供生成访问器与其他声明式依赖边界复用；required 只控制严格依赖缺失诊断，
+不改变 strict_dependency_lookup 对父级回退的限制。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">module_kind: 要解析的 Model、System 或 Utility 类型。</tag>
+				<tag name="param">script_cls: 模块脚本类。</tag>
+				<tag name="param">lookup_scope: 父级可见或仅当前架构的查询作用域。</tag>
+				<tag name="param">required: 为 true 时，严格查询模式下缺失模块会输出 required miss。</tag>
+				<tag name="param">require_ready: 为 true 时，仅返回已完成 ready 阶段的实例。</tag>
+				<tag name="return">符合全部冻结策略的模块实例；未命中时返回 null。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_system">

--- a/docs/api_catalog/classes/GFInputMappingUtility.xml
+++ b/docs/api_catalog/classes/GFInputMappingUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFInputMappingUtility" path="addons/gf/standard/input/runtime/gf_input_mapping_utility.gd" module="standard" extends="GFUtility" classDigest="6b15f48677ae02305a0a8d15556cb19a5d3297e30b686b40381ea84ebcce7e52">
+<class name="GFInputMappingUtility" path="addons/gf/standard/input/runtime/gf_input_mapping_utility.gd" module="standard" extends="GFUtility" classDigest="65acd0ab4cd04d2fe9864c21173a38c9f633d941554580f8ce0452b7dffcff2a">
 	<description>GFInputMappingUtility: 资源化输入上下文与动作映射运行时。
 负责把 Godot InputEvent 转换为项目定义的抽象动作状态，并支持上下文优先级、
 运行时重绑定、动作值查询和一次性触发消费。</description>
@@ -222,13 +222,15 @@
 			</tags>
 		</member>
 		<member kind="method" name="create_virtual_source">
-			<signature>func create_virtual_source( source_id: StringName = &amp;"virtual", player_index: int = -1 ) -&gt; GFVirtualInputSource:</signature>
+			<signature>func create_virtual_source( source_id: StringName = &amp;"virtual", player_index: int = -1, timer_utility: GFTimerUtility = null ) -&gt; GFVirtualInputSource:</signature>
 			<description>创建可编程虚拟输入源。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">source_id: 虚拟输入源标识。</tag>
 				<tag name="param">player_index: 玩家索引；小于 0 时只写入全局动作状态。</tag>
+				<tag name="param">timer_utility: 可选的虚拟脉冲定时器注入。</tag>
 				<tag name="return">虚拟输入源。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="set_virtual_action_value">
@@ -242,6 +244,7 @@
 				<tag name="param">player_index: 玩家索引；小于 0 时只写入全局动作状态。</tag>
 				<tag name="return">写入成功返回 true。</tag>
 				<tag name="schema">value: Variant，要转换为动作运行时向量贡献的 bool、float、Vector2 或 Vector3 值。</tag>
+				<tag name="since">2.6.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="clear_virtual_action">

--- a/docs/api_catalog/classes/GFUIPanelAsyncOperation.xml
+++ b/docs/api_catalog/classes/GFUIPanelAsyncOperation.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFUIPanelAsyncOperation" path="addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd" module="standard" extends="RefCounted" classDigest="e92db01bed357ca0c9021950aa442df3f39088908ecd87117686fed064f642cc">
+	<description>GFUIPanelAsyncOperation: 单次异步 UI 面板请求的可观察句柄。
+句柄冻结 UI 分配的请求序号、路径、层级与操作类型，并且只接受一个终态。
+成功面板仅以弱引用保存，句柄不会延长面板节点的生命周期。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="completed">
+			<signature>signal completed(handle: GFUIPanelAsyncOperation)</signature>
+			<description>请求进入终态时发出一次。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">handle: 已完成的当前句柄。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_PENDING">
+			<signature>const STATUS_PENDING: int = -1</signature>
+			<description>请求尚未进入终态时由 get_status() 返回的状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_PUSH">
+			<signature>const OPERATION_PUSH: StringName = &amp;"push"</signature>
+			<description>压入面板操作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_REPLACE">
+			<signature>const OPERATION_REPLACE: StringName = &amp;"replace"</signature>
+			<description>替换层级操作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="get_serial">
+			<signature>func get_serial() -&gt; int:</signature>
+			<description>获取 UI 分配的请求序号。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">配置后为大于零的请求序号；未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_path">
+			<signature>func get_path() -&gt; String:</signature>
+			<description>获取面板场景路径。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">请求创建时冻结的场景路径。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_layer">
+			<signature>func get_layer() -&gt; int:</signature>
+			<description>获取目标 UI 层级。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">请求创建时冻结的逻辑层 ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_operation">
+			<signature>func get_operation() -&gt; StringName:</signature>
+			<description>获取 push 或 replace 操作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`OPERATION_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_pending">
+			<signature>func is_pending() -&gt; bool:</signature>
+			<description>检查请求是否仍在等待终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已配置且尚未完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_completed">
+			<signature>func is_completed() -&gt; bool:</signature>
+			<description>检查请求是否已有终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; int:</signature>
+			<description>获取请求状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">等待中返回 STATUS_PENDING；完成后返回 GFUIUtility.AsyncPanelLoadStatus。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_panel">
+			<signature>func get_panel() -&gt; Node:</signature>
+			<description>获取成功打开的面板。
+句柄只保存弱引用；面板已释放、请求失败或请求取消时返回 null。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前仍有效的成功面板；否则返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_debug_snapshot">
+			<signature>func get_debug_snapshot() -&gt; Dictionary:</signature>
+			<description>获取稳定调试快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">请求身份与终态摘要。</tag>
+				<tag name="schema">return: Dictionary，包含 serial、path、layer、operation、pending、completed、status、has_panel 和 panel_instance_id。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFUIRouteResult.xml
+++ b/docs/api_catalog/classes/GFUIRouteResult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFUIRouteResult" path="addons/gf/standard/utilities/ui/gf_ui_route_result.gd" module="standard" extends="RefCounted" classDigest="53f489f2fd5253c1571d364a84135cccf5ec7c03e6284c13b92296e6f0b0afda">
+<class name="GFUIRouteResult" path="addons/gf/standard/utilities/ui/gf_ui_route_result.gd" module="standard" extends="RefCounted" classDigest="cc0e78b2089bd6f13d1c7d135b765cd72b50bb6392e73297191c4a1c1886d60a">
 	<description>GFUIRouteResult: UI 路由异步打开的不可变终态。
 结果把路由校验、可选预加载、面板提交和生命周期中止统一为稳定状态，
 并保留预加载事务结果，避免项目通过日志或时序猜测失败阶段。</description>
@@ -67,6 +67,14 @@
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
+		<member kind="const" name="STATUS_INVALID_LIFECYCLE">
+			<signature>const STATUS_INVALID_LIFECYCLE: StringName = &amp;"invalid_lifecycle"</signature>
+			<description>请求 owner 或异步作用域不满足生命周期契约。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="const" name="STATUS_MISSING_ASSET_UTILITY">
 			<signature>const STATUS_MISSING_ASSET_UTILITY: StringName = &amp;"missing_asset_utility"</signature>
 			<description>预加载策略需要 Asset Utility，但当前架构未提供。</description>
@@ -101,7 +109,7 @@
 		</member>
 		<member kind="const" name="STATUS_CANCELLED">
 			<signature>const STATUS_CANCELLED: StringName = &amp;"cancelled"</signature>
-			<description>底层 UI 请求在完成前被取消。</description>
+			<description>请求在面板提交前因 owner/scope 结束，或在提交后被底层 UI 取消。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">10.0.0</tag>

--- a/docs/api_catalog/classes/GFUIRouterUtility.xml
+++ b/docs/api_catalog/classes/GFUIRouterUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFUIRouterUtility" path="addons/gf/standard/utilities/ui/gf_ui_router_utility.gd" module="standard" extends="GFUtility" classDigest="edbd00a005e1f2cb0e2e454d4077c094e4b30d97248b116df7f743d90a847108">
+<class name="GFUIRouterUtility" path="addons/gf/standard/utilities/ui/gf_ui_router_utility.gd" module="standard" extends="GFUtility" classDigest="178725610abee26c28a2d772be793501cc5b322de94b6af46fa58291c76e9880">
 	<description>GFUIRouterUtility: 基于路由 ID 的 UI 导航工具。
 作为 GFUIUtility 之上的轻量路由层，负责把稳定 route_id 映射到面板场景、
 打开参数、层级和历史记录，不接管具体页面业务或动画表现。</description>
@@ -110,9 +110,12 @@
 	<methods>
 		<member kind="method" name="init">
 			<signature>func init() -&gt; void:</signature>
-			<description>初始化路由表、UI 工具引用和历史记录。</description>
+			<description>初始化路由表、UI 工具引用和历史记录。
+重复初始化会先以 dispose 语义终结旧 pending 请求；请求 ID 在同一实例内保持单调，
+避免旧异步回调或临时预加载组与新生命周期串线。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="dispose">
@@ -120,6 +123,16 @@
 			<description>释放路由表、UI 工具引用和历史记录。</description>
 			<tags>
 				<tag name="api">public</tag>
+			</tags>
+		</member>
+		<member kind="method" name="tick">
+			<signature>func tick(_delta: float) -&gt; void:</signature>
+			<description>清理普通 Object owner 已释放的提交前路由请求。
+Node owner 和 GFAsyncScope 会通过信号即时取消；普通 Object 依赖本帧弱引用检查。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">_delta: 本帧时间增量；生命周期清理不依赖具体数值。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="configure">
@@ -252,7 +265,7 @@
 				<tag name="return">可观察的异步路由句柄；相同 pending 请求返回同一句柄。</tag>
 				<tag name="schema">params: Dictionary，本次打开路由携带的项目自定义参数。</tag>
 				<tag name="schema">option_overrides: Dictionary，字段同 GFUIUtility 打开面板 options，会覆盖路由 default_options。</tag>
-				<tag name="schema">async_options: Dictionary，可包含 preload_policy、preload_plan_options 和 metadata；preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。</tag>
+				<tag name="schema">async_options: Dictionary，可包含 preload_policy、preload_plan_options、metadata、owner: Object 和 scope: GFAsyncScope；owner 与 scope 使用 OR 取消语义且只约束面板提交前，preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
@@ -269,7 +282,7 @@
 				<tag name="return">可观察的异步路由句柄；相同 pending 请求返回同一句柄。</tag>
 				<tag name="schema">params: Dictionary，本次打开路由携带的项目自定义参数。</tag>
 				<tag name="schema">option_overrides: Dictionary，字段同 GFUIUtility 打开面板 options，会覆盖路由 default_options。</tag>
-				<tag name="schema">async_options: Dictionary，可包含 preload_policy、preload_plan_options 和 metadata；preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。</tag>
+				<tag name="schema">async_options: Dictionary，可包含 preload_policy、preload_plan_options、metadata、owner: Object 和 scope: GFAsyncScope；owner 与 scope 使用 OR 取消语义且只约束面板提交前，preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
@@ -314,7 +327,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">诊断快照。</tag>
-				<tag name="schema">return: Dictionary，包含 route_count、history_count、pending_async_route_count、pending_async_routes、current_route_id、has_ui_utility 和 disposed。</tag>
+				<tag name="schema">return: Dictionary，包含 route_count、history_count、pending_async_route_count、current_route_id、has_ui_utility、disposed，以及 pending_async_routes；其中每个 pending 条目额外包含 panel_submitted、has_owner、has_scope 与 lifecycle_cancellation_open。</tag>
 				<tag name="since">3.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFUIUtility.xml
+++ b/docs/api_catalog/classes/GFUIUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFUIUtility" path="addons/gf/standard/utilities/ui/gf_ui_utility.gd" module="standard" extends="GFUtility" classDigest="49a97b5afa17cebe9fa5bf611f4af3d1a8a0205c15ffd7ca338f0f1a565fe160">
+<class name="GFUIUtility" path="addons/gf/standard/utilities/ui/gf_ui_utility.gd" module="standard" extends="GFUtility" classDigest="7e222e5479f92fc1b3a0d7e7bc7831bbd4068976e047b228fd24d833072f62a7">
 	<description>GFUIUtility: 栈式 UI 管理器。
 负责可扩展逻辑层中的入栈、出栈、层内可见性策略与异步加载，
 适合 HUD、并行窗口、弹窗和顶层遮罩等需要分层管理的 UI 场景。
@@ -201,18 +201,20 @@
 			</tags>
 		</member>
 		<member kind="method" name="push_panel_async">
-			<signature>func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -&gt; void:</signature>
+			<signature>func push_panel_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -&gt; GFUIPanelAsyncOperation:</signature>
 			<description>异步压入一个面板场景。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">path: 面板场景路径。</tag>
 				<tag name="param">layer: 目标层级。</tag>
 				<tag name="param">config_callback: 实例化后、入栈前的可选配置回调。</tag>
+				<tag name="param">completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。</tag>
+				<tag name="return">已接受请求的类型化句柄；路径无效时返回 null。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="push_panel_async_with_options">
-			<signature>func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -&gt; void:</signature>
+			<signature>func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -&gt; GFUIPanelAsyncOperation:</signature>
 			<description>异步压入一个带策略选项的面板场景。</description>
 			<tags>
 				<tag name="api">public</tag>
@@ -220,6 +222,8 @@
 				<tag name="param">layer: 目标层级。</tag>
 				<tag name="param">options: 面板策略，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close、metadata。</tag>
 				<tag name="param">config_callback: 实例化后、入栈前的可选配置回调。</tag>
+				<tag name="param">completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。</tag>
+				<tag name="return">已接受请求的类型化句柄；同步回退可能返回已完成句柄，路径无效时返回 null。</tag>
 				<tag name="schema">options: Dictionary，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close 和 metadata。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
@@ -277,18 +281,20 @@
 			</tags>
 		</member>
 		<member kind="method" name="replace_layer_async">
-			<signature>func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -&gt; void:</signature>
+			<signature>func replace_layer_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -&gt; GFUIPanelAsyncOperation:</signature>
 			<description>异步替换指定层级的面板栈。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">path: 面板场景路径。</tag>
 				<tag name="param">layer: 目标层级。</tag>
 				<tag name="param">config_callback: 实例化后、入栈前的可选配置回调。</tag>
+				<tag name="param">completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。</tag>
+				<tag name="return">已接受请求的类型化句柄；路径无效时返回 null。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="replace_layer_async_with_options">
-			<signature>func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -&gt; void:</signature>
+			<signature>func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -&gt; GFUIPanelAsyncOperation:</signature>
 			<description>异步替换指定层级为带策略选项的面板。</description>
 			<tags>
 				<tag name="api">public</tag>
@@ -296,6 +302,8 @@
 				<tag name="param">layer: 目标层级。</tag>
 				<tag name="param">options: 面板策略，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close、metadata。</tag>
 				<tag name="param">config_callback: 实例化后、入栈前的可选配置回调。</tag>
+				<tag name="param">completion_callback: 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。</tag>
+				<tag name="return">已接受请求的类型化句柄；同步回退可能返回已完成句柄，路径无效时返回 null。</tag>
 				<tag name="schema">options: Dictionary，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close 和 metadata。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
@@ -502,8 +510,9 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">layer: 指定层级；小于 0 时返回所有层级。</tag>
-				<tag name="return">请求快照数组，每项包含 path、layer、operation 和 serial。</tag>
-				<tag name="schema">return: Array，元素为 Dictionary，包含 path、layer、operation 和 serial。</tag>
+				<tag name="return">请求快照数组，每项包含 path、layer、operation、serial 和 operation_handle。</tag>
+				<tag name="schema">return: Array，元素为 Dictionary，包含 path、layer、operation、serial 和 GFUIPanelAsyncOperation operation_handle。</tag>
+				<tag name="since">3.15.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_modal_count">

--- a/docs/api_catalog/classes/GFVirtualInputPulseOperation.xml
+++ b/docs/api_catalog/classes/GFVirtualInputPulseOperation.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFVirtualInputPulseOperation" path="addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd" module="standard" extends="RefCounted" classDigest="63c12ae5dff0cfb05d2ae35a659b1abc205af9cf765c64d590616bb28629c78e">
+	<description>GFVirtualInputPulseOperation: 单次虚拟输入脉冲的类型化运行时句柄。
+句柄冻结创建时的 Mapping、source_id、player_index 与 action_id，并由
+GFInputMappingUtility 的权威 lease 保证旧定时器不会释放后续脉冲。owner 与
+cancellation_token 均为可选锚点；同时提供时，任一先结束都会取消脉冲。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="completed">
+			<signature>signal completed(operation: GFVirtualInputPulseOperation)</signature>
+			<description>脉冲首次进入终态时发出一次。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">operation: 已进入终态的当前句柄。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums>
+		<member kind="enum" name="Status">
+			<signature>enum Status {
+	## 等待定时、生命周期或显式终止。
+	PENDING,
+	## 到达脉冲时长并完成匹配释放。
+	COMPLETED,
+	## 被调用方、owner、token 或状态清理取消。
+	CANCELLED,
+	## 被同一稳定输入键上的新脉冲替换。
+	REPLACED,
+	## 因同一稳定输入键已有脉冲而拒绝启动。
+	REJECTED,
+	## 输入或运行时依赖无效，未能启动。
+	FAILED,
+}</signature>
+			<description>脉冲操作状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="cancel">
+			<signature>func cancel(reason: StringName = &amp;"cancelled") -&gt; bool:</signature>
+			<description>取消仍在等待的脉冲。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">reason: 稳定取消原因；空值会规范化为 cancelled。</tag>
+				<tag name="return">本次调用是否首次使操作进入终态。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_generation">
+			<signature>func get_generation() -&gt; int:</signature>
+			<description>获取 Source 分配的单调 generation。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">大于零的 generation；配置失败前可能为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_id">
+			<signature>func get_source_id() -&gt; StringName:</signature>
+			<description>获取冻结的虚拟输入源标识。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">创建脉冲时的 source_id。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_player_index">
+			<signature>func get_player_index() -&gt; int:</signature>
+			<description>获取冻结的玩家索引。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">创建脉冲时的 player_index。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_action_id">
+			<signature>func get_action_id() -&gt; StringName:</signature>
+			<description>获取冻结的动作标识。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">创建脉冲时的 action_id。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_duration_seconds">
+			<signature>func get_duration_seconds() -&gt; float:</signature>
+			<description>获取规范化脉冲时长。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">秒数。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; Status:</signature>
+			<description>获取当前状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Status 枚举值。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_terminal_reason">
+			<signature>func get_terminal_reason() -&gt; StringName:</signature>
+			<description>获取终态原因。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">等待中为空 StringName；终态时为稳定原因。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_pending">
+			<signature>func is_pending() -&gt; bool:</signature>
+			<description>返回操作是否仍在等待。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">等待中返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_completed">
+			<signature>func is_completed() -&gt; bool:</signature>
+			<description>返回操作是否已经进入任意终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已完成、取消、替换、拒绝或失败时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_release_count">
+			<signature>func get_release_count() -&gt; int:</signature>
+			<description>获取该脉冲完成的匹配释放次数。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">仅当前 lease 实际清除动作贡献时为 1；无释放交接、未取得 lease 或未释放时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_debug_snapshot">
+			<signature>func get_debug_snapshot() -&gt; Dictionary:</signature>
+			<description>获取稳定调试快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">冻结身份、状态、时长、时间戳与释放证明。</tag>
+				<tag name="schema">return: Dictionary，包含 generation、source_id、player_index、action_id、duration_seconds、status、status_name、terminal_reason、pending、completed、started_at_msec、completed_at_msec、release_count、lease_acquired 和 timer_handle。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFVirtualInputSource.xml
+++ b/docs/api_catalog/classes/GFVirtualInputSource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFVirtualInputSource" path="addons/gf/standard/input/sources/gf_virtual_input_source.gd" module="standard" extends="RefCounted" classDigest="166a33c220b8085f42c1a2ae7a9cbfdd810294cce0fbc8173e1b9dd9af7d6cff">
+<class name="GFVirtualInputSource" path="addons/gf/standard/input/sources/gf_virtual_input_source.gd" module="standard" extends="RefCounted" classDigest="2779be2b7af218fbed799576de84afe51b4592e81e6de25718df2dae26f6321f">
 	<description>GFVirtualInputSource: 可编程虚拟输入源。
 用于测试、回放、AI 控制或项目自定义输入桥接，向 GFInputMappingUtility
 注入抽象动作值；它不读取 InputMap，也不规定具体设备或玩法语义。</description>
@@ -9,7 +9,21 @@
 		<tag name="since">3.17.0</tag>
 	</tags>
 	<signals />
-	<enums />
+	<enums>
+		<member kind="enum" name="PulseReplacementPolicy">
+			<signature>enum PulseReplacementPolicy {
+	## 原子交接同一动作贡献，不产生中间释放。
+	REPLACE,
+	## 保留旧脉冲，并让新句柄立即进入 REJECTED 终态。
+	REJECT_NEW,
+}</signature>
+			<description>同一 source_id、player_index 与 action_id 已存在脉冲时的处理策略。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
 	<constants />
 	<properties>
 		<member kind="property" name="source_id">
@@ -29,14 +43,55 @@
 	</properties>
 	<methods>
 		<member kind="method" name="configure">
-			<signature>func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &amp;"virtual", p_player_index: int = -1 ) -&gt; GFVirtualInputSource:</signature>
+			<signature>func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &amp;"virtual", p_player_index: int = -1, timer_utility: GFTimerUtility = null ) -&gt; GFVirtualInputSource:</signature>
 			<description>配置虚拟输入源。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">input_mapping: 输入映射工具。</tag>
 				<tag name="param">p_source_id: 虚拟输入源标识。</tag>
 				<tag name="param">p_player_index: 玩家索引。</tag>
-				<tag name="return">当前输入源。</tag>
+				<tag name="param">timer_utility: 可选的脉冲定时器注入。</tag>
+				<tag name="return">当前输入源；dispose 后返回同一终态实例且不修改配置。</tag>
+				<tag name="since">3.17.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_timer_utility">
+			<signature>func set_timer_utility(timer_utility: GFTimerUtility) -&gt; GFVirtualInputSource:</signature>
+			<description>替换后续脉冲使用的定时器工具。
+已启动操作会继续使用其创建时冻结的定时器，不受本次替换影响。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">timer_utility: 可注入的定时器工具；null 会禁用后续 pulse_action()。</tag>
+				<tag name="return">当前输入源；dispose 后返回同一终态实例且不修改配置。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_timer_utility">
+			<signature>func get_timer_utility() -&gt; GFTimerUtility:</signature>
+			<description>获取后续脉冲使用的定时器工具。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前注入且仍存活的 GFTimerUtility。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="pulse_action">
+			<signature>func pulse_action( action_id: StringName, value: Variant = true, duration_seconds: float = 0.1, owner: Variant = null, cancellation_token: GFCancellationToken = null, replacement_policy: PulseReplacementPolicy = PulseReplacementPolicy.REPLACE ) -&gt; GFVirtualInputPulseOperation:</signature>
+			<description>启动一次有界虚拟动作脉冲。
+owner 与 cancellation_token 均可省略；同时提供时采用 OR 语义。返回句柄冻结
+当前 Mapping、source_id、player_index 和 action_id，Source 后续重配不会改写旧操作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">action_id: 已注册的抽象动作标识。</tag>
+				<tag name="param">value: 脉冲期间的动作值。</tag>
+				<tag name="param">duration_seconds: 非负且有限的脉冲时长；0 会同步释放。</tag>
+				<tag name="param">owner: 可选生命周期 owner；Node 离树或普通 Object 释放后取消。</tag>
+				<tag name="param">cancellation_token: 可选取消 token。</tag>
+				<tag name="param">replacement_policy: 同一稳定输入键已有脉冲时的策略。</tag>
+				<tag name="return">类型化脉冲句柄；输入无效时返回立即 FAILED 的句柄。</tag>
+				<tag name="schema">value: Variant，GFInputMappingUtility 接受的 bool、float、Vector2 或 Vector3 动作值。</tag>
+				<tag name="schema">owner: Variant，null 或仍有效的 Object；无效及已释放对象会在写入前失败。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="set_action_value">
@@ -135,6 +190,14 @@
 			<description>清除当前虚拟源的所有动作贡献。</description>
 			<tags>
 				<tag name="api">public</tag>
+			</tags>
+		</member>
+		<member kind="method" name="dispose">
+			<signature>func dispose() -&gt; void:</signature>
+			<description>取消全部 Source-owned 脉冲、清除当前 source_id 贡献并释放依赖引用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_snapshot">

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="64a5352766a4740db7d147a74d23e0d911a664091176fbddf23d8cac74a01cc5" classCount="802" methodCount="7289">
-	<module id="kernel" label="Kernel" classCount="74" methodCount="792">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="cab721c60c4bbbd57b0bb2e664fd538696903620585f73a376637c59a2b56124" classCount="804" methodCount="7316">
+	<module id="kernel" label="Kernel" classCount="74" methodCount="793">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
 		<class name="GFArchitectureShutdownResult" path="classes/GFArchitectureShutdownResult.xml" sourcePath="addons/gf/kernel/core/gf_architecture_shutdown_result.gd" extends="RefCounted" />
@@ -76,7 +76,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="443" methodCount="4467">
+	<module id="standard" label="Standard" classCount="445" methodCount="4493">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />
@@ -488,6 +488,7 @@
 		<class name="GFTrajectoryMath" path="classes/GFTrajectoryMath.xml" sourcePath="addons/gf/standard/foundation/math/gf_trajectory_math.gd" extends="RefCounted" />
 		<class name="GFTransform3DMath" path="classes/GFTransform3DMath.xml" sourcePath="addons/gf/standard/foundation/math/gf_transform_3d_math.gd" extends="RefCounted" />
 		<class name="GFUILayerDefinition" path="classes/GFUILayerDefinition.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_layer_definition.gd" extends="Resource" />
+		<class name="GFUIPanelAsyncOperation" path="classes/GFUIPanelAsyncOperation.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd" extends="RefCounted" />
 		<class name="GFUIRoute" path="classes/GFUIRoute.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_route.gd" extends="Resource" />
 		<class name="GFUIRouteOperation" path="classes/GFUIRouteOperation.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_route_operation.gd" extends="RefCounted" />
 		<class name="GFUIRoutePreloadUtility" path="classes/GFUIRoutePreloadUtility.xml" sourcePath="addons/gf/standard/utilities/ui/gf_ui_route_preload_utility.gd" extends="RefCounted" />
@@ -512,6 +513,7 @@
 		<class name="GFVariantReferenceCodec" path="classes/GFVariantReferenceCodec.xml" sourcePath="addons/gf/standard/foundation/variant/gf_variant_reference_codec.gd" extends="RefCounted" />
 		<class name="GFViewportUtility" path="classes/GFViewportUtility.xml" sourcePath="addons/gf/standard/utilities/display/gf_viewport_utility.gd" extends="GFUtility" />
 		<class name="GFVirtualInputBridge" path="classes/GFVirtualInputBridge.xml" sourcePath="addons/gf/standard/input/common/gf_virtual_input_bridge.gd" extends="RefCounted" />
+		<class name="GFVirtualInputPulseOperation" path="classes/GFVirtualInputPulseOperation.xml" sourcePath="addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd" extends="RefCounted" />
 		<class name="GFVirtualInputSource" path="classes/GFVirtualInputSource.xml" sourcePath="addons/gf/standard/input/sources/gf_virtual_input_source.gd" extends="RefCounted" />
 		<class name="GFVirtualListFocusModel" path="classes/GFVirtualListFocusModel.xml" sourcePath="addons/gf/standard/utilities/ui/gf_virtual_list_focus_model.gd" extends="RefCounted" />
 		<class name="GFVirtualListModel" path="classes/GFVirtualListModel.xml" sourcePath="addons/gf/standard/utilities/ui/gf_virtual_list_model.gd" extends="RefCounted" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -24,7 +24,7 @@
 
 ## [未发布]
 
-**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，为 Save Profile 增加精确 provider domain、活动身份与显式恢复/对账事务，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；框架只提供可验证的通用机制，不内置项目启动、存档业务、部署协议、环境模型或轮询式音频模拟。
+**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，为 Save Profile 增加精确 provider domain、活动身份与显式恢复/对账事务，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；此外加入冻结模块访问策略、Route 请求生命周期和类型化虚拟输入 Pulse，使生成访问、异步 UI 与定时输入都具备明确的身份、终态与所有权边界；框架只提供可验证的通用机制，不内置项目启动、存档业务、部署协议、环境模型或轮询式音频模拟。
 
 ### 🚀 新增特性 (Added)
 
@@ -55,6 +55,9 @@
 - 新增 `GFSaveSectionMutation` 与 `GFSaveProfileMutationRequest`：用 move-only 候选 section
   清单替代事务内任意回调，固定 Provider 顺序并在确定失败时逆序恢复。
 - `GFStorageAsyncResult` 新增 `WriteFailureKind` 与隔离的 worker 载荷预检报告，区分非法请求、不可持久化载荷、编码、线程、生命周期和 IO 故障。
+- `GFArchitecture` 新增统一的 `resolve_module_access()`、模块类型与查询作用域枚举；Access Generator 可按精确模块脚本路径冻结 inherited/local、required 与 require-ready 策略，生成结果不再依赖运行时隐式选择。
+- 新增 `GFUIPanelAsyncOperation`：为每次底层异步 push/replace 冻结单调 serial、路径、层级和操作类型，并以弱面板引用暴露唯一终态；`GFUIRouterUtility` 的异步打开选项新增 owner 与 `GFAsyncScope` 生命周期锚点。
+- 新增 `GFVirtualInputPulseOperation` 与 `GFVirtualInputSource.PulseReplacementPolicy`：以类型化句柄表达有界虚拟动作脉冲、OR 生命周期取消、原子替换/拒绝策略、单调 generation 和匹配释放证明。
 
 ### 🔄 机制更改 (Changed)
 
@@ -91,6 +94,9 @@
   不自动回滚、重试、补偿或猜测迟到终态；Reconcile Lease 等待底层 generation 证据
   settled，随后仍须由项目提交 `GFSaveProfileReconcileRequest`，严格重读 lease 指定
   Profile 并完整应用后才解锁。Request 不接受项目布尔结论或可执行恢复策略。
+- Access Generator 在调用扩展或构建源码前事务式验证整批策略，统一 String/StringName 字段键并拒绝等价重复、未知、失配或错误类型配置；失败报告固定为零写入且不会覆盖既有产物。生成的 Model/System/Utility 访问器统一委托 Architecture 共享解析原语。
+- `GFUIUtility.push_panel_async*()` / `replace_layer_async*()` 改为返回精确请求句柄并可预绑定完成回调；Router 只关联返回句柄，不再把无请求身份的全局完成信号当作协议。Route 在 UI 提交前接受 owner/scope 任一终止，提交后则保持结果未知边界，不尝试撤销已提交 UI 工作。
+- 虚拟输入 Pulse 由 Source 持有操作 generation、Mapping 持有稳定输入键的权威 lease；同键替换和手动写入在单次原子边界交接，不发出中间 inactive 状态，清理、重建与 dispose 只释放仍匹配的当前贡献。
 
 ### 🐛 Bug 修复 (Fixed)
 
@@ -114,6 +120,8 @@
   与单次身份提交。
 - 修复 section 修改与保存分离时，已知写入失败、未知提交和生命周期关闭之间没有统一
   所有权的问题；类型化 mutation 现在区分可逆确定失败与必须 fence 的未知结果。
+- 修复异步 UI 的全局完成遥测缺少请求身份，可能被同键重入或旧生命周期迟到回调误关联的问题；Router 现在在发出可重入信号前原子移除旧 pending，并以单调 request ID 与精确底层句柄双重校验终态。
+- 修复旧虚拟输入定时器、同 `source_id` 的不同 Source 实例或手动覆盖可能清除后续输入贡献的问题；lease 同时校验操作对象、generation 与单调 lease ID，迟到回调无法释放新脉冲。Pulse 计时改用 owner-bound timer，并通过内部 handle + owner 精确存活契约识别 `GFTimerUtility` dispose/reinit 后的排程丢失，以 `FAILED / timer_schedule_lost` 补偿释放，避免 handle ABA 误取消或动作粘住。
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
@@ -155,6 +163,9 @@
 - `GFArchitecture.init(cancellation_token = null)` 保留无参数调用形状并新增显式取消输入；新增 `activation_timeout_seconds`、`shutdown_timeout_seconds`、`is_activating()`、`is_quiescing()`、`is_accepting_runtime_work()`、`is_module_active()`、`shutdown_async()`、`get_last_shutdown_result()` 与 `shutdown_finished`。`module_async_init_timeout_seconds` 与两个新增 timeout 属性统一为有限 `0..86400` 契约，`0` 禁用 deadline；并发 init/shutdown 都由首个调用拥有共享流程策略，后续 init token 只取消自身等待，后续 shutdown 调用只复制同一终态。父级 required module/factory 由 child generation 弱租约保护；模块租约冻结相关父级模块拓扑，任一外部依赖租约都使父级正常关闭以 `ERR_BUSY` 失败。`create_instance()` 现在属于 READY 运行时准入，在 activation、热拓扑事务或 quiesce 期间不会调用 provider。依赖诊断固定复用四类 typed Hook 与真实父级解析语义，不再提供 `include_parent_lookup` / `include_factories` 行为开关。
 - `GFArchitecture.unregister_model()`、`unregister_system()`、`unregister_utility()` 及 classless Autoload facade `Gf.unregister_*()` 均改为必须 `await` 且返回 `bool` 的拓扑事务；旧同步 fire-and-forget 调用不再受支持。
 - 新增公开值对象 `GFArchitectureShutdownResult`；`GFNodeContext.context_ready` 的既有信号形状不变，但成功语义从第三阶段准备完成收紧为第四阶段 activation 已提交。
+- `GFArchitecture.ModuleKind`、`ModuleLookupScope` 与 `resolve_module_access(module_kind, script_cls, lookup_scope, required, require_ready)` 是新的公开共享模块解析 API；`GFAccessGenerator.ACCESS_SCOPE_*`、`ACCESS_POLICIES_SETTING` 和 `gf/codegen/access_policies` 是新的生成期策略契约。
+- `GFUIUtility.push_panel_async()`、`push_panel_async_with_options()`、`replace_layer_async()` 与 `replace_layer_async_with_options()` 现在返回 `GFUIPanelAsyncOperation`，并在末尾接收可选完成回调；`GFUIRouterUtility.push_route_async()` / `replace_route_async()` 的 `async_options` 支持 `owner` 与 `scope`，`GFUIRouteResult` 新增 `STATUS_INVALID_LIFECYCLE`。
+- `GFVirtualInputSource.configure()` 新增可选 `GFTimerUtility`，并新增 `set_timer_utility()`、`get_timer_utility()`、`pulse_action()` 与不可逆 `dispose()`；`GFVirtualInputPulseOperation` 公开冻结身份、状态、取消、调试快照和匹配释放计数。
 
 ### 📘 升级指南 (Migration Guide)
 
@@ -194,6 +205,9 @@
     `reconcile_pending` 且不 claim Request。lease ready 后用同一 lease 与
     `GFSaveProfileReconcileRequest` 重试，等待严格重读和应用成功；不要用直接 load/save
     绕过 fence，也不要把迟到成功当成原 switch 会自动继续目标。
+26. 若项目依赖生成访问器的本地/父级、必需性或 ready 语义，在 `gf/codegen/access_policies` 中按精确 `res://` 模块脚本路径声明策略并重新生成；删除未知、重复或已失配路径，生成器会整批失败关闭而不保留部分源码。
+27. 把依赖全局 `panel_async_load_finished` 识别单次请求的代码迁移到异步 UI 方法返回的 `GFUIPanelAsyncOperation` 或完成回调；全局信号只用于无身份遥测。Route 调用若需要生命周期绑定，在 options 中传有效 owner 和/或未完成的 `GFAsyncScope`。
+28. 需要短时虚拟动作时，为 `GFVirtualInputSource` 注入共享 `GFTimerUtility` 并调用 `pulse_action()`；用返回句柄观察终态，不自行安排延迟 `clear_action()`。同键覆盖语义应显式选择 REPLACE 或 REJECT_NEW，Source 与 Mapping 关闭后不得复用。
 
 ### 📁 核心受影响文件 (Affected Files)
 
@@ -203,6 +217,7 @@
 - `addons/gf/standard/utilities/audio/gf_audio_backend.gd`
 - `addons/gf/standard/utilities/audio/gf_audio_backend_capability.gd`
 - `addons/gf/standard/utilities/audio/gf_audio_clip.gd`
+- `addons/gf/kernel/editor/gf_access_generator.gd`
 - `addons/gf/kernel/core/gf_architecture.gd`
 - `addons/gf/kernel/core/gf_binding.gd`
 - `addons/gf/kernel/core/gf_architecture_lifecycle_plan.gd`
@@ -223,6 +238,14 @@
 - `addons/gf/standard/utilities/assets/gf_resource_lease.gd`
 - `addons/gf/standard/utilities/assets/gf_asset_utility.gd`
 - `addons/gf/standard/utilities/scene/gf_scene_utility.gd`
+- `addons/gf/standard/utilities/time/gf_timer_utility.gd`
+- `addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd`
+- `addons/gf/standard/utilities/ui/gf_ui_route_result.gd`
+- `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd`
+- `addons/gf/standard/utilities/ui/gf_ui_utility.gd`
+- `addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd`
+- `addons/gf/standard/input/sources/gf_virtual_input_source.gd`
+- `addons/gf/standard/input/runtime/gf_input_mapping_utility.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_payload_transfer.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_async_operation.gd`
 - `addons/gf/standard/utilities/storage/gf_storage_async_result.gd`

--- a/docs/zh/editor/access-generator.md
+++ b/docs/zh/editor/access-generator.md
@@ -8,6 +8,33 @@
 
 保存生成物时可以给 `GFGeneratedArtifactReport.save_text()` 传入 `allowed_roots`，把写入限制在 `res://` 或 `user://` 的指定生成目录内。绝对文件系统路径、非 Godot URI 和越过允许根目录的路径会被报告为失败；项目工具不应把生成脚本直接写进手写源码目录，除非调用方明确声明该目录属于生成物。
 
+## 冻结模块访问策略
+
+`gf/codegen/access_policies` 可以按稳定的 `res://` 脚本路径为 Model、System 和 Utility 声明生成策略：
+
+```gdscript
+{
+	"res://game/models/player_model.gd": {
+		"scope": "inherited",
+		"required": true,
+		"require_ready": true,
+	},
+	"res://game/debug/local_console_utility.gd": {
+		"scope": "local",
+		"required": false,
+		"require_ready": false,
+	},
+}
+```
+
+- `scope = "inherited"` 使用当前架构的父链规则；`scope = "local"` 只查询传入的当前架构。
+- `required = true` 保留 `strict_dependency_lookup` 下的必需项缺失诊断；`false` 表示可选查询，未命中时静默返回 `null`。该字段只定义生成访问器的消费语义，不会替代模块的 required dependency Hook。
+- `require_ready = true` 会过滤已注册但尚未完成 `ready()` 的实例。
+
+没有配置的类型默认使用 `inherited` / `required = true` / `require_ready = false`。生成器在扩展已追加记录后深复制候选记录，完整验证设置根、每个精确路径和全部策略值，再把三项值作为字面量写入 `GFAccess`；运行时不再读取 ProjectSettings，扩展持有的原始记录也不会被生成过程改写。策略字段键接受 `String` 或 `StringName`，验证后统一冻结为 canonical `String` 键；验证器会拒绝规范化后仍可观测到的等价重复字段，而普通 Godot `Dictionary` 会在赋值阶段先折叠同文本的 `String` / `StringName` 键。修改策略后需要重新生成访问器。设置根类型非法、路径不是当前可生成的 Model/System/Utility、未知或重复字段、未知 `scope`、非布尔值或非 Dictionary 策略都会使本次生成整体返回 `failed`，且不会覆盖已有产物；`build_source()` 同样会在创建源码 Builder 和调用扩展钩子前验证完整批次，因此不会输出部分访问器或静默回落默认策略。
+
+父架构回退、严格查询与 ready 遮蔽的完整语义见[依赖诊断](../kernel/architecture/assembly-diagnostics/dependency-diagnostics.md)。
+
 ## 扩展生成结果
 
 扩展可以通过 manifest 的 `access_generator_extension_paths` 扩展生成结果。扩展脚本可实现以下约定方法：

--- a/docs/zh/editor/project-settings.md
+++ b/docs/zh/editor/project-settings.md
@@ -8,6 +8,7 @@ GF 编辑器插件启用后会注册几组项目设置及其进程内默认值�
 - `gf/project/fail_on_installer_error`：Installer 配置或执行失败时是否中断初始化。
 - `gf/project/installer_timeout_seconds`：单个 Installer 的最长等待时间。
 - `gf/codegen/access_output_path`：`GFAccess` 生成路径。
+- `gf/codegen/access_policies`：按 `res://` 脚本路径声明 Model、System 和 Utility 访问器的 `scope`、`required` 与 `require_ready` 冻结策略；详见[访问器生成](access-generator.md)。
 - `gf/codegen/project_access_output_path`：`GFProjectAccess` 生成路径。
 - `gf/build/export/*`：标准库 debug 编辑器贡献的构建信息导出设置。
 - `gf/extensions/*`：扩展启用、扩展 Installer 自动装配、禁用扩展导出排除和禁用扩展引用审计策略。

--- a/docs/zh/reference/api/classes/GFAccessGenerator.md
+++ b/docs/zh/reference/api/classes/GFAccessGenerator.md
@@ -18,6 +18,9 @@
 | 枚举 | [`TargetKind`](#member-gfaccessgenerator-enums-targetkind) | `enum TargetKind` |
 | 常量 | [`DEFAULT_OUTPUT_PATH`](#member-gfaccessgenerator-constants-default_output_path) | `const DEFAULT_OUTPUT_PATH: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.ACCESS_OUTPUT_PATH` |
 | 常量 | [`DEFAULT_PROJECT_OUTPUT_PATH`](#member-gfaccessgenerator-constants-default_project_output_path) | `const DEFAULT_PROJECT_OUTPUT_PATH: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.PROJECT_ACCESS_OUTPUT_PATH` |
+| 常量 | [`ACCESS_SCOPE_INHERITED`](#member-gfaccessgenerator-constants-access_scope_inherited) | `const ACCESS_SCOPE_INHERITED: StringName = &"inherited"` |
+| 常量 | [`ACCESS_SCOPE_LOCAL`](#member-gfaccessgenerator-constants-access_scope_local) | `const ACCESS_SCOPE_LOCAL: StringName = &"local"` |
+| 常量 | [`ACCESS_POLICIES_SETTING`](#member-gfaccessgenerator-constants-access_policies_setting) | `const ACCESS_POLICIES_SETTING: String = "gf/codegen/access_policies"` |
 | 方法 | [`generate`](#member-gfaccessgenerator-methods-generate) | `func generate(output_path: String = DEFAULT_OUTPUT_PATH, overwrite_existing: bool = true) -> Error:` |
 | 方法 | [`generate_with_report`](#member-gfaccessgenerator-methods-generate_with_report) | `func generate_with_report(output_path: String = DEFAULT_OUTPUT_PATH, options: Dictionary = {}) -> Dictionary:` |
 | 方法 | [`generate_project_access`](#member-gfaccessgenerator-methods-generate_project_access) | `func generate_project_access(output_path: String = DEFAULT_PROJECT_OUTPUT_PATH, overwrite_existing: bool = true) -> Error:` |
@@ -83,6 +86,45 @@ const DEFAULT_PROJECT_OUTPUT_PATH: String = _GF_PROJECT_ARTIFACT_PATHS_SCRIPT.PR
 ```
 
 默认项目常量访问器输出路径。
+
+<a id="member-gfaccessgenerator-constants-access_scope_inherited"></a>
+
+### `ACCESS_SCOPE_INHERITED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ACCESS_SCOPE_INHERITED: StringName = &"inherited"
+```
+
+访问器按父级回退规则解析模块。
+
+<a id="member-gfaccessgenerator-constants-access_scope_local"></a>
+
+### `ACCESS_SCOPE_LOCAL`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ACCESS_SCOPE_LOCAL: StringName = &"local"
+```
+
+访问器只解析传入架构的本地模块。
+
+<a id="member-gfaccessgenerator-constants-access_policies_setting"></a>
+
+### `ACCESS_POLICIES_SETTING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ACCESS_POLICIES_SETTING: String = "gf/codegen/access_policies"
+```
+
+每个生成类型的冻结访问策略 ProjectSettings 键。
 
 ## 方法
 
@@ -187,6 +229,7 @@ func generate_project_access_with_report( output_path: String = DEFAULT_PROJECT_
 ### `collect_records`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func collect_records() -> Array[Dictionary]:
@@ -194,11 +237,11 @@ func collect_records() -> Array[Dictionary]:
 
 收集当前项目中可生成访问器的 GF 类型记录。
 
-返回：类型记录列表。
+返回：类型记录列表；访问策略配置无效时返回空数组且不会返回部分冻结结果。
 
 结构：
 
-- `return`: Array of Dictionary type records with class_name, path, script, kind, and access metadata.
+- `return`: Array of Dictionary type records with class_name, path, and kind; Model/System/Utility records additionally contain scope, required, and require_ready.
 
 <a id="member-gfaccessgenerator-methods-collect_project_records"></a>
 
@@ -223,6 +266,7 @@ func collect_project_records() -> Dictionary:
 ### `build_source`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func build_source(records: Array) -> String:
@@ -236,11 +280,11 @@ func build_source(records: Array) -> String:
 |---|---|
 | `records` | 生成访问器时使用的类型记录列表。 |
 
-返回：GDScript 源码。
+返回：完整 GDScript 源码；任一记录或模块访问策略无效时整批失败并返回空字符串。
 
 结构：
 
-- `records`: Array of Dictionary type records containing class_name, path, and kind.
+- `records`: Array of Dictionary type records containing class_name, path, and kind; Model/System/Utility records may additionally contain scope, required, and require_ready.
 
 <a id="member-gfaccessgenerator-methods-build_project_source"></a>
 

--- a/docs/zh/reference/api/classes/GFArchitecture.md
+++ b/docs/zh/reference/api/classes/GFArchitecture.md
@@ -19,6 +19,8 @@
 | 信号 | [`initialization_failed`](#member-gfarchitecture-signals-initialization_failed) | `signal initialization_failed(reason: String)` |
 | 信号 | [`shutdown_finished`](#member-gfarchitecture-signals-shutdown_finished) | `signal shutdown_finished(result: GFArchitectureShutdownResult)` |
 | 信号 | [`project_installers_finished`](#member-gfarchitecture-signals-project_installers_finished) | `signal project_installers_finished` |
+| 枚举 | [`ModuleKind`](#member-gfarchitecture-enums-modulekind) | `enum ModuleKind` |
+| 枚举 | [`ModuleLookupScope`](#member-gfarchitecture-enums-modulelookupscope) | `enum ModuleLookupScope` |
 | 常量 | [`SERVICE_COMMAND_HISTORY_STORE`](#member-gfarchitecture-constants-service_command_history_store) | `const SERVICE_COMMAND_HISTORY_STORE: StringName = &"gf.kernel.command_history_store"` |
 | 常量 | [`DEFAULT_SNAPSHOT_MODELS_PER_FRAME`](#member-gfarchitecture-constants-default_snapshot_models_per_frame) | `const DEFAULT_SNAPSHOT_MODELS_PER_FRAME: int = 8` |
 | 属性 | [`module_async_init_timeout_seconds`](#member-gfarchitecture-properties-module_async_init_timeout_seconds) | `var module_async_init_timeout_seconds: float = 0.0:` |
@@ -111,6 +113,7 @@
 | 方法 | [`unregister_system`](#member-gfarchitecture-methods-unregister_system) | `func unregister_system(script_cls: Script) -> bool:` |
 | 方法 | [`unregister_model`](#member-gfarchitecture-methods-unregister_model) | `func unregister_model(script_cls: Script) -> bool:` |
 | 方法 | [`unregister_utility`](#member-gfarchitecture-methods-unregister_utility) | `func unregister_utility(script_cls: Script) -> bool:` |
+| 方法 | [`resolve_module_access`](#member-gfarchitecture-methods-resolve_module_access) | `func resolve_module_access( module_kind: ModuleKind, script_cls: Script, lookup_scope: ModuleLookupScope = ModuleLookupScope.INHERITED, required: bool = true, require_ready: bool = false ) -> Object:` |
 | 方法 | [`get_system`](#member-gfarchitecture-methods-get_system) | `func get_system(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_model`](#member-gfarchitecture-methods-get_model) | `func get_model(script_cls: Script, require_ready: bool = false) -> Object:` |
 | 方法 | [`get_utility`](#member-gfarchitecture-methods-get_utility) | `func get_utility(script_cls: Script, require_ready: bool = false) -> Object:` |
@@ -199,6 +202,46 @@ signal project_installers_finished
 ```
 
 当项目级 Installer 应用完成或被 dispose() 中断后发出。
+
+## 枚举
+
+<a id="member-gfarchitecture-enums-modulekind"></a>
+
+### `ModuleKind`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum ModuleKind {
+	## Model 模块。
+	MODEL,
+	## System 模块。
+	SYSTEM,
+	## Utility 模块。
+	UTILITY,
+}
+```
+
+可由架构访问策略解析的模块类型。
+
+<a id="member-gfarchitecture-enums-modulelookupscope"></a>
+
+### `ModuleLookupScope`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum ModuleLookupScope {
+	## 按当前架构的父级回退与 strict_dependency_lookup 规则解析。
+	INHERITED,
+	## 只解析当前架构，不回退父级。
+	LOCAL,
+}
+```
+
+模块访问的架构作用域。
 
 ## 常量
 
@@ -1945,6 +1988,31 @@ func unregister_utility(script_cls: Script) -> bool:
 | `script_cls` | 工具的脚本类。 |
 
 返回：模块完成 quiesce 并从活动拓扑移除时返回 true。
+
+<a id="member-gfarchitecture-methods-resolve_module_access"></a>
+
+### `resolve_module_access`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func resolve_module_access( module_kind: ModuleKind, script_cls: Script, lookup_scope: ModuleLookupScope = ModuleLookupScope.INHERITED, required: bool = true, require_ready: bool = false ) -> Object:
+```
+
+按冻结的作用域、必需性和 ready 策略解析已注册模块。 该入口供生成访问器与其他声明式依赖边界复用；required 只控制严格依赖缺失诊断， 不改变 strict_dependency_lookup 对父级回退的限制。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `module_kind` | 要解析的 Model、System 或 Utility 类型。 |
+| `script_cls` | 模块脚本类。 |
+| `lookup_scope` | 父级可见或仅当前架构的查询作用域。 |
+| `required` | 为 true 时，严格查询模式下缺失模块会输出 required miss。 |
+| `require_ready` | 为 true 时，仅返回已完成 ready 阶段的实例。 |
+
+返回：符合全部冻结策略的模块实例；未命中时返回 null。
 
 <a id="member-gfarchitecture-methods-get_system"></a>
 

--- a/docs/zh/reference/api/classes/GFInputMappingUtility.md
+++ b/docs/zh/reference/api/classes/GFInputMappingUtility.md
@@ -38,7 +38,7 @@
 | 方法 | [`is_context_enabled`](#member-gfinputmappingutility-methods-is_context_enabled) | `func is_context_enabled(context: GFInputContext) -> bool:` |
 | 方法 | [`get_enabled_contexts`](#member-gfinputmappingutility-methods-get_enabled_contexts) | `func get_enabled_contexts() -> Array[GFInputContext]:` |
 | 方法 | [`handle_input_event`](#member-gfinputmappingutility-methods-handle_input_event) | `func handle_input_event(event: InputEvent) -> void:` |
-| 方法 | [`create_virtual_source`](#member-gfinputmappingutility-methods-create_virtual_source) | `func create_virtual_source( source_id: StringName = &"virtual", player_index: int = -1 ) -> GFVirtualInputSource:` |
+| 方法 | [`create_virtual_source`](#member-gfinputmappingutility-methods-create_virtual_source) | `func create_virtual_source( source_id: StringName = &"virtual", player_index: int = -1, timer_utility: GFTimerUtility = null ) -> GFVirtualInputSource:` |
 | 方法 | [`set_virtual_action_value`](#member-gfinputmappingutility-methods-set_virtual_action_value) | `func set_virtual_action_value( action_id: StringName, value: Variant, source_id: StringName = &"virtual", player_index: int = -1 ) -> bool:` |
 | 方法 | [`clear_virtual_action`](#member-gfinputmappingutility-methods-clear_virtual_action) | `func clear_virtual_action( action_id: StringName, source_id: StringName = &"virtual", player_index: int = -1 ) -> bool:` |
 | 方法 | [`clear_virtual_source`](#member-gfinputmappingutility-methods-clear_virtual_source) | `func clear_virtual_source(source_id: StringName = &"virtual") -> void:` |
@@ -518,9 +518,10 @@ func handle_input_event(event: InputEvent) -> void:
 ### `create_virtual_source`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
-func create_virtual_source( source_id: StringName = &"virtual", player_index: int = -1 ) -> GFVirtualInputSource:
+func create_virtual_source( source_id: StringName = &"virtual", player_index: int = -1, timer_utility: GFTimerUtility = null ) -> GFVirtualInputSource:
 ```
 
 创建可编程虚拟输入源。
@@ -531,6 +532,7 @@ func create_virtual_source( source_id: StringName = &"virtual", player_index: in
 |---|---|
 | `source_id` | 虚拟输入源标识。 |
 | `player_index` | 玩家索引；小于 0 时只写入全局动作状态。 |
+| `timer_utility` | 可选的虚拟脉冲定时器注入。 |
 
 返回：虚拟输入源。
 
@@ -539,6 +541,7 @@ func create_virtual_source( source_id: StringName = &"virtual", player_index: in
 ### `set_virtual_action_value`
 
 - API：`public`
+- 首次版本：`2.6.0`
 
 ```gdscript
 func set_virtual_action_value( action_id: StringName, value: Variant, source_id: StringName = &"virtual", player_index: int = -1 ) -> bool:

--- a/docs/zh/reference/api/classes/GFUIPanelAsyncOperation.md
+++ b/docs/zh/reference/api/classes/GFUIPanelAsyncOperation.md
@@ -1,0 +1,233 @@
+# GFUIPanelAsyncOperation
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+单次异步 UI 面板请求的可观察句柄。 句柄冻结 UI 分配的请求序号、路径、层级与操作类型，并且只接受一个终态。 成功面板仅以弱引用保存，句柄不会延长面板节点的生命周期。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`completed`](#member-gfuipanelasyncoperation-signals-completed) | `signal completed(handle: GFUIPanelAsyncOperation)` |
+| 常量 | [`STATUS_PENDING`](#member-gfuipanelasyncoperation-constants-status_pending) | `const STATUS_PENDING: int = -1` |
+| 常量 | [`OPERATION_PUSH`](#member-gfuipanelasyncoperation-constants-operation_push) | `const OPERATION_PUSH: StringName = &"push"` |
+| 常量 | [`OPERATION_REPLACE`](#member-gfuipanelasyncoperation-constants-operation_replace) | `const OPERATION_REPLACE: StringName = &"replace"` |
+| 方法 | [`get_serial`](#member-gfuipanelasyncoperation-methods-get_serial) | `func get_serial() -> int:` |
+| 方法 | [`get_path`](#member-gfuipanelasyncoperation-methods-get_path) | `func get_path() -> String:` |
+| 方法 | [`get_layer`](#member-gfuipanelasyncoperation-methods-get_layer) | `func get_layer() -> int:` |
+| 方法 | [`get_operation`](#member-gfuipanelasyncoperation-methods-get_operation) | `func get_operation() -> StringName:` |
+| 方法 | [`is_pending`](#member-gfuipanelasyncoperation-methods-is_pending) | `func is_pending() -> bool:` |
+| 方法 | [`is_completed`](#member-gfuipanelasyncoperation-methods-is_completed) | `func is_completed() -> bool:` |
+| 方法 | [`get_status`](#member-gfuipanelasyncoperation-methods-get_status) | `func get_status() -> int:` |
+| 方法 | [`get_panel`](#member-gfuipanelasyncoperation-methods-get_panel) | `func get_panel() -> Node:` |
+| 方法 | [`get_debug_snapshot`](#member-gfuipanelasyncoperation-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
+
+## 信号
+
+<a id="member-gfuipanelasyncoperation-signals-completed"></a>
+
+### `completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal completed(handle: GFUIPanelAsyncOperation)
+```
+
+请求进入终态时发出一次。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `handle` | 已完成的当前句柄。 |
+
+## 常量
+
+<a id="member-gfuipanelasyncoperation-constants-status_pending"></a>
+
+### `STATUS_PENDING`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_PENDING: int = -1
+```
+
+请求尚未进入终态时由 get_status() 返回的状态。
+
+<a id="member-gfuipanelasyncoperation-constants-operation_push"></a>
+
+### `OPERATION_PUSH`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_PUSH: StringName = &"push"
+```
+
+压入面板操作。
+
+<a id="member-gfuipanelasyncoperation-constants-operation_replace"></a>
+
+### `OPERATION_REPLACE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_REPLACE: StringName = &"replace"
+```
+
+替换层级操作。
+
+## 方法
+
+<a id="member-gfuipanelasyncoperation-methods-get_serial"></a>
+
+### `get_serial`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_serial() -> int:
+```
+
+获取 UI 分配的请求序号。
+
+返回：配置后为大于零的请求序号；未配置时为 0。
+
+<a id="member-gfuipanelasyncoperation-methods-get_path"></a>
+
+### `get_path`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_path() -> String:
+```
+
+获取面板场景路径。
+
+返回：请求创建时冻结的场景路径。
+
+<a id="member-gfuipanelasyncoperation-methods-get_layer"></a>
+
+### `get_layer`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_layer() -> int:
+```
+
+获取目标 UI 层级。
+
+返回：请求创建时冻结的逻辑层 ID。
+
+<a id="member-gfuipanelasyncoperation-methods-get_operation"></a>
+
+### `get_operation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_operation() -> StringName:
+```
+
+获取 push 或 replace 操作。
+
+返回：`OPERATION_*` 常量之一。
+
+<a id="member-gfuipanelasyncoperation-methods-is_pending"></a>
+
+### `is_pending`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_pending() -> bool:
+```
+
+检查请求是否仍在等待终态。
+
+返回：已配置且尚未完成时返回 true。
+
+<a id="member-gfuipanelasyncoperation-methods-is_completed"></a>
+
+### `is_completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_completed() -> bool:
+```
+
+检查请求是否已有终态。
+
+返回：已完成时返回 true。
+
+<a id="member-gfuipanelasyncoperation-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> int:
+```
+
+获取请求状态。
+
+返回：等待中返回 STATUS_PENDING；完成后返回 GFUIUtility.AsyncPanelLoadStatus。
+
+<a id="member-gfuipanelasyncoperation-methods-get_panel"></a>
+
+### `get_panel`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_panel() -> Node:
+```
+
+获取成功打开的面板。 句柄只保存弱引用；面板已释放、请求失败或请求取消时返回 null。
+
+返回：当前仍有效的成功面板；否则返回 null。
+
+<a id="member-gfuipanelasyncoperation-methods-get_debug_snapshot"></a>
+
+### `get_debug_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_debug_snapshot() -> Dictionary:
+```
+
+获取稳定调试快照。
+
+返回：请求身份与终态摘要。
+
+结构：
+
+- `return`: Dictionary，包含 serial、path、layer、operation、pending、completed、status、has_panel 和 panel_instance_id。

--- a/docs/zh/reference/api/classes/GFUIRouteResult.md
+++ b/docs/zh/reference/api/classes/GFUIRouteResult.md
@@ -22,6 +22,7 @@ UI 路由异步打开的不可变终态。 结果把路由校验、可选预加�
 | 常量 | [`STATUS_MISSING_UI_LAYER`](#member-gfuirouteresult-constants-status_missing_ui_layer) | `const STATUS_MISSING_UI_LAYER: StringName = &"missing_ui_layer"` |
 | 常量 | [`STATUS_ASYNC_CONFLICT`](#member-gfuirouteresult-constants-status_async_conflict) | `const STATUS_ASYNC_CONFLICT: StringName = &"async_conflict"` |
 | 常量 | [`STATUS_INVALID_PRELOAD_POLICY`](#member-gfuirouteresult-constants-status_invalid_preload_policy) | `const STATUS_INVALID_PRELOAD_POLICY: StringName = &"invalid_preload_policy"` |
+| 常量 | [`STATUS_INVALID_LIFECYCLE`](#member-gfuirouteresult-constants-status_invalid_lifecycle) | `const STATUS_INVALID_LIFECYCLE: StringName = &"invalid_lifecycle"` |
 | 常量 | [`STATUS_MISSING_ASSET_UTILITY`](#member-gfuirouteresult-constants-status_missing_asset_utility) | `const STATUS_MISSING_ASSET_UTILITY: StringName = &"missing_asset_utility"` |
 | 常量 | [`STATUS_PRELOAD_PLAN_FAILED`](#member-gfuirouteresult-constants-status_preload_plan_failed) | `const STATUS_PRELOAD_PLAN_FAILED: StringName = &"preload_plan_failed"` |
 | 常量 | [`STATUS_PRELOAD_FAILED`](#member-gfuirouteresult-constants-status_preload_failed) | `const STATUS_PRELOAD_FAILED: StringName = &"preload_failed"` |
@@ -142,6 +143,19 @@ const STATUS_INVALID_PRELOAD_POLICY: StringName = &"invalid_preload_policy"
 
 预加载策略不受支持。
 
+<a id="member-gfuirouteresult-constants-status_invalid_lifecycle"></a>
+
+### `STATUS_INVALID_LIFECYCLE`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_LIFECYCLE: StringName = &"invalid_lifecycle"
+```
+
+请求 owner 或异步作用域不满足生命周期契约。
+
 <a id="member-gfuirouteresult-constants-status_missing_asset_utility"></a>
 
 ### `STATUS_MISSING_ASSET_UTILITY`
@@ -205,7 +219,7 @@ const STATUS_PANEL_FAILED: StringName = &"panel_failed"
 const STATUS_CANCELLED: StringName = &"cancelled"
 ```
 
-底层 UI 请求在完成前被取消。
+请求在面板提交前因 owner/scope 结束，或在提交后被底层 UI 取消。
 
 <a id="member-gfuirouteresult-constants-status_disposed"></a>
 

--- a/docs/zh/reference/api/classes/GFUIRouterUtility.md
+++ b/docs/zh/reference/api/classes/GFUIRouterUtility.md
@@ -27,6 +27,7 @@
 | 属性 | [`max_history`](#member-gfuirouterutility-properties-max_history) | `var max_history: int = 64` |
 | 方法 | [`init`](#member-gfuirouterutility-methods-init) | `func init() -> void:` |
 | 方法 | [`dispose`](#member-gfuirouterutility-methods-dispose) | `func dispose() -> void:` |
+| 方法 | [`tick`](#member-gfuirouterutility-methods-tick) | `func tick(_delta: float) -> void:` |
 | 方法 | [`configure`](#member-gfuirouterutility-methods-configure) | `func configure(routes: Array[GFUIRoute] = [], ui_utility: GFUIUtility = null) -> void:` |
 | 方法 | [`set_ui_utility`](#member-gfuirouterutility-methods-set_ui_utility) | `func set_ui_utility(ui_utility: GFUIUtility) -> void:` |
 | 方法 | [`register_route`](#member-gfuirouterutility-methods-register_route) | `func register_route(route: GFUIRoute) -> bool:` |
@@ -231,12 +232,13 @@ var max_history: int = 64
 ### `init`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func init() -> void:
 ```
 
-初始化路由表、UI 工具引用和历史记录。
+初始化路由表、UI 工具引用和历史记录。 重复初始化会先以 dispose 语义终结旧 pending 请求；请求 ID 在同一实例内保持单调， 避免旧异步回调或临时预加载组与新生命周期串线。
 
 <a id="member-gfuirouterutility-methods-dispose"></a>
 
@@ -249,6 +251,25 @@ func dispose() -> void:
 ```
 
 释放路由表、UI 工具引用和历史记录。
+
+<a id="member-gfuirouterutility-methods-tick"></a>
+
+### `tick`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func tick(_delta: float) -> void:
+```
+
+清理普通 Object owner 已释放的提交前路由请求。 Node owner 和 GFAsyncScope 会通过信号即时取消；普通 Object 依赖本帧弱引用检查。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_delta` | 本帧时间增量；生命周期清理不依赖具体数值。 |
 
 <a id="member-gfuirouterutility-methods-configure"></a>
 
@@ -521,7 +542,7 @@ func push_route_async( route_id: StringName, params: Dictionary = {}, option_ove
 
 - `params`: Dictionary，本次打开路由携带的项目自定义参数。
 - `option_overrides`: Dictionary，字段同 GFUIUtility 打开面板 options，会覆盖路由 default_options。
-- `async_options`: Dictionary，可包含 preload_policy、preload_plan_options 和 metadata；preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
+- `async_options`: Dictionary，可包含 preload_policy、preload_plan_options、metadata、owner: Object 和 scope: GFAsyncScope；owner 与 scope 使用 OR 取消语义且只约束面板提交前，preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
 
 <a id="member-gfuirouterutility-methods-replace_route_async"></a>
 
@@ -552,7 +573,7 @@ func replace_route_async( route_id: StringName, params: Dictionary = {}, option_
 
 - `params`: Dictionary，本次打开路由携带的项目自定义参数。
 - `option_overrides`: Dictionary，字段同 GFUIUtility 打开面板 options，会覆盖路由 default_options。
-- `async_options`: Dictionary，可包含 preload_policy、preload_plan_options 和 metadata；preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
+- `async_options`: Dictionary，可包含 preload_policy、preload_plan_options、metadata、owner: Object 和 scope: GFAsyncScope；owner 与 scope 使用 OR 取消语义且只约束面板提交前，preload_policy 使用 PRELOAD_* 常量，自动预加载始终包含当前路由，未指定 max_depth 时只加载当前页面。
 
 <a id="member-gfuirouterutility-methods-back"></a>
 
@@ -642,4 +663,4 @@ func get_debug_snapshot() -> Dictionary:
 
 结构：
 
-- `return`: Dictionary，包含 route_count、history_count、pending_async_route_count、pending_async_routes、current_route_id、has_ui_utility 和 disposed。
+- `return`: Dictionary，包含 route_count、history_count、pending_async_route_count、current_route_id、has_ui_utility、disposed，以及 pending_async_routes；其中每个 pending 条目额外包含 panel_submitted、has_owner、has_scope 与 lifecycle_cancellation_open。

--- a/docs/zh/reference/api/classes/GFUIUtility.md
+++ b/docs/zh/reference/api/classes/GFUIUtility.md
@@ -33,14 +33,14 @@
 | 方法 | [`get_layer_definition`](#member-gfuiutility-methods-get_layer_definition) | `func get_layer_definition(layer: int) -> GFUILayerDefinition:` |
 | 方法 | [`get_layer_ids`](#member-gfuiutility-methods-get_layer_ids) | `func get_layer_ids() -> Array[int]:` |
 | 方法 | [`set_layer_auto_hide_under`](#member-gfuiutility-methods-set_layer_auto_hide_under) | `func set_layer_auto_hide_under(layer: int, auto_hide_under: bool) -> bool:` |
-| 方法 | [`push_panel_async`](#member-gfuiutility-methods-push_panel_async) | `func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void:` |
-| 方法 | [`push_panel_async_with_options`](#member-gfuiutility-methods-push_panel_async_with_options) | `func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void:` |
+| 方法 | [`push_panel_async`](#member-gfuiutility-methods-push_panel_async) | `func push_panel_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:` |
+| 方法 | [`push_panel_async_with_options`](#member-gfuiutility-methods-push_panel_async_with_options) | `func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:` |
 | 方法 | [`push_panel`](#member-gfuiutility-methods-push_panel) | `func push_panel(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> Node:` |
 | 方法 | [`push_panel_with_options`](#member-gfuiutility-methods-push_panel_with_options) | `func push_panel_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> Node:` |
 | 方法 | [`replace_layer`](#member-gfuiutility-methods-replace_layer) | `func replace_layer(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> Node:` |
 | 方法 | [`replace_layer_with_options`](#member-gfuiutility-methods-replace_layer_with_options) | `func replace_layer_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> Node:` |
-| 方法 | [`replace_layer_async`](#member-gfuiutility-methods-replace_layer_async) | `func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void:` |
-| 方法 | [`replace_layer_async_with_options`](#member-gfuiutility-methods-replace_layer_async_with_options) | `func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void:` |
+| 方法 | [`replace_layer_async`](#member-gfuiutility-methods-replace_layer_async) | `func replace_layer_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:` |
+| 方法 | [`replace_layer_async_with_options`](#member-gfuiutility-methods-replace_layer_async_with_options) | `func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:` |
 | 方法 | [`push_panel_instance`](#member-gfuiutility-methods-push_panel_instance) | `func push_panel_instance( panel_instance: Node, layer: int = Layer.POPUP, config_callback: Callable = Callable() ) -> void:` |
 | 方法 | [`push_panel_instance_with_options`](#member-gfuiutility-methods-push_panel_instance_with_options) | `func push_panel_instance_with_options( panel_instance: Node, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void:` |
 | 方法 | [`replace_layer_instance`](#member-gfuiutility-methods-replace_layer_instance) | `func replace_layer_instance( panel_instance: Node, layer: int = Layer.POPUP, config_callback: Callable = Callable() ) -> void:` |
@@ -413,7 +413,7 @@ func set_layer_auto_hide_under(layer: int, auto_hide_under: bool) -> bool:
 - 首次版本：`3.17.0`
 
 ```gdscript
-func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void:
+func push_panel_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:
 ```
 
 异步压入一个面板场景。
@@ -425,6 +425,9 @@ func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: C
 | `path` | 面板场景路径。 |
 | `layer` | 目标层级。 |
 | `config_callback` | 实例化后、入栈前的可选配置回调。 |
+| `completion_callback` | 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。 |
+
+返回：已接受请求的类型化句柄；路径无效时返回 null。
 
 <a id="member-gfuiutility-methods-push_panel_async_with_options"></a>
 
@@ -434,7 +437,7 @@ func push_panel_async(path: String, layer: int = Layer.POPUP, config_callback: C
 - 首次版本：`3.17.0`
 
 ```gdscript
-func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void:
+func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:
 ```
 
 异步压入一个带策略选项的面板场景。
@@ -447,6 +450,9 @@ func push_panel_async_with_options( path: String, layer: int = Layer.POPUP, opti
 | `layer` | 目标层级。 |
 | `options` | 面板策略，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close、metadata。 |
 | `config_callback` | 实例化后、入栈前的可选配置回调。 |
+| `completion_callback` | 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。 |
+
+返回：已接受请求的类型化句柄；同步回退可能返回已完成句柄，路径无效时返回 null。
 
 结构：
 
@@ -562,7 +568,7 @@ func replace_layer_with_options( path: String, layer: int = Layer.POPUP, options
 - 首次版本：`3.17.0`
 
 ```gdscript
-func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable()) -> void:
+func replace_layer_async( path: String, layer: int = Layer.POPUP, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:
 ```
 
 异步替换指定层级的面板栈。
@@ -574,6 +580,9 @@ func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback
 | `path` | 面板场景路径。 |
 | `layer` | 目标层级。 |
 | `config_callback` | 实例化后、入栈前的可选配置回调。 |
+| `completion_callback` | 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。 |
+
+返回：已接受请求的类型化句柄；路径无效时返回 null。
 
 <a id="member-gfuiutility-methods-replace_layer_async_with_options"></a>
 
@@ -583,7 +592,7 @@ func replace_layer_async(path: String, layer: int = Layer.POPUP, config_callback
 - 首次版本：`3.17.0`
 
 ```gdscript
-func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable() ) -> void:
+func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, options: Dictionary = {}, config_callback: Callable = Callable(), completion_callback: Callable = Callable() ) -> GFUIPanelAsyncOperation:
 ```
 
 异步替换指定层级为带策略选项的面板。
@@ -596,6 +605,9 @@ func replace_layer_async_with_options( path: String, layer: int = Layer.POPUP, o
 | `layer` | 目标层级。 |
 | `options` | 面板策略，支持 mode、modal、hide_under、dismiss_on_cancel、focus_on_open、restore_focus_on_close、metadata。 |
 | `config_callback` | 实例化后、入栈前的可选配置回调。 |
+| `completion_callback` | 可选终态回调，接收当前 GFUIPanelAsyncOperation；同步回退时可能在本方法返回前调用。 |
+
+返回：已接受请求的类型化句柄；同步回退可能返回已完成句柄，路径无效时返回 null。
 
 结构：
 
@@ -1008,6 +1020,7 @@ func has_pending_async_panel(layer: int = -1, path: String = "") -> bool:
 ### `get_pending_async_panel_requests`
 
 - API：`public`
+- 首次版本：`3.15.0`
 
 ```gdscript
 func get_pending_async_panel_requests(layer: int = -1) -> Array[Dictionary]:
@@ -1021,11 +1034,11 @@ func get_pending_async_panel_requests(layer: int = -1) -> Array[Dictionary]:
 |---|---|
 | `layer` | 指定层级；小于 0 时返回所有层级。 |
 
-返回：请求快照数组，每项包含 path、layer、operation 和 serial。
+返回：请求快照数组，每项包含 path、layer、operation、serial 和 operation_handle。
 
 结构：
 
-- `return`: Array，元素为 Dictionary，包含 path、layer、operation 和 serial。
+- `return`: Array，元素为 Dictionary，包含 path、layer、operation、serial 和 GFUIPanelAsyncOperation operation_handle。
 
 <a id="member-gfuiutility-methods-get_modal_count"></a>
 

--- a/docs/zh/reference/api/classes/GFVirtualInputPulseOperation.md
+++ b/docs/zh/reference/api/classes/GFVirtualInputPulseOperation.md
@@ -1,0 +1,272 @@
+# GFVirtualInputPulseOperation
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+单次虚拟输入脉冲的类型化运行时句柄。 句柄冻结创建时的 Mapping、source_id、player_index 与 action_id，并由 GFInputMappingUtility 的权威 lease 保证旧定时器不会释放后续脉冲。owner 与 cancellation_token 均为可选锚点；同时提供时，任一先结束都会取消脉冲。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`completed`](#member-gfvirtualinputpulseoperation-signals-completed) | `signal completed(operation: GFVirtualInputPulseOperation)` |
+| 枚举 | [`Status`](#member-gfvirtualinputpulseoperation-enums-status) | `enum Status` |
+| 方法 | [`cancel`](#member-gfvirtualinputpulseoperation-methods-cancel) | `func cancel(reason: StringName = &"cancelled") -> bool:` |
+| 方法 | [`get_generation`](#member-gfvirtualinputpulseoperation-methods-get_generation) | `func get_generation() -> int:` |
+| 方法 | [`get_source_id`](#member-gfvirtualinputpulseoperation-methods-get_source_id) | `func get_source_id() -> StringName:` |
+| 方法 | [`get_player_index`](#member-gfvirtualinputpulseoperation-methods-get_player_index) | `func get_player_index() -> int:` |
+| 方法 | [`get_action_id`](#member-gfvirtualinputpulseoperation-methods-get_action_id) | `func get_action_id() -> StringName:` |
+| 方法 | [`get_duration_seconds`](#member-gfvirtualinputpulseoperation-methods-get_duration_seconds) | `func get_duration_seconds() -> float:` |
+| 方法 | [`get_status`](#member-gfvirtualinputpulseoperation-methods-get_status) | `func get_status() -> Status:` |
+| 方法 | [`get_terminal_reason`](#member-gfvirtualinputpulseoperation-methods-get_terminal_reason) | `func get_terminal_reason() -> StringName:` |
+| 方法 | [`is_pending`](#member-gfvirtualinputpulseoperation-methods-is_pending) | `func is_pending() -> bool:` |
+| 方法 | [`is_completed`](#member-gfvirtualinputpulseoperation-methods-is_completed) | `func is_completed() -> bool:` |
+| 方法 | [`get_release_count`](#member-gfvirtualinputpulseoperation-methods-get_release_count) | `func get_release_count() -> int:` |
+| 方法 | [`get_debug_snapshot`](#member-gfvirtualinputpulseoperation-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
+
+## 信号
+
+<a id="member-gfvirtualinputpulseoperation-signals-completed"></a>
+
+### `completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal completed(operation: GFVirtualInputPulseOperation)
+```
+
+脉冲首次进入终态时发出一次。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `operation` | 已进入终态的当前句柄。 |
+
+## 枚举
+
+<a id="member-gfvirtualinputpulseoperation-enums-status"></a>
+
+### `Status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum Status {
+	## 等待定时、生命周期或显式终止。
+	PENDING,
+	## 到达脉冲时长并完成匹配释放。
+	COMPLETED,
+	## 被调用方、owner、token 或状态清理取消。
+	CANCELLED,
+	## 被同一稳定输入键上的新脉冲替换。
+	REPLACED,
+	## 因同一稳定输入键已有脉冲而拒绝启动。
+	REJECTED,
+	## 输入或运行时依赖无效，未能启动。
+	FAILED,
+}
+```
+
+脉冲操作状态。
+
+## 方法
+
+<a id="member-gfvirtualinputpulseoperation-methods-cancel"></a>
+
+### `cancel`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func cancel(reason: StringName = &"cancelled") -> bool:
+```
+
+取消仍在等待的脉冲。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `reason` | 稳定取消原因；空值会规范化为 cancelled。 |
+
+返回：本次调用是否首次使操作进入终态。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_generation"></a>
+
+### `get_generation`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_generation() -> int:
+```
+
+获取 Source 分配的单调 generation。
+
+返回：大于零的 generation；配置失败前可能为 0。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_source_id"></a>
+
+### `get_source_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_id() -> StringName:
+```
+
+获取冻结的虚拟输入源标识。
+
+返回：创建脉冲时的 source_id。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_player_index"></a>
+
+### `get_player_index`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_player_index() -> int:
+```
+
+获取冻结的玩家索引。
+
+返回：创建脉冲时的 player_index。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_action_id"></a>
+
+### `get_action_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_action_id() -> StringName:
+```
+
+获取冻结的动作标识。
+
+返回：创建脉冲时的 action_id。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_duration_seconds"></a>
+
+### `get_duration_seconds`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_duration_seconds() -> float:
+```
+
+获取规范化脉冲时长。
+
+返回：秒数。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> Status:
+```
+
+获取当前状态。
+
+返回：Status 枚举值。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_terminal_reason"></a>
+
+### `get_terminal_reason`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_terminal_reason() -> StringName:
+```
+
+获取终态原因。
+
+返回：等待中为空 StringName；终态时为稳定原因。
+
+<a id="member-gfvirtualinputpulseoperation-methods-is_pending"></a>
+
+### `is_pending`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_pending() -> bool:
+```
+
+返回操作是否仍在等待。
+
+返回：等待中返回 true。
+
+<a id="member-gfvirtualinputpulseoperation-methods-is_completed"></a>
+
+### `is_completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_completed() -> bool:
+```
+
+返回操作是否已经进入任意终态。
+
+返回：已完成、取消、替换、拒绝或失败时返回 true。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_release_count"></a>
+
+### `get_release_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_release_count() -> int:
+```
+
+获取该脉冲完成的匹配释放次数。
+
+返回：仅当前 lease 实际清除动作贡献时为 1；无释放交接、未取得 lease 或未释放时为 0。
+
+<a id="member-gfvirtualinputpulseoperation-methods-get_debug_snapshot"></a>
+
+### `get_debug_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_debug_snapshot() -> Dictionary:
+```
+
+获取稳定调试快照。
+
+返回：冻结身份、状态、时长、时间戳与释放证明。
+
+结构：
+
+- `return`: Dictionary，包含 generation、source_id、player_index、action_id、duration_seconds、status、status_name、terminal_reason、pending、completed、started_at_msec、completed_at_msec、release_count、lease_acquired 和 timer_handle。

--- a/docs/zh/reference/api/classes/GFVirtualInputSource.md
+++ b/docs/zh/reference/api/classes/GFVirtualInputSource.md
@@ -15,9 +15,13 @@
 
 | 类型 | 名称 | 签名 |
 |---|---|---|
+| 枚举 | [`PulseReplacementPolicy`](#member-gfvirtualinputsource-enums-pulsereplacementpolicy) | `enum PulseReplacementPolicy` |
 | 属性 | [`source_id`](#member-gfvirtualinputsource-properties-source_id) | `var source_id: StringName = &"virtual"` |
 | 属性 | [`player_index`](#member-gfvirtualinputsource-properties-player_index) | `var player_index: int = -1` |
-| 方法 | [`configure`](#member-gfvirtualinputsource-methods-configure) | `func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &"virtual", p_player_index: int = -1 ) -> GFVirtualInputSource:` |
+| 方法 | [`configure`](#member-gfvirtualinputsource-methods-configure) | `func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &"virtual", p_player_index: int = -1, timer_utility: GFTimerUtility = null ) -> GFVirtualInputSource:` |
+| 方法 | [`set_timer_utility`](#member-gfvirtualinputsource-methods-set_timer_utility) | `func set_timer_utility(timer_utility: GFTimerUtility) -> GFVirtualInputSource:` |
+| 方法 | [`get_timer_utility`](#member-gfvirtualinputsource-methods-get_timer_utility) | `func get_timer_utility() -> GFTimerUtility:` |
+| 方法 | [`pulse_action`](#member-gfvirtualinputsource-methods-pulse_action) | `func pulse_action( action_id: StringName, value: Variant = true, duration_seconds: float = 0.1, owner: Variant = null, cancellation_token: GFCancellationToken = null, replacement_policy: PulseReplacementPolicy = PulseReplacementPolicy.REPLACE ) -> GFVirtualInputPulseOperation:` |
 | 方法 | [`set_action_value`](#member-gfvirtualinputsource-methods-set_action_value) | `func set_action_value(action_id: StringName, value: Variant) -> bool:` |
 | 方法 | [`set_action_value_for_player`](#member-gfvirtualinputsource-methods-set_action_value_for_player) | `func set_action_value_for_player(action_id: StringName, value: Variant, next_player_index: int) -> bool:` |
 | 方法 | [`press`](#member-gfvirtualinputsource-methods-press) | `func press(action_id: StringName, strength: float = 1.0) -> bool:` |
@@ -28,7 +32,28 @@
 | 方法 | [`clear_action`](#member-gfvirtualinputsource-methods-clear_action) | `func clear_action(action_id: StringName) -> bool:` |
 | 方法 | [`clear_action_for_player`](#member-gfvirtualinputsource-methods-clear_action_for_player) | `func clear_action_for_player(action_id: StringName, next_player_index: int) -> bool:` |
 | 方法 | [`clear_all`](#member-gfvirtualinputsource-methods-clear_all) | `func clear_all() -> void:` |
+| 方法 | [`dispose`](#member-gfvirtualinputsource-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`get_snapshot`](#member-gfvirtualinputsource-methods-get_snapshot) | `func get_snapshot() -> Dictionary:` |
+
+## 枚举
+
+<a id="member-gfvirtualinputsource-enums-pulsereplacementpolicy"></a>
+
+### `PulseReplacementPolicy`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum PulseReplacementPolicy {
+	## 原子交接同一动作贡献，不产生中间释放。
+	REPLACE,
+	## 保留旧脉冲，并让新句柄立即进入 REJECTED 终态。
+	REJECT_NEW,
+}
+```
+
+同一 source_id、player_index 与 action_id 已存在脉冲时的处理策略。
 
 ## 属性
 
@@ -63,9 +88,10 @@ var player_index: int = -1
 ### `configure`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
-func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &"virtual", p_player_index: int = -1 ) -> GFVirtualInputSource:
+func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = &"virtual", p_player_index: int = -1, timer_utility: GFTimerUtility = null ) -> GFVirtualInputSource:
 ```
 
 配置虚拟输入源。
@@ -77,8 +103,76 @@ func configure( input_mapping: GFInputMappingUtility, p_source_id: StringName = 
 | `input_mapping` | 输入映射工具。 |
 | `p_source_id` | 虚拟输入源标识。 |
 | `p_player_index` | 玩家索引。 |
+| `timer_utility` | 可选的脉冲定时器注入。 |
 
-返回：当前输入源。
+返回：当前输入源；dispose 后返回同一终态实例且不修改配置。
+
+<a id="member-gfvirtualinputsource-methods-set_timer_utility"></a>
+
+### `set_timer_utility`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_timer_utility(timer_utility: GFTimerUtility) -> GFVirtualInputSource:
+```
+
+替换后续脉冲使用的定时器工具。 已启动操作会继续使用其创建时冻结的定时器，不受本次替换影响。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `timer_utility` | 可注入的定时器工具；null 会禁用后续 pulse_action()。 |
+
+返回：当前输入源；dispose 后返回同一终态实例且不修改配置。
+
+<a id="member-gfvirtualinputsource-methods-get_timer_utility"></a>
+
+### `get_timer_utility`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_timer_utility() -> GFTimerUtility:
+```
+
+获取后续脉冲使用的定时器工具。
+
+返回：当前注入且仍存活的 GFTimerUtility。
+
+<a id="member-gfvirtualinputsource-methods-pulse_action"></a>
+
+### `pulse_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func pulse_action( action_id: StringName, value: Variant = true, duration_seconds: float = 0.1, owner: Variant = null, cancellation_token: GFCancellationToken = null, replacement_policy: PulseReplacementPolicy = PulseReplacementPolicy.REPLACE ) -> GFVirtualInputPulseOperation:
+```
+
+启动一次有界虚拟动作脉冲。 owner 与 cancellation_token 均可省略；同时提供时采用 OR 语义。返回句柄冻结 当前 Mapping、source_id、player_index 和 action_id，Source 后续重配不会改写旧操作。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `action_id` | 已注册的抽象动作标识。 |
+| `value` | 脉冲期间的动作值。 |
+| `duration_seconds` | 非负且有限的脉冲时长；0 会同步释放。 |
+| `owner` | 可选生命周期 owner；Node 离树或普通 Object 释放后取消。 |
+| `cancellation_token` | 可选取消 token。 |
+| `replacement_policy` | 同一稳定输入键已有脉冲时的策略。 |
+
+返回：类型化脉冲句柄；输入无效时返回立即 FAILED 的句柄。
+
+结构：
+
+- `value`: Variant，GFInputMappingUtility 接受的 bool、float、Vector2 或 Vector3 动作值。
+- `owner`: Variant，null 或仍有效的 Object；无效及已释放对象会在写入前失败。
 
 <a id="member-gfvirtualinputsource-methods-set_action_value"></a>
 
@@ -287,6 +381,19 @@ func clear_all() -> void:
 ```
 
 清除当前虚拟源的所有动作贡献。
+
+<a id="member-gfvirtualinputsource-methods-dispose"></a>
+
+### `dispose`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func dispose() -> void:
+```
+
+取消全部 Source-owned 脉冲、清除当前 source_id 贡献并释放依赖引用。
 
 <a id="member-gfvirtualinputsource-methods-get_snapshot"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -6,8 +6,8 @@
 
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
-| Kernel | 74 | 1088 | [Kernel](#module-kernel) |
-| Standard | 443 | 7068 | [Standard](#module-standard) |
+| Kernel | 74 | 1094 | [Kernel](#module-kernel) |
+| Standard | 445 | 7102 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -35,7 +35,7 @@
 
 | 类 | 类别 | 继承 | 成员 | 源文件 |
 |---|---|---|---:|---|
-| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 121 | `addons/gf/kernel/core/gf_architecture.gd` |
+| [`GFArchitecture`](GFArchitecture.md#gfarchitecture) | 运行时服务 (`runtime_service`) | `Object` | 124 | `addons/gf/kernel/core/gf_architecture.gd` |
 | [`GFDependencyGraphTools`](GFDependencyGraphTools.md#gfdependencygraphtools) | 运行时服务 (`runtime_service`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_dependency_graph_tools.gd` |
 | [`GFExtensionCatalog`](GFExtensionCatalog.md#gfextensioncatalog) | 运行时服务 (`runtime_service`) | `RefCounted` | 5 | `addons/gf/kernel/extension/gf_extension_catalog.gd` |
 | [`GFExtensionManifestDiscovery`](GFExtensionManifestDiscovery.md#gfextensionmanifestdiscovery) | 运行时服务 (`runtime_service`) | `RefCounted` | 2 | `addons/gf/kernel/extension/gf_extension_manifest_discovery.gd` |
@@ -82,7 +82,7 @@
 | [`GFArchitectureShutdownResult`](GFArchitectureShutdownResult.md#gfarchitectureshutdownresult) | 值对象 (`value_object`) | `RefCounted` | 22 | `addons/gf/kernel/core/gf_architecture_shutdown_result.gd` |
 | [`GFBindingLifetimes`](GFBindingLifetimes.md#gfbindinglifetimes) | 值对象 (`value_object`) | `RefCounted` | 1 | `addons/gf/kernel/core/gf_binding_lifetimes.gd` |
 | [`GFEventListener`](GFEventListener.md#gfeventlistener) | 事件契约 (`event_contract`) | `RefCounted` | 10 | `addons/gf/kernel/core/gf_event_listener.gd` |
-| [`GFAccessGenerator`](GFAccessGenerator.md#gfaccessgenerator) | 编辑器 API (`editor_api`) | `RefCounted` | 13 | `addons/gf/kernel/editor/gf_access_generator.gd` |
+| [`GFAccessGenerator`](GFAccessGenerator.md#gfaccessgenerator) | 编辑器 API (`editor_api`) | `RefCounted` | 16 | `addons/gf/kernel/editor/gf_access_generator.gd` |
 | [`GFBakeDependencyReport`](GFBakeDependencyReport.md#gfbakedependencyreport) | 编辑器 API (`editor_api`) | `RefCounted` | 21 | `addons/gf/kernel/editor/gf_bake_dependency_report.gd` |
 | [`GFEditorActionDefinition`](GFEditorActionDefinition.md#gfeditoractiondefinition) | 编辑器 API (`editor_api`) | `RefCounted` | 23 | `addons/gf/kernel/editor/gf_editor_action_definition.gd` |
 | [`GFEditorCommand`](GFEditorCommand.md#gfeditorcommand) | 编辑器 API (`editor_api`) | `RefCounted` | 16 | `addons/gf/kernel/editor/gf_editor_command.gd` |
@@ -287,7 +287,7 @@
 | [`GFTrajectoryMath`](GFTrajectoryMath.md#gftrajectorymath) | 运行时服务 (`runtime_service`) | `RefCounted` | 16 | `addons/gf/standard/foundation/math/gf_trajectory_math.gd` |
 | [`GFTransform3DMath`](GFTransform3DMath.md#gftransform3dmath) | 运行时服务 (`runtime_service`) | `RefCounted` | 11 | `addons/gf/standard/foundation/math/gf_transform_3d_math.gd` |
 | [`GFUIRoutePreloadUtility`](GFUIRoutePreloadUtility.md#gfuiroutepreloadutility) | 运行时服务 (`runtime_service`) | `RefCounted` | 6 | `addons/gf/standard/utilities/ui/gf_ui_route_preload_utility.gd` |
-| [`GFUIRouterUtility`](GFUIRouterUtility.md#gfuirouterutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 31 | `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd` |
+| [`GFUIRouterUtility`](GFUIRouterUtility.md#gfuirouterutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 32 | `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd` |
 | [`GFUIUtility`](GFUIUtility.md#gfuiutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 49 | `addons/gf/standard/utilities/ui/gf_ui_utility.gd` |
 | [`GFValidationDiagnosticAdapter`](GFValidationDiagnosticAdapter.md#gfvalidationdiagnosticadapter) | 运行时服务 (`runtime_service`) | `RefCounted` | 6 | `addons/gf/standard/foundation/validation/gf_validation_diagnostic_adapter.gd` |
 | [`GFValidationJUnitExporter`](GFValidationJUnitExporter.md#gfvalidationjunitexporter) | 运行时服务 (`runtime_service`) | `RefCounted` | 2 | `addons/gf/standard/foundation/validation/gf_validation_junit_exporter.gd` |
@@ -493,8 +493,10 @@
 | [`GFTextGenerationContext`](GFTextGenerationContext.md#gftextgenerationcontext) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 24 | `addons/gf/standard/foundation/text/gf_text_generation_context.gd` |
 | [`GFTimeoutController`](GFTimeoutController.md#gftimeoutcontroller) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 19 | `addons/gf/standard/common/gf_timeout_controller.gd` |
 | [`GFTouchControl2D`](GFTouchControl2D.md#gftouchcontrol2d) | 运行时句柄 (`runtime_handle`) | `Node2D` | 3 | `addons/gf/standard/input/touch/gf_touch_control_2d.gd` |
+| [`GFUIPanelAsyncOperation`](GFUIPanelAsyncOperation.md#gfuipanelasyncoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 13 | `addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd` |
 | [`GFUIRouteOperation`](GFUIRouteOperation.md#gfuirouteoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 13 | `addons/gf/standard/utilities/ui/gf_ui_route_operation.gd` |
-| [`GFVirtualInputSource`](GFVirtualInputSource.md#gfvirtualinputsource) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 14 | `addons/gf/standard/input/sources/gf_virtual_input_source.gd` |
+| [`GFVirtualInputPulseOperation`](GFVirtualInputPulseOperation.md#gfvirtualinputpulseoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 14 | `addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd` |
+| [`GFVirtualInputSource`](GFVirtualInputSource.md#gfvirtualinputsource) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 19 | `addons/gf/standard/input/sources/gf_virtual_input_source.gd` |
 | [`GFAssetLoadSessionResult`](GFAssetLoadSessionResult.md#gfassetloadsessionresult) | 值对象 (`value_object`) | `RefCounted` | 16 | `addons/gf/standard/utilities/assets/gf_asset_load_session_result.gd` |
 | [`GFAudioBackendCapability`](GFAudioBackendCapability.md#gfaudiobackendcapability) | 值对象 (`value_object`) | `Resource` | 15 | `addons/gf/standard/utilities/audio/gf_audio_backend_capability.gd` |
 | [`GFAudioPlaybackRegionResult`](GFAudioPlaybackRegionResult.md#gfaudioplaybackregionresult) | 值对象 (`value_object`) | `RefCounted` | 14 | `addons/gf/standard/utilities/audio/gf_audio_playback_region_result.gd` |
@@ -531,7 +533,7 @@
 | [`GFStorageConflictReport`](GFStorageConflictReport.md#gfstorageconflictreport) | 值对象 (`value_object`) | `Resource` | 14 | `addons/gf/standard/utilities/storage/gf_storage_conflict_report.gd` |
 | [`GFStorageReadResult`](GFStorageReadResult.md#gfstoragereadresult) | 值对象 (`value_object`) | `RefCounted` | 20 | `addons/gf/standard/utilities/storage/gf_storage_read_result.gd` |
 | [`GFStorageSectionCache`](GFStorageSectionCache.md#gfstoragesectioncache) | 值对象 (`value_object`) | `RefCounted` | 14 | `addons/gf/standard/utilities/storage/gf_storage_section_cache.gd` |
-| [`GFUIRouteResult`](GFUIRouteResult.md#gfuirouteresult) | 值对象 (`value_object`) | `RefCounted` | 33 | `addons/gf/standard/utilities/ui/gf_ui_route_result.gd` |
+| [`GFUIRouteResult`](GFUIRouteResult.md#gfuirouteresult) | 值对象 (`value_object`) | `RefCounted` | 34 | `addons/gf/standard/utilities/ui/gf_ui_route_result.gd` |
 | [`GFUuid`](GFUuid.md#gfuuid) | 值对象 (`value_object`) | `RefCounted` | 5 | `addons/gf/standard/foundation/identity/gf_uuid.gd` |
 | [`GFValidationIssue`](GFValidationIssue.md#gfvalidationissue) | 值对象 (`value_object`) | `RefCounted` | 32 | `addons/gf/standard/foundation/validation/gf_validation_issue.gd` |
 | [`GFValidationReport`](GFValidationReport.md#gfvalidationreport) | 值对象 (`value_object`) | `RefCounted` | 29 | `addons/gf/standard/foundation/validation/gf_validation_report.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,16 +5,16 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`802`
-- 公开成员：`11811`
-- 公开方法：`7289`
+- 公开类：`804`
+- 公开成员：`11851`
+- 公开方法：`7316`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
-| Kernel | 74 | 1088 | 792 | [kernel.md](kernel.md) |
-| Standard | 443 | 7068 | 4467 | [standard.md](standard.md) |
+| Kernel | 74 | 1094 | 793 | [kernel.md](kernel.md) |
+| Standard | 445 | 7102 | 4493 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/kernel.md
+++ b/docs/zh/reference/api/kernel.md
@@ -6,13 +6,13 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 14 | 300 | 238 |
+| [运行时服务](#category-runtime_service) | 14 | 303 | 239 |
 | [协议与扩展点](#category-protocol) | 19 | 213 | 188 |
 | [资源定义](#category-resource_definition) | 2 | 45 | 15 |
 | [运行时句柄](#category-runtime_handle) | 9 | 86 | 70 |
 | [值对象](#category-value_object) | 2 | 23 | 21 |
 | [事件契约](#category-event_contract) | 1 | 10 | 10 |
-| [编辑器 API](#category-editor_api) | 26 | 389 | 242 |
+| [编辑器 API](#category-editor_api) | 26 | 392 | 242 |
 | [工具 API](#category-tool_api) | 1 | 22 | 8 |
 
 ## 类

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,11 +6,11 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 188 | 3401 | 2291 |
+| [运行时服务](#category-runtime_service) | 188 | 3402 | 2292 |
 | [协议与扩展点](#category-protocol) | 24 | 338 | 267 |
 | [资源定义](#category-resource_definition) | 120 | 1538 | 792 |
-| [运行时句柄](#category-runtime_handle) | 47 | 821 | 521 |
-| [值对象](#category-value_object) | 40 | 735 | 460 |
+| [运行时句柄](#category-runtime_handle) | 49 | 853 | 546 |
+| [值对象](#category-value_object) | 40 | 736 | 460 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |
 | [事件契约](#category-event_contract) | 6 | 61 | 23 |
 | [编辑器 API](#category-editor_api) | 11 | 68 | 46 |
@@ -422,7 +422,9 @@
 | [`GFTextGenerationContext`](classes/GFTextGenerationContext.md#gftextgenerationcontext) | `RefCounted` | `addons/gf/standard/foundation/text/gf_text_generation_context.gd` |
 | [`GFTimeoutController`](classes/GFTimeoutController.md#gftimeoutcontroller) | `RefCounted` | `addons/gf/standard/common/gf_timeout_controller.gd` |
 | [`GFTouchControl2D`](classes/GFTouchControl2D.md#gftouchcontrol2d) | `Node2D` | `addons/gf/standard/input/touch/gf_touch_control_2d.gd` |
+| [`GFUIPanelAsyncOperation`](classes/GFUIPanelAsyncOperation.md#gfuipanelasyncoperation) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd` |
 | [`GFUIRouteOperation`](classes/GFUIRouteOperation.md#gfuirouteoperation) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_ui_route_operation.gd` |
+| [`GFVirtualInputPulseOperation`](classes/GFVirtualInputPulseOperation.md#gfvirtualinputpulseoperation) | `RefCounted` | `addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd` |
 | [`GFVirtualInputSource`](classes/GFVirtualInputSource.md#gfvirtualinputsource) | `RefCounted` | `addons/gf/standard/input/sources/gf_virtual_input_source.gd` |
 
 <a id="category-value_object"></a>

--- a/docs/zh/standard/input-flow/input-assist/virtual-recording-remap/virtual-recording.md
+++ b/docs/zh/standard/input-flow/input-assist/virtual-recording-remap/virtual-recording.md
@@ -13,6 +13,30 @@ ai_input.release(&"confirm")
 
 虚拟源只表达“某个抽象动作现在有什么值”，不代表真实设备、不参与重绑定冲突分析，也不决定玩家加入、角色控制权或回放文件格式。需要清理一整段注入时，可调用 `clear_all()` 或 `GFInputMappingUtility.clear_virtual_source(source_id)`。
 
+## 有界动作脉冲
+
+按钮、触摸手势或自动化驱动需要“立即写入、短暂保持、恰好释放一次”时，可在创建 `GFVirtualInputSource` 时注入 `GFTimerUtility`，再调用 `pulse_action()`。计时由框架 `tick()` 驱动，因此测试可以显式推进时间，不依赖场景树 `Timer` 或真实等待。
+
+```gdscript
+var input_map := Gf.get_utility(GFInputMappingUtility) as GFInputMappingUtility
+var timers := Gf.get_utility(GFTimerUtility) as GFTimerUtility
+var touch_input := input_map.create_virtual_source(&"touch_ui", 0, timers)
+
+var pulse := touch_input.pulse_action(
+	&"confirm",
+	true,
+	0.12,
+	confirm_button,
+	cancel_source.get_token()
+)
+```
+
+`pulse_action()` 返回 `GFVirtualInputPulseOperation`。句柄冻结创建时的 Mapping、`source_id`、`player_index`、`action_id` 和 generation；之后修改 Source 配置不会让旧定时回调释放错误的输入键。`get_status()`、`get_terminal_reason()` 与 `get_release_count()` 可用于诊断完成、取消、替换、拒绝或启动失败。`release_count` 只证明当前 lease 是否实际清除过动作贡献：到时、取消、clear 或生命周期清理为 `1`；未取得 lease，以及由新脉冲或手动写入直接接管贡献的旧句柄为 `0`。
+
+权威并发键是 `source_id + player_index + action_id`，而不是 `GFVirtualInputSource` 对象身份。因此两个同 ID Source 也不会让旧定时器清除新脉冲。默认 `REPLACE` 通过比较并交换移除旧 lease、提交新 generation 并覆盖同一动作贡献，不会在交接期间发出一次虚假的 inactive 状态；旧句柄进入 `REPLACED`，但不计为实际释放。需要保留旧脉冲时传 `PulseReplacementPolicy.REJECT_NEW`，新句柄会直接进入 `REJECTED`，且不会改写动作值。
+
+`owner` 与 `cancellation_token` 都是可选锚点，同时提供时采用 OR 语义。二者都不提供也可以：脉冲仍受有界 duration、Source 生命周期和 Mapping 弱 lease 清理约束。树外 Node、已经释放的 owner、已完成的 `GFAsyncScope` 或无法建立的 token 连接会在写入前 fail closed；已取消 token 则让句柄立即进入 `CANCELLED`。手动 `set_action_value()`、`press()` 等写入会原子接管匹配 lease，不制造 inactive 间隙；`release()`、`clear_action()`，以及 Source/Mapping 的 clear、重建或 dispose 会终止并实际释放匹配 lease。已经失效的旧定时器不能回头清除后写入的值；若注入的 `GFTimerUtility` 在脉冲期间 dispose/reinit，下一次 Mapping tick 会把丢失的排程收敛为 `FAILED / timer_schedule_lost` 并释放匹配贡献。`GFVirtualInputSource.dispose()` 是不可逆终态，释放后不能通过 `configure()` 复活。
+
 ## 录制回放
 
 需要把抽象动作序列保存下来再回放时，可用 `GFInputRecording` 记录 action id、时间、值、玩家索引和元数据，再交给 `GFInputPlayback` 按时间写入 `GFVirtualInputSource`。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/ui-router.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/ui-router.md
@@ -76,9 +76,35 @@ func _handle_route_result(result: GFUIRouteResult) -> void:
 
 句柄只接受一个终态，`get_result()` 返回隔离副本。Router 也会发出 `route_operation_completed(result)`，适合统一遥测；单次调用优先观察句柄，避免按 route id 猜测并发请求。`GFUIRouteResult.to_dict()` 使用 `GFReportValueCodec` 收束调用方 metadata、非有限浮点和运行时对象，可直接进入 JSON 报告边界；`get_metadata()` 则保留原始类型并返回深副本。
 
-相同 pending 请求只有在规范化 route id、操作、参数、面板选项、回调、预加载策略、预加载计划选项和 metadata 全部一致时才复用同一句柄。不同 Router 请求若占用相同场景路径、逻辑层和操作，会以 `STATUS_ASYNC_CONFLICT` 结束，不会静默覆盖先到请求。若项目绕过 Router，直接在同一 `GFUIUtility` 通道提交了相同 pending 面板请求，Router 也会返回 `ui_async_request_conflict`，避免把未执行路由配置回调的外部面板误记为路由成功。
+Router 在提交前为底层 `GFUIPanelAsyncOperation` 预绑定弱终态回调，并同时校验 Route request ID 与精确 UI 句柄身份；同步 fallback 也不会丢失完成通知。`panel_async_load_finished` 只保留为聚合 telemetry，不承担单次 Route 相关性，因此全局监听器在完成信号中重入并提交同键新请求时，旧请求也不能终结替代请求。
+
+相同 pending 请求只有在规范化 route id、操作、参数、面板选项、回调、预加载策略、预加载计划选项、metadata 以及 owner/scope 实例身份全部一致时才复用同一句柄。不同 Router 请求若占用相同场景路径、逻辑层和操作，会以 `STATUS_ASYNC_CONFLICT` 结束，不会静默覆盖先到请求。若项目绕过 Router，直接在同一 `GFUIUtility` 通道提交了相同 pending 面板请求，Router 也会返回 `ui_async_request_conflict`，避免把未执行路由配置回调的外部面板误记为路由成功。
 
 Router 释放时，尚未提交面板的预加载会回滚并返回 `STATUS_DISPOSED`。面板已经交给当前 `GFUIUtility` 后无法按单个路由请求撤回；此时返回 `STATUS_OUTCOME_UNKNOWN`，明确表示 Router 已失去观察能力，而不是声称面板一定取消或一定打开。调用方不应把 `outcome_unknown` 当作失败后可安全重试的证明。
+
+## 提交前生命周期取消
+
+`async_options` 可以同时提供 `owner: Object` 与 `scope: GFAsyncScope`。两者是 OR 关系：任意一个先结束，尚未提交的路由就以 `STATUS_CANCELLED` 进入唯一终态，回滚 Router 拥有的预加载会话，并忽略迟到的预加载回调。Node owner 必须在调用时已进入场景树，离树会即时取消；普通 Object 只被弱持有，释放后由 Router 的 `tick()` 剪枝。正常注册在 Architecture 中的 Router 会随架构 tick 自动执行该剪枝。
+
+```gdscript
+var route_scope: GFAsyncScope = GFAsyncScope.new()
+var operation: GFUIRouteOperation = router.push_route_async(
+	&"inventory",
+	{},
+	{},
+	Callable(),
+	{
+		"owner": self,
+		"scope": route_scope,
+		"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+	}
+)
+
+# 页面所属流程终止时，取消尚未提交的路由。
+route_scope.cancel("flow_replaced")
+```
+
+已取消的 scope 会立即返回 `STATUS_CANCELLED`；已完成的 scope、类型错误的 scope 或不在场景树内的 Node owner 会返回 `STATUS_INVALID_LIFECYCLE`。提交边界是 Router 实际调用 `GFUIUtility` 异步打开入口的时刻；跨过边界后 Router 会解除 owner/scope 监听，后续离树或取消不会关闭已提交的面板，也不会改写其最终打开结果。需要关闭已打开面板时，项目应显式使用 UI 栈 API，不要把取消令牌当作隐式关闭指令。
 
 ## 打开前预加载策略
 

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/ui-stack-modal/async-lifecycle.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/ui-stack-modal/async-lifecycle.md
@@ -8,16 +8,58 @@
 
 ## 异步请求保护
 
-`push_panel_async()` 和 `replace_layer_async()` 会优先使用 `GFAssetUtility`，未注册时回退同步加载。同步 fallback 与真正异步路径共享同一 terminal 流程，都会清理 pending 请求并发出 finished。每个 UI 层都有单调 operation intent：`pop_panel()`、`clear_layer()`、push、replace 或释放工具后，较旧回调都会被忽略，旧 replace 不会在新 push 已完成后清掉新面板。同一层级同一路径的重复异步压栈请求会在资源返回前合并，避免按钮连点时叠出多层相同面板。
+`push_panel_async()` 和 `replace_layer_async()` 会优先使用 `GFAssetUtility`，未注册时回退同步加载。同步 fallback 与真正异步路径共享同一 terminal 流程，都会返回 `GFUIPanelAsyncOperation`、清理 pending 请求并发出终态。每个句柄冻结同一 `GFUIUtility` 实例内全局单调且跨 `init()` / `dispose()` 不复用的 UI serial，以及 path、layer 和 `push` / `replace` operation；成功面板仅由句柄弱引用，关闭面板后不会因为观察句柄而延长节点生命周期。
 
-## 加载状态信号
+每个 UI 层仍有独立的 operation intent：`pop_panel()`、`clear_layer()`、push、replace 或释放工具后，较旧回调都会被忽略，旧 replace 不会在新 push 已完成后清掉新面板。同一层级同一路径的重复异步压栈请求会在资源返回前合并并返回同一句柄，避免按钮连点时叠出多层相同面板。完成路径会先同时移除请求表和 push 去重索引，再完成精确句柄，最后发送全局 telemetry；因此终态回调内可以安全地提交同层同路径的新请求，旧回调也不能命中新句柄。
 
-异步加载的视觉 Loading 属于项目 UI。框架不创建默认遮罩、进度条或转场动画，但会通过信号报告请求状态：
+## 类型化终态
+
+需要把一次请求与终态精确关联时，优先观察返回的 `GFUIPanelAsyncOperation`，不要用 path/layer 猜测某条全局 finished 信号属于哪个调用。句柄只进入一个 `AsyncPanelLoadStatus.OPENED`、`FAILED` 或 `CANCELLED` 终态；迟到资源回调不能覆盖或重复发出终态。
+
+由于未注册 `GFAssetUtility` 时同步 fallback 可能在 async 方法返回前完成，请把必须可靠接收的回调作为最后一个 `completion_callback` 参数传入。UI 会在 started telemetry 和任何完成路径之前连接该回调；回调参数就是当前句柄，不要在回调中读取尚未完成赋值的外部局部变量：
+
+```gdscript
+func _on_settings_loaded(operation: GFUIPanelAsyncOperation) -> void:
+	match operation.get_status():
+		GFUIUtility.AsyncPanelLoadStatus.OPENED:
+			var panel: Node = operation.get_panel()
+			if panel != null:
+				configure_opened_settings(panel)
+		GFUIUtility.AsyncPanelLoadStatus.CANCELLED:
+			handle_settings_cancelled(operation.get_serial())
+
+var operation: GFUIPanelAsyncOperation = ui_util.push_panel_async(
+	"res://ui/settings_panel.tscn",
+	GFUIUtility.Layer.POPUP,
+	Callable(),
+	_on_settings_loaded
+)
+if operation == null:
+	handle_request_rejected()
+```
+
+仅在调用返回后临时接入观察者时，采用 connect 后再次检查的 lost-wakeup 防护，并让消费函数按 serial 幂等；同步已完成句柄应直接消费：
+
+```gdscript
+func observe_panel_operation(operation: GFUIPanelAsyncOperation) -> void:
+	if operation == null:
+		return
+	if operation.is_completed():
+		consume_panel_terminal_once(operation)
+		return
+	operation.completed.connect(consume_panel_terminal_once, CONNECT_ONE_SHOT)
+	if operation.is_completed():
+		consume_panel_terminal_once(operation)
+```
+
+## 全局加载 telemetry
+
+异步加载的视觉 Loading 属于项目 UI。框架不创建默认遮罩、进度条或转场动画，但会保留全局信号用于汇总诊断与 Loading 计数。这些信号没有 serial，不应用作单次请求的相关性协议：
 
 - `panel_async_load_started`：报告 `push` / `replace` 请求开始。
 - `panel_async_load_finished`：报告请求结束，状态为 `AsyncPanelLoadStatus.OPENED`、`FAILED` 或 `CANCELLED`。
 - `has_pending_async_panel()`：查询指定层级是否仍有等待资源回调的请求。
-- `get_pending_async_panel_requests()`：返回当前 pending 请求快照。
+- `get_pending_async_panel_requests()`：返回当前 pending 请求快照，其中 `operation_handle` 保留精确类型化身份。
 
 常见做法是只在同层没有 pending 请求时关闭项目自己的 loading 面板：
 

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/ui-stack-modal/panel-stack.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/ui-stack-modal/panel-stack.md
@@ -57,7 +57,12 @@ if ui == null:
 ## 基本操作
 
 ```gdscript
-ui.push_panel_async("res://ui/settings_panel.tscn", GFUIUtility.Layer.POPUP)
+var settings_operation: GFUIPanelAsyncOperation = ui.push_panel_async(
+	"res://ui/settings_panel.tscn",
+	GFUIUtility.Layer.POPUP
+)
+if settings_operation == null:
+	push_error("设置面板请求未被接受。")
 ui.push_panel("res://ui/inventory_panel.tscn", GFUIUtility.Layer.POPUP)
 
 var inventory_panel := preload("res://ui/inventory_panel.tscn").instantiate()
@@ -67,6 +72,8 @@ ui.pop_panel(GFUIUtility.Layer.POPUP)
 ui.replace_layer("res://ui/main_menu.tscn", GFUIUtility.Layer.POPUP)
 ui.pop_to_panel(inventory_panel, GFUIUtility.Layer.POPUP)
 ```
+
+异步请求的精确终态、同步 fallback 与回调时序见[生命周期与异步加载](async-lifecycle.md)。
 
 ## 并行窗口与遮挡策略
 

--- a/packages/standard/gf.standard.ui.navigation.json
+++ b/packages/standard/gf.standard.ui.navigation.json
@@ -14,6 +14,8 @@
   "paths": [
     "addons/gf/standard/utilities/ui/gf_ui_layer_definition.gd",
     "addons/gf/standard/utilities/ui/gf_ui_layer_definition.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd",
+    "addons/gf/standard/utilities/ui/gf_ui_panel_async_operation.gd.uid",
     "addons/gf/standard/utilities/ui/gf_ui_route.gd",
     "addons/gf/standard/utilities/ui/gf_ui_route.gd.uid",
     "addons/gf/standard/utilities/ui/gf_ui_route_operation.gd",

--- a/tests/gf_core/kernel/core/test_gf_singleton.gd
+++ b/tests/gf_core/kernel/core/test_gf_singleton.gd
@@ -1436,6 +1436,134 @@ func test_child_architecture_falls_back_to_parent() -> void:
 	parent_arch.dispose()
 
 
+## 验证声明式模块解析器覆盖三种模块类别与 ready 过滤。
+func test_resolve_module_access_dispatches_module_kinds_and_ready_policy() -> void:
+	var arch: GFArchitecture = GFArchitecture.new()
+	var model: DummyModel = DummyModel.new()
+	var system: DummySystem = DummySystem.new()
+	var utility: DummyUtility = DummyUtility.new()
+	await arch.register_model_instance(model)
+	await arch.register_system_instance(system)
+	await arch.register_utility_instance(utility)
+
+	assert_eq(
+		arch.resolve_module_access(GFArchitecture.ModuleKind.MODEL, DummyModel),
+		model,
+		"Model 策略应路由到 Model 注册表。"
+	)
+	assert_eq(
+		arch.resolve_module_access(GFArchitecture.ModuleKind.SYSTEM, DummySystem),
+		system,
+		"System 策略应路由到 System 注册表。"
+	)
+	assert_eq(
+		arch.resolve_module_access(GFArchitecture.ModuleKind.UTILITY, DummyUtility),
+		utility,
+		"Utility 策略应路由到 Utility 注册表。"
+	)
+	assert_null(
+		arch.resolve_module_access(
+			GFArchitecture.ModuleKind.UTILITY,
+			DummyUtility,
+			GFArchitecture.ModuleLookupScope.INHERITED,
+			true,
+			true
+		),
+		"完成 ready 前，require_ready 应拒绝已注册实例。"
+	)
+
+	await arch.init()
+
+	assert_eq(
+		arch.resolve_module_access(
+			GFArchitecture.ModuleKind.UTILITY,
+			DummyUtility,
+			GFArchitecture.ModuleLookupScope.INHERITED,
+			true,
+			true
+		),
+		utility,
+		"完成 ready 后，require_ready 应返回活动实例。"
+	)
+
+	arch.dispose()
+
+
+## 验证 inherited 与 local 策略使用不同的父架构可见性。
+func test_resolve_module_access_distinguishes_inherited_and_local_scope() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	var parent_utility: ParentScopedUtility = ParentScopedUtility.new()
+	await parent_arch.register_utility_instance(parent_utility)
+
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+
+	assert_eq(
+		child_arch.resolve_module_access(
+			GFArchitecture.ModuleKind.UTILITY,
+			ParentScopedUtility,
+			GFArchitecture.ModuleLookupScope.INHERITED,
+			true
+		),
+		parent_utility,
+		"inherited 策略应允许非严格子架构回退父架构。"
+	)
+	assert_null(
+		child_arch.resolve_module_access(
+			GFArchitecture.ModuleKind.UTILITY,
+			ParentScopedUtility,
+			GFArchitecture.ModuleLookupScope.LOCAL,
+			false
+		),
+		"local 可选策略不应回退父架构。"
+	)
+	assert_push_error_count(0, "非严格查询与 local 可选未命中都应保持静默。")
+
+	child_arch.dispose()
+	parent_arch.dispose()
+
+
+## 验证 strict 架构中 required 策略报错，optional 策略保持静默。
+func test_resolve_module_access_preserves_required_strict_diagnostics() -> void:
+	var parent_arch: GFArchitecture = GFArchitecture.new()
+	var parent_utility: ParentScopedUtility = ParentScopedUtility.new()
+	await parent_arch.register_utility_instance(parent_utility)
+
+	var child_arch: GFArchitecture = GFArchitecture.new(parent_arch)
+	child_arch.strict_dependency_lookup = true
+
+	assert_null(child_arch.resolve_module_access(
+		GFArchitecture.ModuleKind.UTILITY,
+		ParentScopedUtility,
+		GFArchitecture.ModuleLookupScope.INHERITED,
+		true
+	))
+	assert_null(child_arch.resolve_module_access(
+		GFArchitecture.ModuleKind.UTILITY,
+		ParentScopedUtility,
+		GFArchitecture.ModuleLookupScope.INHERITED,
+		false
+	))
+	assert_null(child_arch.resolve_module_access(
+		GFArchitecture.ModuleKind.UTILITY,
+		ParentScopedUtility,
+		GFArchitecture.ModuleLookupScope.LOCAL,
+		true
+	))
+	assert_null(child_arch.resolve_module_access(
+		GFArchitecture.ModuleKind.UTILITY,
+		ParentScopedUtility,
+		GFArchitecture.ModuleLookupScope.LOCAL,
+		false
+	))
+	assert_push_error_count(
+		2,
+		"strict 模式下仅两次 required miss 应产生诊断。"
+	)
+
+	child_arch.dispose()
+	parent_arch.dispose()
+
+
 ## 验证严格依赖查询模式不会静默回退父架构。
 func test_strict_dependency_lookup_blocks_parent_fallback() -> void:
 	var parent_arch: GFArchitecture = GFArchitecture.new()
@@ -1541,6 +1669,26 @@ func test_child_local_unready_module_shadows_parent_require_ready_lookup() -> vo
 	assert_eq(child_arch.get_utility(ParentScopedUtility), child_utility, "普通查询应返回子架构本地实例。")
 	assert_null(child_arch.get_utility(ParentScopedUtility, true), "本地存在但未 ready 的实例应遮蔽父级同类型 ready 实例。")
 	assert_eq(child_arch.get_local_utility(ParentScopedUtility), child_utility, "本地查询仍应能看到未 ready 的本地实例。")
+	assert_null(
+		child_arch.resolve_module_access(
+			GFArchitecture.ModuleKind.UTILITY,
+			ParentScopedUtility,
+			GFArchitecture.ModuleLookupScope.INHERITED,
+			true,
+			true
+		),
+		"声明式 inherited 查询也不应越过本地未 ready 实例。"
+	)
+	assert_null(
+		child_arch.resolve_module_access(
+			GFArchitecture.ModuleKind.UTILITY,
+			ParentScopedUtility,
+			GFArchitecture.ModuleLookupScope.LOCAL,
+			false,
+			true
+		),
+		"声明式 local 查询应对本地实例应用 ready 过滤。"
+	)
 
 	child_arch.dispose()
 	parent_arch.dispose()

--- a/tests/gf_core/kernel/editor/test_gf_access_generator.gd
+++ b/tests/gf_core/kernel/editor/test_gf_access_generator.gd
@@ -60,7 +60,9 @@ func test_build_source_generates_typed_accessors() -> void:
 	var unsafe_cast_snippet: String = "return resolved_architecture.get_system(BattleSystem) " + "as BattleSystem"
 
 	assert_true(source.contains("static func get_player_model(architecture: GFArchitecture = null) -> PlayerModel:"), "应生成 Model 强类型访问器。")
-	assert_true(source.contains("var system_value: Variant = resolved_architecture.get_system(BattleSystem)"), "应生成 System 查询。")
+	assert_true(source.contains("var system_value: Variant = resolved_architecture.resolve_module_access("), "应通过共享解析入口查询 System。")
+	assert_true(source.contains("GFArchitecture.ModuleKind.SYSTEM,"), "System 访问器应冻结模块类型。")
+	assert_true(source.contains("GFArchitecture.ModuleLookupScope.INHERITED,"), "默认访问器应冻结 inherited 作用域。")
 	assert_true(source.contains("if system_value is BattleSystem:"), "System 查询应先收窄再返回。")
 	assert_false(source.contains(unsafe_cast_snippet), "生成访问器不应传播 unsafe cast。")
 	assert_true(source.contains("static func get_storage_utility(architecture: GFArchitecture = null) -> StorageUtility:"), "应生成 Utility 强类型访问器。")
@@ -71,6 +73,390 @@ func test_build_source_generates_typed_accessors() -> void:
 	assert_true(source.contains("static func if_has_health_capability(receiver: Object, callback: Callable, architecture: GFArchitecture = null) -> Variant:"), "应生成能力条件回调入口。")
 	assert_true(source.contains("_CAPABILITY_UTILITY_SCRIPT_PATH"), "包含能力记录时才应生成能力扩展运行时入口。")
 	assert_true(source.contains("instance.call(\"_gf_set_dependency_scope\", architecture)"), "fallback new() 的对象应先绑定内部依赖作用域。")
+
+
+func test_project_access_policy_is_frozen_into_generated_accessor() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	ProjectSettings.set_setting(setting_name, {
+		"res://addons/gf/standard/utilities/time/gf_time_utility.gd": {
+			"scope": "local",
+			"required": false,
+			"require_ready": true,
+		},
+	})
+
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var records: Array[Dictionary] = [
+		{
+			"class_name": "GFTimeUtility",
+			"path": "res://addons/gf/standard/utilities/time/gf_time_utility.gd",
+			"kind": GFAccessGenerator.TargetKind.UTILITY,
+		},
+	]
+	var policy_result: Dictionary = generator._apply_access_policies(records)
+	var frozen_records: Array = GF_VARIANT_ACCESS.get_option_array(policy_result, "records")
+	var source: String = generator.build_source(frozen_records)
+	var accessor_source: String = _get_generated_function_source(
+		source,
+		"static func get_gf_time_utility("
+	)
+
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	assert_false(accessor_source.is_empty(), "GFTimeUtility 应有生成访问器。")
+	assert_true(
+		accessor_source.contains("GFArchitecture.ModuleKind.UTILITY,"),
+		"应冻结 Utility 模块类型。"
+	)
+	assert_true(
+		accessor_source.contains("GFArchitecture.ModuleLookupScope.LOCAL,"),
+		"应冻结 local 作用域。"
+	)
+	assert_true(
+		accessor_source.contains("\n\t\tfalse,\n\t\ttrue\n\t)"),
+		"应按顺序冻结 required=false 与 require_ready=true。"
+	)
+	assert_false(
+		accessor_source.contains("ProjectSettings"),
+		"运行时访问器不应重新读取生成期策略。"
+	)
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(policy_result, "valid"), "合法策略应整体冻结成功。")
+	assert_false(records[0].has("scope"), "策略冻结不得修改调用方或扩展持有的原始记录。")
+
+
+func test_frozen_access_policy_source_parses_as_gdscript() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var script_path: String = "res://addons/gf/standard/utilities/time/gf_time_utility.gd"
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var local_policies: Dictionary = {}
+	local_policies[StringName(script_path)] = {
+		"scope": "local",
+		"required": false,
+		"require_ready": true,
+	}
+	ProjectSettings.set_setting(setting_name, local_policies)
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var result: Dictionary = generator._apply_access_policies([{
+		"class_name": "GFTimeUtility",
+		"path": script_path,
+		"kind": GFAccessGenerator.TargetKind.UTILITY,
+	}])
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+	var source: String = generator.build_source(
+		GF_VARIANT_ACCESS.get_option_array(result, "records")
+	)
+	var generated_script: GDScript = GDScript.new()
+	generated_script.source_code = source
+
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(result, "valid"))
+	assert_eq(generated_script.reload(), OK, "冻结策略生成物必须通过真实 GDScript 解析。")
+
+
+func test_string_name_access_policy_fields_are_canonicalized_before_freezing() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var script_path: String = "res://addons/gf/standard/utilities/time/gf_time_utility.gd"
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var configured_policy: Dictionary = {}
+	configured_policy[StringName("scope")] = StringName("local")
+	configured_policy[StringName("required")] = false
+	configured_policy[StringName("require_ready")] = true
+	var configured_policies: Dictionary = {}
+	configured_policies[StringName(script_path)] = configured_policy
+	ProjectSettings.set_setting(setting_name, configured_policies)
+
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var records: Array[Dictionary] = [{
+		"class_name": "GFTimeUtility",
+		"path": script_path,
+		"kind": GFAccessGenerator.TargetKind.UTILITY,
+	}]
+	var result: Dictionary = generator._apply_access_policies(records)
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	var frozen_records: Array = GF_VARIANT_ACCESS.get_option_array(result, "records")
+	var frozen_record: Dictionary = GF_VARIANT_ACCESS.as_dictionary(frozen_records[0])
+	var string_name_policy_key_count: int = 0
+	for raw_key: Variant in frozen_record:
+		if raw_key is StringName:
+			var policy_key_name: StringName = raw_key
+			if ["scope", "required", "require_ready"].has(String(policy_key_name)):
+				string_name_policy_key_count += 1
+
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(result, "valid"))
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(frozen_record, "scope"),
+		GFAccessGenerator.ACCESS_SCOPE_LOCAL
+	)
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(frozen_record, "required", true))
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(frozen_record, "require_ready"))
+	assert_eq(string_name_policy_key_count, 0, "冻结记录只应保留 canonical String 策略键。")
+	assert_false(records[0].has("scope"), "字段键规范化不得修改调用方记录。")
+
+
+func test_string_and_string_name_policy_aliases_freeze_one_canonical_value() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var script_path: String = "res://addons/gf/standard/utilities/time/gf_time_utility.gd"
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var aliased_policy: Dictionary = {
+		"scope": "local",
+	}
+	aliased_policy[StringName("scope")] = "inherited"
+	ProjectSettings.set_setting(setting_name, {
+		script_path: aliased_policy,
+	})
+
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var result: Dictionary = generator._apply_access_policies([{
+		"class_name": "GFTimeUtility",
+		"path": script_path,
+		"kind": GFAccessGenerator.TargetKind.UTILITY,
+	}])
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	var frozen_records: Array = GF_VARIANT_ACCESS.get_option_array(result, "records")
+	var frozen_record: Dictionary = GF_VARIANT_ACCESS.as_dictionary(frozen_records[0])
+	assert_eq(aliased_policy.size(), 1, "Godot Dictionary 会在验证前折叠等价字符串键。")
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(result, "valid"))
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(frozen_record, "scope"),
+		GFAccessGenerator.ACCESS_SCOPE_INHERITED,
+		"折叠后的最终值应冻结到 canonical String 字段。"
+	)
+
+
+func test_string_name_access_policy_field_with_wrong_type_fails_closed() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var script_path: String = "res://addons/gf/standard/utilities/time/gf_time_utility.gd"
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var invalid_policy: Dictionary = {}
+	invalid_policy[StringName("required")] = 1
+	ProjectSettings.set_setting(setting_name, {
+		script_path: invalid_policy,
+	})
+
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var result: Dictionary = generator._apply_access_policies([{
+		"class_name": "GFTimeUtility",
+		"path": script_path,
+		"kind": GFAccessGenerator.TargetKind.UTILITY,
+	}])
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(result, "valid"))
+	assert_true(GF_VARIANT_ACCESS.get_option_array(result, "records").is_empty())
+	assert_push_error("[GFAccessGenerator] access policy 值无效：%s" % script_path)
+
+
+func test_invalid_access_policy_fails_closed_without_generating_accessor() -> void:
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var source: String = generator.build_source([
+		{
+			"class_name": "ValidPolicyModel",
+			"path": "res://valid_policy_model.gd",
+			"kind": GFAccessGenerator.TargetKind.MODEL,
+		},
+		{
+			"class_name": "InvalidPolicyUtility",
+			"path": "res://invalid_policy_utility.gd",
+			"kind": GFAccessGenerator.TargetKind.UTILITY,
+			"scope": "nearest",
+			"required": false,
+			"require_ready": true,
+		},
+	])
+
+	assert_true(source.is_empty(), "任一 policy 非法时不得生成同批合法记录或扩展源码。")
+	assert_push_error(
+		"[GFAccessGenerator] access policy 无效，整批生成已中止：InvalidPolicyUtility"
+	)
+
+
+func test_unknown_configured_access_policy_field_fails_closed() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var script_path: String = "res://addons/gf/standard/utilities/time/gf_time_utility.gd"
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	ProjectSettings.set_setting(setting_name, {
+		script_path: {
+			"scope": "local",
+			"requires": false,
+		},
+	})
+
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var records: Array[Dictionary] = [
+		{
+			"class_name": "GFTimeUtility",
+			"path": script_path,
+			"kind": GFAccessGenerator.TargetKind.UTILITY,
+		},
+	]
+	var policy_result: Dictionary = generator._apply_access_policies(records)
+	var frozen_records: Array = GF_VARIANT_ACCESS.get_option_array(policy_result, "records")
+	var source: String = generator.build_source(frozen_records)
+
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	assert_false(
+		source.contains("static func get_gf_time_utility("),
+		"未知字段不应回退默认策略生成访问器。"
+	)
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(policy_result, "valid"), "未知字段应使整批策略失败。")
+	assert_true(frozen_records.is_empty(), "失败批次不得暴露部分冻结记录。")
+	assert_push_error(
+		"[GFAccessGenerator] access policy 包含未知字段：%s" % script_path
+	)
+
+
+func test_access_policy_freezing_is_transactional_across_reuse() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var script_path: String = "res://addons/gf/standard/utilities/time/gf_time_utility.gd"
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var records: Array[Dictionary] = [{
+		"class_name": "GFTimeUtility",
+		"path": script_path,
+		"kind": GFAccessGenerator.TargetKind.UTILITY,
+	}]
+	ProjectSettings.set_setting(setting_name, {
+		script_path: {
+			"scope": "local",
+			"required": false,
+			"require_ready": true,
+		},
+	})
+	var local_result: Dictionary = generator._apply_access_policies(records)
+	ProjectSettings.set_setting(setting_name, {})
+	var default_result: Dictionary = generator._apply_access_policies(records)
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	var local_records: Array = GF_VARIANT_ACCESS.get_option_array(local_result, "records")
+	var default_records: Array = GF_VARIANT_ACCESS.get_option_array(default_result, "records")
+	var local_record: Dictionary = GF_VARIANT_ACCESS.as_dictionary(local_records[0])
+	var default_record: Dictionary = GF_VARIANT_ACCESS.as_dictionary(default_records[0])
+	assert_eq(GF_VARIANT_ACCESS.get_option_string_name(local_record, "scope"), GFAccessGenerator.ACCESS_SCOPE_LOCAL)
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(local_record, "required", true))
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(local_record, "require_ready"))
+	assert_eq(GF_VARIANT_ACCESS.get_option_string_name(default_record, "scope"), GFAccessGenerator.ACCESS_SCOPE_INHERITED)
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(default_record, "required"))
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(default_record, "require_ready"))
+	assert_false(records[0].has("scope"), "重复冻结不得把上次策略残留到原始记录。")
+
+
+func test_stale_access_policy_path_fails_closed() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var stale_path: String = "res://moved/old_time_utility.gd"
+	ProjectSettings.set_setting(setting_name, {
+		stale_path: { "scope": "local" },
+	})
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var result: Dictionary = generator._apply_access_policies([{
+		"class_name": "GFTimeUtility",
+		"path": "res://addons/gf/standard/utilities/time/gf_time_utility.gd",
+		"kind": GFAccessGenerator.TargetKind.UTILITY,
+	}])
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(result, "valid"), "移动后遗留路径必须阻断生成。")
+	assert_true(GF_VARIANT_ACCESS.get_option_array(result, "records").is_empty())
+	assert_push_error("[GFAccessGenerator] access policy 路径未匹配可生成模块：%s" % stale_path)
+
+
+func test_invalid_access_policy_root_does_not_overwrite_generated_artifact() -> void:
+	var setting_name: String = GFAccessGenerator.ACCESS_POLICIES_SETTING
+	var had_setting: bool = ProjectSettings.has_setting(setting_name)
+	var previous_value: Variant = ProjectSettings.get_setting(setting_name, null)
+	var path: String = "user://gf_access_generator_invalid_policy_%d.gd" % Time.get_ticks_usec()
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file)
+	if file == null:
+		return
+	var _stored: bool = file.store_string("sentinel")
+	file.close()
+	ProjectSettings.set_setting(setting_name, "invalid")
+
+	var generator: GFAccessGenerator = GFAccessGenerator.new()
+	var report: Dictionary = generator.generate_with_report(path, {
+		"written": true,
+		"changed": true,
+		"size_bytes": 1024,
+		"content_sha256": "spoofed-content",
+		"previous_sha256": "spoofed-previous",
+		"dry_run": true,
+		"artifact_owner": GFGeneratedArtifactReport.OWNER_EXTERNAL,
+		"source_id": "access-policy-test",
+		"metadata": {
+			"case": "invalid-policy",
+		},
+	})
+	if had_setting:
+		ProjectSettings.set_setting(setting_name, previous_value)
+	else:
+		ProjectSettings.clear(setting_name)
+	var read_file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	assert_not_null(read_file)
+	var content: String = read_file.get_as_text() if read_file != null else ""
+	if read_file != null:
+		read_file.close()
+	var _removed: Error = DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "success"))
+	assert_eq(GF_VARIANT_ACCESS.get_option_string_name(report, "status"), GFGeneratedArtifactReport.STATUS_FAILED)
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "error_code"), ERR_INVALID_DATA)
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "written"), "失败报告不得接受伪造写入状态。")
+	assert_false(GF_VARIANT_ACCESS.get_option_bool(report, "changed"), "验证失败尚未形成可比较产物。")
+	assert_eq(GF_VARIANT_ACCESS.get_option_int(report, "size_bytes", -1), 0)
+	assert_eq(GF_VARIANT_ACCESS.get_option_string(report, "content_sha256"), "")
+	assert_eq(GF_VARIANT_ACCESS.get_option_string(report, "previous_sha256"), "")
+	assert_true(GF_VARIANT_ACCESS.get_option_bool(report, "dry_run"))
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string_name(report, "artifact_owner"),
+		GFGeneratedArtifactReport.OWNER_EXTERNAL
+	)
+	assert_eq(GF_VARIANT_ACCESS.get_option_string(report, "generator_id"), "GFAccessGenerator")
+	assert_eq(GF_VARIANT_ACCESS.get_option_string(report, "source_id"), "access-policy-test")
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_string(
+			GF_VARIANT_ACCESS.get_option_dictionary(report, "metadata"),
+			"case"
+		),
+		"invalid-policy"
+	)
+	assert_eq(content, "sentinel", "策略根非法时不得覆盖既有生成物。")
+	assert_push_error("[GFAccessGenerator] gf/codegen/access_policies 必须是 Dictionary。")
 
 
 func test_build_source_omits_capability_helper_without_capability_records() -> void:
@@ -269,12 +655,26 @@ func test_collect_project_records_includes_known_gf_settings_without_plugin_regi
 	var settings: Array = GF_VARIANT_ACCESS.get_option_array(records, "settings")
 
 	assert_true(settings.has("gf/codegen/access_output_path"), "生成器应稳定包含 GF codegen 设置。")
+	assert_true(settings.has("gf/codegen/access_policies"), "生成器应稳定包含访问策略设置。")
 	assert_true(settings.has("gf/project/installers"), "生成器应稳定包含 GF installer 设置。")
 	assert_false(settings.has("gf/build/export/write_metadata"), "kernel 生成器不应硬编码标准库 debug 导出设置。")
 	assert_false(settings.has("gf/build/export/build_metadata"), "kernel 生成器不应硬编码标准库 debug 导出元数据设置。")
 
 
 # --- 私有/辅助方法 ---
+
+func _get_generated_function_source(source: String, signature_prefix: String) -> String:
+	var start_index: int = source.find(signature_prefix)
+	if start_index < 0:
+		return ""
+	var next_function_index: int = source.find(
+		"\nstatic func ",
+		start_index + signature_prefix.length()
+	)
+	if next_function_index < 0:
+		return source.substr(start_index)
+	return source.substr(start_index, next_function_index - start_index)
+
 
 func _new_object(script: Variant) -> Object:
 	if script is Script:

--- a/tests/gf_core/kernel/editor/test_gf_plugin_helpers.gd
+++ b/tests/gf_core/kernel/editor/test_gf_plugin_helpers.gd
@@ -814,13 +814,20 @@ func test_resource_path_editor_maps_file_hints_to_resource_types() -> void:
 	assert_true(script_filters[0].contains("*.gd"), "Script 过滤器应包含 GDScript 扩展名。")
 
 
-func test_codegen_outputs_use_save_file_semantics() -> void:
+func test_codegen_settings_register_output_and_access_policy_semantics() -> void:
 	GF_PLUGIN_PROJECT_SETTINGS.ensure_all()
 	var access_output_info: Dictionary = _find_project_setting_property_info(
 		GF_PLUGIN_PROJECT_SETTINGS.ACCESS_OUTPUT_SETTING
 	)
+	var access_policies_info: Dictionary = _find_project_setting_property_info(
+		GF_PLUGIN_PROJECT_SETTINGS.ACCESS_POLICIES_SETTING
+	)
 	var project_access_output_info: Dictionary = _find_project_setting_property_info(
 		GF_PLUGIN_PROJECT_SETTINGS.PROJECT_ACCESS_OUTPUT_SETTING
+	)
+	var access_policies_value: Variant = ProjectSettings.get_setting(
+		GF_PLUGIN_PROJECT_SETTINGS.ACCESS_POLICIES_SETTING,
+		null
 	)
 
 	assert_eq(
@@ -833,6 +840,15 @@ func test_codegen_outputs_use_save_file_semantics() -> void:
 		PROPERTY_HINT_SAVE_FILE,
 		"项目访问器输出应使用保存文件语义。"
 	)
+	assert_eq(
+		GF_VARIANT_ACCESS.get_option_int(access_policies_info, "type", TYPE_NIL),
+		TYPE_DICTIONARY,
+		"访问策略应注册为 Dictionary ProjectSetting。"
+	)
+	assert_true(access_policies_value is Dictionary, "访问策略应注册空 Dictionary 默认值。")
+	if access_policies_value is Dictionary:
+		var access_policies: Dictionary = access_policies_value
+		assert_true(access_policies.is_empty(), "默认访问策略不应为项目预置类型规则。")
 
 
 func test_project_installers_use_script_resource_path_array_semantics() -> void:

--- a/tests/gf_core/kernel/editor/test_gf_project_settings_inspector_plugin.gd
+++ b/tests/gf_core/kernel/editor/test_gf_project_settings_inspector_plugin.gd
@@ -5,6 +5,7 @@ extends GutTest
 
 const _GF_PROJECT_SETTINGS_INSPECTOR_PLUGIN_SCRIPT = preload("res://addons/gf/kernel/editor/gf_project_settings_inspector_plugin.gd")
 const _GF_PROJECT_SETTING_PRESENTATION_CATALOG_SCRIPT = preload("res://addons/gf/kernel/editor/gf_project_setting_presentation_catalog.gd")
+const _GF_PLUGIN_PROJECT_SETTINGS_SCRIPT = preload("res://addons/gf/kernel/editor/gf_plugin_project_settings.gd")
 const _GF_EDITOR_CONTRIBUTION_REGISTRY_SCRIPT = preload("res://addons/gf/kernel/editor/gf_editor_contribution_registry.gd")
 const _GF_EXTENSION_SETTINGS_SCRIPT = preload("res://addons/gf/kernel/extension/gf_extension_settings.gd")
 const _GF_VARIANT_ACCESS_SCRIPT = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
@@ -51,6 +52,27 @@ func test_builtin_setting_presentation_uses_tool_locale_and_english_fallback() -
 		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(fallback, "label"),
 		"Extension Selection Mode",
 		"未提供的工具语言应回退英文。"
+	)
+
+
+func test_access_policy_setting_has_builtin_presentation() -> void:
+	var catalog: Object = _GF_PROJECT_SETTING_PRESENTATION_CATALOG_SCRIPT.new()
+	var presentation: Dictionary = _get_presentation(
+		catalog,
+		_GF_PLUGIN_PROJECT_SETTINGS_SCRIPT.ACCESS_POLICIES_SETTING,
+		"zh_CN"
+	)
+
+	assert_eq(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(presentation, "label"),
+		"框架访问策略",
+		"访问策略 ProjectSetting 应有内核维护的中文名称。"
+	)
+	assert_true(
+		_GF_VARIANT_ACCESS_SCRIPT.get_option_string(presentation, "tooltip").contains(
+			_GF_PLUGIN_PROJECT_SETTINGS_SCRIPT.ACCESS_POLICIES_SETTING
+		),
+		"访问策略悬浮说明应保留稳定设置键。"
 	)
 
 

--- a/tests/gf_core/standard/common/test_gf_async_keyed_gate_and_requests.gd
+++ b/tests/gf_core/standard/common/test_gf_async_keyed_gate_and_requests.gd
@@ -923,7 +923,9 @@ func test_keyed_gate_bounds_release_pump_work_including_expired_requests() -> vo
 			GFVariantData.get_option_string_name(queued, "status"),
 			GFAsyncKeyedGate.STATUS_QUEUED
 		)
-	await get_tree().create_timer(0.01).timeout
+	var expiration_target_msec: int = Time.get_ticks_msec() + 2
+	while Time.get_ticks_msec() < expiration_target_msec:
+		await get_tree().process_frame
 
 	var _released: bool = blocker.release(&"done")
 	var immediate_snapshot: Dictionary = gate.get_debug_snapshot()

--- a/tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
+++ b/tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
@@ -912,6 +912,503 @@ func test_virtual_source_ids_with_delimiters_do_not_clear_each_other() -> void:
 	assert_false(_utility.is_action_active(&"boost"), "释放剩余贡献后动作才应结束。")
 
 
+func test_virtual_input_pulse_completes_with_exactly_one_release() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", 0, timer_utility)
+
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 0.1)
+
+	assert_true(operation.is_pending(), "有效脉冲应返回 pending 类型化句柄。")
+	assert_true(_utility.is_action_active(&"confirm"), "脉冲启动后应立即写入动作值。")
+	timer_utility.tick(0.1)
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.COMPLETED, "到时后应进入 COMPLETED。")
+	assert_eq(operation.get_release_count(), 1, "取得 lease 的脉冲必须恰好完成一次匹配释放。")
+	assert_false(_utility.is_action_active(&"confirm"), "匹配释放后动作应结束。")
+	timer_utility.tick(1.0)
+	assert_eq(operation.get_release_count(), 1, "后续 tick 不得重复释放已完成脉冲。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_zero_duration_completes_synchronously() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", 0, timer_utility)
+
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 0.0)
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.COMPLETED, "0 秒脉冲应在返回前同步完成。")
+	assert_eq(operation.get_release_count(), 1, "0 秒脉冲也必须完成一次匹配释放。")
+	assert_false(_utility.is_action_active(&"confirm"), "同步完成后不得遗留动作贡献。")
+	assert_eq(
+		GFVariantData.get_option_int(timer_utility.get_debug_snapshot(), "pending_count"),
+		0,
+		"0 秒脉冲不得遗留排队 timer。"
+	)
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_replacement_is_safe_across_duplicate_source_objects() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var first_source: GFVirtualInputSource = _utility.create_virtual_source(&"shared", 0, timer_utility)
+	var second_source: GFVirtualInputSource = _utility.create_virtual_source(&"shared", 0, timer_utility)
+	var first: GFVirtualInputPulseOperation = first_source.pulse_action(&"confirm", true, 0.1)
+	var completed_actions: Array[StringName] = []
+	var on_action_completed: Callable = func(action_id: StringName, _value: Variant) -> void:
+		completed_actions.append(action_id)
+	var _connected: Error = _utility.action_completed.connect(on_action_completed) as Error
+	timer_utility.tick(0.04)
+
+	var second: GFVirtualInputPulseOperation = second_source.pulse_action(&"confirm", true, 0.2)
+
+	assert_eq(first.get_status(), GFVirtualInputPulseOperation.Status.REPLACED, "同稳定输入键的新脉冲应替换旧 lease。")
+	assert_eq(first.get_release_count(), 0, "原子交接不得把旧 lease 计为实际释放。")
+	assert_true(second.is_pending(), "新脉冲应持有权威 lease。")
+	assert_true(_utility.is_action_active(&"confirm"), "替换完成后新脉冲应保持动作激活。")
+	assert_eq(completed_actions.size(), 0, "同键替换不得暴露中间 inactive 状态。")
+	timer_utility.tick(0.07)
+	assert_true(_utility.is_action_active(&"confirm"), "旧脉冲原到期点不得清除新 generation。")
+	assert_true(second.is_pending(), "旧定时器不得终止新句柄。")
+	timer_utility.tick(0.13)
+	assert_eq(second.get_status(), GFVirtualInputPulseOperation.Status.COMPLETED, "新脉冲应按自己的时长完成。")
+	assert_eq(second.get_release_count(), 1, "新 lease 也应只释放一次。")
+	assert_false(_utility.is_action_active(&"confirm"), "新脉冲完成后动作应结束。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_reject_new_preserves_current_lease() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var current: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 0.2)
+
+	var rejected: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		0.1,
+		null,
+		null,
+		GFVirtualInputSource.PulseReplacementPolicy.REJECT_NEW
+	)
+
+	assert_eq(rejected.get_status(), GFVirtualInputPulseOperation.Status.REJECTED, "REJECT_NEW 应让新句柄立即拒绝。")
+	assert_eq(rejected.get_release_count(), 0, "未取得 lease 的拒绝句柄不得执行释放。")
+	assert_true(current.is_pending(), "拒绝新请求不得终止当前 lease。")
+	assert_true(_utility.is_action_active(&"confirm"), "拒绝新请求不得改变当前动作值。")
+	timer_utility.tick(0.2)
+	assert_eq(current.get_status(), GFVirtualInputPulseOperation.Status.COMPLETED, "原脉冲仍应正常完成。")
+	timer_utility.dispose()
+
+
+func test_manual_virtual_write_terminates_pulse_before_overwrite() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 0.1)
+	var reentrant_operations: Array[GFVirtualInputPulseOperation] = []
+	var completed_actions: Array[StringName] = []
+	var on_action_completed: Callable = func(action_id: StringName, _value: Variant) -> void:
+		completed_actions.append(action_id)
+	var _action_connected: Error = _utility.action_completed.connect(on_action_completed) as Error
+	var on_completed: Callable = func(_completed_operation: GFVirtualInputPulseOperation) -> void:
+		reentrant_operations.append(source.pulse_action(&"confirm", true, 0.1))
+	var _connected: Error = operation.completed.connect(on_completed, CONNECT_ONE_SHOT as Object.ConnectFlags) as Error
+
+	assert_true(source.press(&"confirm"), "手动写入应覆盖当前脉冲。")
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "手动写入前应取消匹配 pulse lease。")
+	assert_eq(operation.get_terminal_reason(), &"manual_write", "终态应暴露稳定覆盖原因。")
+	assert_eq(operation.get_release_count(), 0, "无中间 clear 的手动覆盖不得计为实际释放。")
+	assert_eq(completed_actions.size(), 0, "同键手动覆盖不得暴露中间 inactive 状态。")
+	assert_eq(reentrant_operations.size(), 1, "终态回调应被同步观察。")
+	assert_eq(
+		reentrant_operations[0].get_status(),
+		GFVirtualInputPulseOperation.Status.REJECTED,
+		"权威手动写事务中重入的新脉冲必须 fail closed。"
+	)
+	timer_utility.tick(0.2)
+	assert_true(_utility.is_action_active(&"confirm"), "旧定时器不得清除覆盖后的手动值。")
+	assert_true(source.release(&"confirm"), "手动值仍应由调用方显式释放。")
+	timer_utility.dispose()
+
+
+func test_manual_virtual_clear_terminates_matching_pulse_once() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 0.1)
+
+	assert_true(source.clear_action(&"confirm"), "手动 clear 应终止当前脉冲并报告状态变化。")
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "手动 clear 应取消匹配 lease。")
+	assert_eq(operation.get_terminal_reason(), &"manual_clear", "clear 终态原因应稳定。")
+	assert_eq(operation.get_release_count(), 1, "手动 clear 应只释放一次。")
+	assert_false(_utility.is_action_active(&"confirm"), "手动 clear 后动作应结束。")
+	timer_utility.tick(0.2)
+	assert_eq(operation.get_release_count(), 1, "旧定时器不得重复 clear。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_fails_closed_for_invalid_lifecycle_anchors() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var released_owner: Object = Object.new()
+	released_owner.free()
+	var released_owner_operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		released_owner
+	)
+
+	assert_eq(
+		released_owner_operation.get_status(),
+		GFVirtualInputPulseOperation.Status.FAILED,
+		"已释放 owner 不得被当作未提供 owner。"
+	)
+	assert_eq(
+		released_owner_operation.get_terminal_reason(),
+		&"invalid_owner_lifecycle",
+		"已释放 owner 应提供稳定失败原因。"
+	)
+	assert_eq(released_owner_operation.get_release_count(), 0, "已释放 owner 不得取得 lease。")
+	assert_false(_utility.is_action_active(&"confirm"), "已释放 owner 不得产生输入写入。")
+
+	var tree_outside_owner: Node = Node.new()
+
+	var invalid_owner_operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		tree_outside_owner
+	)
+
+	assert_eq(
+		invalid_owner_operation.get_status(),
+		GFVirtualInputPulseOperation.Status.FAILED,
+		"树外 Node 不能形成可靠生命周期锚点，应 fail closed。"
+	)
+	assert_eq(
+		invalid_owner_operation.get_terminal_reason(),
+		&"invalid_owner_lifecycle",
+		"无效 owner 应提供稳定失败原因。"
+	)
+	assert_eq(invalid_owner_operation.get_release_count(), 0, "绑定失败不得写入或释放 lease。")
+	assert_false(_utility.is_action_active(&"confirm"), "生命周期校验失败时不得产生输入写入。")
+	tree_outside_owner.free()
+
+	var completed_scope: GFAsyncScope = GFAsyncScope.new()
+	completed_scope.complete()
+	var completed_scope_operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		null,
+		completed_scope
+	)
+
+	assert_eq(
+		completed_scope_operation.get_status(),
+		GFVirtualInputPulseOperation.Status.FAILED,
+		"已完成 GFAsyncScope 不得被重新用作活动取消锚点。"
+	)
+	assert_eq(
+		completed_scope_operation.get_terminal_reason(),
+		&"cancellation_scope_completed",
+		"已完成 scope 应提供可诊断的稳定原因。"
+	)
+	assert_eq(completed_scope_operation.get_release_count(), 0, "scope 绑定失败不得取得 lease。")
+	assert_false(_utility.is_action_active(&"confirm"), "scope 绑定失败时不得写入动作。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_honors_pre_cancelled_token_before_write() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var cancellation_source: GFCancellationSource = GFCancellationSource.new()
+	var _cancelled: bool = cancellation_source.cancel(&"already_closed")
+
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		null,
+		cancellation_source.get_token()
+	)
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "预取消 token 应同步取消句柄。")
+	assert_eq(operation.get_terminal_reason(), &"already_closed", "应保留预取消 token 的首次原因。")
+	assert_eq(operation.get_release_count(), 0, "预取消操作不得取得或释放 lease。")
+	assert_false(_utility.is_action_active(&"confirm"), "预取消 token 不得产生瞬时输入写入。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_owner_and_token_use_or_cancellation() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var owner_node: Node = Node.new()
+	add_child(owner_node)
+	var cancellation_source: GFCancellationSource = GFCancellationSource.new()
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		owner_node,
+		cancellation_source.get_token()
+	)
+
+	var cancel_requested: bool = cancellation_source.cancel(&"view_closed")
+
+	assert_true(cancel_requested, "测试 token 应成功提交首次取消。")
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "任一锚点取消都应终止脉冲。")
+	assert_eq(operation.get_terminal_reason(), &"view_closed", "应保留 first-terminal token 原因。")
+	assert_eq(operation.get_release_count(), 1, "token 取消应完成一次匹配释放。")
+	owner_node.queue_free()
+	await get_tree().process_frame
+	assert_eq(operation.get_release_count(), 1, "后到 owner 终态不得重复释放。")
+	assert_false(_utility.is_action_active(&"confirm"), "OR 取消后动作应结束。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_node_owner_tree_exit_releases_matching_lease() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var owner_node: Node = Node.new()
+	add_child(owner_node)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		owner_node
+	)
+
+	owner_node.queue_free()
+	await get_tree().process_frame
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "Node owner 离树应取消脉冲。")
+	assert_eq(operation.get_terminal_reason(), &"owner_released", "Node owner 离树应提供稳定原因。")
+	assert_eq(operation.get_release_count(), 1, "Node owner 离树应完成一次匹配释放。")
+	assert_false(_utility.is_action_active(&"confirm"), "Node owner 离树后动作不得粘住。")
+	timer_utility.tick(2.0)
+	assert_eq(operation.get_release_count(), 1, "owner 终止后旧 timer 不得重复释放。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_prunes_released_ref_counted_owner_on_mapping_tick() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var lifecycle_owner: RefCounted = RefCounted.new()
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		lifecycle_owner
+	)
+	lifecycle_owner = null
+
+	_utility.tick(0.0)
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "Mapping tick 应发现普通 Object owner 已释放。")
+	assert_eq(operation.get_terminal_reason(), &"owner_released", "弱 owner 清理应提供稳定原因。")
+	assert_eq(operation.get_release_count(), 1, "弱 owner 释放应完成一次匹配释放。")
+	assert_false(_utility.is_action_active(&"confirm"), "普通 Object owner 释放后动作不得粘住。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_source_dispose_releases_owned_pulses() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 1.0)
+
+	source.dispose()
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "Source dispose 应取消其活动脉冲。")
+	assert_eq(operation.get_terminal_reason(), &"source_disposed", "Source dispose 应提供稳定原因。")
+	assert_eq(operation.get_release_count(), 1, "Source dispose 应释放 lease 一次。")
+	assert_false(_utility.is_action_active(&"confirm"), "Source dispose 后动作不得粘住。")
+	timer_utility.tick(2.0)
+	assert_eq(operation.get_release_count(), 1, "dispose 后旧 timer 不得重复释放。")
+	var _reconfigure_result: GFVirtualInputSource = source.configure(
+		_utility,
+		&"revived",
+		-1,
+		timer_utility
+	)
+	assert_false(source.press(&"confirm"), "dispose 应为不可逆终态，configure 不得复活手动写入。")
+	var refused_after_dispose: GFVirtualInputPulseOperation = source.pulse_action(&"confirm")
+	assert_eq(
+		refused_after_dispose.get_status(),
+		GFVirtualInputPulseOperation.Status.FAILED,
+		"dispose 后 pulse 应 fail closed。"
+	)
+	assert_eq(refused_after_dispose.get_terminal_reason(), &"source_disposed", "失败原因应稳定。")
+	timer_utility.dispose()
+
+
+func test_mapping_rebuild_and_dispose_terminate_pulse_leases() -> void:
+	var bindings: Array[GFInputBinding] = []
+	var context: GFInputContext = _make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	])
+	_utility.enable_context(context)
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var rebuilt_operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 1.0)
+
+	_utility.set_enabled_contexts([context])
+
+	assert_eq(rebuilt_operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "Mapping rebuild 应取消旧 lease。")
+	assert_eq(rebuilt_operation.get_terminal_reason(), &"mapping_rebuilt", "重建原因应稳定。")
+	assert_eq(rebuilt_operation.get_release_count(), 1, "重建应先完成一次匹配释放。")
+	var disposed_operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 1.0)
+	assert_true(disposed_operation.is_pending(), "重建后的 Source 应能启动新脉冲。")
+
+	_utility.dispose()
+
+	assert_eq(disposed_operation.get_status(), GFVirtualInputPulseOperation.Status.CANCELLED, "Mapping dispose 应取消活动 lease。")
+	assert_eq(disposed_operation.get_terminal_reason(), &"mapping_disposed", "dispose 原因应稳定。")
+	assert_eq(disposed_operation.get_release_count(), 1, "Mapping dispose 应释放一次。")
+	timer_utility.tick(2.0)
+	assert_eq(disposed_operation.get_release_count(), 1, "dispose 后旧 timer 不得重复释放。")
+	_utility = null
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_releases_when_timer_schedule_is_rebuilt() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 1.0)
+	var original_timer_handle: int = GFVariantData.get_option_int(
+		operation.get_debug_snapshot(),
+		"timer_handle"
+	)
+
+	timer_utility.dispose()
+	timer_utility.init()
+	var unrelated_state: Dictionary = {"count": 0}
+	var unrelated_handle: int = timer_utility.execute_after(0.25, func() -> void:
+		unrelated_state["count"] = GFVariantData.get_option_int(unrelated_state, "count") + 1
+	)
+	assert_eq(unrelated_handle, original_timer_handle, "夹具应证明 dispose/init 后 timer handle 已被复用。")
+
+	_utility.tick(0.0)
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.FAILED, "丢失的 timer 排程应 fail closed。")
+	assert_eq(operation.get_terminal_reason(), &"timer_schedule_lost", "timer 重建应提供稳定失败原因。")
+	assert_eq(operation.get_release_count(), 1, "timer 排程丢失后应补偿释放当前 lease。")
+	assert_false(_utility.is_action_active(&"confirm"), "timer 排程丢失后动作不得粘住。")
+	timer_utility.tick(0.25)
+	assert_eq(
+		GFVariantData.get_option_int(unrelated_state, "count"),
+		1,
+		"旧 pulse 终止不得误取消复用 handle 的无关 timer。"
+	)
+	timer_utility.dispose()
+
+
+func test_mapping_tick_releases_pulse_when_source_and_handle_are_dropped() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"ephemeral", -1, timer_utility)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 1.0)
+	var operation_ref: WeakRef = weakref(operation)
+	operation = null
+	source = null
+
+	_utility.tick(0.0)
+
+	assert_false(operation_ref.get_ref() is Object, "Mapping lease 不得强持有已丢弃的 pulse operation。")
+	assert_false(_utility.is_action_active(&"confirm"), "Mapping tick 应补偿释放弱 operation 遗留贡献。")
+	timer_utility.dispose()
+
+
+func test_virtual_input_pulse_freezes_identity_across_source_reconfiguration() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"before", 0, timer_utility)
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(&"confirm", true, 0.1)
+	source.source_id = &"after"
+	source.player_index = 1
+
+	assert_eq(operation.get_source_id(), &"before", "操作应冻结创建时 source_id。")
+	assert_eq(operation.get_player_index(), 0, "操作应冻结创建时 player_index。")
+	timer_utility.tick(0.1)
+
+	assert_eq(operation.get_status(), GFVirtualInputPulseOperation.Status.COMPLETED, "重配 Source 不应阻断旧操作完成。")
+	assert_false(_utility.is_action_active(&"confirm"), "旧操作应按冻结身份完成匹配释放。")
+	timer_utility.dispose()
+
+
 func test_input_recording_playback_drives_virtual_source() -> void:
 	var bindings: Array[GFInputBinding] = []
 	var context: GFInputContext = _make_context(&"gameplay", [

--- a/tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
+++ b/tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
@@ -1153,6 +1153,45 @@ func test_virtual_input_pulse_fails_closed_for_invalid_lifecycle_anchors() -> vo
 	timer_utility.dispose()
 
 
+func test_virtual_input_pulse_releases_when_scope_completes_after_lease_acquisition() -> void:
+	var bindings: Array[GFInputBinding] = []
+	_utility.enable_context(_make_context(&"gameplay", [
+		_make_mapping(_make_action(&"confirm"), bindings),
+	]))
+	var timer_utility: GFTimerUtility = GFTimerUtility.new()
+	timer_utility.init()
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"touch", -1, timer_utility)
+	var scope: GFAsyncScope = GFAsyncScope.new()
+	var operation: GFVirtualInputPulseOperation = source.pulse_action(
+		&"confirm",
+		true,
+		1.0,
+		null,
+		scope
+	)
+
+	assert_true(operation.is_pending(), "活动 scope 应允许 pulse 取得 lease。")
+	assert_true(_utility.is_action_active(&"confirm"), "scope 完成前动作应保持活动。")
+	scope.complete()
+	_utility.tick(0.0)
+
+	assert_eq(
+		operation.get_status(),
+		GFVirtualInputPulseOperation.Status.CANCELLED,
+		"scope 完成后 Mapping tick 应取消 pulse。"
+	)
+	assert_eq(
+		operation.get_terminal_reason(),
+		&"cancellation_scope_completed",
+		"scope 完成应提供稳定终态原因。"
+	)
+	assert_eq(operation.get_release_count(), 1, "scope 完成应执行一次匹配释放。")
+	assert_false(_utility.is_action_active(&"confirm"), "scope 完成后动作不得保持粘滞。")
+	timer_utility.tick(2.0)
+	assert_eq(operation.get_release_count(), 1, "scope 终止后旧 timer 不得重复释放。")
+	timer_utility.dispose()
+
+
 func test_virtual_input_pulse_honors_pre_cancelled_token_before_write() -> void:
 	var bindings: Array[GFInputBinding] = []
 	_utility.enable_context(_make_context(&"gameplay", [

--- a/tests/gf_core/standard/utilities/ui/test_gf_ui_router_utility.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_ui_router_utility.gd
@@ -38,6 +38,10 @@ class ManualAssetUtility extends GFAssetUtility:
 	func get_pending_count(path: String) -> int:
 		return _callback_list(path).size() if _callbacks.has(path) else 0
 
+	func dispose() -> void:
+		_callbacks.clear()
+		super.dispose()
+
 	func _callback_list(path: String) -> Array:
 		var callbacks_value: Variant = _callbacks[path]
 		if callbacks_value is Array:
@@ -269,6 +273,96 @@ func test_async_route_sync_fallback_reaches_terminal_state() -> void:
 	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
 
 
+func test_legacy_ui_telemetry_reentry_cannot_complete_replacement_route() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/ui_telemetry_reentry_route_panel.tscn"
+	assert_true(_router.register_route(route))
+	_router.set_ui_utility(null)
+	var replacement_operations: Array[GFUIRouteOperation] = []
+	var reentry_state: Dictionary = { "started": false }
+	var telemetry_callback: Callable = func(
+		_path: String,
+		_layer: int,
+		_operation: StringName,
+		_status: int,
+		_panel: Node
+	) -> void:
+		if GFVariantData.get_option_bool(reentry_state, "started"):
+			return
+		reentry_state["started"] = true
+		replacement_operations.append(_router.push_route_async(&"inventory"))
+	var _connected: Error = _ui_utility.panel_async_load_finished.connect(
+		telemetry_callback
+	) as Error
+	_router.set_ui_utility(_ui_utility)
+
+	var first_operation: GFUIRouteOperation = _router.push_route_async(&"inventory")
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+
+	assert_eq(first_operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
+	assert_eq(replacement_operations.size(), 1, "旧请求 telemetry 的重入只应创建一个替代请求。")
+	var replacement_operation: GFUIRouteOperation = replacement_operations[0]
+	assert_true(replacement_operation.is_pending(), "旧请求 telemetry 不得终结同键替代请求。")
+	assert_eq(asset_util.get_pending_count(route.scene_path), 1, "替代请求应保留自己的底层加载。")
+	assert_eq(_router.get_route_history().size(), 1, "替代请求完成前只记录首个路由。")
+
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_eq(replacement_operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
+	assert_eq(_router.get_route_history().size(), 2, "替代请求应按自己的句柄终态独立记录。")
+	if _ui_utility.panel_async_load_finished.is_connected(telemetry_callback):
+		_ui_utility.panel_async_load_finished.disconnect(telemetry_callback)
+
+
+func test_route_opened_reentry_creates_distinct_same_key_request() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/route_opened_reentry_panel.tscn"
+	assert_true(_router.register_route(route))
+	var replacement_operations: Array[GFUIRouteOperation] = []
+	var reentry_state: Dictionary = { "started": false }
+	var opened_callback: Callable = func(
+		_route_id: StringName,
+		_panel: Node,
+		_operation: GFUIRouterUtility.Operation
+	) -> void:
+		if GFVariantData.get_option_bool(reentry_state, "started"):
+			return
+		reentry_state["started"] = true
+		replacement_operations.append(_router.push_route_async(&"inventory"))
+	var _connected: Error = _router.route_opened.connect(opened_callback) as Error
+
+	var first_operation: GFUIRouteOperation = _router.push_route_async(&"inventory")
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+
+	assert_eq(first_operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
+	assert_eq(replacement_operations.size(), 1)
+	var replacement_operation: GFUIRouteOperation = replacement_operations[0]
+	assert_ne(replacement_operation, first_operation, "route_opened 重入不得合流到正在完成的旧句柄。")
+	assert_true(replacement_operation.is_pending(), "重入创建的新请求必须保留自己的终态。")
+	assert_eq(asset_util.get_pending_count(route.scene_path), 1)
+
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_eq(replacement_operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
+	assert_eq(_router.get_route_history().size(), 2)
+	if _router.route_opened.is_connected(opened_callback):
+		_router.route_opened.disconnect(opened_callback)
+
+
 func test_conflicting_pending_async_routes_fail_instead_of_silently_overwriting() -> void:
 	_arch = GFArchitecture.new()
 	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
@@ -304,7 +398,10 @@ func test_router_rejects_matching_external_ui_async_request() -> void:
 	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
 	route.scene_path = "res://tests/external_pending_route_panel.tscn"
 	assert_true(_router.register_route(route))
-	_ui_utility.push_panel_async(route.scene_path, route.layer)
+	var _external_operation: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		route.scene_path,
+		route.layer
+	)
 	watch_signals(_router)
 
 	var operation: GFUIRouteOperation = _router.push_route_async(&"inventory")
@@ -400,6 +497,387 @@ func test_invalid_async_preload_policy_returns_typed_failure() -> void:
 		[&"inventory", "invalid_preload_policy"]
 	)
 	assert_push_warning("[GFUIRouterUtility] 路由打开失败：inventory (invalid_preload_policy)")
+
+
+func test_async_route_returns_cancelled_for_pre_cancelled_scope() -> void:
+	assert_true(_router.register_route(_make_route(&"inventory", GFUIUtility.Layer.POPUP)))
+	var scope: GFAsyncScope = GFAsyncScope.new()
+	var _cancelled: bool = scope.cancel("navigation_abandoned")
+	watch_signals(_router)
+
+	var operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{ "scope": scope }
+	)
+
+	assert_true(operation.is_completed(), "已取消 scope 应立即返回终态。")
+	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_CANCELLED)
+	assert_eq(operation.get_result().get_reason(), &"navigation_abandoned")
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0)
+	assert_signal_emit_count(_router, "route_open_requested", 0, "已取消 scope 不应进入路由提交流程。")
+	assert_signal_emit_count(_router, "route_operation_completed", 1, "立即取消也只能产生一个终态。")
+
+
+func test_async_route_rejects_completed_or_invalid_scope() -> void:
+	assert_true(_router.register_route(_make_route(&"inventory", GFUIUtility.Layer.POPUP)))
+	var completed_scope: GFAsyncScope = GFAsyncScope.new()
+	completed_scope.complete()
+
+	var completed_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{ "scope": completed_scope }
+	)
+	assert_eq(
+		completed_operation.get_result().get_status(),
+		GFUIRouteResult.STATUS_INVALID_LIFECYCLE
+	)
+	assert_eq(completed_operation.get_result().get_reason(), &"scope_completed")
+	assert_push_warning("[GFUIRouterUtility] 路由打开失败：inventory (scope_completed)")
+
+	var invalid_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{ "scope": RefCounted.new() }
+	)
+	assert_eq(
+		invalid_operation.get_result().get_status(),
+		GFUIRouteResult.STATUS_INVALID_LIFECYCLE
+	)
+	assert_eq(invalid_operation.get_result().get_reason(), &"invalid_scope")
+	assert_push_warning("[GFUIRouterUtility] 路由打开失败：inventory (invalid_scope)")
+
+
+func test_async_route_rejects_node_owner_outside_scene_tree() -> void:
+	assert_true(_router.register_route(_make_route(&"inventory", GFUIUtility.Layer.POPUP)))
+	var owner_node: Node = Node.new()
+
+	var operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{ "owner": owner_node }
+	)
+
+	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_INVALID_LIFECYCLE)
+	assert_eq(operation.get_result().get_reason(), &"owner_not_in_tree")
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0)
+	assert_push_warning("[GFUIRouterUtility] 路由打开失败：inventory (owner_not_in_tree)")
+	owner_node.free()
+
+
+func test_owner_and_scope_use_or_cancellation_before_panel_submit() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/lifecycle_or_route_panel.tscn"
+	assert_true(_router.register_route(route))
+	var owner_node: Node = Node.new()
+	add_child(owner_node)
+	var scope: GFAsyncScope = GFAsyncScope.new()
+	watch_signals(_router)
+
+	var operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{
+			"owner": owner_node,
+			"scope": scope,
+			"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+		}
+	)
+	assert_true(operation.is_pending())
+	assert_eq(asset_util.get_pending_count(route.scene_path), 1, "请求应先停留在预加载阶段。")
+
+	var _cancelled: bool = scope.cancel("route_scope_cancelled")
+	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_CANCELLED)
+	assert_eq(operation.get_result().get_reason(), &"route_scope_cancelled")
+	owner_node.queue_free()
+	await get_tree().process_frame
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0, "取消后的迟到预加载不得再提交面板。")
+	assert_signal_emit_count(_router, "route_operation_completed", 1, "scope 与 owner 后续终止只能共享一个终态。")
+
+
+func test_node_owner_tree_exit_cancels_before_panel_submit() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/node_owner_route_panel.tscn"
+	assert_true(_router.register_route(route))
+	var owner_node: Node = Node.new()
+	add_child(owner_node)
+
+	var operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{
+			"owner": owner_node,
+			"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+		}
+	)
+	owner_node.queue_free()
+	await get_tree().process_frame
+
+	assert_true(operation.is_completed())
+	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_CANCELLED)
+	assert_eq(operation.get_result().get_reason(), &"owner_tree_exited")
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0)
+
+
+func test_ref_counted_owner_release_is_pruned_on_tick() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/ref_counted_owner_route_panel.tscn"
+	assert_true(_router.register_route(route))
+	var route_owner: RefCounted = RefCounted.new()
+	var route_owner_ref: WeakRef = weakref(route_owner)
+
+	var operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{
+			"owner": route_owner,
+			"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+		}
+	)
+	route_owner = null
+	var owner_was_released: bool = route_owner_ref.get_ref() == null
+	assert_true(owner_was_released, "Router 只应弱持有普通 Object owner。")
+	_router.tick(0.0)
+
+	assert_true(operation.is_completed())
+	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_CANCELLED)
+	assert_eq(operation.get_result().get_reason(), &"owner_released")
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0)
+
+
+func test_duplicate_pending_route_requires_same_lifecycle_identity() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/lifecycle_identity_route_panel.tscn"
+	assert_true(_router.register_route(route))
+	var route_owner: RefCounted = RefCounted.new()
+	var other_owner: RefCounted = RefCounted.new()
+	var scope: GFAsyncScope = GFAsyncScope.new()
+	var async_options: Dictionary = {
+		"owner": route_owner,
+		"scope": scope,
+		"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+	}
+
+	var first_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		async_options
+	)
+	var duplicate_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		async_options
+	)
+	var conflict_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{
+			"owner": other_owner,
+			"scope": scope,
+			"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+		}
+	)
+
+	assert_eq(duplicate_operation, first_operation, "只有生命周期身份相同的请求才能合流。")
+	assert_eq(conflict_operation.get_result().get_status(), GFUIRouteResult.STATUS_ASYNC_CONFLICT)
+	assert_eq(conflict_operation.get_result().get_reason(), &"route_async_conflict")
+	assert_push_warning("[GFUIRouterUtility] 路由打开失败：inventory (route_async_conflict)")
+	var _cancelled: bool = scope.cancel("test_cleanup")
+	assert_eq(first_operation.get_result().get_status(), GFUIRouteResult.STATUS_CANCELLED)
+
+
+func test_lifecycle_cancellation_is_ignored_after_panel_submit() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/submitted_lifecycle_route_panel.tscn"
+	assert_true(_router.register_route(route))
+	var owner_node: Node = Node.new()
+	add_child(owner_node)
+	var scope: GFAsyncScope = GFAsyncScope.new()
+	watch_signals(_router)
+
+	var operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{
+			"owner": owner_node,
+			"scope": scope,
+		}
+	)
+	assert_true(operation.is_pending(), "面板已提交但尚未加载时句柄应保持 pending。")
+	assert_eq(asset_util.get_pending_count(route.scene_path), 1)
+	var _cancelled: bool = scope.cancel("too_late")
+	owner_node.queue_free()
+	await get_tree().process_frame
+	assert_true(operation.is_pending(), "面板提交后的 owner/scope 取消不得改写路由结果。")
+
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 1)
+	assert_signal_emit_count(_router, "route_operation_completed", 1, "提交后取消不得制造第二终态。")
+
+
+func test_route_open_requested_reentry_cannot_advance_replacement_request_twice() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/reentrant_route_identity_panel.tscn"
+	assert_true(_router.register_route(route))
+	var first_scope: GFAsyncScope = GFAsyncScope.new()
+	var replacement_operations: Array[GFUIRouteOperation] = []
+	var replacement_state: Dictionary = { "started": false }
+	var callback: Callable
+	callback = func(_route_id: StringName, _operation: GFUIRouterUtility.Operation, _params: Dictionary) -> void:
+		if GFVariantData.get_option_bool(replacement_state, "started"):
+			return
+		replacement_state["started"] = true
+		var _cancelled: bool = first_scope.cancel("route_replaced_during_signal")
+		replacement_operations.append(_router.push_route_async(
+			&"inventory",
+			{},
+			{},
+			Callable(),
+			{ "preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED }
+		))
+	var _connected: Error = _router.route_open_requested.connect(callback) as Error
+
+	var first_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{
+			"scope": first_scope,
+			"preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED,
+		}
+	)
+
+	assert_eq(first_operation.get_result().get_status(), GFUIRouteResult.STATUS_CANCELLED)
+	assert_eq(replacement_operations.size(), 1, "重入监听器只应创建一个替代请求。")
+	assert_eq(asset_util.get_pending_count(route.scene_path), 1, "旧调用栈不得再次推进替代请求。")
+	var replacement_operation: GFUIRouteOperation = replacement_operations[0]
+	assert_true(replacement_operation.is_pending())
+
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+	assert_true(replacement_operation.is_pending(), "预加载完成后应等待独立的面板加载终态。")
+	assert_eq(asset_util.get_pending_count(route.scene_path), 1, "面板提交只应创建一个后续加载。")
+	asset_util.resolve(route.scene_path, _make_control_scene())
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	assert_eq(replacement_operation.get_result().get_status(), GFUIRouteResult.STATUS_OPENED)
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 1)
+	if _router.route_open_requested.is_connected(callback):
+		_router.route_open_requested.disconnect(callback)
+
+
+func test_reinit_rejects_terminal_reentry_and_keeps_request_ids_monotonic() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
+	route.scene_path = "res://tests/reinit_route_identity_panel.tscn"
+	assert_true(_router.register_route(route))
+	var reentrant_operations: Array[GFUIRouteOperation] = []
+	var reentry_state: Dictionary = { "started": false }
+	var completion_callback: Callable
+	completion_callback = func(result: GFUIRouteResult) -> void:
+		if GFVariantData.get_option_bool(reentry_state, "started") or result.get_route_id() != &"inventory":
+			return
+		reentry_state["started"] = true
+		reentrant_operations.append(_router.push_route_async(&"inventory"))
+	var _connected: Error = _router.route_operation_completed.connect(
+		completion_callback
+	) as Error
+	var first_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{ "preload_policy": GFUIRouterUtility.PRELOAD_REQUIRED }
+	)
+
+	_router.init()
+
+	assert_eq(first_operation.get_result().get_status(), GFUIRouteResult.STATUS_DISPOSED)
+	assert_eq(reentrant_operations.size(), 1, "重置期间的重入请求必须同步收敛。")
+	var rejected_operation: GFUIRouteOperation = reentrant_operations[0]
+	assert_eq(rejected_operation.get_result().get_status(), GFUIRouteResult.STATUS_DISPOSED)
+	assert_gt(
+		rejected_operation.get_request_id(),
+		first_operation.get_request_id(),
+		"同一 Router 实例重置时 request_id 不得回退。"
+	)
+
+	_router.configure([route], _ui_utility)
+	var next_scope: GFAsyncScope = GFAsyncScope.new()
+	var _next_cancelled: bool = next_scope.cancel("request_id_probe")
+	var next_operation: GFUIRouteOperation = _router.push_route_async(
+		&"inventory",
+		{},
+		{},
+		Callable(),
+		{ "scope": next_scope }
+	)
+	assert_gt(
+		next_operation.get_request_id(),
+		rejected_operation.get_request_id(),
+		"重置后的新请求仍应继续使用单调 request_id。"
+	)
+	if _router.route_operation_completed.is_connected(completion_callback):
+		_router.route_operation_completed.disconnect(completion_callback)
 
 
 func test_required_route_preload_completes_before_panel_open() -> void:
@@ -592,6 +1070,7 @@ func test_router_dispose_rolls_back_preload_before_panel_submit() -> void:
 	var route: GFUIRoute = _make_route(&"inventory", GFUIUtility.Layer.POPUP)
 	route.scene_path = "res://tests/disposed_preloading_route.tscn"
 	assert_true(_router.register_route(route))
+	watch_signals(_router)
 
 	var operation: GFUIRouteOperation = _router.push_route_async(
 		&"inventory",
@@ -610,6 +1089,7 @@ func test_router_dispose_rolls_back_preload_before_panel_submit() -> void:
 	await get_tree().process_frame
 	assert_eq(operation.get_result().get_status(), GFUIRouteResult.STATUS_DISPOSED)
 	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0)
+	assert_signal_emit_count(_router, "route_operation_completed", 1, "dispose 与迟到预加载只能共享一个终态。")
 
 
 # --- 私有/辅助方法 ---

--- a/tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd
@@ -3,6 +3,7 @@ extends GutTest
 
 
 const _GF_AUTOLOAD_SCRIPT = preload("res://addons/gf/kernel/core/gf_autoload.gd")
+const _PANEL_SCENE_PATH: String = "res://tests/gf_core/fixtures/scene_signal_audit_valid.tscn"
 
 
 var _ui_utility: GFUIUtility
@@ -31,6 +32,23 @@ class ManualAssetUtility extends GFAssetUtility:
 			return
 		var callbacks: Array = callbacks_value
 		for callback: Callable in callbacks:
+			callback.call(resource)
+
+	func resolve_next(path: String, resource: Resource) -> void:
+		if not _callbacks.has(path):
+			return
+		var callbacks_value: Variant = _callbacks[path]
+		if not callbacks_value is Array:
+			return
+		var callbacks: Array = callbacks_value
+		if callbacks.is_empty():
+			var _empty_erase_result: bool = _callbacks.erase(path)
+			return
+		var callback_value: Variant = callbacks.pop_front()
+		if callbacks.is_empty():
+			var _erase_result: bool = _callbacks.erase(path)
+		if callback_value is Callable:
+			var callback: Callable = callback_value
 			callback.call(resource)
 
 
@@ -598,13 +616,35 @@ func test_push_panel_async_ignores_late_callback_after_dispose() -> void:
 	await Gf.set_architecture(_arch)
 
 	var scene: PackedScene = _make_control_scene()
-	_ui_utility.push_panel_async("res://tests/pending_async_panel.tscn", GFUIUtility.Layer.POPUP)
+	var _disposed_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		"res://tests/pending_async_panel.tscn",
+		GFUIUtility.Layer.POPUP
+	)
 	_ui_utility.dispose()
 
 	asset_util.resolve("res://tests/pending_async_panel.tscn", scene)
 	await get_tree().process_frame
 
 	assert_null(_ui_utility.get_top_panel(GFUIUtility.Layer.POPUP), "销毁后的异步回调不应再把面板压入栈。")
+
+
+func test_panel_async_operation_rejects_invalid_terminal_payloads() -> void:
+	var operation: GFUIPanelAsyncOperation = GFUIPanelAsyncOperation.new()
+	assert_true(operation.configure_for_framework(1, "res://tests/panel.tscn", 3, &"push"))
+	assert_false(operation.complete_for_framework(99, null), "未知终态不得完成句柄。")
+	assert_false(
+		operation.complete_for_framework(GFUIUtility.AsyncPanelLoadStatus.OPENED, null),
+		"OPENED 必须携带有效面板。"
+	)
+	assert_true(operation.is_pending(), "非法终态输入不得污染 pending 句柄。")
+
+	var ignored_panel: Node = Node.new()
+	assert_true(
+		operation.complete_for_framework(GFUIUtility.AsyncPanelLoadStatus.FAILED, ignored_panel),
+		"合法失败终态应完成句柄。"
+	)
+	assert_null(operation.get_panel(), "失败与取消终态不得保留面板引用。")
+	ignored_panel.free()
 
 
 func test_push_panel_async_reports_pending_load_lifecycle() -> void:
@@ -629,10 +669,29 @@ func test_push_panel_async_reports_pending_load_lifecycle() -> void:
 		finished.append([load_path, layer, operation, status, panel])
 	)
 
-	_ui_utility.push_panel_async(path, GFUIUtility.Layer.POPUP)
+	var operation_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP
+	)
 
+	assert_not_null(operation_handle, "有效异步请求应返回类型化句柄。")
+	assert_true(operation_handle.is_pending(), "资源返回前句柄应保持 pending。")
+	assert_false(operation_handle.is_completed(), "pending 句柄不应已有终态。")
+	assert_eq(operation_handle.get_serial(), 1, "句柄应冻结 UI 分配的请求序号。")
+	assert_eq(operation_handle.get_path(), path, "句柄应冻结场景路径。")
+	assert_eq(operation_handle.get_layer(), GFUIUtility.Layer.POPUP, "句柄应冻结目标层级。")
+	assert_eq(operation_handle.get_operation(), GFUIPanelAsyncOperation.OPERATION_PUSH)
+	assert_eq(operation_handle.get_status(), GFUIPanelAsyncOperation.STATUS_PENDING)
 	assert_true(_ui_utility.has_pending_async_panel(GFUIUtility.Layer.POPUP, path), "异步加载期间应暴露 pending 状态。")
-	assert_eq(_ui_utility.get_pending_async_panel_requests(GFUIUtility.Layer.POPUP).size(), 1, "pending 快照应包含当前请求。")
+	var pending_requests: Array[Dictionary] = _ui_utility.get_pending_async_panel_requests(
+		GFUIUtility.Layer.POPUP
+	)
+	assert_eq(pending_requests.size(), 1, "pending 快照应包含当前请求。")
+	assert_same(
+		_ui_panel_async_operation(pending_requests[0].get("operation_handle")),
+		operation_handle,
+		"pending 快照应保留同一类型化请求身份。"
+	)
 	assert_eq(started, [[path, GFUIUtility.Layer.POPUP, &"push"]], "异步请求开始时应发出开始信号。")
 
 	asset_util.resolve(path, _make_control_scene())
@@ -643,6 +702,174 @@ func test_push_panel_async_reports_pending_load_lifecycle() -> void:
 	var opened_event: Array = _array_item_as_array(finished, 0)
 	assert_eq(_array_int(opened_event, 3), GFUIUtility.AsyncPanelLoadStatus.OPENED, "成功入栈应报告 OPENED。")
 	assert_not_null(_array_node(opened_event, 4), "成功状态应携带已打开面板。")
+	assert_true(operation_handle.is_completed(), "资源返回后句柄应进入终态。")
+	assert_eq(operation_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.OPENED)
+	assert_same(operation_handle.get_panel(), _array_node(opened_event, 4))
+
+	_ui_utility.clear_layer(GFUIUtility.Layer.POPUP)
+	await get_tree().process_frame
+	assert_null(operation_handle.get_panel(), "句柄弱引用不应延长已关闭面板的生命周期。")
+
+
+func test_push_panel_async_sync_fallback_prebinds_callback_before_telemetry() -> void:
+	var events: Array[StringName] = []
+	var state: Dictionary = {}
+	var _finished_connection: Error = _ui_utility.panel_async_load_finished.connect(func(
+		_path: String,
+		_layer: int,
+		_operation: StringName,
+		_status: int,
+		_panel: Node
+	) -> void:
+		events.append(&"telemetry")
+	) as Error
+
+	var first_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		_PANEL_SCENE_PATH,
+		GFUIUtility.Layer.POPUP,
+		Callable(),
+		func(completed_handle: GFUIPanelAsyncOperation) -> void:
+			events.append(&"first_handle")
+			state["first_callback_handle"] = completed_handle
+			state["second_handle"] = _ui_utility.push_panel_async(
+				_PANEL_SCENE_PATH,
+				GFUIUtility.Layer.POPUP,
+				Callable(),
+				func(_second_completed_handle: GFUIPanelAsyncOperation) -> void:
+					events.append(&"second_handle")
+			)
+	)
+	assert_push_warning("[GFUIUtility] GFAssetUtility 未注册，回退为同步加载。")
+	assert_push_warning("[GFUIUtility] GFAssetUtility 未注册，回退为同步加载。")
+
+	var second_handle: GFUIPanelAsyncOperation = _ui_panel_async_operation(
+		state.get("second_handle")
+	)
+	assert_not_null(first_handle, "同步 fallback 也应返回句柄。")
+	assert_not_null(second_handle, "终态回调应能立即提交同键新请求。")
+	assert_not_same(second_handle, first_handle, "同键重入必须得到独立的新句柄。")
+	assert_same(
+		_ui_panel_async_operation(state.get("first_callback_handle")),
+		first_handle,
+		"预绑定回调应收到即将返回的同一句柄。"
+	)
+	assert_true(first_handle.is_completed())
+	assert_true(second_handle.is_completed())
+	assert_eq(first_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.OPENED)
+	assert_eq(second_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.OPENED)
+	assert_ne(first_handle.get_panel(), second_handle.get_panel(), "两个句柄不得串用成功面板。")
+	assert_eq(
+		events,
+		[&"first_handle", &"second_handle", &"telemetry", &"telemetry"],
+		"句柄回调必须先于各自 telemetry，且嵌套请求应保持独立顺序。"
+	)
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 2)
+
+
+func test_async_completion_callback_can_reenter_same_key_without_handle_crosstalk() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+
+	var path: String = "res://tests/reentrant_async_panel.tscn"
+	var first_completions: Array[GFUIPanelAsyncOperation] = []
+	var second_completions: Array[GFUIPanelAsyncOperation] = []
+	var state: Dictionary = {}
+	var first_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP,
+		Callable(),
+		func(completed_handle: GFUIPanelAsyncOperation) -> void:
+			first_completions.append(completed_handle)
+			state["second_handle"] = _ui_utility.push_panel_async(
+				path,
+				GFUIUtility.Layer.POPUP,
+				Callable(),
+				func(second_completed_handle: GFUIPanelAsyncOperation) -> void:
+					second_completions.append(second_completed_handle)
+			)
+	)
+
+	asset_util.resolve(path, _make_control_scene())
+	var second_handle: GFUIPanelAsyncOperation = _ui_panel_async_operation(
+		state.get("second_handle")
+	)
+	assert_not_null(second_handle, "首个终态回调应能提交同键新请求。")
+	assert_not_same(second_handle, first_handle, "新请求不能复用已完成句柄。")
+	assert_true(first_handle.is_completed())
+	assert_true(second_handle.is_pending(), "新请求应独立等待第二次资源结果。")
+	assert_eq(first_completions, [first_handle])
+	assert_true(second_completions.is_empty())
+
+	asset_util.resolve(path, _make_control_scene())
+	await get_tree().process_frame
+
+	assert_true(second_handle.is_completed())
+	assert_eq(second_completions, [second_handle])
+	assert_eq(first_completions.size(), 1, "第二个终态不得回流到首个句柄。")
+	assert_ne(first_handle.get_panel(), second_handle.get_panel(), "两个请求必须保留各自面板弱引用。")
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 2)
+
+
+func test_request_serial_survives_dispose_reinit_and_rejects_old_callback_collision() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+
+	var path: String = "res://tests/reinitialized_async_panel.tscn"
+	var old_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP
+	)
+	_ui_utility.dispose()
+	assert_true(old_handle.is_completed(), "dispose 应立即终止旧请求。")
+	assert_eq(old_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.CANCELLED)
+
+	_ui_utility.init()
+	var new_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP
+	)
+	assert_true(new_handle.get_serial() > old_handle.get_serial(), "重新初始化不得复用请求序号。")
+
+	asset_util.resolve_next(path, _make_control_scene())
+	assert_true(new_handle.is_pending(), "旧生命周期的迟到回调不得命中新请求身份。")
+	assert_null(_ui_utility.get_top_panel(GFUIUtility.Layer.POPUP))
+
+	asset_util.resolve_next(path, _make_control_scene())
+	await get_tree().process_frame
+
+	assert_true(new_handle.is_completed())
+	assert_eq(new_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.OPENED)
+	assert_same(new_handle.get_panel(), _ui_utility.get_top_panel(GFUIUtility.Layer.POPUP))
+	assert_eq(old_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.CANCELLED)
+
+
+func test_replace_layer_async_returns_typed_operation_handle() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+
+	var path: String = "res://tests/pending_replace_panel.tscn"
+	var operation_handle: GFUIPanelAsyncOperation = _ui_utility.replace_layer_async(
+		path,
+		GFUIUtility.Layer.TOP
+	)
+	assert_not_null(operation_handle)
+	assert_true(operation_handle.is_pending())
+	assert_eq(operation_handle.get_operation(), GFUIPanelAsyncOperation.OPERATION_REPLACE)
+	assert_eq(operation_handle.get_path(), path)
+	assert_eq(operation_handle.get_layer(), GFUIUtility.Layer.TOP)
+
+	asset_util.resolve(path, _make_control_scene())
+	await get_tree().process_frame
+
+	assert_true(operation_handle.is_completed())
+	assert_eq(operation_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.OPENED)
+	assert_same(operation_handle.get_panel(), _ui_utility.get_top_panel(GFUIUtility.Layer.TOP))
 
 
 func test_pending_async_panel_cancel_clears_state_and_reports_finished() -> void:
@@ -653,6 +880,7 @@ func test_pending_async_panel_cancel_clears_state_and_reports_finished() -> void
 
 	var path: String = "res://tests/pending_async_panel.tscn"
 	var finished: Array = []
+	var completed_handles: Array[GFUIPanelAsyncOperation] = []
 	var _connect_result_545: Variant = _ui_utility.panel_async_load_finished.connect(func(
 		load_path: String,
 		layer: int,
@@ -663,9 +891,20 @@ func test_pending_async_panel_cancel_clears_state_and_reports_finished() -> void
 		finished.append([load_path, layer, operation, status, panel])
 	)
 
-	_ui_utility.push_panel_async(path, GFUIUtility.Layer.POPUP)
+	var operation_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP,
+		Callable(),
+		func(completed_handle: GFUIPanelAsyncOperation) -> void:
+			completed_handles.append(completed_handle)
+	)
 	_ui_utility.clear_layer(GFUIUtility.Layer.POPUP)
 
+	assert_not_null(operation_handle)
+	assert_true(operation_handle.is_completed(), "清层应同步完成对应句柄。")
+	assert_eq(operation_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.CANCELLED)
+	assert_null(operation_handle.get_panel(), "取消终态不应携带面板。")
+	assert_eq(completed_handles, [operation_handle], "句柄应只发出当前请求的取消终态。")
 	assert_false(_ui_utility.has_pending_async_panel(GFUIUtility.Layer.POPUP, path), "清层应立即清理 pending 状态。")
 	assert_eq(finished.size(), 1, "取消异步请求应发出结束信号。")
 	var cancelled_event: Array = _array_item_as_array(finished, 0)
@@ -676,6 +915,8 @@ func test_pending_async_panel_cancel_clears_state_and_reports_finished() -> void
 	await get_tree().process_frame
 
 	assert_eq(finished.size(), 1, "迟到资源回调不应重复发出结束信号。")
+	assert_eq(completed_handles.size(), 1, "迟到资源回调不应重复完成句柄。")
+	assert_eq(operation_handle.get_status(), GFUIUtility.AsyncPanelLoadStatus.CANCELLED)
 	assert_null(_ui_utility.get_top_panel(GFUIUtility.Layer.POPUP), "取消后的迟到异步回调不应打开面板。")
 
 
@@ -697,7 +938,10 @@ func test_push_panel_async_reports_failed_when_resource_is_not_scene() -> void:
 		finished.append([load_path, layer, operation, status, panel])
 	)
 
-	_ui_utility.push_panel_async(path, GFUIUtility.Layer.POPUP)
+	var _failed_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP
+	)
 	asset_util.resolve(path, Resource.new())
 	await get_tree().process_frame
 
@@ -716,7 +960,10 @@ func test_push_panel_async_ignores_late_callback_after_layer_clear() -> void:
 	await Gf.set_architecture(_arch)
 
 	var scene: PackedScene = _make_control_scene()
-	_ui_utility.push_panel_async("res://tests/pending_async_panel.tscn", GFUIUtility.Layer.POPUP)
+	var _cleared_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		"res://tests/pending_async_panel.tscn",
+		GFUIUtility.Layer.POPUP
+	)
 	_ui_utility.clear_layer(GFUIUtility.Layer.POPUP)
 
 	asset_util.resolve("res://tests/pending_async_panel.tscn", scene)
@@ -732,7 +979,10 @@ func test_push_panel_async_ignores_late_callback_after_pop_cancel() -> void:
 	await Gf.set_architecture(_arch)
 
 	var scene: PackedScene = _make_control_scene()
-	_ui_utility.push_panel_async("res://tests/pending_async_panel.tscn", GFUIUtility.Layer.POPUP)
+	var _popped_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		"res://tests/pending_async_panel.tscn",
+		GFUIUtility.Layer.POPUP
+	)
 	_ui_utility.pop_panel(GFUIUtility.Layer.POPUP)
 
 	asset_util.resolve("res://tests/pending_async_panel.tscn", scene)
@@ -748,8 +998,15 @@ func test_duplicate_pending_push_panel_async_is_coalesced() -> void:
 	await Gf.set_architecture(_arch)
 
 	var scene: PackedScene = _make_control_scene()
-	_ui_utility.push_panel_async("res://tests/pending_async_panel.tscn", GFUIUtility.Layer.POPUP)
-	_ui_utility.push_panel_async("res://tests/pending_async_panel.tscn", GFUIUtility.Layer.POPUP)
+	var first_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		"res://tests/pending_async_panel.tscn",
+		GFUIUtility.Layer.POPUP
+	)
+	var second_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		"res://tests/pending_async_panel.tscn",
+		GFUIUtility.Layer.POPUP
+	)
+	assert_same(second_handle, first_handle, "合流请求应共享同一类型化句柄。")
 
 	asset_util.resolve("res://tests/pending_async_panel.tscn", scene)
 	await get_tree().process_frame
@@ -765,8 +1022,14 @@ func test_later_async_push_cancels_older_replace_intent() -> void:
 
 	var replace_path: String = "res://tests/older_replace_panel.tscn"
 	var push_path: String = "res://tests/newer_push_panel.tscn"
-	_ui_utility.replace_layer_async(replace_path, GFUIUtility.Layer.POPUP)
-	_ui_utility.push_panel_async(push_path, GFUIUtility.Layer.POPUP)
+	var _replace_handle: GFUIPanelAsyncOperation = _ui_utility.replace_layer_async(
+		replace_path,
+		GFUIUtility.Layer.POPUP
+	)
+	var _push_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		push_path,
+		GFUIUtility.Layer.POPUP
+	)
 
 	assert_false(
 		_ui_utility.has_pending_async_panel(GFUIUtility.Layer.POPUP, replace_path),
@@ -813,6 +1076,13 @@ func _array_node(values: Array, index: int) -> Node:
 	var value: Variant = _array_value(values, index)
 	if value is Node:
 		return value
+	return null
+
+
+func _ui_panel_async_operation(value: Variant) -> GFUIPanelAsyncOperation:
+	if value is GFUIPanelAsyncOperation:
+		var operation_handle: GFUIPanelAsyncOperation = value
+		return operation_handle
 	return null
 
 

--- a/tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd
@@ -591,6 +591,46 @@ func test_config_callback_destroying_panel_restores_hidden_panel() -> void:
 	assert_true(panel1.visible, "取消入栈后原本被隐藏的面板应恢复可见。")
 
 
+func test_panel_opened_queue_free_rolls_back_options_and_emits_closed_once() -> void:
+	var under_panel: Control = Control.new()
+	_ui_utility.push_panel_instance(under_panel, GFUIUtility.Layer.POPUP)
+	var panel: Control = Control.new()
+	var panel_id: int = panel.get_instance_id()
+	var closed_panel_ids: Array[int] = []
+	var navigation_tops: Array[Node] = []
+	var _opened_connection: Error = _ui_utility.panel_opened.connect(
+		func(opened_panel: Node, _layer: int) -> void:
+			opened_panel.queue_free(),
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	var _closed_connection: Error = _ui_utility.panel_closed.connect(
+		func(closed_panel: Node, _layer: int) -> void:
+			closed_panel_ids.append(closed_panel.get_instance_id())
+	) as Error
+	var _navigation_connection: Error = _ui_utility.navigation_changed.connect(
+		func(_layer: int, top_panel: Node) -> void:
+			navigation_tops.append(top_panel)
+	) as Error
+
+	var added: bool = _ui_utility._add_panel_instance(
+		panel,
+		GFUIUtility.Layer.POPUP,
+		Callable(),
+		{"metadata": {"source": "review_regression"}}
+	)
+
+	assert_false(added, "观察者已排队释放的面板不得提交为成功入栈。")
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 1)
+	assert_same(_ui_utility.get_top_panel(GFUIUtility.Layer.POPUP), under_panel)
+	assert_false(_ui_utility.is_panel_open(panel), "已排队释放的面板不得被报告为 open。")
+	assert_false(_ui_utility._panel_options.has(panel_id), "结构回滚必须清理面板策略快照。")
+	assert_eq(closed_panel_ids, [panel_id], "已发出 opened 的面板必须获得唯一配对 closed。")
+	assert_eq(navigation_tops, [under_panel], "回滚后应只报告一次最终有效栈顶。")
+	await get_tree().process_frame
+	assert_eq(closed_panel_ids.size(), 1, "后到 tree_exited 不得重复发出 closed。")
+	assert_eq(navigation_tops.size(), 1, "后到 tree_exited 不得重复发出导航变更。")
+
+
 func test_clear_layer() -> void:
 	var p1: Control = Control.new()
 	var p2: Control = Control.new()
@@ -709,6 +749,61 @@ func test_push_panel_async_reports_pending_load_lifecycle() -> void:
 	_ui_utility.clear_layer(GFUIUtility.Layer.POPUP)
 	await get_tree().process_frame
 	assert_null(operation_handle.get_panel(), "句柄弱引用不应延长已关闭面板的生命周期。")
+
+
+func test_push_panel_async_fails_when_panel_opened_listener_frees_panel() -> void:
+	_arch = GFArchitecture.new()
+	var asset_util: ManualAssetUtility = ManualAssetUtility.new()
+	await _arch.register_utility_instance(asset_util)
+	await Gf.set_architecture(_arch)
+
+	var path: String = "res://tests/freed_during_panel_opened.tscn"
+	var finished: Array = []
+	var completed_handles: Array[GFUIPanelAsyncOperation] = []
+	var navigation_tops: Array = []
+	var _opened_connection: Error = _ui_utility.panel_opened.connect(
+		func(panel: Node, _layer: int) -> void:
+			panel.free(),
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	var _finished_connection: Error = _ui_utility.panel_async_load_finished.connect(func(
+		load_path: String,
+		layer: int,
+		operation: StringName,
+		status: int,
+		panel: Node
+	) -> void:
+		finished.append([load_path, layer, operation, status, panel])
+	) as Error
+	var _navigation_connection: Error = _ui_utility.navigation_changed.connect(
+		func(_layer: int, top_panel: Node) -> void:
+			navigation_tops.append(top_panel)
+	) as Error
+
+	var operation_handle: GFUIPanelAsyncOperation = _ui_utility.push_panel_async(
+		path,
+		GFUIUtility.Layer.POPUP,
+		Callable(),
+		func(completed_handle: GFUIPanelAsyncOperation) -> void:
+			completed_handles.append(completed_handle)
+	)
+	asset_util.resolve(path, _make_control_scene())
+
+	assert_true(operation_handle.is_completed(), "监听器释放面板后句柄仍必须进入终态。")
+	assert_eq(
+		operation_handle.get_status(),
+		GFUIUtility.AsyncPanelLoadStatus.FAILED,
+		"已被同步释放的面板不能作为 OPENED 结果。"
+	)
+	assert_null(operation_handle.get_panel(), "失败终态不得保留已释放面板。")
+	assert_eq(completed_handles, [operation_handle], "句柄应且仅应发出一次失败终态。")
+	assert_false(_ui_utility.has_pending_async_panel(GFUIUtility.Layer.POPUP, path))
+	assert_eq(_ui_utility.get_stack_count(GFUIUtility.Layer.POPUP), 0)
+	assert_eq(finished.size(), 1, "异步 telemetry 应收到唯一失败终态。")
+	var failed_event: Array = _array_item_as_array(finished, 0)
+	assert_eq(_array_int(failed_event, 3), GFUIUtility.AsyncPanelLoadStatus.FAILED)
+	assert_true(_array_value(failed_event, 4) == null, "失败 telemetry 不得携带无效面板。")
+	assert_eq(navigation_tops, [null], "同步释放路径应只报告一次最终空栈导航。")
 
 
 func test_push_panel_async_sync_fallback_prebinds_callback_before_telemetry() -> void:


### PR DESCRIPTION
## Summary

- add exact `GFUIPanelAsyncOperation` identities for asynchronous panel push/replace requests, and bind pending `GFUIRouterUtility` routes to optional owner / `GFAsyncScope` lifetimes until panel submission
- add shared `GFArchitecture.resolve_module_access()` semantics plus exact-path `gf/codegen/access_policies`, freezing inherited/local scope, required/optional diagnostics, and ready requirements into generated typed accessors
- add source-owned `GFVirtualInputPulseOperation` handles and Mapping-owned per-key leases with deterministic timers, atomic replacement/rejection, lifecycle cancellation, and matching-release proof
- harden pulse timer ownership against `GFTimerUtility` dispose/reinit and handle reuse
- update project setting presentation, package ownership, Chinese guides, changelog, API Catalog/Reference, and AI Developer knowledge

## Why

The previous flows relied on aggregate UI telemetry, runtime-reinterpreted access intent, and untyped virtual-input timing. Those boundaries could not prove which request completed, which lifecycle still owned pending work, or whether a stale timer was allowed to release authoritative input state.

This change makes request identity, generation-time access policy, and input leases explicit and typed, while keeping gameplay and project-specific policy outside the framework.

## Key boundaries

- route owner/scope cancellation applies only before the Router submits work to `GFUIUtility`; accepted panels still require an explicit UI-stack close operation
- Router disposal after panel submission returns `STATUS_OUTCOME_UNKNOWN`; it does not prove that retrying is safe
- global panel completion signals remain aggregate telemetry and are not request-correlation primitives
- access policies are generation-time inputs; changing `gf/codegen/access_policies` requires regeneration, and an invalid record fails the full generation transaction without overwriting an existing artifact
- `required` controls strict lookup diagnostics and does not replace required dependency declarations
- pulse authority is keyed by source/player/action; stale generations, duplicate source objects, manual takeover, and reused timer handles cannot release a newer contribution
- `GFTimerUtility` dispose/reinit settles an affected pulse as `FAILED / timer_schedule_lost` on the next Mapping tick with compensating release
- no compatibility aliases, gameplay actions, navigation policy, or project-specific ownership rules are introduced

## Validation

- framework GUT: 5,634/5,634 tests, 47,374 assertions; lifecycle and Godot exit-leak gates clean
- framework static suite: API, AI API, docs, changelog, public/dependency/package boundaries, credential gate, repository policy, maintenance self-test, and diff checks passed
- framework LSP: 1,268 files, 0 diagnostics, 0 timeouts
- Access Generator focused GUT: 25/25 tests, 116 assertions
- Input Mapping / Pulse focused GUT: 72/72 tests, 264 assertions
- UI Router focused GUT: 35/35 tests, 211 assertions
- UI Utility focused GUT: 40/40 tests, 209 assertions
- API Surface Contract: 28/28 tests, 4,446 assertions
- GDScript Layout Contract: 9/9 tests, 14 assertions
- API Catalog/Reference: 804 classes, 11,851 members; current
- AI API coverage: 799 public classes; current
- project-settings drift and `git diff --check`: clean

Development version remains `11.0.0-dev.0`.

Closes #67
Closes #70
Closes #71
