### PR TITLE
Fix Save Profile transaction review boundaries

### DIFF
--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
@@ -85,6 +85,7 @@ const _STAGE_MUTATION_QUEUED: StringName = &"mutation_queued"
 const _STAGE_MUTATION_APPLY: StringName = &"mutation_apply"
 const _STAGE_MUTATION_SAVE: StringName = &"mutation_save"
 const _STAGE_RECONCILE_LOAD: StringName = &"reconcile_load"
+const _MAX_PROFILE_RESULT_EVIDENCE_ERROR_LENGTH: int = 2_048
 
 
 # --- 私有变量 ---
@@ -1633,21 +1634,45 @@ func _start_recovery_save(
 			"Recovery save request is uninitialized or was already claimed.",
 			_STAGE_RECOVERY_SAVE
 		)
+	var owned_request: GFSaveProfileRequest = request
+	if owned_request == null:
+		owned_request = GFSaveProfileRequest.take_ownership({}, {}, {})
+	_begin_processing()
+	var profile_operation: GFSaveProfileOperation = (
+		_profile_utility.save_profile_for_manager_for_framework(
+			profile_id,
+			owned_request,
+			profile.permit
+		)
+		if _profile_utility != null
+		else null
+	)
+	var save_admitted: bool = (
+		profile_operation != null
+		and owned_request.is_claimed()
+		and profile_operation.get_requested_generation() > 0
+	)
+	if not save_admitted:
+		var rejected_operation: GFSaveProfileTransactionOperation = (
+			_reject_recovery_save_admission(
+				operation_kind,
+				profile_id,
+				profile_operation
+			)
+		)
+		_end_processing()
+		return rejected_operation
 	var lease_claim: Dictionary = lease.claim_for_framework(
 		profile_id,
 		domain.domain_id,
 		domain.domain_generation,
 		domain.transaction_epoch
 	)
+	# 底层成功准入只会同步 claim request 与入队，不会执行 Provider 或开放回调；
+	# 因此同一调用栈内、同一 recovery record 的 Lease claim 失败属于内部不变量破坏。
 	if lease_claim.is_empty():
-		return _reject_transaction(
-			operation_kind,
-			&"",
-			profile_id,
-			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
-			ERR_INVALID_PARAMETER,
-			"Recovery Lease no longer matches the Provider domain.",
-			_STAGE_RECOVERY_SAVE
+		push_error(
+			"[GFSaveProfileTransactionCoordinator] Admitted recovery lease could not commit."
 		)
 	var _record_erased: bool = _recovery_records.erase(lease.get_lease_id())
 	var transaction: TransactionState = _begin_domain_transaction(
@@ -1658,11 +1683,48 @@ func _start_recovery_save(
 		{}
 	)
 	transaction.stage = _STAGE_RECOVERY_SAVE
-	var owned_request: GFSaveProfileRequest = request
-	if owned_request == null:
-		owned_request = GFSaveProfileRequest.take_ownership({}, {}, {})
-	_start_save(domain, transaction, profile_id, owned_request)
+	transaction.write_admitted = true
+	_observe_profile_operation(domain, transaction, profile_operation)
+	_end_processing()
 	return transaction.operation
+
+
+func _reject_recovery_save_admission(
+	operation_kind: StringName,
+	profile_id: StringName,
+	profile_operation: GFSaveProfileOperation
+) -> GFSaveProfileTransactionOperation:
+	var status: StringName = GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST
+	var error_code: Error = ERR_CANT_CREATE
+	var error: String = "GFSaveProfileUtility did not admit the recovery save."
+	var result: GFSaveProfileResult = (
+		profile_operation.get_result()
+		if profile_operation != null and profile_operation.is_completed()
+		else null
+	)
+	if result != null:
+		error_code = result.get_error_code()
+		error = result.get_error()
+		match result.get_status():
+			GFSaveProfileResult.STATUS_BUSY:
+				status = GFSaveProfileTransactionResult.STATUS_BUSY
+			GFSaveProfileResult.STATUS_INVALID_PROFILE:
+				status = GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE
+			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION:
+				status = GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION
+			GFSaveProfileResult.STATUS_DISPOSED:
+				status = GFSaveProfileTransactionResult.STATUS_DISPOSED
+			_:
+				status = GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST
+	return _reject_transaction(
+		operation_kind,
+		&"",
+		profile_id,
+		status,
+		error_code,
+		error,
+		_STAGE_RECOVERY_SAVE
+	)
 
 
 func _begin_domain_transaction(
@@ -2367,7 +2429,9 @@ func _make_profile_result_evidence(result: GFSaveProfileResult) -> Dictionary:
 		"recovery_action": result.get_recovery_action(),
 		"failed_section_id": result.get_failed_section_id(),
 		"error_code": int(result.get_error_code()),
-		"error": result.get_error(),
+		"error": result.get_error().left(
+			_MAX_PROFILE_RESULT_EVIDENCE_ERROR_LENGTH
+		),
 		"duration_msec": result.get_duration_msec(),
 		"preparation_duration_msec": result.get_preparation_duration_msec(),
 		"storage_duration_msec": result.get_storage_duration_msec(),

--- a/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
@@ -2425,12 +2425,8 @@ func _complete_ready_flushes(state: ProfileState) -> void:
 	var remaining: Array[GFSaveProfileOperation] = []
 	for operation: GFSaveProfileOperation in state.flush_operations:
 		var target: int = operation.get_requested_generation()
-		if _has_pending_save_covering_generation(state, target):
-			remaining.append(operation)
-			continue
-		var barrier_failure: Dictionary = _get_barrier_failure(state, target)
-		if target <= state.persisted_generation and barrier_failure.is_empty():
-			var _started: bool = operation.start_for_framework()
+		if target <= state.persisted_generation:
+			var _started_persisted_flush: bool = operation.start_for_framework()
 			_complete_operation(
 				state,
 				operation,
@@ -2439,23 +2435,27 @@ func _complete_ready_flushes(state: ProfileState) -> void:
 				OK,
 				""
 			)
-		else:
-			if barrier_failure.is_empty():
-				remaining.append(operation)
-				continue
-			var _started: bool = operation.start_for_framework()
-			_complete_operation(
-				state,
-				operation,
-				false,
-				GFVariantData.get_option_string_name(barrier_failure, "status"),
-				_get_error_code(barrier_failure, "error_code", FAILED),
-				"Flush target generation failed: %s" % GFVariantData.get_option_string(
-					barrier_failure,
-					"error"
-				),
-				barrier_failure
-			)
+			continue
+		if _has_pending_save_covering_generation(state, target):
+			remaining.append(operation)
+			continue
+		var barrier_failure: Dictionary = _get_barrier_failure(state, target)
+		if barrier_failure.is_empty():
+			remaining.append(operation)
+			continue
+		var _started_failed_flush: bool = operation.start_for_framework()
+		_complete_operation(
+			state,
+			operation,
+			false,
+			GFVariantData.get_option_string_name(barrier_failure, "status"),
+			_get_error_code(barrier_failure, "error_code", FAILED),
+			"Flush target generation failed: %s" % GFVariantData.get_option_string(
+				barrier_failure,
+				"error"
+			),
+			barrier_failure
+		)
 	state.flush_operations = remaining
 
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -122,6 +122,11 @@
   所有权的问题；类型化 mutation 现在区分可逆确定失败与必须 fence 的未知结果。
 - 修复异步 UI 的全局完成遥测缺少请求身份，可能被同键重入或旧生命周期迟到回调误关联的问题；Router 现在在发出可重入信号前原子移除旧 pending，并以单调 request ID 与精确底层句柄双重校验终态。
 - 修复旧虚拟输入定时器、同 `source_id` 的不同 Source 实例或手动覆盖可能清除后续输入贡献的问题；lease 同时校验操作对象、generation 与单调 lease ID，迟到回调无法释放新脉冲。Pulse 计时改用 owner-bound timer，并通过内部 handle + owner 精确存活契约识别 `GFTimerUtility` dispose/reinit 后的排程丢失，以 `FAILED / timer_schedule_lost` 补偿释放，避免 handle ABA 误取消或动作粘住。
+- 修复 Save Profile 的三项事务边界：flush 在调用时捕获的 generation 已持久化后立即
+  进入唯一成功终态，不再等待或继承更晚 generation 的失败；Bootstrap/Adopt 只在底层
+  保存实际 claim Request 后消费 Recovery Lease 并推进 domain epoch，瞬时准入拒绝可用
+  同一 Lease/Request 重试；底层超长错误进入事务 stage evidence 前限制为 2048 字符，
+  missing/corrupt 激活仍可靠返回 `recovery_required` 与可用恢复能力。
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 

--- a/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
@@ -287,6 +287,183 @@ func test_missing_activate_requires_lease_before_bootstrap_can_activate() -> voi
 	assert_true(retained_activation_result.get_recovery_lease().is_claimed())
 
 
+func test_missing_activate_bounds_stage_error_and_preserves_recovery_lease() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 7)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.long_missing_error",
+		providers
+	)
+	assert_true(_register(profile))
+	var operation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	var storage_error: String = "missing-profile-prefix:" + "x".repeat(4_096)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_failure(
+		ERR_FILE_NOT_FOUND,
+		storage_error,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	))
+
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_eq(
+		result.get_status(),
+		GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED,
+		"超长底层错误不得使事务结果契约降级为 disposed。"
+	)
+	var recovery_lease: GFSaveProfileRecoveryLease = result.get_recovery_lease()
+	assert_not_null(recovery_lease)
+	if recovery_lease == null:
+		return
+	assert_true(recovery_lease.is_available(), "有界化证据后仍必须保留显式恢复能力。")
+	var evidence_error: String = GFVariantData.get_option_string(
+		result.get_stage_evidence(),
+		"error"
+	)
+	assert_eq(evidence_error.length(), 2_048)
+	assert_eq(evidence_error, storage_error.left(2_048), "证据截断必须稳定保留错误前缀。")
+
+
+func test_recovery_save_rejection_preserves_lease_request_and_domain_epoch() -> void:
+	var active_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"active", 11)
+	)
+	var recovery_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"recovery", 22)
+	)
+	var active_providers: Array[GFSaveSectionProvider] = [active_provider]
+	var recovery_providers: Array[GFSaveSectionProvider] = [recovery_provider]
+	var active_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.recovery_admission.active",
+		active_providers
+	)
+	var recovery_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.recovery_admission.target",
+		recovery_providers
+	)
+	assert_true(_register(active_profile))
+	assert_true(_register(recovery_profile))
+	_activate_existing(active_profile, { &"active": { "value": 11 } })
+
+	var activation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		recovery_profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_load_for_file(
+		recovery_profile.file_name,
+		GFSaveProfileTransactionTestSupport.read_failure(
+			ERR_FILE_NOT_FOUND,
+			"Injected missing recovery target.",
+			GFStorageReadResult.FailureKind.NOT_FOUND
+		)
+	)
+	var recovery_lease: GFSaveProfileRecoveryLease = (
+		activation.get_result().get_recovery_lease()
+	)
+	assert_not_null(recovery_lease)
+	assert_true(recovery_lease.is_available())
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "attempt": "retryable" }
+	)
+	var epoch_before_rejection: int = GFVariantData.get_option_int(
+		_coordinator.get_domain_state_snapshot(recovery_profile.profile_id),
+		"transaction_epoch"
+	)
+	var domain_before_rejection: Dictionary = _coordinator.get_domain_state_snapshot(
+		recovery_profile.profile_id
+	)
+	var profile_before_rejection: Dictionary = (
+		_profile_utility.get_profile_state_snapshot(recovery_profile.profile_id)
+	)
+	var rejected_operations: Array[GFSaveProfileTransactionOperation] = []
+	active_provider.save_snapshot_callback = func() -> void:
+		rejected_operations.append(_coordinator.bootstrap_profile(
+			recovery_lease,
+			request
+		))
+	active_provider.value = 12
+	var active_save: GFSaveProfileOperation = _profile_utility.save_profile(
+		active_profile.profile_id
+	)
+
+	_profile_utility.tick(0.0)
+	active_provider.save_snapshot_callback = Callable()
+
+	assert_eq(rejected_operations.size(), 1)
+	if rejected_operations.is_empty():
+		return
+	assert_true(rejected_operations[0].is_completed())
+	assert_eq(
+		rejected_operations[0].get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BUSY
+	)
+	assert_false(request.is_claimed(), "底层准入拒绝不得消费恢复保存 request。")
+	assert_true(recovery_lease.is_available(), "底层准入拒绝不得烧毁 Recovery Lease。")
+	var domain_after_rejection: Dictionary = _coordinator.get_domain_state_snapshot(
+		recovery_profile.profile_id
+	)
+	assert_eq(
+		GFVariantData.get_option_int(
+			domain_after_rejection,
+			"transaction_epoch"
+		),
+		epoch_before_rejection,
+		"未接纳的恢复保存不得推进 domain epoch。"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(domain_after_rejection, "domain_generation"),
+		GFVariantData.get_option_int(domain_before_rejection, "domain_generation")
+	)
+	assert_eq(GFVariantData.get_option_int(domain_after_rejection, "transaction_id"), 0)
+	assert_eq(
+		GFVariantData.get_option_string_name(domain_after_rejection, "active_profile_id"),
+		&""
+	)
+	var profile_after_rejection: Dictionary = (
+		_profile_utility.get_profile_state_snapshot(recovery_profile.profile_id)
+	)
+	assert_eq(
+		GFVariantData.get_option_int(profile_after_rejection, "generation"),
+		GFVariantData.get_option_int(profile_before_rejection, "generation"),
+		"未接纳的恢复保存不得分配底层 generation。"
+	)
+	assert_eq(_storage.get_pending_save_count(), 1, "只有回调外层 domain A 可以进入存储。")
+
+	var retry: GFSaveProfileTransactionOperation = _coordinator.bootstrap_profile(
+		recovery_lease,
+		request
+	)
+	_profile_utility.tick(0.0)
+	assert_true(request.is_claimed(), "同一 request 应可在回调退出后重试。")
+	assert_true(recovery_lease.is_claimed(), "同一 Recovery Lease 应在实际准入后提交。")
+	assert_eq(
+		GFVariantData.get_option_int(
+			_coordinator.get_domain_state_snapshot(recovery_profile.profile_id),
+			"transaction_epoch"
+		),
+		epoch_before_rejection + 1
+	)
+	assert_eq(_storage.get_pending_save_count(), 2)
+	_storage.complete_next_save(OK)
+	assert_true(active_save.get_result().is_successful())
+	_storage.complete_next_save(OK)
+	assert_true(retry.get_result().is_successful(), "回调退出后的同 Lease/Request 重试应成功。")
+	assert_eq(
+		_coordinator.get_active_profile_id(recovery_profile.profile_id),
+		recovery_profile.profile_id
+	)
+	assert_eq(
+		rejected_operations[0].get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BUSY,
+		"后续成功不得改写先前准入拒绝终态。"
+	)
+
+
 func test_recovery_result_remains_copyable_after_later_transaction_stales_lease() -> void:
 	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
 		GFSaveProfileTransactionTestSupport.make_provider(&"state", 8)

--- a/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
@@ -368,6 +368,42 @@ func test_flush_waits_for_latest_generation_visible_at_call_time() -> void:
 	assert_eq(flush.get_result().get_persisted_generation(), 2)
 
 
+func test_flush_completes_when_its_captured_generation_persists() -> void:
+	var provider: MemorySectionProvider = _make_provider(&"state", 1)
+	assert_true(_register(_make_profile(&"test.flush_captured", provider)))
+
+	var first_save: GFSaveProfileOperation = _utility.save_profile(&"test.flush_captured")
+	_utility.tick(0.0)
+	var flush: GFSaveProfileOperation = _utility.flush_profile(&"test.flush_captured")
+	var flush_results: Array[GFSaveProfileResult] = []
+	var _connected: Error = flush.completed.connect(
+		func(result: GFSaveProfileResult) -> void:
+			flush_results.append(result)
+	) as Error
+	provider.value = 2
+	var second_save: GFSaveProfileOperation = _utility.save_profile(&"test.flush_captured")
+
+	_storage.complete_save(OK)
+
+	assert_true(first_save.get_result().is_successful())
+	assert_true(flush.is_completed(), "捕获的 generation 已持久化后 flush 必须立即完成。")
+	if not flush.is_completed():
+		return
+	assert_true(flush.get_result().is_successful())
+	assert_eq(flush.get_result().get_status(), GFSaveProfileResult.STATUS_FLUSHED)
+	assert_eq(flush.get_result().get_requested_generation(), 1)
+	assert_eq(flush.get_result().get_persisted_generation(), 1)
+	assert_eq(flush_results.size(), 1, "捕获屏障满足时只允许一次 flush 终态通知。")
+	assert_false(second_save.is_completed(), "调用后产生的 generation 不属于该 flush 屏障。")
+
+	_storage.complete_save(FAILED)
+
+	assert_true(flush.get_result().is_successful(), "后续 generation 失败不得改写既有 flush 终态。")
+	assert_eq(flush.get_result().get_persisted_generation(), 1)
+	assert_eq(flush_results.size(), 1, "后续 generation 终态不得重复完成旧 flush。")
+	assert_false(second_save.get_result().is_successful())
+
+
 func test_load_waits_for_save_barrier_before_starting_storage_read() -> void:
 	var provider: MemorySectionProvider = _make_provider(&"state", 1)
 	var profile: GFSaveProfile = _make_profile(&"test.load_barrier", provider)


### PR DESCRIPTION
## Summary

- complete flush barriers as soon as their captured generation is persisted
- preserve the Recovery Lease, Save Request, and domain epoch until the lower save is actually admitted
- bound Profile result errors before adding transaction-stage evidence

## Validation

- focused Save Profile utility tests — 47/47 tests, 4,281 assertions
- focused Save Profile session transaction tests — 17/17 tests, 213 assertions
- `python tools/gf_maintenance.py check --suite framework-static --failed-only` — 22/22 checks passed
- `python tools/gf_maintenance.py check --suite framework-gut --timeout 900 --json` — 4/4 checks passed
- `python tools/gf_maintenance.py check --suite framework-lsp --json` — 1,266 files, 0 diagnostics
- project settings drift and `git diff --check` — clean

Follow-up for review feedback on #79.