### PR TITLE
Add UI composition contracts

### DIFF
--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd
@@ -108,6 +108,29 @@ enum SelectionMode {
 	SUBTRACT,
 }
 
+## 输入处理结果。
+##
+## 手工转发调用只观察该返回值；只有 [constant InputDisposition.CONSUMED]
+## 会让画布自身的 [code]_gui_input()[/code] 调用 [method Control.accept_event]。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum InputDisposition {
+	## 事件未被画布识别或当前策略要求继续交给其他接收者。
+	IGNORED,
+	## 事件已更新画布，但仍允许 GUI 冒泡。
+	HANDLED,
+	## 事件已更新画布，并应在 GUI 边界停止传播。
+	CONSUMED,
+}
+
+enum _InputCaptureOwner {
+	NONE,
+	MOUSE,
+	RAW_TOUCH,
+}
+
 
 # --- 常量 ---
 
@@ -147,7 +170,7 @@ const _DEFAULT_MAX_ITEMS: int = 16384
 const _DEFAULT_MAX_SELECTION: int = 4096
 const _DEFAULT_MAX_QUERY_CANDIDATES: int = 4096
 const _DEFAULT_MAX_GRID_LINES: int = 512
-const _DEFAULT_DRAG_THRESHOLD: float = 4.0
+const _ABSOLUTE_MAX_WHEEL_EVENT_FACTOR: float = 64.0
 const _PLACEMENT_OPERATION_VERSION: int = 1
 const _GRID_OPTION_KEYS: Array[String] = [
 	"rotation_step_radians",
@@ -216,17 +239,26 @@ var _history_hook: Callable = Callable()
 var _callback_active: bool = false
 
 var _input_enabled: bool = true
+var _input_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+var _mouse_pan_active: bool = false
+var _mouse_pan_button: MouseButton = MOUSE_BUTTON_NONE
+var _mouse_pan_last_position: Vector2 = Vector2.ZERO
 var _selection_drag_active: bool = false
 var _selection_drag_start: Vector2 = Vector2.ZERO
 var _selection_drag_end: Vector2 = Vector2.ZERO
+var _selection_drag_mode: SelectionMode = SelectionMode.REPLACE
+var _selection_capture_button: MouseButton = MOUSE_BUTTON_NONE
+var _touch_selection_index: int = -1
 var _gesture_active: bool = false
-var _drag_threshold: float = _DEFAULT_DRAG_THRESHOLD
+var _input_capture_owner: _InputCaptureOwner = _InputCaptureOwner.NONE
 
 
 # --- Godot 生命周期方法 ---
 
 func _ready() -> void:
 	focus_mode = Control.FOCUS_ALL
+	mouse_filter = Control.MOUSE_FILTER_PASS
+	mouse_force_pass_scroll_events = false
 	_ensure_runtime_nodes()
 	_ensure_gesture_utility()
 	if not focus_exited.is_connected(_on_focus_exited):
@@ -239,15 +271,22 @@ func _exit_tree() -> void:
 
 
 func _notification(what: int) -> void:
-	if what == NOTIFICATION_RESIZED:
-		var resolved_center: Vector2 = _clamp_world_center(_world_center, _zoom)
-		if _is_view_state_finite(resolved_center, _zoom):
-			_world_center = resolved_center
-			_apply_view(is_node_ready())
+	match what:
+		NOTIFICATION_RESIZED:
+			var resolved_center: Vector2 = _clamp_world_center(_world_center, _zoom)
+			if _is_view_state_finite(resolved_center, _zoom):
+				_world_center = resolved_center
+				_apply_view(is_node_ready())
+		NOTIFICATION_APPLICATION_FOCUS_OUT, NOTIFICATION_APPLICATION_PAUSED:
+			_reset_transient_input()
+		CanvasItem.NOTIFICATION_VISIBILITY_CHANGED:
+			if not is_visible_in_tree():
+				_reset_transient_input()
 
 
 func _gui_input(event: InputEvent) -> void:
-	if handle_input_event(event):
+	var disposition: InputDisposition = handle_input_event(event)
+	if disposition == InputDisposition.CONSUMED:
 		accept_event()
 
 
@@ -924,12 +963,12 @@ func query_items_in_rect(
 ## [br]
 ## @param item_ids: 候选条目 ID。
 ## [br]
-## @param mode: SelectionMode 值。
+## @param mode: [enum SelectionMode] 值。
 ## [br]
 ## @return 更新后的隔离选择副本。
 func set_selection(
 	item_ids: PackedStringArray,
-	mode: int = SelectionMode.REPLACE
+	mode: SelectionMode = SelectionMode.REPLACE
 ) -> PackedStringArray:
 	if (
 		_callback_active
@@ -978,12 +1017,12 @@ func set_selection(
 ## [br]
 ## @param canvas_position: 本 Control 的画布坐标。
 ## [br]
-## @param mode: SelectionMode 值。
+## @param mode: [enum SelectionMode] 值。
 ## [br]
 ## @return 更新后的选择。
 func select_point(
 	canvas_position: Vector2,
-	mode: int = SelectionMode.REPLACE
+	mode: SelectionMode = SelectionMode.REPLACE
 ) -> PackedStringArray:
 	if not _is_finite_vector2(canvas_position) or not _is_selection_mode_valid(mode):
 		return get_selection()
@@ -1009,14 +1048,14 @@ func select_point(
 ## [br]
 ## @param canvas_rect: 画布选择矩形。
 ## [br]
-## @param mode: SelectionMode 值。
+## @param mode: [enum SelectionMode] 值。
 ## [br]
 ## @param fully_contained: 为 true 时只选择完全位于矩形内的条目。
 ## [br]
 ## @return 更新后的选择。
 func select_rect(
 	canvas_rect: Rect2,
-	mode: int = SelectionMode.REPLACE,
+	mode: SelectionMode = SelectionMode.REPLACE,
 	fully_contained: bool = false
 ) -> PackedStringArray:
 	if not _is_finite_rect2(canvas_rect) or not _is_selection_mode_valid(mode):
@@ -1329,10 +1368,48 @@ func get_placement_snapshot() -> Dictionary:
 
 # --- 公共方法（输入与诊断） ---
 
+## 原子替换输入解释策略。
+##
+## 方法先完整校验并深拷贝候选策略；失败时保留当前策略和所有瞬态状态。
+## 成功切换会释放当前指针捕获，但不会清除选择集合或活动放置会话。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param policy: 候选输入策略。
+## [br]
+## @return 策略有效并完成替换时返回 true。
+func set_input_policy(policy: GFSpatialCanvasInputPolicy) -> bool:
+	var isolated_policy: GFSpatialCanvasInputPolicy = _isolate_input_policy(policy)
+	if isolated_policy == null:
+		return false
+	var report: Dictionary = isolated_policy.validate_policy()
+	if not GFVariantData.get_option_bool(report, "ok"):
+		return false
+	_reset_transient_input()
+	_input_policy = isolated_policy
+	return true
+
+
+## 获取当前输入策略的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前策略的深拷贝。
+func get_input_policy() -> GFSpatialCanvasInputPolicy:
+	return _isolate_input_policy(_input_policy)
+
+
 ## 处理一个项目转发的输入事件。
 ##
-## 中键/单指拖动用于平移，滚轮/捏合用于焦点缩放，左键用于点选、框选或活动放置。
-## 只有实际识别和消费的事件返回 true。
+## 事件按当前 [GFSpatialCanvasInputPolicy] 解释。方法不会调用 Viewport 的 handled API；
+## 手工路由方应根据 [enum InputDisposition] 决定是否继续传播。
+## 鼠标与原始触摸只允许一个来源持有瞬态捕获；冲突来源及系统手势在物理释放或
+## 显式取消前返回 [constant InputDisposition.IGNORED] 且不修改画布状态。
+## 系统标记为 canceled 的当前捕获事件只释放瞬态状态，不提交选择或放置。
 ## [br]
 ## @api public
 ## [br]
@@ -1340,49 +1417,55 @@ func get_placement_snapshot() -> Dictionary:
 ## [br]
 ## @param event: Godot 输入事件。
 ## [br]
-## @return 事件被画布消费时返回 true。
-func handle_input_event(event: InputEvent) -> bool:
+## @return [enum InputDisposition] 值。
+func handle_input_event(event: InputEvent) -> InputDisposition:
 	if not _input_enabled or event == null:
-		return false
+		return InputDisposition.IGNORED
 	_ensure_gesture_utility()
 
-	var key_event: InputEventKey = event as InputEventKey
-	if key_event != null and key_event.pressed and key_event.keycode == KEY_ESCAPE:
+	if event.is_canceled():
+		return _handle_canceled_input_event(event)
+
+	if _matches_cancel_action(event):
 		if has_active_placement():
 			var _cancel_report: Dictionary = cancel_placement(&"input_cancelled")
-			return true
-		if _selection_drag_active:
-			_reset_selection_drag()
-			return true
-		return false
+			_reset_transient_input()
+			return _general_disposition()
+		if _has_transient_input_state():
+			_reset_transient_input()
+			return _general_disposition()
+		return InputDisposition.IGNORED
+
+	if _input_capture_conflicts_with_event(event):
+		return InputDisposition.IGNORED
 
 	var mouse_button: InputEventMouseButton = event as InputEventMouseButton
-	if mouse_button != null and mouse_button.button_index == MOUSE_BUTTON_LEFT:
-		return _handle_primary_mouse_button(mouse_button)
-
-	if (
-		_gesture_utility.get_active_pointer_count() > 0
-		and _gesture_utility.handle_input_event(event)
-	):
-		return true
+	if mouse_button != null:
+		if _is_mouse_wheel_button(mouse_button.button_index):
+			return _handle_wheel_input(mouse_button)
+		return _handle_mouse_button_input(mouse_button)
 
 	var mouse_motion: InputEventMouseMotion = event as InputEventMouseMotion
 	if mouse_motion != null:
-		if not _is_finite_vector2(mouse_motion.position):
-			return false
-		if has_active_placement():
-			var world_position_result: Dictionary = _try_canvas_to_world(mouse_motion.position)
-			if not GFVariantData.get_option_bool(world_position_result, "ok"):
-				return false
-			return update_placement(
-				GFVariantData.get_option_vector2(world_position_result, "value")
-			)
-		if _selection_drag_active:
-			_selection_drag_end = mouse_motion.position
-			_request_overlay_redraw()
-			return true
+		return _handle_mouse_motion_input(mouse_motion)
 
-	return _gesture_utility.handle_input_event(event)
+	var screen_touch: InputEventScreenTouch = event as InputEventScreenTouch
+	if screen_touch != null:
+		return _handle_screen_touch_input(screen_touch)
+	var screen_drag: InputEventScreenDrag = event as InputEventScreenDrag
+	if screen_drag != null:
+		return _handle_screen_drag_input(screen_drag)
+
+	if event is InputEventPanGesture:
+		if not _input_policy.system_pan_gesture_enabled:
+			return InputDisposition.IGNORED
+		return _handle_system_gesture_input(event)
+	if event is InputEventMagnifyGesture:
+		if not _input_policy.system_magnify_gesture_enabled:
+			return InputDisposition.IGNORED
+		return _handle_system_gesture_input(event)
+
+	return InputDisposition.IGNORED
 
 
 ## 处理一个使用 Viewport 屏幕坐标的输入事件。
@@ -1396,14 +1479,14 @@ func handle_input_event(event: InputEvent) -> bool:
 ## [br]
 ## @param event: 使用 Viewport 屏幕坐标的 Godot 输入事件。
 ## [br]
-## @return 事件被画布消费时返回 true；变换不可逆时返回 false。
-func handle_screen_input_event(event: InputEvent) -> bool:
+## @return [enum InputDisposition] 值；变换不可逆时返回 [constant InputDisposition.IGNORED]。
+func handle_screen_input_event(event: InputEvent) -> InputDisposition:
 	if event == null or not _input_enabled:
-		return false
+		return InputDisposition.IGNORED
 	var canvas_transform: Transform2D = get_global_transform_with_canvas()
 	var determinant: float = canvas_transform.determinant()
 	if not _is_finite_float(determinant) or is_zero_approx(determinant):
-		return false
+		return InputDisposition.IGNORED
 	var local_event: InputEvent = make_input_local(event)
 	return handle_input_event(local_event)
 
@@ -1458,7 +1541,14 @@ func get_debug_snapshot() -> Dictionary:
 		"item_count": _items.size(),
 		"selection_count": _selected_ids.size(),
 		"placement_active": has_active_placement(),
-		"input_active": _gesture_active or _selection_drag_active,
+		"input_active": (
+			_input_capture_owner != _InputCaptureOwner.NONE
+			or _gesture_active
+			or _mouse_pan_active
+			or _selection_drag_active
+			or _selection_capture_button != MOUSE_BUTTON_NONE
+			or _touch_selection_index >= 0
+		),
 		"last_query_candidate_count": _last_query_candidate_count,
 		"last_query_truncated": _last_query_truncated,
 		"last_grid_line_count": _last_grid_line_count,
@@ -1501,8 +1591,8 @@ func _ensure_gesture_utility() -> void:
 	if _gesture_utility != null:
 		return
 	_gesture_utility = GFPointerGestureUtility.new()
-	_gesture_utility.mouse_button_index = MOUSE_BUTTON_MIDDLE
-	_gesture_utility.track_mouse_wheel = true
+	_gesture_utility.track_mouse = false
+	_gesture_utility.track_mouse_wheel = false
 	_gesture_utility.track_touch = true
 	_gesture_utility.track_gesture_events = true
 	var _gesture_updated_connected: Error = _gesture_utility.gesture_updated.connect(
@@ -1511,6 +1601,58 @@ func _ensure_gesture_utility() -> void:
 	var _gesture_ended_connected: Error = _gesture_utility.gesture_ended.connect(
 		_on_gesture_ended
 	) as Error
+
+
+func _isolate_input_policy(
+	source: GFSpatialCanvasInputPolicy
+) -> GFSpatialCanvasInputPolicy:
+	if source == null:
+		return null
+	var isolated: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	isolated.pan_mouse_button = source.pan_mouse_button
+	isolated.pan_action = source.pan_action
+	isolated.pan_modifier_mask = source.pan_modifier_mask
+	isolated.selection_mouse_button = source.selection_mouse_button
+	isolated.selection_action = source.selection_action
+	isolated.selection_default_mode = source.selection_default_mode
+	isolated.selection_modifier_bindings.clear()
+	var binding_count: int = mini(
+		source.selection_modifier_bindings.size(),
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS
+	)
+	for binding_index: int in range(binding_count):
+		var source_binding: GFSpatialCanvasSelectionModeBinding = (
+			source.selection_modifier_bindings[binding_index]
+		)
+		if source_binding == null:
+			isolated.selection_modifier_bindings.append(null)
+			continue
+		var isolated_binding: GFSpatialCanvasSelectionModeBinding = (
+			GFSpatialCanvasSelectionModeBinding.new()
+		)
+		isolated_binding.modifier_mask = source_binding.modifier_mask
+		isolated_binding.selection_mode = source_binding.selection_mode
+		isolated.selection_modifier_bindings.append(isolated_binding)
+	if (
+		source.selection_modifier_bindings.size()
+		> GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS
+	):
+		isolated.selection_modifier_bindings.append(null)
+	isolated.drag_threshold = source.drag_threshold
+	isolated.wheel_axis = source.wheel_axis
+	isolated.wheel_routing = source.wheel_routing
+	isolated.wheel_modifier_mask = source.wheel_modifier_mask
+	isolated.wheel_zoom_factor = source.wheel_zoom_factor
+	isolated.touch_enabled = source.touch_enabled
+	isolated.touch_primary_behavior = source.touch_primary_behavior
+	isolated.touch_multi_pan_enabled = source.touch_multi_pan_enabled
+	isolated.touch_multi_zoom_enabled = source.touch_multi_zoom_enabled
+	isolated.system_pan_gesture_enabled = source.system_pan_gesture_enabled
+	isolated.system_magnify_gesture_enabled = source.system_magnify_gesture_enabled
+	isolated.placement_cancel_action = source.placement_cancel_action
+	isolated.consume_handled_events = source.consume_handled_events
+	isolated.consume_wheel_events = source.consume_wheel_events
+	return isolated
 
 
 func _apply_view(emit_change: bool) -> void:
@@ -2000,71 +2142,530 @@ func _placement_session_matches(expected_session_id: int) -> bool:
 	)
 
 
-func _handle_primary_mouse_button(event: InputEventMouseButton) -> bool:
+func _handle_mouse_button_input(event: InputEventMouseButton) -> InputDisposition:
+	if not event.pressed:
+		if _mouse_pan_active and event.button_index == _mouse_pan_button:
+			if _is_finite_vector2(event.position):
+				var final_delta: Vector2 = event.position - _mouse_pan_last_position
+				if not final_delta.is_zero_approx():
+					var _panned: bool = pan_by_canvas_delta(final_delta)
+			_reset_mouse_pan_capture()
+			_release_input_capture(_InputCaptureOwner.MOUSE)
+			return _general_disposition()
+		if (
+			_selection_capture_button != MOUSE_BUTTON_NONE
+			and event.button_index == _selection_capture_button
+		):
+			if _is_finite_vector2(event.position):
+				_finish_selection_capture_at(event.position)
+			else:
+				_reset_selection_capture()
+			_release_input_capture(_InputCaptureOwner.MOUSE)
+			return _general_disposition()
+		return InputDisposition.IGNORED
+
 	if not _is_finite_vector2(event.position):
-		return false
-	if event.pressed and is_inside_tree():
-		grab_focus()
-	if has_active_placement():
-		var world_position_result: Dictionary = _try_canvas_to_world(event.position)
-		if not GFVariantData.get_option_bool(world_position_result, "ok"):
-			return false
-		var _updated: bool = update_placement(
-			GFVariantData.get_option_vector2(world_position_result, "value")
+		return InputDisposition.IGNORED
+	if _mouse_pan_active or _selection_capture_button != MOUSE_BUTTON_NONE:
+		return InputDisposition.IGNORED
+
+	var pan_matches: bool = _matches_pan_press(event)
+	var selection_matches: bool = _matches_pointer_press(
+		event,
+		_input_policy.selection_mouse_button,
+		_input_policy.selection_action
+	)
+	if pan_matches and selection_matches:
+		return InputDisposition.IGNORED
+	if pan_matches:
+		if not _acquire_input_capture(_InputCaptureOwner.MOUSE):
+			return InputDisposition.IGNORED
+		if is_inside_tree():
+			grab_focus()
+		_mouse_pan_active = true
+		_mouse_pan_button = event.button_index
+		_mouse_pan_last_position = event.position
+		return _general_disposition()
+	if selection_matches:
+		if not _acquire_input_capture(_InputCaptureOwner.MOUSE):
+			return InputDisposition.IGNORED
+		if is_inside_tree():
+			grab_focus()
+		var selection_mode: SelectionMode = _selection_mode_from_modifier_mask(
+			_modifier_mask_from_mouse_event(event)
 		)
-		if not _updated:
-			return false
-		if event.pressed:
-			return true
-		var _report: Dictionary = commit_placement()
-		return true
-	if event.pressed:
-		_selection_drag_active = true
-		_selection_drag_start = event.position
+		if not _start_selection_capture(
+			event.position,
+			selection_mode,
+			event.button_index,
+			-1
+		):
+			_release_input_capture(_InputCaptureOwner.MOUSE)
+			return InputDisposition.IGNORED
+		return _general_disposition()
+	return InputDisposition.IGNORED
+
+
+func _handle_mouse_motion_input(event: InputEventMouseMotion) -> InputDisposition:
+	if not _is_finite_vector2(event.position):
+		return InputDisposition.IGNORED
+	if _mouse_pan_active:
+		var pan_delta: Vector2 = event.position - _mouse_pan_last_position
+		_mouse_pan_last_position = event.position
+		if not pan_delta.is_zero_approx():
+			var _panned: bool = pan_by_canvas_delta(pan_delta)
+		return _general_disposition()
+	if _selection_drag_active and _selection_capture_button != MOUSE_BUTTON_NONE:
 		_selection_drag_end = event.position
 		_request_overlay_redraw()
-		return true
-	if not _selection_drag_active:
-		return false
-	_selection_drag_end = event.position
-	var mode: int = _selection_mode_from_mouse_event(event)
-	var drag_size: float = _selection_drag_start.distance_to(_selection_drag_end)
-	if drag_size <= _drag_threshold:
-		var _selected_point: PackedStringArray = select_point(_selection_drag_end, mode)
+		return _general_disposition()
+	if has_active_placement():
+		if _update_placement_from_canvas_position(event.position):
+			return _general_disposition()
+	return InputDisposition.IGNORED
+
+
+func _handle_wheel_input(event: InputEventMouseButton) -> InputDisposition:
+	if (
+		not event.pressed
+		or not _is_finite_vector2(event.position)
+		or not _is_finite_float(event.factor)
+		or event.factor <= 0.0
+		or event.factor > _ABSOLUTE_MAX_WHEEL_EVENT_FACTOR
+	):
+		return InputDisposition.IGNORED
+	if _input_policy.wheel_routing == GFSpatialCanvasInputPolicy.WheelRouting.PARENT_ONLY:
+		return InputDisposition.IGNORED
+	if not _wheel_button_matches_axis(event.button_index):
+		return InputDisposition.IGNORED
+	if (
+		_input_policy.wheel_routing
+		== GFSpatialCanvasInputPolicy.WheelRouting.MODIFIER_GATED
+		and _modifier_mask_from_mouse_event(event) != _input_policy.wheel_modifier_mask
+	):
+		return InputDisposition.IGNORED
+	var factor: float = pow(_input_policy.wheel_zoom_factor, event.factor)
+	if not _is_finite_float(factor) or factor <= 0.0:
+		return InputDisposition.IGNORED
+	if (
+		event.button_index == MOUSE_BUTTON_WHEEL_DOWN
+		or event.button_index == MOUSE_BUTTON_WHEEL_RIGHT
+	):
+		factor = 1.0 / factor
+	if not zoom_at(event.position, factor):
+		return InputDisposition.IGNORED
+	return _wheel_disposition()
+
+
+func _handle_screen_touch_input(event: InputEventScreenTouch) -> InputDisposition:
+	if not _input_policy.touch_enabled:
+		return InputDisposition.IGNORED
+	if (
+		_input_policy.touch_primary_behavior
+		== GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.NONE
+		and not _has_raw_touch_multi_behavior()
+	):
+		return InputDisposition.IGNORED
+	var tracked: bool = _gesture_tracks_pointer(event.index)
+	if not _is_finite_vector2(event.position):
+		if not event.pressed and tracked:
+			_reset_transient_input()
+			return _general_disposition()
+		return InputDisposition.IGNORED
+
+	if event.pressed:
+		if tracked:
+			return InputDisposition.IGNORED
+		var active_pointer_count: int = _gesture_utility.get_active_pointer_count()
+		var starts_capture: bool = active_pointer_count == 0
+		if starts_capture:
+			if not _acquire_input_capture(_InputCaptureOwner.RAW_TOUCH):
+				return InputDisposition.IGNORED
+		elif _input_capture_owner != _InputCaptureOwner.RAW_TOUCH:
+			return InputDisposition.IGNORED
+		if active_pointer_count > 0:
+			if not _has_raw_touch_multi_behavior():
+				return InputDisposition.IGNORED
+			if (
+				_input_policy.touch_primary_behavior
+				== GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+			):
+				_reset_selection_capture()
+		elif (
+			_input_policy.touch_primary_behavior
+			== GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+		):
+			if not _start_selection_capture(
+				event.position,
+				_input_policy.selection_default_mode,
+				MOUSE_BUTTON_NONE,
+				event.index
+			):
+				_release_input_capture(_InputCaptureOwner.RAW_TOUCH)
+				return InputDisposition.IGNORED
+		if _gesture_utility.handle_input_event(event):
+			return _general_disposition()
+		if starts_capture:
+			_reset_transient_input()
+		return InputDisposition.IGNORED
+
+	if not tracked:
+		return InputDisposition.IGNORED
+	if _touch_selection_index == event.index:
+		_finish_selection_capture_at(event.position)
+	var handled: bool = _gesture_utility.handle_input_event(event)
+	if handled:
+		return _general_disposition()
+	return InputDisposition.IGNORED
+
+
+func _handle_screen_drag_input(event: InputEventScreenDrag) -> InputDisposition:
+	if (
+		not _input_policy.touch_enabled
+		or _input_capture_owner != _InputCaptureOwner.RAW_TOUCH
+		or not _gesture_tracks_pointer(event.index)
+	):
+		return InputDisposition.IGNORED
+	if not _is_finite_vector2(event.position):
+		_reset_transient_input()
+		return _general_disposition()
+	if _touch_selection_index == event.index:
+		if has_active_placement():
+			var _updated: bool = _update_placement_from_canvas_position(event.position)
+		elif _selection_drag_active:
+			_selection_drag_end = event.position
+			_request_overlay_redraw()
+	var handled: bool = _gesture_utility.handle_input_event(event)
+	if handled:
+		return _general_disposition()
+	return InputDisposition.IGNORED
+
+
+func _handle_system_gesture_input(event: InputEvent) -> InputDisposition:
+	var pan_gesture: InputEventPanGesture = event as InputEventPanGesture
+	if pan_gesture != null:
+		if (
+			not _is_finite_vector2(pan_gesture.position)
+			or not _is_finite_vector2(pan_gesture.delta)
+		):
+			return InputDisposition.IGNORED
+	var magnify_gesture: InputEventMagnifyGesture = event as InputEventMagnifyGesture
+	if magnify_gesture != null:
+		if (
+			not _is_finite_vector2(magnify_gesture.position)
+			or not _is_finite_float(magnify_gesture.factor)
+			or magnify_gesture.factor <= 0.0
+		):
+			return InputDisposition.IGNORED
+	if _gesture_utility.handle_input_event(event):
+		return _general_disposition()
+	return InputDisposition.IGNORED
+
+
+func _start_selection_capture(
+	canvas_position: Vector2,
+	selection_mode: SelectionMode,
+	mouse_button: MouseButton,
+	touch_index: int
+) -> bool:
+	if has_active_placement():
+		if not _update_placement_from_canvas_position(canvas_position):
+			return false
 	else:
-		var drag_rect: Rect2 = Rect2(
-			_selection_drag_start,
-			_selection_drag_end - _selection_drag_start
-		)
-		var _selected_rect: PackedStringArray = select_rect(drag_rect, mode)
-	_reset_selection_drag()
+		_selection_drag_active = true
+		_selection_drag_start = canvas_position
+		_selection_drag_end = canvas_position
+		_selection_drag_mode = selection_mode
+		_request_overlay_redraw()
+	_selection_capture_button = mouse_button
+	_touch_selection_index = touch_index
 	return true
 
 
-func _selection_mode_from_mouse_event(event: InputEventMouseButton) -> int:
-	if event.ctrl_pressed or event.meta_pressed:
-		return SelectionMode.TOGGLE
+func _finish_selection_capture_at(canvas_position: Vector2) -> void:
+	if has_active_placement():
+		if _update_placement_from_canvas_position(canvas_position):
+			var _report: Dictionary = commit_placement()
+		_reset_selection_capture()
+		return
+	if _selection_drag_active:
+		_selection_drag_end = canvas_position
+		var drag_size: float = _selection_drag_start.distance_to(_selection_drag_end)
+		if drag_size <= _input_policy.drag_threshold:
+			var _selected_point: PackedStringArray = select_point(
+				_selection_drag_end,
+				_selection_drag_mode
+			)
+		else:
+			var drag_rect: Rect2 = Rect2(
+				_selection_drag_start,
+				_selection_drag_end - _selection_drag_start
+			)
+			var _selected_rect: PackedStringArray = select_rect(
+				drag_rect,
+				_selection_drag_mode
+			)
+	_reset_selection_capture()
+
+
+func _handle_canceled_input_event(event: InputEvent) -> InputDisposition:
+	var mouse_button: InputEventMouseButton = event as InputEventMouseButton
+	if mouse_button != null:
+		if _input_capture_owner != _InputCaptureOwner.MOUSE:
+			return InputDisposition.IGNORED
+		var matches_pan: bool = (
+			_mouse_pan_active
+			and mouse_button.button_index == _mouse_pan_button
+		)
+		var matches_selection: bool = (
+			_selection_capture_button != MOUSE_BUTTON_NONE
+			and mouse_button.button_index == _selection_capture_button
+		)
+		if not matches_pan and not matches_selection:
+			return InputDisposition.IGNORED
+		_reset_transient_input()
+		return _general_disposition()
+
+	var screen_touch: InputEventScreenTouch = event as InputEventScreenTouch
+	if (
+		screen_touch == null
+		or _input_capture_owner != _InputCaptureOwner.RAW_TOUCH
+		or not _gesture_tracks_pointer(screen_touch.index)
+	):
+		return InputDisposition.IGNORED
+	_reset_transient_input()
+	return _general_disposition()
+
+
+func _update_placement_from_canvas_position(canvas_position: Vector2) -> bool:
+	var world_position_result: Dictionary = _try_canvas_to_world(canvas_position)
+	if not GFVariantData.get_option_bool(world_position_result, "ok"):
+		return false
+	return update_placement(
+		GFVariantData.get_option_vector2(world_position_result, "value")
+	)
+
+
+func _selection_mode_from_modifier_mask(modifier_mask: int) -> SelectionMode:
+	for binding: GFSpatialCanvasSelectionModeBinding in _input_policy.selection_modifier_bindings:
+		if binding != null and binding.modifier_mask == modifier_mask:
+			return binding.selection_mode as SelectionMode
+	return _input_policy.selection_default_mode as SelectionMode
+
+
+func _matches_pointer_press(
+	event: InputEventMouseButton,
+	direct_button: MouseButton,
+	action: StringName
+) -> bool:
+	if direct_button != MOUSE_BUTTON_NONE:
+		return event.button_index == direct_button
+	if action == &"":
+		return false
+	return _runtime_pointer_action_matches(event, action)
+
+
+func _matches_pan_press(event: InputEventMouseButton) -> bool:
+	if _input_policy.pan_mouse_button != MOUSE_BUTTON_NONE:
+		return (
+			event.button_index == _input_policy.pan_mouse_button
+			and _modifier_mask_from_mouse_event(event) == _input_policy.pan_modifier_mask
+		)
+	if _input_policy.pan_action == &"":
+		return false
+	return _runtime_pointer_action_matches(event, _input_policy.pan_action)
+
+
+func _matches_cancel_action(event: InputEvent) -> bool:
+	if _is_pointer_action_event(event):
+		return false
+	if _input_policy.placement_cancel_action == &"":
+		return false
+	if not _runtime_cancel_action_is_safe(_input_policy.placement_cancel_action):
+		return false
+	return event.is_action_pressed(
+		_input_policy.placement_cancel_action,
+		false,
+		true
+	)
+
+
+func _runtime_pointer_action_matches(
+	event: InputEventMouseButton,
+	action: StringName
+) -> bool:
+	if action == &"" or not InputMap.has_action(action):
+		return false
+	var action_events: Array[InputEvent] = InputMap.action_get_events(action)
+	if action_events.size() > GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS:
+		return false
+	var has_pointer_event: bool = false
+	for action_event: InputEvent in action_events:
+		if not action_event is InputEventMouseButton:
+			continue
+		var mouse_action_event: InputEventMouseButton = action_event
+		if (
+			not _is_mouse_wheel_button(mouse_action_event.button_index)
+			and mouse_action_event.button_index != MOUSE_BUTTON_NONE
+		):
+			has_pointer_event = true
+			break
+	if not has_pointer_event:
+		return false
+	return event.is_action_pressed(action, false, true)
+
+
+func _runtime_cancel_action_is_safe(action: StringName) -> bool:
+	if action == &"" or not InputMap.has_action(action):
+		return false
+	var action_events: Array[InputEvent] = InputMap.action_get_events(action)
+	if action_events.size() > GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS:
+		return false
+	for action_event: InputEvent in action_events:
+		if _is_pointer_action_event(action_event):
+			return false
+	return true
+
+
+func _is_pointer_action_event(event: InputEvent) -> bool:
+	return (
+		event is InputEventMouse
+		or event is InputEventScreenTouch
+		or event is InputEventScreenDrag
+		or event is InputEventGesture
+	)
+
+
+func _modifier_mask_from_mouse_event(event: InputEventMouseButton) -> int:
+	var result: int = GFSpatialCanvasInputPolicy.ModifierMask.NONE
 	if event.shift_pressed:
-		return SelectionMode.ADD
-	return SelectionMode.REPLACE
+		result |= GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	if event.ctrl_pressed:
+		result |= GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+	if event.alt_pressed:
+		result |= GFSpatialCanvasInputPolicy.ModifierMask.ALT
+	if event.meta_pressed:
+		result |= GFSpatialCanvasInputPolicy.ModifierMask.META
+	return result
+
+
+func _is_mouse_wheel_button(button: MouseButton) -> bool:
+	return (
+		button == MOUSE_BUTTON_WHEEL_UP
+		or button == MOUSE_BUTTON_WHEEL_DOWN
+		or button == MOUSE_BUTTON_WHEEL_LEFT
+		or button == MOUSE_BUTTON_WHEEL_RIGHT
+	)
+
+
+func _wheel_button_matches_axis(button: MouseButton) -> bool:
+	if _input_policy.wheel_axis == GFSpatialCanvasInputPolicy.WheelAxis.VERTICAL:
+		return button == MOUSE_BUTTON_WHEEL_UP or button == MOUSE_BUTTON_WHEEL_DOWN
+	return button == MOUSE_BUTTON_WHEEL_LEFT or button == MOUSE_BUTTON_WHEEL_RIGHT
+
+
+func _gesture_tracks_pointer(pointer_index: int) -> bool:
+	var snapshot: Dictionary = _gesture_utility.get_gesture_snapshot()
+	for pointer_value: Variant in GFVariantData.get_option_array(snapshot, "pointer_ids"):
+		if not pointer_value is int:
+			continue
+		var pointer_id: int = pointer_value
+		if pointer_id == pointer_index:
+			return true
+	return false
+
+
+func _has_raw_touch_multi_behavior() -> bool:
+	return (
+		_input_policy.touch_multi_pan_enabled
+		or _input_policy.touch_multi_zoom_enabled
+	)
+
+
+func _acquire_input_capture(capture_owner: _InputCaptureOwner) -> bool:
+	if capture_owner == _InputCaptureOwner.NONE:
+		return false
+	if _input_capture_owner == _InputCaptureOwner.NONE:
+		_input_capture_owner = capture_owner
+	return _input_capture_owner == capture_owner
+
+
+func _release_input_capture(capture_owner: _InputCaptureOwner) -> void:
+	if _input_capture_owner == capture_owner:
+		_input_capture_owner = _InputCaptureOwner.NONE
+
+
+func _input_capture_conflicts_with_event(event: InputEvent) -> bool:
+	if _input_capture_owner == _InputCaptureOwner.MOUSE:
+		return (
+			event is InputEventScreenTouch
+			or event is InputEventScreenDrag
+			or event is InputEventPanGesture
+			or event is InputEventMagnifyGesture
+		)
+	if _input_capture_owner == _InputCaptureOwner.RAW_TOUCH:
+		return (
+			event is InputEventMouse
+			or event is InputEventPanGesture
+			or event is InputEventMagnifyGesture
+		)
+	return false
+
+
+func _has_transient_input_state() -> bool:
+	return (
+		_input_capture_owner != _InputCaptureOwner.NONE
+		or _gesture_active
+		or _mouse_pan_active
+		or _selection_drag_active
+		or _selection_capture_button != MOUSE_BUTTON_NONE
+		or _touch_selection_index >= 0
+	)
+
+
+func _general_disposition() -> InputDisposition:
+	if _input_policy.consume_handled_events:
+		return InputDisposition.CONSUMED
+	return InputDisposition.HANDLED
+
+
+func _wheel_disposition() -> InputDisposition:
+	if _input_policy.consume_wheel_events:
+		return InputDisposition.CONSUMED
+	return InputDisposition.HANDLED
 
 
 func _on_gesture_updated(snapshot: Dictionary, _event: InputEvent) -> void:
-	_gesture_active = (
-		GFVariantData.get_option_bool(snapshot, "active")
-		and GFVariantData.get_option_int(snapshot, "pointer_count") > 0
-	)
+	var active: bool = GFVariantData.get_option_bool(snapshot, "active")
+	var pointer_count: int = GFVariantData.get_option_int(snapshot, "pointer_count")
+	_gesture_active = active and pointer_count > 0
+	var source: StringName = GFVariantData.get_option_string_name(snapshot, "source")
+	var apply_pan: bool = true
+	var apply_zoom: bool = true
+	if String(source).begins_with("touch_"):
+		if not _input_policy.touch_enabled:
+			return
+		if pointer_count >= 2:
+			apply_pan = _input_policy.touch_multi_pan_enabled
+			apply_zoom = _input_policy.touch_multi_zoom_enabled
+		else:
+			apply_pan = (
+				_input_policy.touch_primary_behavior
+				== GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.PAN
+			)
+			apply_zoom = false
 	var pan_delta: Vector2 = GFVariantData.get_option_vector2(snapshot, "pan_delta")
 	var scale_factor: float = GFVariantData.get_option_float(snapshot, "scale", 1.0)
 	var center: Vector2 = GFVariantData.get_option_vector2(snapshot, "center", size * 0.5)
-	if not pan_delta.is_zero_approx():
+	if apply_pan and not pan_delta.is_zero_approx():
 		var _panned: bool = pan_by_canvas_delta(pan_delta)
-	if not is_equal_approx(scale_factor, 1.0):
+	if apply_zoom and not is_equal_approx(scale_factor, 1.0):
 		var _zoomed: bool = zoom_at(center, scale_factor)
 
 
 func _on_gesture_ended(_snapshot: Dictionary) -> void:
 	_gesture_active = false
+	_release_input_capture(_InputCaptureOwner.RAW_TOUCH)
 
 
 func _on_focus_exited() -> void:
@@ -2072,16 +2673,31 @@ func _on_focus_exited() -> void:
 
 
 func _reset_transient_input() -> void:
-	_reset_selection_drag()
+	_input_capture_owner = _InputCaptureOwner.NONE
+	_reset_mouse_pan_capture()
+	_reset_selection_capture()
 	_gesture_active = false
 	if _gesture_utility != null:
 		_gesture_utility.reset_gesture()
+
+
+func _reset_mouse_pan_capture() -> void:
+	_mouse_pan_active = false
+	_mouse_pan_button = MOUSE_BUTTON_NONE
+	_mouse_pan_last_position = Vector2.ZERO
+
+
+func _reset_selection_capture() -> void:
+	_selection_capture_button = MOUSE_BUTTON_NONE
+	_touch_selection_index = -1
+	_reset_selection_drag()
 
 
 func _reset_selection_drag() -> void:
 	_selection_drag_active = false
 	_selection_drag_start = Vector2.ZERO
 	_selection_drag_end = Vector2.ZERO
+	_selection_drag_mode = SelectionMode.REPLACE
 	_request_overlay_redraw()
 
 
@@ -2184,7 +2800,7 @@ func _rect_encloses_rect(outer: Rect2, inner: Rect2) -> bool:
 	)
 
 
-func _is_selection_mode_valid(mode: int) -> bool:
+func _is_selection_mode_valid(mode: SelectionMode) -> bool:
 	return (
 		mode == SelectionMode.REPLACE
 		or mode == SelectionMode.ADD

--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd
@@ -251,6 +251,7 @@ var _selection_capture_button: MouseButton = MOUSE_BUTTON_NONE
 var _touch_selection_index: int = -1
 var _gesture_active: bool = false
 var _input_capture_owner: _InputCaptureOwner = _InputCaptureOwner.NONE
+var _input_capture_device: int = 0
 
 
 # --- Godot 生命周期方法 ---
@@ -2178,7 +2179,7 @@ func _handle_mouse_button_input(event: InputEventMouseButton) -> InputDispositio
 	if pan_matches and selection_matches:
 		return InputDisposition.IGNORED
 	if pan_matches:
-		if not _acquire_input_capture(_InputCaptureOwner.MOUSE):
+		if not _acquire_input_capture(_InputCaptureOwner.MOUSE, event.device):
 			return InputDisposition.IGNORED
 		if is_inside_tree():
 			grab_focus()
@@ -2187,7 +2188,7 @@ func _handle_mouse_button_input(event: InputEventMouseButton) -> InputDispositio
 		_mouse_pan_last_position = event.position
 		return _general_disposition()
 	if selection_matches:
-		if not _acquire_input_capture(_InputCaptureOwner.MOUSE):
+		if not _acquire_input_capture(_InputCaptureOwner.MOUSE, event.device):
 			return InputDisposition.IGNORED
 		if is_inside_tree():
 			grab_focus()
@@ -2279,7 +2280,7 @@ func _handle_screen_touch_input(event: InputEventScreenTouch) -> InputDispositio
 		var active_pointer_count: int = _gesture_utility.get_active_pointer_count()
 		var starts_capture: bool = active_pointer_count == 0
 		if starts_capture:
-			if not _acquire_input_capture(_InputCaptureOwner.RAW_TOUCH):
+			if not _acquire_input_capture(_InputCaptureOwner.RAW_TOUCH, event.device):
 				return InputDisposition.IGNORED
 		elif _input_capture_owner != _InputCaptureOwner.RAW_TOUCH:
 			return InputDisposition.IGNORED
@@ -2411,7 +2412,10 @@ func _finish_selection_capture_at(canvas_position: Vector2) -> void:
 func _handle_canceled_input_event(event: InputEvent) -> InputDisposition:
 	var mouse_button: InputEventMouseButton = event as InputEventMouseButton
 	if mouse_button != null:
-		if _input_capture_owner != _InputCaptureOwner.MOUSE:
+		if (
+			_input_capture_owner != _InputCaptureOwner.MOUSE
+			or mouse_button.device != _input_capture_device
+		):
 			return InputDisposition.IGNORED
 		var matches_pan: bool = (
 			_mouse_pan_active
@@ -2430,6 +2434,7 @@ func _handle_canceled_input_event(event: InputEvent) -> InputDisposition:
 	if (
 		screen_touch == null
 		or _input_capture_owner != _InputCaptureOwner.RAW_TOUCH
+		or screen_touch.device != _input_capture_device
 		or not _gesture_tracks_pointer(screen_touch.index)
 	):
 		return InputDisposition.IGNORED
@@ -2582,30 +2587,37 @@ func _has_raw_touch_multi_behavior() -> bool:
 	)
 
 
-func _acquire_input_capture(capture_owner: _InputCaptureOwner) -> bool:
+func _acquire_input_capture(capture_owner: _InputCaptureOwner, device: int) -> bool:
 	if capture_owner == _InputCaptureOwner.NONE:
 		return false
 	if _input_capture_owner == _InputCaptureOwner.NONE:
 		_input_capture_owner = capture_owner
-	return _input_capture_owner == capture_owner
+		_input_capture_device = device
+	return _input_capture_owner == capture_owner and _input_capture_device == device
 
 
 func _release_input_capture(capture_owner: _InputCaptureOwner) -> void:
 	if _input_capture_owner == capture_owner:
 		_input_capture_owner = _InputCaptureOwner.NONE
+		_input_capture_device = 0
 
 
 func _input_capture_conflicts_with_event(event: InputEvent) -> bool:
 	if _input_capture_owner == _InputCaptureOwner.MOUSE:
 		return (
-			event is InputEventScreenTouch
+			(event is InputEventMouse and event.device != _input_capture_device)
+			or event is InputEventScreenTouch
 			or event is InputEventScreenDrag
 			or event is InputEventPanGesture
 			or event is InputEventMagnifyGesture
 		)
 	if _input_capture_owner == _InputCaptureOwner.RAW_TOUCH:
 		return (
-			event is InputEventMouse
+			(
+				(event is InputEventScreenTouch or event is InputEventScreenDrag)
+				and event.device != _input_capture_device
+			)
+			or event is InputEventMouse
 			or event is InputEventPanGesture
 			or event is InputEventMagnifyGesture
 		)
@@ -2674,6 +2686,7 @@ func _on_focus_exited() -> void:
 
 func _reset_transient_input() -> void:
 	_input_capture_owner = _InputCaptureOwner.NONE
+	_input_capture_device = 0
 	_reset_mouse_pan_capture()
 	_reset_selection_capture()
 	_gesture_active = false

--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd
@@ -356,7 +356,12 @@ func duplicate_policy() -> GFSpatialCanvasInputPolicy:
 		if binding == null:
 			policy.selection_modifier_bindings.append(null)
 		else:
-			policy.selection_modifier_bindings.append(binding.duplicate_binding())
+			var copied_binding: GFSpatialCanvasSelectionModeBinding = (
+				GFSpatialCanvasSelectionModeBinding.new()
+			)
+			copied_binding.modifier_mask = binding.modifier_mask
+			copied_binding.selection_mode = binding.selection_mode
+			policy.selection_modifier_bindings.append(copied_binding)
 	if selection_modifier_bindings.size() > ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS:
 		policy.selection_modifier_bindings.append(null)
 	policy.drag_threshold = drag_threshold

--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd
@@ -1,0 +1,638 @@
+## GFSpatialCanvasInputPolicy: 空间画布输入解释策略。
+##
+## 以数据方式声明平移、选择、滚轮、触摸和取消输入。策略不持有节点、
+## Viewport 或父容器引用；[code]GFSpatialCanvas2D[/code] 只接受完整校验通过的隔离副本。
+## [br]
+## @api public
+## [br]
+## @category resource_definition
+## [br]
+## @since unreleased
+class_name GFSpatialCanvasInputPolicy
+extends Resource
+
+
+# --- 枚举 ---
+
+## 输入修饰键位掩码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum ModifierMask {
+	## 不要求修饰键。
+	NONE = 0,
+	## Shift 修饰键。
+	SHIFT = 1,
+	## Ctrl 修饰键。
+	CTRL = 2,
+	## Alt 修饰键。
+	ALT = 4,
+	## Meta 修饰键。
+	META = 8,
+}
+
+## 滚轮缩放使用的物理轴。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum WheelAxis {
+	## 使用向上/向下滚轮事件。
+	VERTICAL,
+	## 使用向左/向右滚轮事件。
+	HORIZONTAL,
+}
+
+## 滚轮事件的画布路由策略。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum WheelRouting {
+	## 画布处理目标轴上的所有滚轮事件。
+	CANVAS,
+	## 只有修饰键掩码精确匹配时由画布处理。
+	MODIFIER_GATED,
+	## 画布始终忽略滚轮，让 GUI 祖先继续处理。
+	PARENT_ONLY,
+}
+
+## 单指触摸的主行为。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum TouchPrimaryBehavior {
+	## 单指不执行画布行为；若启用任一多指行为，首触点仍会被捕获以等待后续触点。
+	NONE,
+	## 单指拖动平移画布。
+	PAN,
+	## 单指执行点选、框选或放置确认。
+	SELECT,
+}
+
+
+# --- 常量 ---
+
+## 单份策略允许声明的选择修饰键绑定绝对上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS: int = 15
+
+## 校验单个 InputMap action 时允许扫描的事件绝对上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ABSOLUTE_MAX_ACTION_EVENTS: int = 64
+
+const _ALL_MODIFIER_MASK: int = (
+	ModifierMask.SHIFT
+	| ModifierMask.CTRL
+	| ModifierMask.ALT
+	| ModifierMask.META
+)
+
+
+# --- 导出变量 ---
+
+## 直接触发平移捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var pan_mouse_button: MouseButton = MOUSE_BUTTON_MIDDLE
+
+## 通过 InputMap 触发平移捕获的动作；空名称表示禁用动作绑定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var pan_action: StringName = &""
+
+## 直接平移按钮必须精确匹配的修饰键掩码。
+##
+## 使用 [member pan_action] 时修饰键由 InputMap action 精确声明，本字段必须为 NONE。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export_flags("Shift:1", "Ctrl:2", "Alt:4", "Meta:8") var pan_modifier_mask: int = ModifierMask.NONE
+
+## 直接触发选择捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var selection_mouse_button: MouseButton = MOUSE_BUTTON_LEFT
+
+## 通过 InputMap 触发选择捕获的动作；空名称表示禁用动作绑定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var selection_action: StringName = &""
+
+## 没有选择修饰键绑定精确匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code]。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var selection_default_mode: GFSpatialCanvas2D.SelectionMode = (
+	GFSpatialCanvas2D.SelectionMode.REPLACE
+)
+
+## 修饰键到选择模式的精确匹配表；重复掩码会使策略校验失败。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var selection_modifier_bindings: Array[GFSpatialCanvasSelectionModeBinding] = []
+
+## 区分点选和框选的局部画布像素阈值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var drag_threshold: float = 4.0
+
+## 用于画布缩放的滚轮轴。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var wheel_axis: WheelAxis = WheelAxis.VERTICAL
+
+## 滚轮缩放路由策略。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var wheel_routing: WheelRouting = WheelRouting.CANVAS
+
+## [constant WheelRouting.MODIFIER_GATED] 下必须精确匹配的修饰键掩码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export_flags("Shift:1", "Ctrl:2", "Alt:4", "Meta:8") var wheel_modifier_mask: int = ModifierMask.NONE
+
+## 每个滚轮刻度的缩放倍率，必须为有限且大于 1 的值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var wheel_zoom_factor: float = 1.1
+
+## 是否处理原始 ScreenTouch / ScreenDrag 事件。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var touch_enabled: bool = true
+
+## 单指触摸的主行为。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var touch_primary_behavior: TouchPrimaryBehavior = TouchPrimaryBehavior.PAN
+
+## 是否允许双指及以上触点驱动平移。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var touch_multi_pan_enabled: bool = true
+
+## 是否允许双指及以上触点驱动捏合缩放。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var touch_multi_zoom_enabled: bool = true
+
+## 是否处理 Godot 的系统 PanGesture 事件。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var system_pan_gesture_enabled: bool = true
+
+## 是否处理 Godot 的系统 MagnifyGesture 事件。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var system_magnify_gesture_enabled: bool = true
+
+## 取消活动放置或瞬态选择的非指针 InputMap 动作；空名称表示禁用取消输入。
+##
+## 动作不得包含鼠标、触摸或位置手势事件，避免取消优先级饿死画布指针行为。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var placement_cancel_action: StringName = &"ui_cancel"
+
+## 一般已处理事件是否由 Canvas GUI 边界消费。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var consume_handled_events: bool = true
+
+## 已处理滚轮事件是否由 Canvas GUI 边界消费。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var consume_wheel_events: bool = true
+
+
+# --- Godot 生命周期方法 ---
+
+func _init() -> void:
+	selection_modifier_bindings = [
+		_make_selection_binding(
+			ModifierMask.SHIFT,
+			GFSpatialCanvas2D.SelectionMode.ADD
+		),
+		_make_selection_binding(
+			ModifierMask.CTRL,
+			GFSpatialCanvas2D.SelectionMode.TOGGLE
+		),
+		_make_selection_binding(
+			ModifierMask.META,
+			GFSpatialCanvas2D.SelectionMode.TOGGLE
+		),
+	]
+
+
+# --- 公共方法 ---
+
+## 校验完整策略。
+##
+## 校验失败时调用方必须保留上一份有效策略；报告遵循
+## [code]GFValidationReportDictionary[/code] 结构。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 策略校验报告。
+## [br]
+## @schema return: GFValidationReportDictionary-compatible report with issues describing invalid fields.
+func validate_policy() -> Dictionary:
+	var report: Dictionary = { "issues": [] }
+	_validate_pointer_mapping(report, &"pan", pan_mouse_button, pan_action)
+	_validate_pointer_mapping(report, &"selection", selection_mouse_button, selection_action)
+	_validate_modifier_mask(report, &"pan_modifier_mask", pan_modifier_mask)
+	_validate_modifier_mask(report, &"wheel_modifier_mask", wheel_modifier_mask)
+	_validate_selection_bindings(report)
+	_validate_pointer_mapping_overlap(report)
+
+	if pan_action != &"" and pan_modifier_mask != ModifierMask.NONE:
+		_append_issue(
+			report,
+			&"action_modifier_conflict",
+			"pan_action 的修饰键由 InputMap 精确声明，pan_modifier_mask 必须为 NONE。",
+			&"pan_modifier_mask"
+		)
+	if not _is_valid_selection_mode(selection_default_mode):
+		_append_issue(report, &"invalid_selection_mode", "selection_default_mode 超出有效枚举范围。", &"selection_default_mode")
+	if not _is_finite_float(drag_threshold) or drag_threshold < 0.0:
+		_append_issue(report, &"invalid_drag_threshold", "drag_threshold 必须为有限非负值。", &"drag_threshold")
+	if wheel_axis < WheelAxis.VERTICAL or wheel_axis > WheelAxis.HORIZONTAL:
+		_append_issue(report, &"invalid_wheel_axis", "wheel_axis 超出有效枚举范围。", &"wheel_axis")
+	if wheel_routing < WheelRouting.CANVAS or wheel_routing > WheelRouting.PARENT_ONLY:
+		_append_issue(report, &"invalid_wheel_routing", "wheel_routing 超出有效枚举范围。", &"wheel_routing")
+	if wheel_routing == WheelRouting.MODIFIER_GATED and wheel_modifier_mask == ModifierMask.NONE:
+		_append_issue(report, &"missing_wheel_modifier", "Modifier-gated wheel 必须声明非零修饰键。", &"wheel_modifier_mask")
+	if not _is_finite_float(wheel_zoom_factor) or wheel_zoom_factor <= 1.0:
+		_append_issue(report, &"invalid_wheel_zoom_factor", "wheel_zoom_factor 必须为有限且大于 1 的值。", &"wheel_zoom_factor")
+	if (
+		touch_primary_behavior < TouchPrimaryBehavior.NONE
+		or touch_primary_behavior > TouchPrimaryBehavior.SELECT
+	):
+		_append_issue(report, &"invalid_touch_behavior", "touch_primary_behavior 超出有效枚举范围。", &"touch_primary_behavior")
+	_validate_cancel_action(report)
+
+	return GFValidationReportDictionary.finalize_report(
+		report,
+		"Spatial canvas input policy",
+		{
+			"fallback_action": "Fix the first invalid spatial canvas input policy field.",
+			"no_action": "No action required.",
+		}
+	)
+
+
+## 创建策略及嵌套选择绑定的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新策略。
+func duplicate_policy() -> GFSpatialCanvasInputPolicy:
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.pan_mouse_button = pan_mouse_button
+	policy.pan_action = pan_action
+	policy.pan_modifier_mask = pan_modifier_mask
+	policy.selection_mouse_button = selection_mouse_button
+	policy.selection_action = selection_action
+	policy.selection_default_mode = selection_default_mode
+	policy.selection_modifier_bindings.clear()
+	var binding_count: int = mini(
+		selection_modifier_bindings.size(),
+		ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS
+	)
+	for binding_index: int in range(binding_count):
+		var binding: GFSpatialCanvasSelectionModeBinding = selection_modifier_bindings[binding_index]
+		if binding == null:
+			policy.selection_modifier_bindings.append(null)
+		else:
+			policy.selection_modifier_bindings.append(binding.duplicate_binding())
+	if selection_modifier_bindings.size() > ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS:
+		policy.selection_modifier_bindings.append(null)
+	policy.drag_threshold = drag_threshold
+	policy.wheel_axis = wheel_axis
+	policy.wheel_routing = wheel_routing
+	policy.wheel_modifier_mask = wheel_modifier_mask
+	policy.wheel_zoom_factor = wheel_zoom_factor
+	policy.touch_enabled = touch_enabled
+	policy.touch_primary_behavior = touch_primary_behavior
+	policy.touch_multi_pan_enabled = touch_multi_pan_enabled
+	policy.touch_multi_zoom_enabled = touch_multi_zoom_enabled
+	policy.system_pan_gesture_enabled = system_pan_gesture_enabled
+	policy.system_magnify_gesture_enabled = system_magnify_gesture_enabled
+	policy.placement_cancel_action = placement_cancel_action
+	policy.consume_handled_events = consume_handled_events
+	policy.consume_wheel_events = consume_wheel_events
+	return policy
+
+
+# --- 私有/辅助方法 ---
+
+func _validate_pointer_mapping(
+	report: Dictionary,
+	behavior: StringName,
+	button: MouseButton,
+	action: StringName
+) -> void:
+	if button != MOUSE_BUTTON_NONE and not _is_pointer_button(button):
+		_append_issue(
+			report,
+			&"invalid_pointer_button",
+			"%s_mouse_button 必须是非滚轮鼠标按钮或 MOUSE_BUTTON_NONE。" % String(behavior),
+			StringName("%s_mouse_button" % String(behavior))
+		)
+	if button != MOUSE_BUTTON_NONE and action != &"":
+		_append_issue(
+			report,
+			&"conflicting_pointer_mapping",
+			"%s 不得同时声明直接鼠标按钮与 InputMap action。" % String(behavior),
+			StringName("%s_action" % String(behavior))
+		)
+	if action == &"":
+		return
+	if not InputMap.has_action(action):
+		_append_issue(
+			report,
+			&"missing_input_action",
+			"%s_action 未在 InputMap 中声明。" % String(behavior),
+			StringName("%s_action" % String(behavior))
+		)
+		return
+	var action_events: Array[InputEvent] = InputMap.action_get_events(action)
+	if action_events.size() > ABSOLUTE_MAX_ACTION_EVENTS:
+		_append_issue(
+			report,
+			&"too_many_action_events",
+			"%s_action 的事件数量超过固定校验预算。" % String(behavior),
+			StringName("%s_action" % String(behavior))
+		)
+		return
+	var has_pointer_event: bool = false
+	for action_event_value: Variant in action_events:
+		if not action_event_value is InputEventMouseButton:
+			continue
+		var action_event: InputEventMouseButton = action_event_value
+		if _is_pointer_button(action_event.button_index):
+			has_pointer_event = true
+			break
+	if not has_pointer_event:
+		_append_issue(
+			report,
+			&"missing_pointer_action_event",
+			"%s_action 必须至少包含一个非滚轮 InputEventMouseButton。" % String(behavior),
+			StringName("%s_action" % String(behavior))
+		)
+
+
+func _validate_modifier_mask(report: Dictionary, field_name: StringName, mask: int) -> void:
+	if mask < 0 or (mask & ~_ALL_MODIFIER_MASK) != 0:
+		_append_issue(report, &"invalid_modifier_mask", "%s 包含未知修饰键位。" % String(field_name), field_name)
+
+
+func _validate_selection_bindings(report: Dictionary) -> void:
+	var seen_masks: Dictionary = {}
+	if (
+		selection_modifier_bindings.size()
+		> ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS
+	):
+		_append_issue(
+			report,
+			&"too_many_selection_bindings",
+			"selection_modifier_bindings 超过 15 个非零修饰键组合的固定上限。",
+			&"selection_modifier_bindings"
+		)
+	var binding_count: int = mini(
+		selection_modifier_bindings.size(),
+		ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS
+	)
+	for binding_index: int in range(binding_count):
+		var binding: GFSpatialCanvasSelectionModeBinding = selection_modifier_bindings[binding_index]
+		if binding == null:
+			_append_issue(report, &"null_selection_binding", "selection_modifier_bindings 包含空绑定。", &"selection_modifier_bindings", binding_index)
+			continue
+		_validate_modifier_mask(report, &"selection_modifier_bindings", binding.modifier_mask)
+		if binding.modifier_mask == ModifierMask.NONE:
+			_append_issue(report, &"empty_selection_modifier", "选择修饰键绑定必须声明非零掩码。", &"selection_modifier_bindings", binding_index)
+		if seen_masks.has(binding.modifier_mask):
+			_append_issue(report, &"duplicate_selection_modifier", "选择修饰键掩码不得重复。", &"selection_modifier_bindings", binding_index)
+		else:
+			seen_masks[binding.modifier_mask] = true
+		if not _is_valid_selection_mode(binding.selection_mode):
+			_append_issue(report, &"invalid_selection_mode", "选择修饰键绑定的 selection_mode 无效。", &"selection_modifier_bindings", binding_index)
+
+
+func _validate_cancel_action(report: Dictionary) -> void:
+	if placement_cancel_action == &"":
+		return
+	if not InputMap.has_action(placement_cancel_action):
+		_append_issue(
+			report,
+			&"missing_input_action",
+			"placement_cancel_action 未在 InputMap 中声明。",
+			&"placement_cancel_action"
+		)
+		return
+	var action_events: Array[InputEvent] = InputMap.action_get_events(
+		placement_cancel_action
+	)
+	if action_events.size() > ABSOLUTE_MAX_ACTION_EVENTS:
+		_append_issue(
+			report,
+			&"too_many_action_events",
+			"placement_cancel_action 的事件数量超过固定校验预算。",
+			&"placement_cancel_action"
+		)
+		return
+	for action_event: InputEvent in action_events:
+		if _is_pointer_action_event(action_event):
+			_append_issue(
+				report,
+				&"pointer_cancel_action_event",
+				"placement_cancel_action 不得包含鼠标、触摸或位置手势事件。",
+				&"placement_cancel_action"
+			)
+			return
+
+
+func _validate_pointer_mapping_overlap(report: Dictionary) -> void:
+	var pan_chords: Dictionary = _collect_mapping_chords(
+		pan_mouse_button,
+		pan_action,
+		pan_modifier_mask,
+		false
+	)
+	var selection_chords: Dictionary = _collect_mapping_chords(
+		selection_mouse_button,
+		selection_action,
+		ModifierMask.NONE,
+		true
+	)
+	for chord_key: Variant in pan_chords.keys():
+		if selection_chords.has(chord_key):
+			_append_issue(
+				report,
+				&"ambiguous_pointer_mapping",
+				"pan 与 selection 的物理按钮及修饰键组合发生重叠。",
+				&"pan_mouse_button"
+			)
+			return
+
+
+func _collect_mapping_chords(
+	direct_button: MouseButton,
+	action: StringName,
+	direct_modifier_mask: int,
+	direct_accepts_all_modifiers: bool
+) -> Dictionary:
+	var result: Dictionary = {}
+	if direct_button != MOUSE_BUTTON_NONE:
+		if not _is_pointer_button(direct_button):
+			return result
+		if direct_accepts_all_modifiers:
+			for modifier_mask: int in range(_ALL_MODIFIER_MASK + 1):
+				result[_make_chord_key(direct_button, modifier_mask)] = true
+		else:
+			result[_make_chord_key(direct_button, direct_modifier_mask)] = true
+		return result
+	if action == &"" or not InputMap.has_action(action):
+		return result
+	var action_events: Array[InputEvent] = InputMap.action_get_events(action)
+	if action_events.size() > ABSOLUTE_MAX_ACTION_EVENTS:
+		return result
+	for action_event_value: Variant in action_events:
+		if not action_event_value is InputEventMouseButton:
+			continue
+		var action_event: InputEventMouseButton = action_event_value
+		if not _is_pointer_button(action_event.button_index):
+			continue
+		var modifier_mask: int = _modifier_mask_from_mouse_event(action_event)
+		result[_make_chord_key(action_event.button_index, modifier_mask)] = true
+	return result
+
+
+func _make_chord_key(button: MouseButton, modifier_mask: int) -> int:
+	return (int(button) << 8) | modifier_mask
+
+
+func _modifier_mask_from_mouse_event(event: InputEventMouseButton) -> int:
+	var result: int = ModifierMask.NONE
+	if event.shift_pressed:
+		result |= ModifierMask.SHIFT
+	if event.ctrl_pressed:
+		result |= ModifierMask.CTRL
+	if event.alt_pressed:
+		result |= ModifierMask.ALT
+	if event.meta_pressed:
+		result |= ModifierMask.META
+	return result
+
+
+func _is_pointer_action_event(event: InputEvent) -> bool:
+	return (
+		event is InputEventMouse
+		or event is InputEventScreenTouch
+		or event is InputEventScreenDrag
+		or event is InputEventGesture
+	)
+
+
+func _append_issue(
+	report: Dictionary,
+	kind: StringName,
+	message: String,
+	field_name: StringName,
+	index: int = -1
+) -> void:
+	var fields: Dictionary = { "field": String(field_name) }
+	if index >= 0:
+		fields["index"] = index
+	var _issue: Dictionary = GFValidationReportDictionary.append_issue(
+		report,
+		"error",
+		kind,
+		message,
+		fields
+	)
+
+
+func _is_pointer_button(button: MouseButton) -> bool:
+	return (
+		button == MOUSE_BUTTON_LEFT
+		or button == MOUSE_BUTTON_RIGHT
+		or button == MOUSE_BUTTON_MIDDLE
+		or button == MOUSE_BUTTON_XBUTTON1
+		or button == MOUSE_BUTTON_XBUTTON2
+	)
+
+
+func _is_valid_selection_mode(mode: GFSpatialCanvas2D.SelectionMode) -> bool:
+	return (
+		mode == GFSpatialCanvas2D.SelectionMode.REPLACE
+		or mode == GFSpatialCanvas2D.SelectionMode.ADD
+		or mode == GFSpatialCanvas2D.SelectionMode.TOGGLE
+		or mode == GFSpatialCanvas2D.SelectionMode.SUBTRACT
+	)
+
+
+func _is_finite_float(value: float) -> bool:
+	return not is_nan(value) and not is_inf(value)
+
+
+func _make_selection_binding(
+	mask: int,
+	mode: GFSpatialCanvas2D.SelectionMode
+) -> GFSpatialCanvasSelectionModeBinding:
+	var binding: GFSpatialCanvasSelectionModeBinding = GFSpatialCanvasSelectionModeBinding.new()
+	binding.modifier_mask = mask
+	binding.selection_mode = mode
+	return binding

--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd.uid
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd.uid
@@ -1,0 +1,1 @@
+uid://dysc0ffmeqpye

--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd
@@ -1,0 +1,47 @@
+## GFSpatialCanvasSelectionModeBinding: 空间画布选择修饰键绑定。
+##
+## 只描述修饰键掩码到 [code]GFSpatialCanvas2D.SelectionMode[/code] 的映射，
+## 不读取设备状态，也不拥有输入生命周期。
+## [br]
+## @api public
+## [br]
+## @category resource_definition
+## [br]
+## @since unreleased
+class_name GFSpatialCanvasSelectionModeBinding
+extends Resource
+
+
+# --- 导出变量 ---
+
+## 需要精确匹配的 [code]GFSpatialCanvasInputPolicy.ModifierMask[/code] 掩码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export_flags("Shift:1", "Ctrl:2", "Alt:4", "Meta:8") var modifier_mask: int = 0
+
+## 匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code] 值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var selection_mode: GFSpatialCanvas2D.SelectionMode = (
+	GFSpatialCanvas2D.SelectionMode.REPLACE
+)
+
+
+# --- 公共方法 ---
+
+## 创建隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新绑定。
+func duplicate_binding() -> GFSpatialCanvasSelectionModeBinding:
+	var binding: GFSpatialCanvasSelectionModeBinding = GFSpatialCanvasSelectionModeBinding.new()
+	binding.modifier_mask = modifier_mask
+	binding.selection_mode = selection_mode
+	return binding

--- a/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd.uid
+++ b/addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd.uid
@@ -1,0 +1,1 @@
+uid://nvt1v2cpsdv2

--- a/addons/gf/standard/utilities/ui/gf_table_data_view.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_data_view.gd
@@ -24,14 +24,25 @@ extends RefCounted
 ## @param row_count: 当前行数量。
 signal rows_changed(row_count: int)
 
-## 可见行集合变化后发出。
+## 可见行集合成功提交后发出。
 ## [br]
 ## @api public
 ## [br]
 ## @since 5.2.0
 ## [br]
+## @param view_revision: 单调递增的已提交投影 revision。
+## [br]
 ## @param visible_count: 当前可见行数量。
-signal view_changed(visible_count: int)
+signal view_changed(view_revision: int, visible_count: int)
+
+## 候选投影未提交时发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param result: 保留 prior projection 的类型化失败结果。
+signal view_rebuild_failed(result: GFTableViewRebuildResult)
 
 ## 过滤文本变化后发出。
 ## [br]
@@ -85,32 +96,21 @@ signal cell_value_committed(
 )
 
 
-# --- 公共变量 ---
+# --- 常量 ---
 
-## 用作稳定行 ID 的字段键。为空时使用源行索引。
+## 单个表格允许注册的命名行谓词上限。
 ## [br]
 ## @api public
 ## [br]
-## @since 5.2.0
-var row_id_column: StringName = &"id"
-
-## 过滤时是否区分大小写。
-## [br]
-## @api public
-## [br]
-## @since 5.2.0
-var case_sensitive_filter: bool = false
-
-## 该视图使用的选择模型。
-## [br]
-## @api public
-## [br]
-## @since 5.2.0
-var selection_model: GFTableSelectionModel = GFTableSelectionModel.new()
+## @since unreleased
+const MAX_ROW_PREDICATE_COUNT: int = 64
 
 
 # --- 私有变量 ---
 
+var _row_id_column: StringName = &"id"
+var _case_sensitive_filter: bool = false
+var _selection_model: GFTableSelectionModel = GFTableSelectionModel.new()
 var _rows: Array = []
 var _columns: Array[GFTableColumnDefinition] = []
 var _columns_by_id: Dictionary = {}
@@ -118,9 +118,187 @@ var _visible_row_indices: Array[int] = []
 var _filter_query: String = ""
 var _sort_column_id: StringName = &""
 var _sort_ascending: bool = true
+var _row_predicates: Array[GFTableRowPredicateRegistration] = []
+var _row_predicates_by_id: Dictionary = {}
+var _view_revision: int = 0
+var _last_view_rebuild_result: GFTableViewRebuildResult = null
+var _view_rebuild_in_progress: bool = false
+var _reentrant_rebuild_attempted: bool = false
+var _state_publication_in_progress: bool = false
 
 
 # --- 公共方法 ---
+
+## 事务式设置稳定行 ID 字段键。
+## [br]
+## 新字段键会先参与完整候选投影；失败时保留旧字段键、投影、选择模型与 revision。
+## 成功时按同一源行迁移稳定选择和范围锚点。空字段键表示使用源行索引。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param column_id: 新的稳定行 ID 字段键；为空时使用源行索引。
+## [br]
+## @return 类型化投影重建结果。
+func set_row_id_column(column_id: StringName) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	if _row_id_column == column_id:
+		return _publish_rebuild_success(false, 0, 0)
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		column_id,
+		_case_sensitive_filter,
+		true,
+		_row_id_column
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	var selected_ids_before: Array = _selection_model.get_selected_ids()
+	var anchor_before: Variant = _selection_model.anchor_row_id
+	var row_id_transitions: Array = GFVariantData.get_option_array(
+		build_report,
+		"row_id_transitions"
+	)
+	var mapped_selected_ids: Array = _map_selected_row_ids(
+		selected_ids_before,
+		row_id_transitions
+	)
+	var mapped_anchor: Variant = _map_row_id(anchor_before, row_id_transitions)
+	_state_publication_in_progress = true
+	_row_id_column = column_id
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	var _selection_result: bool = _selection_model.replace_selection_with_anchor(
+		mapped_selected_ids,
+		mapped_anchor
+	)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
+
+
+## 获取稳定行 ID 字段键。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前稳定行 ID 字段键；为空时使用源行索引。
+func get_row_id_column() -> StringName:
+	return _row_id_column
+
+
+## 事务式设置文本过滤是否区分大小写。
+## [br]
+## 新设置会先参与完整候选投影；失败时保留旧设置、投影、选择模型与 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param case_sensitive: 为 true 时区分大小写。
+## [br]
+## @return 类型化投影重建结果。
+func set_filter_case_sensitive(case_sensitive: bool) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	if _case_sensitive_filter == case_sensitive:
+		return _publish_rebuild_success(false, 0, 0)
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		case_sensitive
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
+	_case_sensitive_filter = case_sensitive
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
+
+
+## 查询文本过滤是否区分大小写。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 区分大小写时返回 true。
+func is_filter_case_sensitive() -> bool:
+	return _case_sensitive_filter
+
+
+## 事务式替换该视图使用的选择模型。
+## [br]
+## 新模型只会在完整候选投影成功后成为权威选择模型，并在提交态中按当前行 ID 修剪。
+## 失败时不会修改旧模型、新模型、投影或 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param model: 非空选择模型。
+## [br]
+## @return 类型化投影重建结果。
+func set_selection_model(model: GFTableSelectionModel) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	if model == null:
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"invalid_selection_model",
+			"Table selection model cannot be null."
+		))
+	if is_same(_selection_model, model):
+		return _publish_rebuild_success(false, 0, 0)
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
+	_selection_model = model
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	var _prune_result: bool = _selection_model.prune_to_row_ids(get_row_ids())
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
+
+
+## 获取该视图使用的选择模型。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前非空选择模型。
+func get_selection_model() -> GFTableSelectionModel:
+	return _selection_model
 
 ## 设置列定义列表。
 ## [br]
@@ -131,17 +309,45 @@ var _sort_ascending: bool = true
 ## @param column_definitions: 列定义列表；null 项会被忽略。
 ## [br]
 ## @schema column_definitions: Array，包含 GFTableColumnDefinition。
-func set_columns(column_definitions: Array[GFTableColumnDefinition]) -> void:
-	_columns.clear()
-	_columns_by_id.clear()
+## [br]
+## @return 类型化投影重建结果；失败时保留原列与 prior projection。
+func set_columns(
+	column_definitions: Array[GFTableColumnDefinition]
+) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	var next_columns: Array[GFTableColumnDefinition] = []
+	var next_columns_by_id: Dictionary = {}
 	for column: GFTableColumnDefinition in column_definitions:
 		if column == null or column.column_id == &"":
 			continue
-		_columns.append(column)
-		_columns_by_id[column.column_id] = column
-	if _sort_column_id != &"" and get_column(_sort_column_id) == null:
-		_sort_column_id = &""
-	refresh_view()
+		next_columns.append(column)
+		next_columns_by_id[column.column_id] = column
+	var next_sort_column_id: StringName = _sort_column_id
+	if next_sort_column_id != &"" and not next_columns_by_id.has(next_sort_column_id):
+		next_sort_column_id = &""
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		next_columns,
+		next_columns_by_id,
+		_filter_query,
+		next_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
+	_columns = next_columns
+	_columns_by_id = next_columns_by_id
+	_sort_column_id = next_sort_column_id
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
 
 
 ## 追加列定义。
@@ -154,14 +360,16 @@ func set_columns(column_definitions: Array[GFTableColumnDefinition]) -> void:
 ## [br]
 ## @return 追加成功返回 true。
 func add_column(column: GFTableColumnDefinition) -> bool:
+	if _reject_reentrant_rebuild_request() != null:
+		return false
 	if column == null or column.column_id == &"":
 		return false
 	if _columns_by_id.has(column.column_id):
 		return false
-	_columns.append(column)
-	_columns_by_id[column.column_id] = column
-	refresh_view()
-	return true
+	var next_columns: Array[GFTableColumnDefinition] = _columns.duplicate()
+	next_columns.append(column)
+	var result: GFTableViewRebuildResult = set_columns(next_columns)
+	return result.is_successful()
 
 
 ## 获取列定义列表副本。
@@ -205,17 +413,42 @@ func get_column(column_id: StringName) -> GFTableColumnDefinition:
 ## @param duplicate_rows: 是否复制 Dictionary / Array 行数据。
 ## [br]
 ## @schema row_values: Array，调用方保存的行数据。
-func set_rows(row_values: Array, duplicate_rows: bool = false) -> void:
-	_rows.clear()
+## [br]
+## @return 类型化投影重建结果；失败时保留原 source、projection 与 selection。
+func set_rows(
+	row_values: Array,
+	duplicate_rows: bool = false
+) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	var next_rows: Array = []
 	for row_data: Variant in row_values:
 		if duplicate_rows:
-			_rows.append(GFVariantData.duplicate_variant(row_data, true, false))
+			next_rows.append(GFVariantData.duplicate_variant(row_data, true, false))
 		else:
-			_rows.append(row_data)
-	refresh_view()
-	if selection_model != null:
-		var _prune_result: bool = selection_model.prune_to_row_ids(get_row_ids())
+			next_rows.append(row_data)
+	var build_report: Dictionary = _try_build_projection(
+		next_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
+	_rows = next_rows
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	var _prune_result: bool = _selection_model.prune_to_row_ids(get_row_ids())
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	rows_changed.emit(_rows.size())
+	_state_publication_in_progress = false
+	return result
 
 
 ## 追加源行数据。
@@ -230,10 +463,33 @@ func set_rows(row_values: Array, duplicate_rows: bool = false) -> void:
 ## [br]
 ## @schema row_data: Variant，调用方保存的行数据。
 func append_row(row_data: Variant) -> int:
+	if _reject_reentrant_rebuild_request() != null:
+		return -1
 	var row_index: int = _rows.size()
-	_rows.append(row_data)
-	refresh_view()
+	var next_rows: Array = _rows.duplicate()
+	next_rows.append(row_data)
+	var build_report: Dictionary = _try_build_projection(
+		next_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		var _failure_result: GFTableViewRebuildResult = _publish_rebuild_failure(
+			_get_build_failure(build_report)
+		)
+		return -1
+	_state_publication_in_progress = true
+	_rows = next_rows
+	var _rebuild_result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	rows_changed.emit(_rows.size())
+	_state_publication_in_progress = false
 	return row_index
 
 
@@ -249,13 +505,36 @@ func append_row(row_data: Variant) -> int:
 ## [br]
 ## @return 移除成功返回 true。
 func remove_row(row_index: int, should_prune_selection: bool = true) -> bool:
+	if _reject_reentrant_rebuild_request() != null:
+		return false
 	if not _is_valid_row_index(row_index):
 		return false
-	_rows.remove_at(row_index)
-	refresh_view()
-	if should_prune_selection and selection_model != null:
-		var _prune_result: bool = selection_model.prune_to_row_ids(get_row_ids())
+	var next_rows: Array = _rows.duplicate()
+	next_rows.remove_at(row_index)
+	var build_report: Dictionary = _try_build_projection(
+		next_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		var _failure_result: GFTableViewRebuildResult = _publish_rebuild_failure(
+			_get_build_failure(build_report)
+		)
+		return false
+	_state_publication_in_progress = true
+	_rows = next_rows
+	var _rebuild_result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	if should_prune_selection:
+		var _prune_result: bool = _selection_model.prune_to_row_ids(get_row_ids())
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	rows_changed.emit(_rows.size())
+	_state_publication_in_progress = false
 	return true
 
 
@@ -265,13 +544,34 @@ func remove_row(row_index: int, should_prune_selection: bool = true) -> bool:
 ## [br]
 ## @since 5.2.0
 func clear_rows() -> void:
+	if _reject_reentrant_rebuild_request() != null:
+		return
 	if _rows.is_empty():
 		return
-	_rows.clear()
-	refresh_view()
-	if selection_model != null:
-		selection_model.clear_selection()
+	var next_rows: Array = []
+	var build_report: Dictionary = _try_build_projection(
+		next_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		var _failure_result: GFTableViewRebuildResult = _publish_rebuild_failure(
+			_get_build_failure(build_report)
+		)
+		return
+	_state_publication_in_progress = true
+	_rows = next_rows
+	var _rebuild_result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	_selection_model.clear_selection()
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	rows_changed.emit(0)
+	_state_publication_in_progress = false
 
 
 ## 获取源行数量。
@@ -375,9 +675,9 @@ func get_visible_row_indices() -> PackedInt32Array:
 func get_row_id(row_index: int) -> Variant:
 	if not _is_valid_row_index(row_index):
 		return null
-	if row_id_column == &"":
+	if _row_id_column == &"":
 		return row_index
-	var row_id: Variant = _read_row_property(_rows[row_index], row_id_column)
+	var row_id: Variant = _read_row_property(_rows[row_index], _row_id_column)
 	if row_id == null:
 		return row_index
 	return row_id
@@ -440,12 +740,34 @@ func get_visible_row_ids() -> Array:
 ## @since 5.2.0
 ## [br]
 ## @param query: 过滤文本；空字符串显示全部行。
-func set_filter_query(query: String) -> void:
+## [br]
+## @return 类型化投影重建结果；失败时保留旧 query 与 prior projection。
+func set_filter_query(query: String) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
 	if _filter_query == query:
-		return
+		return _publish_rebuild_success(false, 0, 0)
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
 	_filter_query = query
-	refresh_view()
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	filter_changed.emit(_filter_query, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
 
 
 ## 获取当前过滤文本。
@@ -457,6 +779,263 @@ func set_filter_query(query: String) -> void:
 ## @return 过滤文本。
 func get_filter_query() -> String:
 	return _filter_query
+
+
+## 事务式替换全部命名行谓词。
+##
+## 注册会先完整校验并按 order 升序、predicate_id 字典序排序，再构建一个候选投影。
+## GFTableDataView 保存 predicate_id、order、enabled 与 predicate 引用的框架自有
+## metadata 快照；调用方后续修改注册对象不会改变已提交 registry。
+## 任一失败都会保留当前 registry、projection、revision 与 selection。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param registrations: 谓词注册定义；提交时复制 metadata。
+## [br]
+## @schema registrations: Array of GFTableRowPredicateRegistration values.
+## [br]
+## @return 类型化投影重建结果。
+func set_row_predicates(
+	registrations: Array[GFTableRowPredicateRegistration]
+) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	if registrations.size() > MAX_ROW_PREDICATE_COUNT:
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"predicate_limit_exceeded",
+			"Table row predicate registration count exceeds the bounded limit."
+		))
+	var next_predicates: Array[GFTableRowPredicateRegistration] = (
+		_snapshot_row_predicate_registrations(registrations)
+	)
+	var validation_failure: GFTableViewRebuildResult = _validate_row_predicate_registrations(
+		next_predicates
+	)
+	if validation_failure != null:
+		return _publish_rebuild_failure(validation_failure)
+	next_predicates.sort_custom(_compare_row_predicate_registrations)
+	if _row_predicate_registrations_equal(_row_predicates, next_predicates):
+		return _publish_rebuild_success(false, 0, 0)
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		next_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
+	_row_predicates = next_predicates
+	_row_predicates_by_id = _make_row_predicate_lookup(next_predicates)
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
+
+
+## 事务式注册一个命名行谓词。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param registration: 谓词注册定义；提交时复制 metadata。
+## [br]
+## @return 类型化投影重建结果。
+func register_row_predicate(
+	registration: GFTableRowPredicateRegistration
+) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	if registration == null:
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"invalid_predicate_registration",
+			"Table row predicate registration cannot be null."
+		))
+	if _row_predicates.size() >= MAX_ROW_PREDICATE_COUNT:
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"predicate_limit_exceeded",
+			"Table row predicate registration count exceeds the bounded limit."
+		))
+	var next_predicates: Array[GFTableRowPredicateRegistration] = _row_predicates.duplicate()
+	next_predicates.append(registration)
+	return set_row_predicates(next_predicates)
+
+
+## 事务式移除一个命名行谓词。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param predicate_id: 要移除的稳定谓词 ID。
+## [br]
+## @return 类型化投影重建结果。
+func unregister_row_predicate(predicate_id: StringName) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	if not _row_predicates_by_id.has(predicate_id):
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"unknown_predicate_id",
+			"Table row predicate id is not registered.",
+			predicate_id
+		))
+	var next_predicates: Array[GFTableRowPredicateRegistration] = []
+	for registration: GFTableRowPredicateRegistration in _row_predicates:
+		if registration.get_predicate_id() != predicate_id:
+			next_predicates.append(registration)
+	return set_row_predicates(next_predicates)
+
+
+## 事务式设置命名行谓词的启用状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param predicate_id: 稳定谓词 ID。
+## [br]
+## @param enabled: 是否参与候选投影。
+## [br]
+## @return 类型化投影重建结果。
+func set_row_predicate_enabled(
+	predicate_id: StringName,
+	enabled: bool
+) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	var current: GFTableRowPredicateRegistration = get_row_predicate(predicate_id)
+	if current == null:
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"unknown_predicate_id",
+			"Table row predicate id is not registered.",
+			predicate_id
+		))
+	if current.is_enabled() == enabled:
+		return _publish_rebuild_success(false, 0, 0)
+	return _replace_row_predicate_registration(GFTableRowPredicateRegistration.create(
+		predicate_id,
+		current.get_predicate(),
+		current.get_order(),
+		enabled
+	))
+
+
+## 事务式设置命名行谓词的执行顺序。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param predicate_id: 稳定谓词 ID。
+## [br]
+## @param order: 新顺序；数值越小越早执行。
+## [br]
+## @return 类型化投影重建结果。
+func set_row_predicate_order(
+	predicate_id: StringName,
+	order: int
+) -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	var current: GFTableRowPredicateRegistration = get_row_predicate(predicate_id)
+	if current == null:
+		return _publish_rebuild_failure(_make_rebuild_failure(
+			&"unknown_predicate_id",
+			"Table row predicate id is not registered.",
+			predicate_id
+		))
+	if current.get_order() == order:
+		return _publish_rebuild_success(false, 0, 0)
+	return _replace_row_predicate_registration(GFTableRowPredicateRegistration.create(
+		predicate_id,
+		current.get_predicate(),
+		order,
+		current.is_enabled()
+	))
+
+
+## 获取一个命名行谓词注册值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param predicate_id: 稳定谓词 ID。
+## [br]
+## @return 独立 metadata 快照；predicate 协议实例保持同一引用，不存在时返回 null。
+func get_row_predicate(predicate_id: StringName) -> GFTableRowPredicateRegistration:
+	var registration_value: Variant = GFVariantData.get_option_value(
+		_row_predicates_by_id,
+		predicate_id
+	)
+	if registration_value is GFTableRowPredicateRegistration:
+		var registration: GFTableRowPredicateRegistration = registration_value
+		return _snapshot_row_predicate_registration(registration)
+	return null
+
+
+## 获取按确定顺序排列的命名行谓词注册值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 独立 metadata 快照数组；predicate 协议实例保持同一引用。
+## [br]
+## @schema return: Array of GFTableRowPredicateRegistration values.
+func get_row_predicates() -> Array[GFTableRowPredicateRegistration]:
+	return _snapshot_row_predicate_registrations(_row_predicates)
+
+
+## 获取按确定顺序排列的命名行谓词 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 稳定谓词 ID 数组。
+func get_row_predicate_ids() -> Array[StringName]:
+	var predicate_ids: Array[StringName] = []
+	for registration: GFTableRowPredicateRegistration in _row_predicates:
+		predicate_ids.append(registration.get_predicate_id())
+	return predicate_ids
+
+
+## 获取当前已提交投影 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 单调递增 revision。
+func get_view_revision() -> int:
+	return _view_revision
+
+
+## 获取最近一次投影事务结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 最近结果的隔离副本；尚未执行时返回 revision 0 的成功 no-op。
+func get_last_view_rebuild_result() -> GFTableViewRebuildResult:
+	if _last_view_rebuild_result == null:
+		_last_view_rebuild_result = _make_rebuild_success(false, 0, 0)
+	return _last_view_rebuild_result.duplicate_result()
 
 
 ## 按列排序。
@@ -471,13 +1050,37 @@ func get_filter_query() -> String:
 ## [br]
 ## @return 排序设置成功返回 true。
 func sort_by_column(column_id: StringName, ascending: bool = true) -> bool:
+	if _reject_reentrant_rebuild_request() != null:
+		return false
 	var column: GFTableColumnDefinition = get_column(column_id)
 	if column == null or not column.sortable:
 		return false
+	if _sort_column_id == column_id and _sort_ascending == ascending:
+		var _noop_result: GFTableViewRebuildResult = _publish_rebuild_success(false, 0, 0)
+		return true
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		column_id,
+		ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		var _failure_result: GFTableViewRebuildResult = _publish_rebuild_failure(
+			_get_build_failure(build_report)
+		)
+		return false
+	_state_publication_in_progress = true
 	_sort_column_id = column_id
 	_sort_ascending = ascending
-	refresh_view()
+	var _rebuild_result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	sort_changed.emit(_sort_column_id, _sort_ascending)
+	_state_publication_in_progress = false
 	return true
 
 
@@ -489,11 +1092,32 @@ func sort_by_column(column_id: StringName, ascending: bool = true) -> bool:
 ## [br]
 ## @return 排序状态发生变化时返回 true。
 func clear_sort() -> bool:
+	if _reject_reentrant_rebuild_request() != null:
+		return false
 	if _sort_column_id == &"":
 		return false
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		&"",
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		var _failure_result: GFTableViewRebuildResult = _publish_rebuild_failure(
+			_get_build_failure(build_report)
+		)
+		return false
+	_state_publication_in_progress = true
 	_sort_column_id = &""
-	refresh_view()
+	var _rebuild_result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
 	sort_changed.emit(_sort_column_id, _sort_ascending)
+	_state_publication_in_progress = false
 	return true
 
 
@@ -524,9 +1148,30 @@ func is_sort_ascending() -> bool:
 ## @api public
 ## [br]
 ## @since 5.2.0
-func refresh_view() -> void:
-	_rebuild_visible_row_indices()
-	view_changed.emit(_visible_row_indices.size())
+## [br]
+## @return 类型化投影重建结果；失败时保留 prior projection。
+func refresh_view() -> GFTableViewRebuildResult:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return reentrant_failure
+	var build_report: Dictionary = _try_build_projection(
+		_rows,
+		_columns,
+		_columns_by_id,
+		_filter_query,
+		_sort_column_id,
+		_sort_ascending,
+		_row_predicates,
+		_row_id_column,
+		_case_sensitive_filter
+	)
+	if not GFVariantData.get_option_bool(build_report, "ok"):
+		return _publish_rebuild_failure(_get_build_failure(build_report))
+	_state_publication_in_progress = true
+	var result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	_state_publication_in_progress = false
+	return result
 
 
 ## 获取源行单元格值。
@@ -551,7 +1196,10 @@ func get_cell_value(row_index: int, column_id: StringName) -> Variant:
 	return column.read_value(_rows[row_index])
 
 
-## 提交源行单元格值。
+## 事务式提交源行单元格值。
+## [br]
+## 写入先发生在隔离候选行上，完整投影成功后才交换权威 source；自定义
+## value_setter 与不可隔离的 Object / 脚本 Resource 会在调用任何 setter 前失败关闭。
 ## [br]
 ## @api public
 ## [br]
@@ -567,17 +1215,20 @@ func get_cell_value(row_index: int, column_id: StringName) -> Variant:
 ## [br]
 ## @schema new_value: Variant，要提交的新值。
 func commit_cell_value(row_index: int, column_id: StringName, new_value: Variant) -> bool:
-	var report: Dictionary = _commit_cell_value_internal(row_index, column_id, new_value)
-	if not GFVariantData.get_option_bool(report, "ok"):
-		return false
+	var batch_report: Dictionary = _commit_cell_value_changes([
+		{
+			"row_index": row_index,
+			"column_id": column_id,
+			"new_value": new_value,
+		},
+	], false)
+	return GFVariantData.get_option_bool(batch_report, "ok")
 
-	if GFVariantData.get_option_bool(report, "changed"):
-		refresh_view()
-		_emit_cell_value_committed(report)
-	return true
 
-
-## 提交可见行单元格值。
+## 事务式提交可见行单元格值。
+## [br]
+## 写入先发生在隔离候选行上，完整投影成功后才交换权威 source；自定义
+## value_setter 与不可隔离的 Object / 脚本 Resource 会在调用任何 setter 前失败关闭。
 ## [br]
 ## @api public
 ## [br]
@@ -597,16 +1248,20 @@ func commit_visible_cell_value(
 	column_id: StringName,
 	new_value: Variant
 ) -> bool:
-	var row_index: int = get_source_row_index(visible_row_index)
-	if row_index < 0:
-		return false
-	return commit_cell_value(row_index, column_id, new_value)
+	var batch_report: Dictionary = _commit_cell_value_changes([
+		{
+			"visible_row_index": visible_row_index,
+			"column_id": column_id,
+			"new_value": new_value,
+		},
+	], true)
+	return GFVariantData.get_option_bool(batch_report, "ok")
 
 
 ## 批量提交源行单元格值。
 ## [br]
-## 该方法会先处理所有变更，再在有实际写入时统一刷新视图并发送单元格提交信号；
-## 它不是事务，部分失败不会回滚已成功的变更。
+## 该方法先在隔离候选 rows 上完成全部写入与投影，成功后统一交换并发送信号。
+## 任一输入、隔离、写入或投影失败都会回滚整批候选变更。
 ## [br]
 ## @api public
 ## [br]
@@ -626,7 +1281,7 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ## 批量提交可见行单元格值。
 ## [br]
 ## 可见行索引会在任何写入发生前解析为源行索引，避免排序或过滤重建导致同一批变更漂移。
-## 该方法不是事务，部分失败不会回滚已成功的变更。
+## 任一输入、隔离、写入或投影失败都会回滚整批候选变更。
 ## [br]
 ## @api public
 ## [br]
@@ -695,7 +1350,7 @@ func describe_row(row_index: int, options: Dictionary = {}) -> Dictionary:
 ## [br]
 ## @schema options: Dictionary，可包含 visible_only: bool、include_values: bool、include_columns: bool、include_hidden_columns: bool、include_row_data: bool、copy_values: bool。
 ## [br]
-## @schema return: Dictionary，包含 row_count、visible_count、column_count、filter_query、sort_column_id、sort_ascending、visible_only、columns 和 rows。
+## @schema return: Dictionary，包含 view_revision、row_count、visible_count、column_count、predicate_count、filter_query、sort_column_id、sort_ascending、visible_only、columns 和 rows。
 func describe_view(options: Dictionary = {}) -> Dictionary:
 	var visible_only: bool = GFVariantData.get_option_bool(options, "visible_only", true)
 	var include_columns: bool = GFVariantData.get_option_bool(options, "include_columns", true)
@@ -710,9 +1365,11 @@ func describe_view(options: Dictionary = {}) -> Dictionary:
 			var visible_row_index: int = visible_row_indices_by_source.get(row_index, -1)
 			rows.append(_describe_row(row_index, visible_row_index, options))
 	return {
+		"view_revision": _view_revision,
 		"row_count": _rows.size(),
 		"visible_count": _visible_row_indices.size(),
 		"column_count": _columns.size(),
+		"predicate_count": _row_predicates.size(),
 		"filter_query": _filter_query,
 		"sort_column_id": _sort_column_id,
 		"sort_ascending": _sort_ascending,
@@ -732,10 +1389,14 @@ func describe_view(options: Dictionary = {}) -> Dictionary:
 ## [br]
 ## @return 选择发生变化时返回 true。
 func prune_selection(visible_only: bool = false) -> bool:
-	if selection_model == null:
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
 		return false
 	var valid_ids: Array = get_visible_row_ids() if visible_only else get_row_ids()
-	return selection_model.prune_to_row_ids(valid_ids)
+	_state_publication_in_progress = true
+	var changed: bool = _selection_model.prune_to_row_ids(valid_ids)
+	_state_publication_in_progress = false
+	return changed
 
 
 ## 获取调试快照。
@@ -746,15 +1407,25 @@ func prune_selection(visible_only: bool = false) -> bool:
 ## [br]
 ## @return 数据视图状态字典。
 ## [br]
-## @schema return: Dictionary，包含 row_count、visible_count、column_count、filter_query、sort_column_id 和 sort_ascending。
+## @schema return: Dictionary，包含 view_revision、row_count、visible_count、column_count、predicate_count、enabled_predicate_count、filter_query、sort_column_id、sort_ascending、last_rebuild_ok 和 last_rebuild_error_code。
 func get_debug_snapshot() -> Dictionary:
+	var enabled_predicate_count: int = 0
+	for registration: GFTableRowPredicateRegistration in _row_predicates:
+		if registration.is_enabled():
+			enabled_predicate_count += 1
+	var last_result: GFTableViewRebuildResult = get_last_view_rebuild_result()
 	return {
+		"view_revision": _view_revision,
 		"row_count": _rows.size(),
 		"visible_count": _visible_row_indices.size(),
 		"column_count": _columns.size(),
+		"predicate_count": _row_predicates.size(),
+		"enabled_predicate_count": enabled_predicate_count,
 		"filter_query": _filter_query,
 		"sort_column_id": _sort_column_id,
 		"sort_ascending": _sort_ascending,
+		"last_rebuild_ok": last_result.is_successful(),
+		"last_rebuild_error_code": last_result.get_error_code(),
 	}
 
 
@@ -778,7 +1449,7 @@ func _describe_row(row_index: int, visible_row_index: int, options: Dictionary) 
 		"row_index": row_index,
 		"visible_row_index": visible_row_index,
 		"row_id": _copy_snapshot_value(row_id, copy_values),
-		"selected": selection_model != null and selection_model.is_selected(row_id),
+		"selected": _selection_model.is_selected(row_id),
 	}
 	if include_values:
 		result["values"] = _describe_row_values(row_data, options)
@@ -833,10 +1504,20 @@ func _make_visible_row_index_map() -> Dictionary:
 
 
 func _commit_cell_value_changes(changes: Array[Dictionary], use_visible_rows: bool) -> Dictionary:
-	var committed: Array[Dictionary] = []
-	var changed_reports: Array[Dictionary] = []
-	var errors: Array[Dictionary] = []
+	var reentrant_failure: GFTableViewRebuildResult = _reject_reentrant_rebuild_request()
+	if reentrant_failure != null:
+		return _make_commit_batch_result(changes.size(), [], [
+			_make_commit_error(
+				-1,
+				reentrant_failure.get_error_code(),
+				-1,
+				&"",
+				{ "message": reentrant_failure.get_error_message() }
+			),
+		])
 
+	var resolved_changes: Array[Dictionary] = []
+	var errors: Array[Dictionary] = []
 	for change_index: int in range(changes.size()):
 		var change: Dictionary = changes[change_index]
 		var column_id: StringName = GFVariantData.get_option_string_name(change, "column_id", &"")
@@ -870,59 +1551,288 @@ func _commit_cell_value_changes(changes: Array[Dictionary], use_visible_rows: bo
 			))
 			continue
 
-		var new_value: Variant = GFVariantData.get_option_value(change, "new_value")
-		var report: Dictionary = _commit_cell_value_internal(row_index, column_id, new_value)
-		report["index"] = change_index
-		if use_visible_rows:
-			report["visible_row_index"] = visible_row_index
-
-		if GFVariantData.get_option_bool(report, "ok"):
-			committed.append(report)
-			if GFVariantData.get_option_bool(report, "changed"):
-				changed_reports.append(report)
-		else:
-			var reason: StringName = GFVariantData.get_option_string_name(report, "reason", &"commit_failed")
-			var failure_context: Dictionary = {
-				"message": GFVariantData.get_option_string(report, "message", String(reason)),
-			}
-			if use_visible_rows:
-				failure_context["visible_row_index"] = visible_row_index
+		if not _is_valid_row_index(row_index):
 			errors.append(_make_commit_error(
 				change_index,
-				reason,
+				&"invalid_row_index",
+				row_index,
+				column_id
+			))
+			continue
+		var column: GFTableColumnDefinition = get_column(column_id)
+		if column == null:
+			errors.append(_make_commit_error(
+				change_index,
+				&"unknown_column",
+				row_index,
+				column_id
+			))
+			continue
+		if not column.editable:
+			errors.append(_make_commit_error(
+				change_index,
+				&"column_not_editable",
+				row_index,
+				column_id
+			))
+			continue
+		if column.value_setter.is_valid():
+			errors.append(_make_commit_error(
+				change_index,
+				&"non_transactional_value_setter",
 				row_index,
 				column_id,
-				failure_context
+				{
+					"message": (
+						"Custom table value setters are not accepted by the "
+						+ "transactional projection path."
+					),
+				}
 			))
+			continue
+		var resolved_change: Dictionary = {
+			"index": change_index,
+			"row_index": row_index,
+			"column_id": column_id,
+			"column": column,
+			"new_value": GFVariantData.get_option_value(change, "new_value"),
+		}
+		if use_visible_rows:
+			resolved_change["visible_row_index"] = visible_row_index
+		resolved_changes.append(resolved_change)
 
-	if not changed_reports.is_empty():
-		refresh_view()
-		for report: Dictionary in changed_reports:
-			_emit_cell_value_committed(report)
+	if not errors.is_empty():
+		return _make_commit_batch_result(changes.size(), [], errors)
 
-	return _make_commit_batch_result(changes.size(), committed, errors)
+	_view_rebuild_in_progress = true
+	_reentrant_rebuild_attempted = false
+	var next_rows: Array = _rows.duplicate()
+	var copied_row_indices: Dictionary = {}
+	var staged_reports: Array[Dictionary] = []
+	var changed_reports: Array[Dictionary] = []
+	var staging_failure: GFTableViewRebuildResult = null
+	for resolved_change: Dictionary in resolved_changes:
+		var row_index: int = GFVariantData.get_option_int(resolved_change, "row_index", -1)
+		var column_id: StringName = GFVariantData.get_option_string_name(
+			resolved_change,
+			"column_id"
+		)
+		var column_value: Variant = GFVariantData.get_option_value(resolved_change, "column")
+		if not column_value is GFTableColumnDefinition:
+			staging_failure = _make_rebuild_failure(
+				&"invalid_column",
+				"Transactional cell staging received an invalid column definition."
+			)
+			break
+		var column: GFTableColumnDefinition = column_value
+		if not copied_row_indices.has(row_index):
+			var copy_report: Dictionary = GFTableRowView.duplicate_isolated_variant_for_framework(
+				_rows[row_index]
+			)
+			if _reentrant_rebuild_attempted:
+				staging_failure = _make_rebuild_failure(
+					&"reentrant_rebuild",
+					"Table source isolation callback attempted a recursive mutation."
+				)
+				break
+			if not GFVariantData.get_option_bool(copy_report, "ok"):
+				staging_failure = _make_rebuild_failure(
+					&"unisolatable_source_row",
+					"Table cell transactions require an isolated candidate source row.",
+					&"",
+					row_index,
+					null
+				)
+				break
+			next_rows[row_index] = GFVariantData.get_option_value(copy_report, "value")
+			copied_row_indices[row_index] = true
+		var candidate_row: Variant = next_rows[row_index]
+		var previous_row_id: Variant = _get_row_id_for_state(
+			row_index,
+			next_rows,
+			_row_id_column
+		)
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table row identity callback attempted a recursive mutation."
+			)
+			break
+		var old_value: Variant = column.read_value(candidate_row)
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table column getter attempted a recursive mutation."
+			)
+			break
+		var new_value_report: Dictionary = (
+			GFTableRowView.duplicate_isolated_variant_for_framework(
+				GFVariantData.get_option_value(resolved_change, "new_value")
+			)
+		)
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table cell value isolation callback attempted a recursive mutation."
+			)
+			break
+		if not GFVariantData.get_option_bool(new_value_report, "ok"):
+			staging_failure = _make_rebuild_failure(
+				&"unisolatable_cell_value",
+				"Table cell transactions require an isolated candidate value.",
+				&"",
+				row_index,
+				previous_row_id
+			)
+			break
+		var new_value: Variant = GFVariantData.get_option_value(new_value_report, "value")
+		var changed: bool = not GFVariantData.values_equal(old_value, new_value)
+		if changed and not column.write_value(candidate_row, new_value):
+			staging_failure = _make_rebuild_failure(
+				&"write_failed",
+				"Table column rejected the staged value."
+			)
+			break
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table column setter attempted a recursive mutation."
+			)
+			break
+		var committed_value: Variant = column.read_value(candidate_row)
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table column getter attempted a recursive mutation."
+			)
+			break
+		var old_value_report: Dictionary = (
+			GFTableRowView.duplicate_isolated_variant_for_framework(old_value)
+		)
+		var committed_value_report: Dictionary = (
+			GFTableRowView.duplicate_isolated_variant_for_framework(committed_value)
+		)
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table cell report isolation callback attempted a recursive mutation."
+			)
+			break
+		if (
+			not GFVariantData.get_option_bool(old_value_report, "ok")
+			or not GFVariantData.get_option_bool(committed_value_report, "ok")
+		):
+			staging_failure = _make_rebuild_failure(
+				&"unisolatable_cell_value",
+				"Table cell transaction report values must be isolated.",
+				&"",
+				row_index,
+				previous_row_id
+			)
+			break
+		var next_row_id: Variant = _get_row_id_for_state(
+			row_index,
+			next_rows,
+			_row_id_column
+		)
+		if _reentrant_rebuild_attempted:
+			staging_failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table row identity callback attempted a recursive mutation."
+			)
+			break
+		var staged_report: Dictionary = _make_cell_commit_success(
+			row_index,
+			previous_row_id,
+			next_row_id,
+			column_id,
+			GFVariantData.get_option_value(old_value_report, "value"),
+			GFVariantData.get_option_value(committed_value_report, "value"),
+			changed
+		)
+		staged_report["index"] = GFVariantData.get_option_int(resolved_change, "index", -1)
+		if use_visible_rows:
+			staged_report["visible_row_index"] = GFVariantData.get_option_int(
+				resolved_change,
+				"visible_row_index",
+				-1
+			)
+		staged_reports.append(staged_report)
+		if changed:
+			changed_reports.append(staged_report)
 
+	var build_report: Dictionary = {}
+	if staging_failure == null and not changed_reports.is_empty():
+		build_report = _build_projection_under_guard(
+			next_rows,
+			_columns,
+			_columns_by_id,
+			_filter_query,
+			_sort_column_id,
+			_sort_ascending,
+			_row_predicates,
+			_row_id_column,
+			_case_sensitive_filter
+		)
+		if not GFVariantData.get_option_bool(build_report, "ok"):
+			staging_failure = _get_build_failure(build_report)
+		else:
+			var transition_report: Dictionary = _make_row_id_transitions_under_guard(
+				_rows,
+				next_rows,
+				_row_id_column,
+				_row_id_column
+			)
+			if GFVariantData.get_option_bool(transition_report, "ok"):
+				build_report["row_id_transitions"] = GFVariantData.get_option_array(
+					transition_report,
+					"transitions"
+				)
+			else:
+				staging_failure = _get_build_failure(transition_report)
+	_view_rebuild_in_progress = false
 
-func _commit_cell_value_internal(row_index: int, column_id: StringName, new_value: Variant) -> Dictionary:
-	if not _is_valid_row_index(row_index):
-		return _make_cell_commit_failure(row_index, column_id, &"invalid_row_index")
-	var column: GFTableColumnDefinition = get_column(column_id)
-	if column == null:
-		return _make_cell_commit_failure(row_index, column_id, &"unknown_column")
-	if not column.editable:
-		return _make_cell_commit_failure(row_index, column_id, &"column_not_editable")
+	if staging_failure != null:
+		var published_failure: GFTableViewRebuildResult = _publish_rebuild_failure(
+			staging_failure
+		)
+		return _make_commit_batch_result(changes.size(), [], [
+			_make_commit_error(
+				-1,
+				published_failure.get_error_code(),
+				published_failure.get_failed_source_row_index(),
+				&"",
+				{ "message": published_failure.get_error_message() }
+			),
+		])
 
-	var row_data: Variant = _rows[row_index]
-	var previous_row_id: Variant = get_row_id(row_index)
-	var old_value: Variant = column.read_value(row_data)
-	if old_value == new_value:
-		return _make_cell_commit_success(row_index, previous_row_id, previous_row_id, column_id, old_value, new_value, false)
-	if not column.write_value(row_data, new_value):
-		return _make_cell_commit_failure(row_index, column_id, &"write_failed")
+	if changed_reports.is_empty():
+		var _noop_result: GFTableViewRebuildResult = _publish_rebuild_success(false, 0, 0)
+		return _make_commit_batch_result(changes.size(), staged_reports, [])
 
-	var next_row_id: Variant = get_row_id(row_index)
-	_preserve_selection_after_row_id_change(previous_row_id, next_row_id)
-	return _make_cell_commit_success(row_index, previous_row_id, next_row_id, column_id, old_value, new_value, true)
+	var selected_ids_before: Array = _selection_model.get_selected_ids()
+	var anchor_before: Variant = _selection_model.anchor_row_id
+	var row_id_transitions: Array = GFVariantData.get_option_array(
+		build_report,
+		"row_id_transitions"
+	)
+	var mapped_selected_ids: Array = _map_selected_row_ids(
+		selected_ids_before,
+		row_id_transitions
+	)
+	var mapped_anchor: Variant = _map_row_id(anchor_before, row_id_transitions)
+	_state_publication_in_progress = true
+	_rows = next_rows
+	var _rebuild_result: GFTableViewRebuildResult = _commit_projection_state(build_report)
+	var _replace_selection_result: bool = _selection_model.replace_selection_with_anchor(
+		mapped_selected_ids,
+		mapped_anchor
+	)
+	view_changed.emit(_view_revision, _visible_row_indices.size())
+	for staged_report: Dictionary in changed_reports:
+		_emit_cell_value_committed(staged_report)
+	_state_publication_in_progress = false
+	return _make_commit_batch_result(changes.size(), staged_reports, [])
 
 
 func _emit_cell_value_committed(report: Dictionary) -> void:
@@ -977,16 +1887,6 @@ func _make_cell_commit_success(
 	}
 
 
-func _make_cell_commit_failure(row_index: int, column_id: StringName, reason: StringName) -> Dictionary:
-	return {
-		"ok": false,
-		"row_index": row_index,
-		"column_id": column_id,
-		"reason": reason,
-		"message": String(reason),
-	}
-
-
 func _make_commit_error(
 	change_index: int,
 	reason: StringName,
@@ -1006,6 +1906,30 @@ func _make_commit_error(
 	return error
 
 
+func _map_selected_row_ids(selected_ids: Array, reports: Array[Dictionary]) -> Array:
+	var mapped_ids: Array = []
+	for selected_id: Variant in selected_ids:
+		var mapped_id: Variant = _map_row_id(selected_id, reports)
+		if not _variant_array_has(mapped_ids, mapped_id):
+			mapped_ids.append(mapped_id)
+	return mapped_ids
+
+
+func _map_row_id(row_id: Variant, reports: Array[Dictionary]) -> Variant:
+	for report: Dictionary in reports:
+		var previous_row_id: Variant = GFVariantData.get_option_value(report, "row_id")
+		if GFVariantData.values_equal(row_id, previous_row_id):
+			return GFVariantData.get_option_value(report, "next_row_id")
+	return row_id
+
+
+func _variant_array_has(values: Array, expected: Variant) -> bool:
+	for value: Variant in values:
+		if GFVariantData.values_equal(value, expected):
+			return true
+	return false
+
+
 func _has_option_key(options: Dictionary, key: Variant) -> bool:
 	if options.has(key):
 		return true
@@ -1018,43 +1942,676 @@ func _has_option_key(options: Dictionary, key: Variant) -> bool:
 	return false
 
 
-func _rebuild_visible_row_indices() -> void:
-	_visible_row_indices.clear()
-	for row_index: int in range(_rows.size()):
-		if _row_matches_filter(row_index):
-			_visible_row_indices.append(row_index)
-	if _sort_column_id != &"":
-		_visible_row_indices.sort_custom(_compare_visible_row_indices)
+func _reject_reentrant_rebuild_request() -> GFTableViewRebuildResult:
+	if not _view_rebuild_in_progress and not _state_publication_in_progress:
+		return null
+	if _view_rebuild_in_progress:
+		_reentrant_rebuild_attempted = true
+	return _make_rebuild_failure(
+		&"reentrant_rebuild",
+		"Table view mutation cannot be entered recursively."
+	)
 
 
-func _row_matches_filter(row_index: int) -> bool:
-	if _filter_query.is_empty():
-		return true
-	var row_data: Variant = _rows[row_index]
-	for column: GFTableColumnDefinition in _columns:
-		if column == null or not column.visible:
+func _try_build_projection(
+	rows: Array,
+	columns: Array[GFTableColumnDefinition],
+	columns_by_id: Dictionary,
+	filter_query: String,
+	sort_column_id: StringName,
+	sort_ascending: bool,
+	registrations: Array[GFTableRowPredicateRegistration],
+	row_id_column_key: StringName,
+	filter_case_sensitive: bool,
+	include_row_id_transitions: bool = false,
+	previous_row_id_column_key: StringName = &""
+) -> Dictionary:
+	if _view_rebuild_in_progress or _state_publication_in_progress:
+		_reentrant_rebuild_attempted = true
+		return {
+			"ok": false,
+			"failure": _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table view rebuild cannot be entered recursively."
+			),
+		}
+
+	_view_rebuild_in_progress = true
+	_reentrant_rebuild_attempted = false
+	var build_report: Dictionary = _build_projection_under_guard(
+		rows,
+		columns,
+		columns_by_id,
+		filter_query,
+		sort_column_id,
+		sort_ascending,
+		registrations,
+		row_id_column_key,
+		filter_case_sensitive
+	)
+	if GFVariantData.get_option_bool(build_report, "ok") and include_row_id_transitions:
+		var transition_report: Dictionary = _make_row_id_transitions_under_guard(
+			rows,
+			rows,
+			previous_row_id_column_key,
+			row_id_column_key
+		)
+		if GFVariantData.get_option_bool(transition_report, "ok"):
+			build_report["row_id_transitions"] = GFVariantData.get_option_array(
+				transition_report,
+				"transitions"
+			)
+		else:
+			build_report = transition_report
+	_view_rebuild_in_progress = false
+	return build_report
+
+
+func _build_projection_under_guard(
+	rows: Array,
+	columns: Array[GFTableColumnDefinition],
+	columns_by_id: Dictionary,
+	filter_query: String,
+	sort_column_id: StringName,
+	sort_ascending: bool,
+	registrations: Array[GFTableRowPredicateRegistration],
+	row_id_column_key: StringName,
+	filter_case_sensitive: bool
+) -> Dictionary:
+	var candidate_indices: Array[int] = []
+	var scanned_row_count: int = 0
+	var predicate_evaluation_count: int = 0
+	var failure: GFTableViewRebuildResult = null
+
+	for row_index: int in range(rows.size()):
+		scanned_row_count += 1
+		var matches_filter: bool = _row_matches_filter_for_state(
+			row_index,
+			rows,
+			columns,
+			filter_query,
+			filter_case_sensitive
+		)
+		if _reentrant_rebuild_attempted:
+			failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table view callback attempted a recursive rebuild.",
+				&"",
+				row_index,
+				null,
+				scanned_row_count,
+				predicate_evaluation_count
+			)
+			break
+		if not matches_filter:
 			continue
-		if column.matches_query(row_data, _filter_query, case_sensitive_filter):
+
+		var should_include_row: bool = true
+		var canonical_row_view: GFTableRowView = null
+		var canonical_row_id: Variant = null
+		for registration: GFTableRowPredicateRegistration in registrations:
+			if not registration.is_enabled():
+				continue
+			if canonical_row_view == null:
+				var row_view_report: Dictionary = _make_predicate_row_view(
+					row_index,
+					rows,
+					columns,
+					row_id_column_key
+				)
+				if not GFVariantData.get_option_bool(row_view_report, "ok"):
+					failure = _make_rebuild_failure(
+						GFVariantData.get_option_string_name(
+							row_view_report,
+							"error_code",
+							&"invalid_row_view_snapshot"
+						),
+						GFVariantData.get_option_string(
+							row_view_report,
+							"error_message",
+							"Table row view snapshot is invalid."
+						),
+						registration.get_predicate_id(),
+						row_index,
+						GFVariantData.get_option_value(row_view_report, "row_id"),
+						scanned_row_count,
+						predicate_evaluation_count
+					)
+					break
+				canonical_row_id = GFVariantData.get_option_value(row_view_report, "row_id")
+				var row_view_value: Variant = GFVariantData.get_option_value(
+					row_view_report,
+					"row_view"
+				)
+				if row_view_value is GFTableRowView:
+					canonical_row_view = row_view_value
+				else:
+					failure = _make_rebuild_failure(
+						&"invalid_row_view_snapshot",
+						"Table row view builder returned an invalid snapshot.",
+						registration.get_predicate_id(),
+						row_index,
+						canonical_row_id,
+						scanned_row_count,
+						predicate_evaluation_count
+					)
+					break
+			if failure != null:
+				break
+			var callback_row_view: GFTableRowView = GFTableRowView.snapshot_for_framework(
+				canonical_row_view
+			)
+			if callback_row_view == null:
+				failure = _make_rebuild_failure(
+					&"invalid_row_view_snapshot",
+					"Table row view callback snapshot could not be isolated.",
+					registration.get_predicate_id(),
+					row_index,
+					canonical_row_id,
+					scanned_row_count,
+					predicate_evaluation_count
+				)
+				break
+			var predicate: GFTableRowPredicate = registration.get_predicate()
+			var predicate_result: GFTableRowPredicateResult = (
+				GFTableRowPredicate.evaluate_for_framework(predicate, callback_row_view)
+			)
+			predicate_evaluation_count += 1
+			if _reentrant_rebuild_attempted:
+				failure = _make_rebuild_failure(
+					&"reentrant_rebuild",
+					"Table row predicate attempted a recursive rebuild.",
+					registration.get_predicate_id(),
+					row_index,
+					canonical_row_id,
+					scanned_row_count,
+					predicate_evaluation_count
+				)
+				break
+			if predicate_result == null:
+				failure = _make_rebuild_failure(
+					&"invalid_predicate_result",
+					"Table row predicate returned a null result.",
+					registration.get_predicate_id(),
+					row_index,
+					canonical_row_id,
+					scanned_row_count,
+					predicate_evaluation_count
+				)
+				break
+			if not predicate_result.is_successful():
+				failure = _make_rebuild_failure(
+					predicate_result.get_error_code(),
+					predicate_result.get_error_message(),
+					registration.get_predicate_id(),
+					row_index,
+					canonical_row_id,
+					scanned_row_count,
+					predicate_evaluation_count
+				)
+				break
+			if not predicate_result.should_include():
+				should_include_row = false
+				break
+		if failure != null:
+			break
+		if should_include_row:
+			candidate_indices.append(row_index)
+
+	if failure == null and sort_column_id != &"":
+		var comparator: Callable = Callable(self, &"_compare_projection_row_indices").bind(
+			rows,
+			columns_by_id,
+			sort_column_id,
+			sort_ascending
+		)
+		candidate_indices.sort_custom(comparator)
+		if _reentrant_rebuild_attempted:
+			failure = _make_rebuild_failure(
+				&"reentrant_rebuild",
+				"Table sort callback attempted a recursive rebuild.",
+				&"",
+				-1,
+				null,
+				scanned_row_count,
+				predicate_evaluation_count
+			)
+
+	if failure != null:
+		return { "ok": false, "failure": failure }
+	return {
+		"ok": true,
+		"indices": candidate_indices,
+		"scanned_row_count": scanned_row_count,
+		"predicate_evaluation_count": predicate_evaluation_count,
+	}
+
+
+func _row_matches_filter_for_state(
+	row_index: int,
+	rows: Array,
+	columns: Array[GFTableColumnDefinition],
+	filter_query: String,
+	filter_case_sensitive: bool
+) -> bool:
+	if filter_query.is_empty():
+		return true
+	var row_data: Variant = rows[row_index]
+	for column: GFTableColumnDefinition in columns:
+		if column == null or not column.visible or not column.filterable:
+			continue
+		var column_value: Variant = column.read_value(row_data)
+		if _reentrant_rebuild_attempted:
+			return false
+		var value_text: String = column.format_value(column_value, row_data)
+		if _reentrant_rebuild_attempted:
+			return false
+		var normalized_query: String = filter_query
+		if not filter_case_sensitive:
+			value_text = value_text.to_lower()
+			normalized_query = normalized_query.to_lower()
+		if value_text.find(normalized_query) >= 0:
 			return true
 	return false
 
 
-func _compare_visible_row_indices(left_index: int, right_index: int) -> bool:
-	var column: GFTableColumnDefinition = get_column(_sort_column_id)
-	if column == null:
-		return left_index < right_index
+func _make_predicate_row_view(
+	row_index: int,
+	rows: Array,
+	columns: Array[GFTableColumnDefinition],
+	row_id_column_key: StringName
+) -> Dictionary:
+	var row_data: Variant = rows[row_index]
+	var row_id: Variant = _get_row_id_for_state(row_index, rows, row_id_column_key)
+	if _reentrant_rebuild_attempted:
+		return _make_row_view_failure(
+			&"reentrant_rebuild",
+			"Table row identity callback attempted a recursive mutation.",
+			row_id
+		)
+	if not GFVariantKeyCodec.is_stable_key(row_id):
+		return _make_row_view_failure(
+			&"invalid_row_id",
+			"Table row predicates require a stable row id accepted by GFVariantKeyCodec.",
+			null
+		)
+	var values: Dictionary = {}
+	for column: GFTableColumnDefinition in columns:
+		if column == null or column.column_id == &"":
+			continue
+		var column_value: Variant = column.read_value(row_data)
+		if _reentrant_rebuild_attempted:
+			return _make_row_view_failure(
+				&"reentrant_rebuild",
+				"Table column getter attempted a recursive mutation.",
+				row_id
+			)
+		values[column.column_id] = column_value
+	var row_view: GFTableRowView = GFTableRowView.new()
+	var configured: bool = row_view.configure_for_framework(
+		row_index,
+		row_id,
+		values
+	)
+	if _reentrant_rebuild_attempted:
+		return _make_row_view_failure(
+			&"reentrant_rebuild",
+			"Table row snapshot callback attempted a recursive mutation.",
+			row_id
+		)
+	if not configured:
+		return _make_row_view_failure(
+			&"invalid_row_view_snapshot",
+			"Table row view contains an unsafe, circular, or over-budget value.",
+			row_id
+		)
+	return {
+		"ok": true,
+		"row_view": row_view,
+		"row_id": row_id,
+		"error_code": &"",
+		"error_message": "",
+	}
 
-	var left_row: Variant = _rows[left_index]
-	var right_row: Variant = _rows[right_index]
+
+func _make_row_view_failure(
+	error_code: StringName,
+	error_message: String,
+	row_id: Variant
+) -> Dictionary:
+	return {
+		"ok": false,
+		"row_view": null,
+		"row_id": row_id,
+		"error_code": error_code,
+		"error_message": error_message,
+	}
+
+
+func _make_row_id_transitions_under_guard(
+	previous_rows: Array,
+	next_rows: Array,
+	previous_row_id_column_key: StringName,
+	next_row_id_column_key: StringName
+) -> Dictionary:
+	if previous_rows.size() != next_rows.size():
+		return {
+			"ok": false,
+			"failure": _make_rebuild_failure(
+				&"invalid_row_id_transition_state",
+				"Table row identity transitions require equal source row counts."
+			),
+		}
+	var transitions: Array[Dictionary] = []
+	for row_index: int in range(previous_rows.size()):
+		var previous_row_id: Variant = _get_row_id_for_state(
+			row_index,
+			previous_rows,
+			previous_row_id_column_key
+		)
+		if _reentrant_rebuild_attempted:
+			return {
+				"ok": false,
+				"failure": _make_rebuild_failure(
+					&"reentrant_rebuild",
+					"Table row identity callback attempted a recursive mutation.",
+					&"",
+					row_index,
+					previous_row_id
+				),
+			}
+		var next_row_id: Variant = _get_row_id_for_state(
+			row_index,
+			next_rows,
+			next_row_id_column_key
+		)
+		if _reentrant_rebuild_attempted:
+			return {
+				"ok": false,
+				"failure": _make_rebuild_failure(
+					&"reentrant_rebuild",
+					"Table row identity callback attempted a recursive mutation.",
+					&"",
+					row_index,
+					previous_row_id
+				),
+			}
+		transitions.append({
+			"row_index": row_index,
+			"row_id": previous_row_id,
+			"next_row_id": next_row_id,
+		})
+	return { "ok": true, "transitions": transitions }
+
+
+func _get_row_id_for_state(
+	row_index: int,
+	rows: Array,
+	row_id_column_key: StringName
+) -> Variant:
+	if row_index < 0 or row_index >= rows.size():
+		return null
+	if row_id_column_key == &"":
+		return row_index
+	var row_id: Variant = _read_row_property(rows[row_index], row_id_column_key)
+	return row_index if row_id == null else row_id
+
+
+func _compare_projection_row_indices(
+	left_index: int,
+	right_index: int,
+	rows: Array,
+	columns_by_id: Dictionary,
+	sort_column_id: StringName,
+	sort_ascending: bool
+) -> bool:
+	var column_value: Variant = GFVariantData.get_option_value(columns_by_id, sort_column_id)
+	if not column_value is GFTableColumnDefinition:
+		return left_index < right_index
+	var column: GFTableColumnDefinition = column_value
+	var left_row: Variant = rows[left_index]
+	var right_row: Variant = rows[right_index]
+	var left_value: Variant = column.read_value(left_row)
+	if _reentrant_rebuild_attempted:
+		return left_index < right_index
+	var right_value: Variant = column.read_value(right_row)
+	if _reentrant_rebuild_attempted:
+		return left_index < right_index
 	var compare_result: int = column.compare_values(
-		column.read_value(left_row),
-		column.read_value(right_row),
+		left_value,
+		right_value,
 		left_row,
 		right_row
 	)
+	if _reentrant_rebuild_attempted:
+		return left_index < right_index
 	if compare_result == 0:
 		return left_index < right_index
-	return compare_result < 0 if _sort_ascending else compare_result > 0
+	return compare_result < 0 if sort_ascending else compare_result > 0
+
+
+func _validate_row_predicate_registrations(
+	registrations: Array[GFTableRowPredicateRegistration]
+) -> GFTableViewRebuildResult:
+	if registrations.size() > MAX_ROW_PREDICATE_COUNT:
+		return _make_rebuild_failure(
+			&"predicate_limit_exceeded",
+			"Table row predicate registration count exceeds the bounded limit."
+		)
+	var predicate_ids: Dictionary = {}
+	for registration: GFTableRowPredicateRegistration in registrations:
+		if registration == null:
+			return _make_rebuild_failure(
+				&"invalid_predicate_registration",
+				"Table row predicate registration cannot be null."
+			)
+		var validation_report: Dictionary = registration.validate_registration()
+		if not GFVariantData.get_option_bool(validation_report, "ok"):
+			var issues: Array = GFVariantData.get_option_array(validation_report, "issues")
+			var issue: Dictionary = GFVariantData.as_dictionary(issues[0]) if not issues.is_empty() else {}
+			return _make_rebuild_failure(
+				GFVariantData.get_option_string_name(issue, "kind", &"invalid_predicate_registration"),
+				GFVariantData.get_option_string(
+					issue,
+					"message",
+					"Table row predicate registration is invalid."
+				),
+				registration.get_predicate_id()
+			)
+		var predicate_id: StringName = registration.get_predicate_id()
+		if predicate_ids.has(predicate_id):
+			return _make_rebuild_failure(
+				&"duplicate_predicate_id",
+				"Table row predicate ids must be unique.",
+				predicate_id
+			)
+		predicate_ids[predicate_id] = true
+	return null
+
+
+func _compare_row_predicate_registrations(
+	left: GFTableRowPredicateRegistration,
+	right: GFTableRowPredicateRegistration
+) -> bool:
+	if left.get_order() != right.get_order():
+		return left.get_order() < right.get_order()
+	return String(left.get_predicate_id()) < String(right.get_predicate_id())
+
+
+func _row_predicate_registrations_equal(
+	left: Array[GFTableRowPredicateRegistration],
+	right: Array[GFTableRowPredicateRegistration]
+) -> bool:
+	if left.size() != right.size():
+		return false
+	for index: int in range(left.size()):
+		var left_registration: GFTableRowPredicateRegistration = left[index]
+		var right_registration: GFTableRowPredicateRegistration = right[index]
+		if left_registration.get_predicate_id() != right_registration.get_predicate_id():
+			return false
+		if left_registration.get_predicate() != right_registration.get_predicate():
+			return false
+		if left_registration.get_order() != right_registration.get_order():
+			return false
+		if left_registration.is_enabled() != right_registration.is_enabled():
+			return false
+	return true
+
+
+func _snapshot_row_predicate_registrations(
+	registrations: Array[GFTableRowPredicateRegistration]
+) -> Array[GFTableRowPredicateRegistration]:
+	var snapshots: Array[GFTableRowPredicateRegistration] = []
+	for registration: GFTableRowPredicateRegistration in registrations:
+		if registration == null:
+			snapshots.append(null)
+		else:
+			snapshots.append(_snapshot_row_predicate_registration(registration))
+	return snapshots
+
+
+func _snapshot_row_predicate_registration(
+	registration: GFTableRowPredicateRegistration
+) -> GFTableRowPredicateRegistration:
+	return GFTableRowPredicateRegistration.snapshot_for_framework(
+		registration
+	)
+
+
+func _make_row_predicate_lookup(
+	registrations: Array[GFTableRowPredicateRegistration]
+) -> Dictionary:
+	var lookup: Dictionary = {}
+	for registration: GFTableRowPredicateRegistration in registrations:
+		lookup[registration.get_predicate_id()] = registration
+	return lookup
+
+
+func _replace_row_predicate_registration(
+	replacement: GFTableRowPredicateRegistration
+) -> GFTableViewRebuildResult:
+	var next_predicates: Array[GFTableRowPredicateRegistration] = []
+	for registration: GFTableRowPredicateRegistration in _row_predicates:
+		if registration.get_predicate_id() == replacement.get_predicate_id():
+			next_predicates.append(replacement)
+		else:
+			next_predicates.append(registration)
+	return set_row_predicates(next_predicates)
+
+
+func _get_build_failure(build_report: Dictionary) -> GFTableViewRebuildResult:
+	var failure_value: Variant = GFVariantData.get_option_value(build_report, "failure")
+	if failure_value is GFTableViewRebuildResult:
+		var failure: GFTableViewRebuildResult = failure_value
+		return failure
+	return _make_rebuild_failure(
+		&"invalid_rebuild_report",
+		"Table view candidate builder returned an invalid failure report."
+	)
+
+
+func _get_build_indices(build_report: Dictionary) -> Array[int]:
+	var indices: Array[int] = []
+	for index_value: Variant in GFVariantData.get_option_array(build_report, "indices"):
+		if index_value is int:
+			var row_index: int = index_value
+			indices.append(row_index)
+	return indices
+
+
+func _commit_projection_state(build_report: Dictionary) -> GFTableViewRebuildResult:
+	_visible_row_indices = _get_build_indices(build_report)
+	_view_revision += 1
+	var scanned_row_count: int = GFVariantData.get_option_int(
+		build_report,
+		"scanned_row_count"
+	)
+	var predicate_evaluation_count: int = GFVariantData.get_option_int(
+		build_report,
+		"predicate_evaluation_count"
+	)
+	var result: GFTableViewRebuildResult = _make_rebuild_success(
+		true,
+		scanned_row_count,
+		predicate_evaluation_count
+	)
+	_last_view_rebuild_result = result.duplicate_result()
+	return result
+
+
+func _publish_rebuild_success(
+	committed: bool,
+	scanned_row_count: int,
+	predicate_evaluation_count: int
+) -> GFTableViewRebuildResult:
+	if _view_rebuild_in_progress or _state_publication_in_progress:
+		_reentrant_rebuild_attempted = true
+		return _make_rebuild_failure(
+			&"reentrant_rebuild",
+			"Table view rebuild cannot be entered recursively."
+		)
+	var result: GFTableViewRebuildResult = _make_rebuild_success(
+		committed,
+		scanned_row_count,
+		predicate_evaluation_count
+	)
+	_last_view_rebuild_result = result.duplicate_result()
+	return result
+
+
+func _publish_rebuild_failure(
+	result: GFTableViewRebuildResult
+) -> GFTableViewRebuildResult:
+	if _view_rebuild_in_progress:
+		_reentrant_rebuild_attempted = true
+		return result
+	if _state_publication_in_progress:
+		return result
+	_state_publication_in_progress = true
+	_last_view_rebuild_result = result.duplicate_result()
+	view_rebuild_failed.emit(result.duplicate_result())
+	_state_publication_in_progress = false
+	return result
+
+
+func _make_rebuild_success(
+	committed: bool,
+	scanned_row_count: int,
+	predicate_evaluation_count: int
+) -> GFTableViewRebuildResult:
+	var result: GFTableViewRebuildResult = GFTableViewRebuildResult.new()
+	var _configured: bool = result.configure_success_for_framework(
+		committed,
+		_view_revision,
+		_visible_row_indices.size(),
+		scanned_row_count,
+		predicate_evaluation_count
+	)
+	return result
+
+
+func _make_rebuild_failure(
+	error_code: StringName,
+	error_message: String,
+	failed_predicate_id: StringName = &"",
+	failed_source_row_index: int = -1,
+	failed_row_id: Variant = null,
+	scanned_row_count: int = 0,
+	predicate_evaluation_count: int = 0
+) -> GFTableViewRebuildResult:
+	var result: GFTableViewRebuildResult = GFTableViewRebuildResult.new()
+	var _configured: bool = result.configure_failure_for_framework(
+		error_code,
+		error_message,
+		_view_revision,
+		_visible_row_indices.size(),
+		scanned_row_count,
+		predicate_evaluation_count,
+		failed_predicate_id,
+		failed_source_row_index,
+		failed_row_id
+	)
+	return result
 
 
 func _read_row_property(row_data: Variant, property_key: StringName) -> Variant:
@@ -1070,15 +2627,6 @@ func _read_row_property(row_data: Variant, property_key: StringName) -> Variant:
 				if property_name == property_key:
 					return object_ref.get(property_key)
 	return null
-
-
-func _preserve_selection_after_row_id_change(previous_row_id: Variant, next_row_id: Variant) -> void:
-	if selection_model == null or previous_row_id == next_row_id:
-		return
-	if not selection_model.is_selected(previous_row_id):
-		return
-	var _deselect_result: bool = selection_model.set_selected(previous_row_id, false)
-	var _select_result: bool = selection_model.set_selected(next_row_id, true)
 
 
 func _is_valid_row_index(row_index: int) -> bool:

--- a/addons/gf/standard/utilities/ui/gf_table_row_predicate.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_row_predicate.gd
@@ -1,0 +1,79 @@
+## GFTableRowPredicate: 表格结构化行过滤协议。
+##
+## 项目通过子类实现同步、只读、有界且无副作用的行判断。
+## GFTableDataView 按注册顺序契约组合多个谓词，并把显式失败视为整次投影失败。
+## [br]
+## @api public
+## [br]
+## @category protocol
+## [br]
+## @since unreleased
+class_name GFTableRowPredicate
+extends RefCounted
+
+
+# --- 公共方法 ---
+
+## 求值一个隔离行视图。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param row_view: 不暴露源 row 的隔离只读视图。
+## [br]
+## @return 类型化包含、排除或失败结果。
+func evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+	return evaluate_for_framework(self, row_view)
+
+
+# --- 可重写钩子 / 虚方法 ---
+
+## 实现一次同步、只读且有界的行判断。
+## [br]
+## @api protected
+## [br]
+## @since unreleased
+## [br]
+## @param _row_view: 当前行的隔离只读视图。
+## [br]
+## @return 类型化包含、排除或失败结果。
+func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+	return GFTableRowPredicateResult.failed(
+		&"predicate_not_implemented",
+		"Row predicate did not implement _evaluate()."
+	)
+
+
+# --- 框架内部方法 ---
+
+## 通过唯一受支持扩展点执行谓词，并把结果归一为纯框架值。
+##
+## 静态入口不会调用候选子类可覆写的 public evaluate() 或结果 getter；
+## 只有 `_evaluate()` 会进入项目代码。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param predicate: 待执行的类型化谓词。
+## [br]
+## @param row_view: 本次调用独占的隔离行视图。
+## [br]
+## @return 纯 GFTableRowPredicateResult。
+static func evaluate_for_framework(
+	predicate: GFTableRowPredicate,
+	row_view: GFTableRowView
+) -> GFTableRowPredicateResult:
+	if predicate == null or not is_instance_valid(predicate):
+		return GFTableRowPredicateResult.failed(
+			&"invalid_predicate",
+			"Row predicate instance is unavailable."
+		)
+	if row_view == null or not is_instance_valid(row_view):
+		return GFTableRowPredicateResult.failed(
+			&"invalid_row_view",
+			"Row predicate received a null or unavailable row view."
+		)
+	var raw_result: GFTableRowPredicateResult = predicate._evaluate(row_view)
+	return GFTableRowPredicateResult.snapshot_for_framework(raw_result)

--- a/addons/gf/standard/utilities/ui/gf_table_row_predicate.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_table_row_predicate.gd.uid
@@ -1,0 +1,1 @@
+uid://c3nfinmwmf53x

--- a/addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd
@@ -1,0 +1,162 @@
+## GFTableRowPredicateRegistration: 命名行谓词的注册定义值。
+##
+## 把项目谓词与稳定 ID、启用状态和显式顺序组合成一次注册定义。
+## GFTableDataView 会复制数组并以 order 升序、predicate_id 字典序稳定执行。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFTableRowPredicateRegistration
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _MAX_PREDICATE_ID_UTF8_BYTES: int = 128
+
+
+# --- 私有变量 ---
+
+var _predicate_id: StringName = &""
+var _predicate: GFTableRowPredicate = null
+var _order: int = 0
+var _enabled: bool = true
+
+
+# --- 公共方法 ---
+
+## 创建注册定义值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param predicate_id: 非空、无首尾空白且 UTF-8 编码不超过 128 字节的稳定 ID。
+## [br]
+## @param predicate: 项目提供的类型化行谓词。
+## [br]
+## @param order: 执行顺序；数值越小越早执行。
+## [br]
+## @param enabled: 是否参与投影。
+## [br]
+## @return 新的注册值；调用方仍应检查 validate_registration()。
+static func create(
+	predicate_id: StringName,
+	predicate: GFTableRowPredicate,
+	order: int = 0,
+	enabled: bool = true
+) -> GFTableRowPredicateRegistration:
+	var registration: GFTableRowPredicateRegistration = GFTableRowPredicateRegistration.new()
+	registration._predicate_id = predicate_id
+	registration._predicate = predicate
+	registration._order = order
+	registration._enabled = enabled
+	return registration
+
+
+## 从候选注册的基类存储创建纯框架快照，不调用候选可覆写方法。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param registration: 待隔离的注册值。
+## [br]
+## @return 纯 GFTableRowPredicateRegistration；输入为空时返回 null。
+static func snapshot_for_framework(
+	registration: GFTableRowPredicateRegistration
+) -> GFTableRowPredicateRegistration:
+	if registration == null or not is_instance_valid(registration):
+		return null
+	return create(
+		registration._predicate_id,
+		registration._predicate,
+		registration._order,
+		registration._enabled
+	)
+
+
+## 获取稳定谓词 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 稳定谓词 ID。
+func get_predicate_id() -> StringName:
+	return _predicate_id
+
+
+## 获取类型化谓词。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 注册的谓词。
+func get_predicate() -> GFTableRowPredicate:
+	return _predicate
+
+
+## 获取显式执行顺序。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return order；数值越小越早执行。
+func get_order() -> int:
+	return _order
+
+
+## 查询注册是否启用。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 启用时返回 true。
+func is_enabled() -> bool:
+	return _enabled
+
+
+## 校验注册定义。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return GFValidationReportDictionary 兼容报告。
+## [br]
+## @schema return: Dictionary with ok, issues, counts, summary, and next_actions.
+func validate_registration() -> Dictionary:
+	var report: Dictionary = { "issues": [] }
+	var predicate_id_text: String = String(_predicate_id)
+	if (
+		predicate_id_text.is_empty()
+		or predicate_id_text != predicate_id_text.strip_edges()
+		or predicate_id_text.length() > _MAX_PREDICATE_ID_UTF8_BYTES
+		or predicate_id_text.to_utf8_buffer().size() > _MAX_PREDICATE_ID_UTF8_BYTES
+	):
+		var _id_issue: Variant = GFValidationReportDictionary.append_issue(
+			report,
+			"error",
+			&"invalid_predicate_id",
+			"Table row predicate id must be non-empty, trimmed, and at most 128 UTF-8 bytes.",
+			{ "path": "predicate_id" }
+		)
+	if _predicate == null or not is_instance_valid(_predicate):
+		var _predicate_issue: Variant = GFValidationReportDictionary.append_issue(
+			report,
+			"error",
+			&"invalid_predicate",
+			"Table row predicate registration requires a predicate instance.",
+			{ "path": "predicate" }
+		)
+	return GFValidationReportDictionary.finalize_report(report, "Table row predicate registration", {
+		"include_issue_count": true,
+		"fallback_action": "Review the first table row predicate registration issue.",
+		"no_action": "Table row predicate registration is valid.",
+	})

--- a/addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd.uid
@@ -1,0 +1,1 @@
+uid://b3opnq8nf6ocr

--- a/addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd
@@ -1,0 +1,192 @@
+## GFTableRowPredicateResult: 类型化行谓词求值结果。
+##
+## 成功结果明确表示包含或排除当前行；失败结果携带稳定错误码和有界说明，
+## 供 GFTableDataView 中止候选投影并保留上一份已提交视图。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFTableRowPredicateResult
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _MAX_ERROR_CODE_UTF8_BYTES: int = 128
+const _MAX_ERROR_MESSAGE_UTF8_BYTES: int = 1_024
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _successful: bool = false
+var _should_include: bool = false
+var _error_code: StringName = &""
+var _error_message: String = ""
+
+
+# --- 公共方法 ---
+
+## 创建包含当前行的成功结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新的包含结果。
+static func included() -> GFTableRowPredicateResult:
+	var result: GFTableRowPredicateResult = GFTableRowPredicateResult.new()
+	result._configured = true
+	result._successful = true
+	result._should_include = true
+	return result
+
+
+## 创建排除当前行的成功结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新的排除结果。
+static func excluded() -> GFTableRowPredicateResult:
+	var result: GFTableRowPredicateResult = GFTableRowPredicateResult.new()
+	result._configured = true
+	result._successful = true
+	result._should_include = false
+	return result
+
+
+## 创建求值失败结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param error_code: 非空、无首尾空白且 UTF-8 编码不超过 128 字节的稳定错误码。
+## [br]
+## @param error_message: 面向维护者的失败说明；最多保留 1024 个 UTF-8 字节。
+## [br]
+## @return 新的失败结果。
+static func failed(
+	error_code: StringName,
+	error_message: String = ""
+) -> GFTableRowPredicateResult:
+	var result: GFTableRowPredicateResult = GFTableRowPredicateResult.new()
+	result._configured = true
+	result._successful = false
+	result._error_code = _normalize_error_code(error_code)
+	result._error_message = _truncate_utf8(error_message, _MAX_ERROR_MESSAGE_UTF8_BYTES)
+	return result
+
+
+## 从候选结果的基类存储创建纯框架归一化快照，不调用候选可覆写方法。
+## [br]
+## 未配置、为空或失效的候选会归一为 invalid_predicate_result 失败。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param source: 项目谓词返回的候选结果。
+## [br]
+## @return 由 included()、excluded() 或 failed() 创建的纯基类结果。
+static func snapshot_for_framework(
+	source: GFTableRowPredicateResult
+) -> GFTableRowPredicateResult:
+	if source == null or not is_instance_valid(source) or not source._configured:
+		return failed(
+			&"invalid_predicate_result",
+			"Row predicate returned an uninitialized typed result."
+		)
+	if source._successful:
+		return included() if source._should_include else excluded()
+	return failed(source._error_code, source._error_message)
+
+
+## 查询求值是否成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时返回 true。
+func is_successful() -> bool:
+	return _successful
+
+
+## 查询成功结果是否包含当前行。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功且应包含当前行时返回 true。
+func should_include() -> bool:
+	return _successful and _should_include
+
+
+## 获取稳定错误码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败错误码；成功时为空。
+func get_error_code() -> StringName:
+	return _error_code
+
+
+## 获取有界错误说明。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败说明；成功时为空。
+func get_error_message() -> String:
+	return _error_message
+
+
+# --- 框架内部方法 ---
+
+## 查询结果是否由类型化工厂完整构建。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @return included()、excluded() 或 failed() 已完成配置时返回 true。
+func is_configured_for_framework() -> bool:
+	return _configured
+
+
+# --- 私有/辅助方法 ---
+
+static func _normalize_error_code(error_code: StringName) -> StringName:
+	var error_text: String = String(error_code)
+	if (
+		error_text.is_empty()
+		or error_text != error_text.strip_edges()
+		or error_text.length() > _MAX_ERROR_CODE_UTF8_BYTES
+		or error_text.to_utf8_buffer().size() > _MAX_ERROR_CODE_UTF8_BYTES
+	):
+		return &"predicate_failed"
+	return error_code
+
+
+static func _truncate_utf8(text_value: String, max_bytes: int) -> String:
+	var bounded_text: String = text_value.left(max_bytes)
+	if text_value.length() <= max_bytes and bounded_text.to_utf8_buffer().size() <= max_bytes:
+		return text_value
+	var low: int = 0
+	var high: int = bounded_text.length()
+	while low < high:
+		var middle: int = floori(float(low + high + 1) / 2.0)
+		if bounded_text.left(middle).to_utf8_buffer().size() <= max_bytes:
+			low = middle
+		else:
+			high = middle - 1
+	return bounded_text.left(low)

--- a/addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd.uid
@@ -1,0 +1,1 @@
+uid://dla877s87gde2

--- a/addons/gf/standard/utilities/ui/gf_table_row_view.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_row_view.gd
@@ -1,0 +1,705 @@
+## GFTableRowView: 表格行谓词使用的隔离只读视图。
+##
+## 只公开稳定行 ID、源索引和已配置列的复制值，不公开源行容器。
+## 项目谓词可以读取隐藏列，但不能通过该视图修改权威表格数据。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFTableRowView
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _MAX_SNAPSHOT_DEPTH: int = 64
+const _MAX_SNAPSHOT_NODE_COUNT: int = 16_384
+const _MAX_SNAPSHOT_COLLECTION_ITEM_COUNT: int = 65_536
+const _MAX_SNAPSHOT_UTF8_BYTES: int = 1_048_576
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _source_row_index: int = -1
+var _row_id: Variant = null
+var _values: Dictionary = {}
+
+
+# --- 公共方法 ---
+
+## 获取稳定行 ID 副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 稳定行 ID 副本。
+## [br]
+## @schema return: Variant stable row identity copy.
+func get_row_id() -> Variant:
+	return _get_isolated_copy(_row_id)
+
+
+## 获取源行索引。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 构建该视图时的源行索引。
+func get_source_row_index() -> int:
+	return _source_row_index
+
+
+## 判断是否包含指定列值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param column_id: 稳定列 ID。
+## [br]
+## @return 存在列值时返回 true。
+func has_value(column_id: StringName) -> bool:
+	return _values.has(column_id) or _values.has(String(column_id))
+
+
+## 获取指定列的隔离值副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param column_id: 稳定列 ID。
+## [br]
+## @param default_value: 列不存在时返回的默认值。
+## [br]
+## @schema default_value: Variant fallback copied before return.
+## [br]
+## @return 列值或默认值的副本。
+## [br]
+## @schema return: Variant isolated column value copy.
+func get_value(column_id: StringName, default_value: Variant = null) -> Variant:
+	return _get_isolated_copy(GFVariantData.get_option_value(_values, column_id, default_value))
+
+
+## 获取全部列值副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 以列 ID 为键的隔离值副本。
+## [br]
+## @schema return: Dictionary keyed by StringName column IDs with copied Variant values.
+func get_values() -> Dictionary:
+	var copied_value: Variant = _get_isolated_copy(_values)
+	return GFVariantData.as_dictionary(copied_value)
+
+
+# --- 框架内部方法 ---
+
+## 在固定预算内复制可安全交给项目回调的隔离 Variant。
+##
+## Dictionary、Array、PackedArray 与可验证深复制的无脚本 Resource 会得到独立副本；
+## 循环、脚本 Resource、其他 Object、Callable、Signal、RID 或超出预算的值会失败关闭。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param value: 待隔离的 Variant。
+## [br]
+## @schema value: Variant snapshot candidate.
+## [br]
+## @return 包含 ok、value 与 error_code 的复制报告。
+## [br]
+## @schema return: Dictionary with ok: bool, value: Variant, and error_code: StringName.
+static func duplicate_isolated_variant_for_framework(value: Variant) -> Dictionary:
+	var preflight_state: Dictionary = _make_snapshot_state()
+	var preflight_report: Dictionary = _preflight_isolated_value(
+		value,
+		preflight_state,
+		0
+	)
+	if not GFVariantData.get_option_bool(preflight_report, "ok"):
+		return preflight_report
+	var copy_state: Dictionary = _make_snapshot_state()
+	return _duplicate_isolated_value(value, copy_state, 0)
+
+
+## 从未暴露的 canonical RowView 基类存储创建项目回调独占快照。
+##
+## 方法不调用候选可覆写 getter，并重新执行完整隔离复制与预算校验。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param source: 框架持有的 canonical RowView。
+## [br]
+## @return 独立的纯 GFTableRowView；输入失效或复制失败时返回 null。
+static func snapshot_for_framework(source: GFTableRowView) -> GFTableRowView:
+	if source == null or not is_instance_valid(source) or not source._configured:
+		return null
+	var snapshot: GFTableRowView = GFTableRowView.new()
+	if not snapshot.configure_for_framework(
+		source._source_row_index,
+		source._row_id,
+		source._values
+	):
+		return null
+	return snapshot
+
+
+## 写入框架构建的行快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param source_row_index: 源行索引。
+## [br]
+## @param row_id: 稳定行 ID。
+## [br]
+## @schema row_id: Variant stable row identity.
+## [br]
+## @param values: 以列 ID 为键的值快照。
+## [br]
+## @schema values: Dictionary keyed by StringName column IDs with Variant values.
+## [br]
+## @return 首次配置且 row_id 是 GFVariantKeyCodec 稳定 key 时返回 true。
+func configure_for_framework(
+	source_row_index: int,
+	row_id: Variant,
+	values: Dictionary
+) -> bool:
+	if _configured or source_row_index < 0 or not GFVariantKeyCodec.is_stable_key(row_id):
+		return false
+	var row_id_report: Dictionary = duplicate_isolated_variant_for_framework(row_id)
+	if not GFVariantData.get_option_bool(row_id_report, "ok"):
+		return false
+	var values_report: Dictionary = duplicate_isolated_variant_for_framework(values)
+	if not GFVariantData.get_option_bool(values_report, "ok"):
+		return false
+	var copied_values_value: Variant = GFVariantData.get_option_value(values_report, "value")
+	if not copied_values_value is Dictionary:
+		return false
+	var copied_values: Dictionary = copied_values_value
+	_configured = true
+	_source_row_index = source_row_index
+	_row_id = GFVariantData.get_option_value(row_id_report, "value")
+	_values = copied_values
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+static func _make_snapshot_state() -> Dictionary:
+	return {
+		"node_count": 0,
+		"collection_item_count": 0,
+		"utf8_byte_count": 0,
+		"active_references": [],
+	}
+
+
+static func _preflight_isolated_value(
+	value: Variant,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	var budget_error: StringName = _consume_snapshot_node(state, depth)
+	if budget_error != &"":
+		return _make_copy_failure(budget_error)
+	if _is_packed_array_type(typeof(value)):
+		if not _reserve_packed_array_bytes(state, value):
+			return _make_copy_failure(&"snapshot_budget_exceeded")
+		return _make_copy_success(null)
+
+	match typeof(value):
+		TYPE_STRING, TYPE_STRING_NAME, TYPE_NODE_PATH:
+			if not _reserve_utf8_bytes(state, GFVariantData.to_text(value)):
+				return _make_copy_failure(&"snapshot_utf8_budget_exceeded")
+		TYPE_ARRAY:
+			var source_array: Array = value
+			if not _reserve_collection_items(state, source_array.size()):
+				return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+			if not _push_active_reference(state, source_array):
+				return _make_copy_failure(&"circular_snapshot_value")
+			for item: Variant in source_array:
+				var item_report: Dictionary = _preflight_isolated_value(
+					item,
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(item_report, "ok"):
+					_pop_active_reference(state)
+					return item_report
+			_pop_active_reference(state)
+		TYPE_DICTIONARY:
+			var source_dictionary: Dictionary = value
+			if not _reserve_collection_items(state, source_dictionary.size() * 2):
+				return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+			if not _push_active_reference(state, source_dictionary):
+				return _make_copy_failure(&"circular_snapshot_value")
+			for source_key: Variant in source_dictionary.keys():
+				var key_report: Dictionary = _preflight_isolated_value(
+					source_key,
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(key_report, "ok"):
+					_pop_active_reference(state)
+					return key_report
+				var value_report: Dictionary = _preflight_isolated_value(
+					source_dictionary[source_key],
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(value_report, "ok"):
+					_pop_active_reference(state)
+					return value_report
+			_pop_active_reference(state)
+		TYPE_OBJECT:
+			if not value is Resource:
+				return _make_copy_failure(&"unsafe_snapshot_reference")
+			var source_resource: Resource = value
+			if source_resource.get_script() != null:
+				return _make_copy_failure(&"scripted_resource_snapshot")
+			if not _push_active_reference(state, source_resource):
+				return _make_copy_failure(&"circular_snapshot_value")
+			var property_list: Array[Dictionary] = source_resource.get_property_list()
+			if not _reserve_collection_items(state, property_list.size()):
+				_pop_active_reference(state)
+				return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+			for property_info: Dictionary in property_list:
+				var usage: int = GFVariantData.get_option_int(property_info, "usage")
+				if (usage & PROPERTY_USAGE_STORAGE) == 0:
+					continue
+				var property_name: StringName = GFVariantData.get_option_string_name(
+					property_info,
+					"name"
+				)
+				if property_name == &"script":
+					continue
+				var property_report: Dictionary = _preflight_isolated_value(
+					source_resource.get(property_name),
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(property_report, "ok"):
+					_pop_active_reference(state)
+					return property_report
+			_pop_active_reference(state)
+		TYPE_CALLABLE, TYPE_SIGNAL, TYPE_RID:
+			return _make_copy_failure(&"unsafe_snapshot_reference")
+	return _make_copy_success(null)
+
+
+static func _get_isolated_copy(value: Variant) -> Variant:
+	var report: Dictionary = duplicate_isolated_variant_for_framework(value)
+	if not GFVariantData.get_option_bool(report, "ok"):
+		return null
+	return GFVariantData.get_option_value(report, "value")
+
+
+static func _duplicate_isolated_value(
+	value: Variant,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	var budget_error: StringName = _consume_snapshot_node(state, depth)
+	if budget_error != &"":
+		return _make_copy_failure(budget_error)
+	if _is_packed_array_type(typeof(value)):
+		if not _reserve_packed_array_bytes(state, value):
+			return _make_copy_failure(&"snapshot_utf8_budget_exceeded")
+		return _make_copy_success(GFVariantData.duplicate_variant(value, true, false))
+
+	match typeof(value):
+		TYPE_STRING, TYPE_STRING_NAME, TYPE_NODE_PATH:
+			if not _reserve_utf8_bytes(state, GFVariantData.to_text(value)):
+				return _make_copy_failure(&"snapshot_utf8_budget_exceeded")
+			return _make_copy_success(value)
+		TYPE_ARRAY:
+			var source_array: Array = value
+			return _duplicate_isolated_array(source_array, state, depth)
+		TYPE_DICTIONARY:
+			var source_dictionary: Dictionary = value
+			return _duplicate_isolated_dictionary(source_dictionary, state, depth)
+		TYPE_OBJECT:
+			if value is Resource:
+				var source_resource: Resource = value
+				return _duplicate_isolated_resource(source_resource, state, depth)
+			return _make_copy_failure(&"unsafe_snapshot_reference")
+		TYPE_CALLABLE, TYPE_SIGNAL, TYPE_RID:
+			return _make_copy_failure(&"unsafe_snapshot_reference")
+		_:
+			return _make_copy_success(value)
+
+
+static func _duplicate_isolated_array(
+	source_array: Array,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	if not _reserve_collection_items(state, source_array.size()):
+		return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+	if not _push_active_reference(state, source_array):
+		return _make_copy_failure(&"circular_snapshot_value")
+	var copied_array: Array = []
+	for item: Variant in source_array:
+		var item_report: Dictionary = _duplicate_isolated_value(item, state, depth + 1)
+		if not GFVariantData.get_option_bool(item_report, "ok"):
+			_pop_active_reference(state)
+			return item_report
+		copied_array.append(GFVariantData.get_option_value(item_report, "value"))
+	_pop_active_reference(state)
+	return _make_copy_success(copied_array)
+
+
+static func _duplicate_isolated_dictionary(
+	source_dictionary: Dictionary,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	if not _reserve_collection_items(state, source_dictionary.size() * 2):
+		return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+	if not _push_active_reference(state, source_dictionary):
+		return _make_copy_failure(&"circular_snapshot_value")
+	var copied_dictionary: Dictionary = {}
+	for source_key: Variant in source_dictionary.keys():
+		var key_report: Dictionary = _duplicate_isolated_value(source_key, state, depth + 1)
+		if not GFVariantData.get_option_bool(key_report, "ok"):
+			_pop_active_reference(state)
+			return key_report
+		var value_report: Dictionary = _duplicate_isolated_value(
+			source_dictionary[source_key],
+			state,
+			depth + 1
+		)
+		if not GFVariantData.get_option_bool(value_report, "ok"):
+			_pop_active_reference(state)
+			return value_report
+		copied_dictionary[GFVariantData.get_option_value(key_report, "value")] = (
+			GFVariantData.get_option_value(value_report, "value")
+		)
+	_pop_active_reference(state)
+	return _make_copy_success(copied_dictionary)
+
+
+static func _duplicate_isolated_resource(
+	source_resource: Resource,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	if source_resource.get_script() != null:
+		return _make_copy_failure(&"scripted_resource_snapshot")
+	if not _push_active_reference(state, source_resource):
+		return _make_copy_failure(&"circular_snapshot_value")
+	var copied_resource: Resource = source_resource.duplicate(true)
+	if copied_resource == null or is_same(copied_resource, source_resource):
+		_pop_active_reference(state)
+		return _make_copy_failure(&"resource_snapshot_duplicate_failed")
+	var validation_report: Dictionary = _validate_resource_copy(
+		source_resource,
+		copied_resource,
+		state,
+		depth + 1
+	)
+	_pop_active_reference(state)
+	if not GFVariantData.get_option_bool(validation_report, "ok"):
+		return validation_report
+	return _make_copy_success(copied_resource)
+
+
+static func _validate_resource_copy(
+	source_resource: Resource,
+	copied_resource: Resource,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	if source_resource.get_script() != null or copied_resource.get_script() != null:
+		return _make_copy_failure(&"scripted_resource_snapshot")
+	var property_list: Array[Dictionary] = source_resource.get_property_list()
+	if not _reserve_collection_items(state, property_list.size()):
+		return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+	for property_info: Dictionary in property_list:
+		var usage: int = GFVariantData.get_option_int(property_info, "usage")
+		if (usage & PROPERTY_USAGE_STORAGE) == 0:
+			continue
+		var property_name: StringName = GFVariantData.get_option_string_name(
+			property_info,
+			"name"
+		)
+		if property_name == &"script":
+			continue
+		var pair_report: Dictionary = _validate_isolated_pair(
+			source_resource.get(property_name),
+			copied_resource.get(property_name),
+			state,
+			depth
+		)
+		if not GFVariantData.get_option_bool(pair_report, "ok"):
+			return pair_report
+	return _make_copy_success(copied_resource)
+
+
+static func _validate_isolated_pair(
+	source_value: Variant,
+	copied_value: Variant,
+	state: Dictionary,
+	depth: int
+) -> Dictionary:
+	var budget_error: StringName = _consume_snapshot_node(state, depth)
+	if budget_error != &"":
+		return _make_copy_failure(budget_error)
+	if typeof(source_value) != typeof(copied_value):
+		return _make_copy_failure(&"resource_snapshot_shape_mismatch")
+	if _is_packed_array_type(typeof(source_value)):
+		if not _reserve_packed_array_bytes(state, copied_value):
+			return _make_copy_failure(&"snapshot_utf8_budget_exceeded")
+		if not GFVariantData.values_equal(source_value, copied_value):
+			return _make_copy_failure(&"resource_snapshot_value_mismatch")
+		return _make_copy_success(copied_value)
+
+	match typeof(source_value):
+		TYPE_STRING, TYPE_STRING_NAME, TYPE_NODE_PATH:
+			if not _reserve_utf8_bytes(state, GFVariantData.to_text(copied_value)):
+				return _make_copy_failure(&"snapshot_utf8_budget_exceeded")
+			if not GFVariantData.values_equal(source_value, copied_value):
+				return _make_copy_failure(&"resource_snapshot_value_mismatch")
+		TYPE_ARRAY:
+			var source_array: Array = source_value
+			var copied_array: Array = copied_value
+			if is_same(source_array, copied_array) or source_array.size() != copied_array.size():
+				return _make_copy_failure(&"resource_snapshot_alias")
+			if not _reserve_collection_items(state, source_array.size()):
+				return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+			if not _push_active_reference(state, source_array):
+				return _make_copy_failure(&"circular_snapshot_value")
+			for index: int in range(source_array.size()):
+				var item_report: Dictionary = _validate_isolated_pair(
+					source_array[index],
+					copied_array[index],
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(item_report, "ok"):
+					_pop_active_reference(state)
+					return item_report
+			_pop_active_reference(state)
+		TYPE_DICTIONARY:
+			var source_dictionary: Dictionary = source_value
+			var copied_dictionary: Dictionary = copied_value
+			if (
+				is_same(source_dictionary, copied_dictionary)
+				or source_dictionary.size() != copied_dictionary.size()
+			):
+				return _make_copy_failure(&"resource_snapshot_alias")
+			var source_keys: Array = source_dictionary.keys()
+			var copied_keys: Array = copied_dictionary.keys()
+			if not _reserve_collection_items(state, source_keys.size() * 2):
+				return _make_copy_failure(&"snapshot_collection_budget_exceeded")
+			if not _push_active_reference(state, source_dictionary):
+				return _make_copy_failure(&"circular_snapshot_value")
+			for index: int in range(source_keys.size()):
+				var key_report: Dictionary = _validate_isolated_pair(
+					source_keys[index],
+					copied_keys[index],
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(key_report, "ok"):
+					_pop_active_reference(state)
+					return key_report
+				var value_report: Dictionary = _validate_isolated_pair(
+					source_dictionary[source_keys[index]],
+					copied_dictionary[copied_keys[index]],
+					state,
+					depth + 1
+				)
+				if not GFVariantData.get_option_bool(value_report, "ok"):
+					_pop_active_reference(state)
+					return value_report
+			_pop_active_reference(state)
+		TYPE_OBJECT:
+			if not source_value is Resource or not copied_value is Resource:
+				return _make_copy_failure(&"unsafe_snapshot_reference")
+			var source_resource: Resource = source_value
+			var copied_resource: Resource = copied_value
+			if source_resource.get_script() != null or copied_resource.get_script() != null:
+				return _make_copy_failure(&"scripted_resource_snapshot")
+			if is_same(source_resource, copied_resource):
+				return _make_copy_failure(&"resource_snapshot_alias")
+			if not _push_active_reference(state, source_resource):
+				return _make_copy_failure(&"circular_snapshot_value")
+			var resource_report: Dictionary = _validate_resource_copy(
+				source_resource,
+				copied_resource,
+				state,
+				depth + 1
+			)
+			_pop_active_reference(state)
+			return resource_report
+		TYPE_CALLABLE, TYPE_SIGNAL, TYPE_RID:
+			return _make_copy_failure(&"unsafe_snapshot_reference")
+		_:
+			if not GFVariantData.values_equal(source_value, copied_value):
+				return _make_copy_failure(&"resource_snapshot_value_mismatch")
+	return _make_copy_success(copied_value)
+
+
+static func _consume_snapshot_node(state: Dictionary, depth: int) -> StringName:
+	if depth > _MAX_SNAPSHOT_DEPTH:
+		return &"snapshot_depth_exceeded"
+	var node_count: int = GFVariantData.get_option_int(state, "node_count") + 1
+	state["node_count"] = node_count
+	if node_count > _MAX_SNAPSHOT_NODE_COUNT:
+		return &"snapshot_node_budget_exceeded"
+	return &""
+
+
+static func _reserve_collection_items(state: Dictionary, item_count: int) -> bool:
+	var next_count: int = (
+		GFVariantData.get_option_int(state, "collection_item_count")
+		+ maxi(item_count, 0)
+	)
+	state["collection_item_count"] = next_count
+	return next_count <= _MAX_SNAPSHOT_COLLECTION_ITEM_COUNT
+
+
+static func _reserve_utf8_bytes(state: Dictionary, text_value: String) -> bool:
+	var used_bytes: int = GFVariantData.get_option_int(state, "utf8_byte_count")
+	var remaining_bytes: int = _MAX_SNAPSHOT_UTF8_BYTES - used_bytes
+	if remaining_bytes < 0 or text_value.length() > remaining_bytes:
+		return false
+	return _reserve_bytes(state, text_value.to_utf8_buffer().size())
+
+
+static func _reserve_packed_array_bytes(state: Dictionary, value: Variant) -> bool:
+	var byte_count: int = 0
+	match typeof(value):
+		TYPE_PACKED_BYTE_ARRAY:
+			var values: PackedByteArray = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 1)
+		TYPE_PACKED_INT32_ARRAY:
+			var values: PackedInt32Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 4)
+		TYPE_PACKED_FLOAT32_ARRAY:
+			var values: PackedFloat32Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 4)
+		TYPE_PACKED_INT64_ARRAY:
+			var values: PackedInt64Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 8)
+		TYPE_PACKED_FLOAT64_ARRAY:
+			var values: PackedFloat64Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 8)
+		TYPE_PACKED_VECTOR2_ARRAY:
+			var values: PackedVector2Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 16)
+		TYPE_PACKED_VECTOR3_ARRAY:
+			var values: PackedVector3Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 24)
+		TYPE_PACKED_COLOR_ARRAY:
+			var values: PackedColorArray = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 16)
+		TYPE_PACKED_VECTOR4_ARRAY:
+			var values: PackedVector4Array = value
+			return _reserve_fixed_width_packed_array(state, values.size(), 32)
+		TYPE_PACKED_STRING_ARRAY:
+			var values: PackedStringArray = value
+			if not _reserve_collection_items(state, values.size()):
+				return false
+			for item: String in values:
+				if not _reserve_utf8_bytes(state, item):
+					return false
+			return true
+	return _reserve_bytes(state, byte_count)
+
+
+static func _reserve_fixed_width_packed_array(
+	state: Dictionary,
+	item_count: int,
+	item_width: int
+) -> bool:
+	if not _reserve_collection_items(state, item_count):
+		return false
+	var used_bytes: int = GFVariantData.get_option_int(state, "utf8_byte_count")
+	var remaining_bytes: int = _MAX_SNAPSHOT_UTF8_BYTES - used_bytes
+	if item_width <= 0 or item_count > floori(float(remaining_bytes) / float(item_width)):
+		return false
+	return _reserve_bytes(state, item_count * item_width)
+
+
+static func _is_packed_array_type(value_type: int) -> bool:
+	return value_type in [
+		TYPE_PACKED_BYTE_ARRAY,
+		TYPE_PACKED_INT32_ARRAY,
+		TYPE_PACKED_INT64_ARRAY,
+		TYPE_PACKED_FLOAT32_ARRAY,
+		TYPE_PACKED_FLOAT64_ARRAY,
+		TYPE_PACKED_STRING_ARRAY,
+		TYPE_PACKED_VECTOR2_ARRAY,
+		TYPE_PACKED_VECTOR3_ARRAY,
+		TYPE_PACKED_COLOR_ARRAY,
+		TYPE_PACKED_VECTOR4_ARRAY,
+	]
+
+
+static func _reserve_bytes(state: Dictionary, byte_count: int) -> bool:
+	var next_count: int = (
+		GFVariantData.get_option_int(state, "utf8_byte_count")
+		+ maxi(byte_count, 0)
+	)
+	state["utf8_byte_count"] = next_count
+	return next_count <= _MAX_SNAPSHOT_UTF8_BYTES
+
+
+static func _push_active_reference(state: Dictionary, value: Variant) -> bool:
+	var active_references_value: Variant = GFVariantData.get_option_value(
+		state,
+		"active_references"
+	)
+	var active_references: Array = []
+	if active_references_value is Array:
+		active_references = active_references_value
+	for active_value: Variant in active_references:
+		if is_same(active_value, value):
+			return false
+	active_references.append(value)
+	state["active_references"] = active_references
+	return true
+
+
+static func _pop_active_reference(state: Dictionary) -> void:
+	var active_references_value: Variant = GFVariantData.get_option_value(
+		state,
+		"active_references"
+	)
+	var active_references: Array = []
+	if active_references_value is Array:
+		active_references = active_references_value
+	if not active_references.is_empty():
+		active_references.pop_back()
+	state["active_references"] = active_references
+
+
+static func _make_copy_success(value: Variant) -> Dictionary:
+	return {
+		"ok": true,
+		"value": value,
+		"error_code": &"",
+	}
+
+
+static func _make_copy_failure(error_code: StringName) -> Dictionary:
+	return {
+		"ok": false,
+		"value": null,
+		"error_code": error_code,
+	}

--- a/addons/gf/standard/utilities/ui/gf_table_row_view.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_row_view.gd
@@ -351,7 +351,7 @@ static func _duplicate_isolated_array(
 		return _make_copy_failure(&"snapshot_collection_budget_exceeded")
 	if not _push_active_reference(state, source_array):
 		return _make_copy_failure(&"circular_snapshot_value")
-	var copied_array: Array = []
+	var copied_array: Array = _create_isolated_array(source_array)
 	for item: Variant in source_array:
 		var item_report: Dictionary = _duplicate_isolated_value(item, state, depth + 1)
 		if not GFVariantData.get_option_bool(item_report, "ok"):
@@ -371,7 +371,7 @@ static func _duplicate_isolated_dictionary(
 		return _make_copy_failure(&"snapshot_collection_budget_exceeded")
 	if not _push_active_reference(state, source_dictionary):
 		return _make_copy_failure(&"circular_snapshot_value")
-	var copied_dictionary: Dictionary = {}
+	var copied_dictionary: Dictionary = _create_isolated_dictionary(source_dictionary)
 	for source_key: Variant in source_dictionary.keys():
 		var key_report: Dictionary = _duplicate_isolated_value(source_key, state, depth + 1)
 		if not GFVariantData.get_option_bool(key_report, "ok"):
@@ -390,6 +390,31 @@ static func _duplicate_isolated_dictionary(
 		)
 	_pop_active_reference(state)
 	return _make_copy_success(copied_dictionary)
+
+
+static func _create_isolated_array(source_array: Array) -> Array:
+	if not source_array.is_typed():
+		return []
+	return Array(
+		[],
+		source_array.get_typed_builtin(),
+		source_array.get_typed_class_name(),
+		source_array.get_typed_script()
+	)
+
+
+static func _create_isolated_dictionary(source_dictionary: Dictionary) -> Dictionary:
+	if not source_dictionary.is_typed():
+		return {}
+	return Dictionary(
+		{},
+		source_dictionary.get_typed_key_builtin(),
+		source_dictionary.get_typed_key_class_name(),
+		source_dictionary.get_typed_key_script(),
+		source_dictionary.get_typed_value_builtin(),
+		source_dictionary.get_typed_value_class_name(),
+		source_dictionary.get_typed_value_script()
+	)
 
 
 static func _duplicate_isolated_resource(

--- a/addons/gf/standard/utilities/ui/gf_table_row_view.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_table_row_view.gd.uid
@@ -1,0 +1,1 @@
+uid://dhcipnwon262b

--- a/addons/gf/standard/utilities/ui/gf_table_selection_model.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_selection_model.gd
@@ -165,21 +165,31 @@ func select_single(row_id: Variant) -> bool:
 ## [br]
 ## @schema row_ids: Array，调用方提供的稳定行 ID。
 func replace_selection(row_ids: Array) -> bool:
-	var previous_ids: Array = get_selected_ids()
-	_clear_selection_internal()
-	if selection_mode != SelectionMode.NONE:
-		for row_id: Variant in row_ids:
-			if not _is_valid_row_id(row_id):
-				continue
-			_select_row_id_internal(row_id)
-			anchor_row_id = row_id
-			if selection_mode == SelectionMode.SINGLE:
-				break
+	return _replace_selection_internal(row_ids, null, false)
 
-	if _arrays_equal(previous_ids, _selected_ids):
-		return false
-	selection_changed.emit(get_selected_ids())
-	return true
+
+## 用一组行 ID 与显式锚点原子替换当前选择。
+## [br]
+## 选择集合和锚点会在发出 selection_changed 前同时完成更新；锚点不在最终选择中时归一为空。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param row_ids: 稳定行 ID 列表。
+## [br]
+## @param selection_anchor: 最终范围选择锚点；null 表示没有锚点。
+## [br]
+## @schema row_ids: Array，调用方提供的稳定行 ID。
+## [br]
+## @schema selection_anchor: Variant，最终选择中的稳定行 ID，或 null。
+## [br]
+## @return 选择集合或锚点发生变化时返回 true。
+func replace_selection_with_anchor(
+	row_ids: Array,
+	selection_anchor: Variant
+) -> bool:
+	return _replace_selection_internal(row_ids, selection_anchor, true)
 
 
 ## 在有序行 ID 列表中选择范围。
@@ -339,6 +349,34 @@ func get_debug_snapshot() -> Dictionary:
 
 
 # --- 私有/辅助方法 ---
+
+func _replace_selection_internal(
+	row_ids: Array,
+	selection_anchor: Variant,
+	has_explicit_anchor: bool
+) -> bool:
+	var previous_ids: Array = get_selected_ids()
+	var previous_anchor: Variant = anchor_row_id
+	_clear_selection_internal()
+	if selection_mode != SelectionMode.NONE:
+		for row_id: Variant in row_ids:
+			if not _is_valid_row_id(row_id):
+				continue
+			_select_row_id_internal(row_id)
+			if selection_mode == SelectionMode.SINGLE:
+				break
+	if has_explicit_anchor:
+		anchor_row_id = selection_anchor if _selected_lookup.has(selection_anchor) else null
+	elif not _selected_ids.is_empty():
+		anchor_row_id = _selected_ids[_selected_ids.size() - 1]
+
+	if (
+		_arrays_equal(previous_ids, _selected_ids)
+		and GFVariantData.values_equal(previous_anchor, anchor_row_id)
+	):
+		return false
+	selection_changed.emit(get_selected_ids())
+	return true
 
 func _set_selection_mode(value: SelectionMode) -> void:
 	if _selection_mode == value:

--- a/addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd
+++ b/addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd
@@ -1,0 +1,347 @@
+## GFTableViewRebuildResult: 表格投影事务的类型化结果。
+##
+## 成功结果描述一次提交或 no-op；失败结果描述未提交的阶段、谓词和行身份。
+## 结果不携带源 row，从而可安全交给 UI 诊断层。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFTableViewRebuildResult
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _MAX_ERROR_CODE_UTF8_BYTES: int = 128
+const _MAX_ERROR_MESSAGE_UTF8_BYTES: int = 1_024
+const _MAX_DIAGNOSTIC_ID_UTF8_BYTES: int = 128
+const _MAX_DIAGNOSTIC_ROW_ID_UTF8_BYTES: int = 256
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _successful: bool = false
+var _committed: bool = false
+var _view_revision: int = 0
+var _visible_count: int = 0
+var _scanned_row_count: int = 0
+var _predicate_evaluation_count: int = 0
+var _error_code: StringName = &""
+var _error_message: String = ""
+var _failed_predicate_id: StringName = &""
+var _failed_source_row_index: int = -1
+var _failed_row_id: Variant = null
+
+
+# --- 公共方法 ---
+
+## 查询事务是否成功。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时返回 true。
+func is_successful() -> bool:
+	return _successful
+
+
+## 查询事务是否提交了新 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 提交时返回 true；成功 no-op 返回 false。
+func was_committed() -> bool:
+	return _committed
+
+
+## 获取结果对应的已提交 revision。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前已提交 revision。
+func get_view_revision() -> int:
+	return _view_revision
+
+
+## 获取当前已提交可见行数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 可见行数量。
+func get_visible_count() -> int:
+	return _visible_count
+
+
+## 获取本次候选扫描的源行数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已扫描行数量。
+func get_scanned_row_count() -> int:
+	return _scanned_row_count
+
+
+## 获取本次候选执行的谓词次数。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 谓词求值次数。
+func get_predicate_evaluation_count() -> int:
+	return _predicate_evaluation_count
+
+
+## 获取稳定错误码。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败错误码；成功时为空。
+func get_error_code() -> StringName:
+	return _error_code
+
+
+## 获取有界错误说明。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败说明；成功时为空。
+func get_error_message() -> String:
+	return _error_message
+
+
+## 获取失败谓词 ID。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败谓词 ID；非谓词失败时为空。
+func get_failed_predicate_id() -> StringName:
+	return _failed_predicate_id
+
+
+## 获取失败源行索引。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败行索引；非行失败时为 -1。
+func get_failed_source_row_index() -> int:
+	return _failed_source_row_index
+
+
+## 获取失败行 ID 副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 失败行 ID；非行失败时为 null。
+## [br]
+## @schema return: Variant stable row identity copy, or null.
+func get_failed_row_id() -> Variant:
+	return GFVariantData.duplicate_variant(_failed_row_id, true, true)
+
+
+## 创建结果的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新结果对象；未配置实例返回新的未配置实例。
+func duplicate_result() -> GFTableViewRebuildResult:
+	var duplicate: GFTableViewRebuildResult = GFTableViewRebuildResult.new()
+	if not _configured:
+		return duplicate
+	if _successful:
+		var _success_configured: bool = duplicate.configure_success_for_framework(
+			_committed,
+			_view_revision,
+			_visible_count,
+			_scanned_row_count,
+			_predicate_evaluation_count
+		)
+	else:
+		var _failure_configured: bool = duplicate.configure_failure_for_framework(
+			_error_code,
+			_error_message,
+			_view_revision,
+			_visible_count,
+			_scanned_row_count,
+			_predicate_evaluation_count,
+			_failed_predicate_id,
+			_failed_source_row_index,
+			_failed_row_id
+		)
+	return duplicate
+
+
+# --- 框架内部方法 ---
+
+## 写入成功结果。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param committed: 是否提交了新 revision。
+## [br]
+## @param view_revision: 当前已提交 revision。
+## [br]
+## @param visible_count: 当前可见行数量。
+## [br]
+## @param scanned_row_count: 候选扫描行数量。
+## [br]
+## @param predicate_evaluation_count: 谓词求值次数。
+## [br]
+## @return 首次配置时返回 true。
+func configure_success_for_framework(
+	committed: bool,
+	view_revision: int,
+	visible_count: int,
+	scanned_row_count: int,
+	predicate_evaluation_count: int
+) -> bool:
+	if _configured:
+		return false
+	_configured = true
+	_successful = true
+	_committed = committed
+	_view_revision = maxi(view_revision, 0)
+	_visible_count = maxi(visible_count, 0)
+	_scanned_row_count = maxi(scanned_row_count, 0)
+	_predicate_evaluation_count = maxi(predicate_evaluation_count, 0)
+	_error_code = &""
+	_error_message = ""
+	_failed_predicate_id = &""
+	_failed_source_row_index = -1
+	_failed_row_id = null
+	return true
+
+
+## 写入失败结果。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param error_code: 稳定错误码。
+## [br]
+## @param error_message: 有界错误说明。
+## [br]
+## @param view_revision: 仍然有效的已提交 revision。
+## [br]
+## @param visible_count: 仍然有效的可见行数量。
+## [br]
+## @param scanned_row_count: 失败前扫描行数量。
+## [br]
+## @param predicate_evaluation_count: 失败前谓词求值次数。
+## [br]
+## @param failed_predicate_id: 失败谓词 ID。
+## [br]
+## @param failed_source_row_index: 失败源行索引。
+## [br]
+## @param failed_row_id: 失败行稳定 ID。
+## [br]
+## @schema failed_row_id: Variant stable key accepted by GFVariantKeyCodec, or null.
+## [br]
+## @return 首次配置时返回 true。
+func configure_failure_for_framework(
+	error_code: StringName,
+	error_message: String,
+	view_revision: int,
+	visible_count: int,
+	scanned_row_count: int = 0,
+	predicate_evaluation_count: int = 0,
+	failed_predicate_id: StringName = &"",
+	failed_source_row_index: int = -1,
+	failed_row_id: Variant = null
+) -> bool:
+	if _configured:
+		return false
+	_configured = true
+	_successful = false
+	_committed = false
+	_view_revision = maxi(view_revision, 0)
+	_visible_count = maxi(visible_count, 0)
+	_scanned_row_count = maxi(scanned_row_count, 0)
+	_predicate_evaluation_count = maxi(predicate_evaluation_count, 0)
+	_error_code = _normalize_error_code(error_code)
+	_error_message = _truncate_utf8(error_message, _MAX_ERROR_MESSAGE_UTF8_BYTES)
+	_failed_predicate_id = _normalize_diagnostic_id(failed_predicate_id)
+	_failed_source_row_index = failed_source_row_index
+	_failed_row_id = _copy_bounded_diagnostic_row_id(failed_row_id)
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+static func _normalize_error_code(error_code: StringName) -> StringName:
+	var error_text: String = String(error_code)
+	if (
+		error_text.is_empty()
+		or error_text != error_text.strip_edges()
+		or error_text.length() > _MAX_ERROR_CODE_UTF8_BYTES
+		or error_text.to_utf8_buffer().size() > _MAX_ERROR_CODE_UTF8_BYTES
+	):
+		return &"view_rebuild_failed"
+	return error_code
+
+
+static func _normalize_diagnostic_id(diagnostic_id: StringName) -> StringName:
+	var id_text: String = String(diagnostic_id)
+	if (
+		id_text.is_empty()
+		or id_text != id_text.strip_edges()
+		or id_text.length() > _MAX_DIAGNOSTIC_ID_UTF8_BYTES
+		or id_text.to_utf8_buffer().size() > _MAX_DIAGNOSTIC_ID_UTF8_BYTES
+	):
+		return &""
+	return diagnostic_id
+
+
+static func _copy_bounded_diagnostic_row_id(row_id: Variant) -> Variant:
+	if not GFVariantKeyCodec.is_stable_key(row_id):
+		return null
+	if row_id is String or row_id is StringName or row_id is NodePath:
+		var row_id_text: String = GFVariantData.to_text(row_id)
+		if (
+			row_id_text.length() > _MAX_DIAGNOSTIC_ROW_ID_UTF8_BYTES
+			or row_id_text.to_utf8_buffer().size() > _MAX_DIAGNOSTIC_ROW_ID_UTF8_BYTES
+		):
+			return null
+	return GFVariantData.duplicate_variant(row_id, true, true)
+
+
+static func _truncate_utf8(text_value: String, max_bytes: int) -> String:
+	var bounded_text: String = text_value.left(max_bytes)
+	if text_value.length() <= max_bytes and bounded_text.to_utf8_buffer().size() <= max_bytes:
+		return text_value
+	var low: int = 0
+	var high: int = bounded_text.length()
+	while low < high:
+		var middle: int = floori(float(low + high + 1) / 2.0)
+		if bounded_text.left(middle).to_utf8_buffer().size() <= max_bytes:
+			low = middle
+		else:
+			high = middle - 1
+	return bounded_text.left(low)

--- a/addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd.uid
@@ -1,0 +1,1 @@
+uid://xcfysd8ex45x

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd
@@ -1,0 +1,3320 @@
+## GFVirtualListBinder: owner-bound 虚拟列表 Control 物化与回收协调器。
+##
+## 连接项目提供的 `ScrollContainer`、绝对布局 content root、`GFVirtualListModel`
+## 与行回调，只物化真实视口及 overscan 范围。项目继续拥有条目数据、稳定 ID、
+## 行视觉、选择、激活、输入和无障碍语义；Binder 拥有 factory 成功交付的 Control，
+## 并在 unbind、任一绑定节点退出或 dispose 时确定性解除回调和节点引用。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFVirtualListBinder
+extends RefCounted
+
+
+# --- 信号 ---
+
+## 一轮同步完成后发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param result: 不含项目条目载荷的 typed 同步结果。
+signal sync_completed(result: GFVirtualListSyncResult)
+
+
+# --- 枚举 ---
+
+## 列表滚动和尺寸测量使用的主轴。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum LayoutAxis {
+	## 以 Y 轴和垂直滚动条组织条目。
+	VERTICAL,
+	## 以 X 轴和水平滚动条组织条目。
+	HORIZONTAL,
+}
+
+## 把条目滚入视口时使用的对齐方式。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum ScrollAlignment {
+	## 已可见时不滚动，否则移动到最近边界。
+	NEAREST,
+	## 条目起点对齐视口起点。
+	START,
+	## 条目中心对齐视口中心。
+	CENTER,
+	## 条目终点对齐视口终点。
+	END,
+}
+
+
+# --- 常量 ---
+
+## 默认活动 Control 硬上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DEFAULT_MAX_MATERIALIZED_ITEMS: int = 512
+
+## 默认 parentless pool Control 上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const DEFAULT_MAX_POOLED_ITEMS: int = 64
+
+## 活动物化 Control 的框架级绝对硬上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ABSOLUTE_MAX_MATERIALIZED_ITEMS: int = 4096
+
+## parentless pool 的框架级绝对硬上限。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ABSOLUTE_MAX_POOLED_ITEMS: int = 1024
+
+## 稳定 identity token 允许的最大 UTF-8 字节数。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH: int = 1024
+
+const _STATE_UNBOUND: StringName = &"unbound"
+const _STATE_IDLE: StringName = &"idle"
+const _STATE_PENDING: StringName = &"pending"
+const _STATE_SYNCING: StringName = &"syncing"
+const _STATE_UNBINDING: StringName = &"unbinding"
+const _STATE_DISPOSING: StringName = &"disposing"
+const _STATE_DISPOSED: StringName = &"disposed"
+
+
+# --- 公共变量 ---
+
+## 布局主轴。只接受 VERTICAL/HORIZONTAL；绑定期间修改后调用 request_sync() 使其生效。
+## 同步 callback 内修改时，当前轮继续使用入口快照，下一轮才采用新值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var layout_axis: LayoutAxis = LayoutAxis.VERTICAL:
+	set(value):
+		if value not in [LayoutAxis.VERTICAL, LayoutAxis.HORIZONTAL]:
+			return
+		layout_axis = value
+
+## 活动物化 Control 硬上限；运行时按至少 1 处理。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var max_materialized_items: int = DEFAULT_MAX_MATERIALIZED_ITEMS:
+	set(value):
+		max_materialized_items = clampi(value, 1, ABSOLUTE_MAX_MATERIALIZED_ITEMS)
+
+## parentless pool 最多保留的 Control 数量；小于 0 时按 0 处理。
+## 同步事务内收紧预算时，会在候选提交或回滚完成后统一裁剪。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var max_pooled_items: int = DEFAULT_MAX_POOLED_ITEMS:
+	set(value):
+		max_pooled_items = clampi(value, 0, ABSOLUTE_MAX_POOLED_ITEMS)
+		if _is_sync_in_progress():
+			_pool_trim_requested = true
+		else:
+			_trim_pool_to_limit()
+
+## 是否在新绑定或数据失效后自动测量活动行；不影响显式 request_measurement()。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var auto_measure: bool = true
+
+## 虚拟焦点变化后是否按最近边界自动滚入视口。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var auto_reveal_focus: bool = true
+
+## 是否让行 Control 填满 content root 的交叉轴。
+## 同步 callback 内修改时，当前轮继续使用入口快照，下一轮才采用新值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+var fill_cross_axis: bool = true
+
+
+# --- 私有变量 ---
+
+var _state: StringName = _STATE_UNBOUND
+var _lifecycle_generation: int = 0
+var _data_revision: int = 0
+var _last_committed_data_revision: int = -1
+var _last_committed_layout_revision: int = -1
+var _pending_sync: bool = false
+var _deferred_sync_scheduled: bool = false
+var _measurement_requested: bool = false
+var _measurement_request_revision: int = 0
+var _unbind_requested: bool = false
+var _dispose_requested: bool = false
+var _applying_scroll_adjustment: bool = false
+var _sync_in_progress: bool = false
+var _teardown_in_progress: bool = false
+var _binding_focus_initialization: bool = false
+var _sync_layout_axis: int = -1
+var _sync_fill_cross_axis: bool = false
+var _sync_max_materialized_items: int = DEFAULT_MAX_MATERIALIZED_ITEMS
+var _sync_auto_measure: bool = true
+var _sync_measurement_requested: bool = false
+var _sync_measurement_request_revision: int = 0
+var _sync_truncated: bool = false
+var _sync_layout_model: GFVirtualListModel = null
+var _sync_expected_layout_revision: int = -1
+var _sync_content_extent: float = 0.0
+var _sync_item_geometries: Dictionary = {}
+var _sync_context_ready: bool = false
+var _pool_trim_requested: bool = false
+
+var _owner_ref: WeakRef = null
+var _scroll_ref: WeakRef = null
+var _content_ref: WeakRef = null
+var _viewport_ref: WeakRef = null
+var _owned_layout_axis: int = -1
+var _owned_layout_axis_baseline: float = 0.0
+var _layout_model: GFVirtualListModel = null
+var _focus_model: GFVirtualListFocusModel = null
+
+var _item_factory: Callable = Callable()
+var _bind_callback: Callable = Callable()
+var _unbind_callback: Callable = Callable()
+var _identity_callback: Callable = Callable()
+var _measure_callback: Callable = Callable()
+var _focus_target_callback: Callable = Callable()
+
+var _active_by_token: Dictionary = {}
+var _token_by_index: Dictionary = {}
+var _pool: Array[Control] = []
+var _known_control_ids: Dictionary = {}
+
+var _pending_focus_index: int = GFVirtualListFocusModel.NO_FOCUS
+var _pending_focus_handoff: bool = false
+var _pending_focus_started_with_owner: bool = false
+var _pending_focus_reveal_index: int = GFVirtualListFocusModel.NO_FOCUS
+var _pending_physical_focus_reconciliation: bool = false
+var _focus_intent_revision: int = 0
+var _focus_handoff_in_progress: bool = false
+var _focus_handoff_index: int = GFVirtualListFocusModel.NO_FOCUS
+var _focus_handoff_observed_target: bool = false
+
+var _binding_tree_exited_callable: Callable = Callable()
+var _binding_tree_exit_refs: Array[WeakRef] = []
+var _scroll_resized_callable: Callable = Callable()
+var _content_resized_callable: Callable = Callable()
+var _vertical_scroll_callable: Callable = Callable()
+var _horizontal_scroll_callable: Callable = Callable()
+var _layout_changed_callable: Callable = Callable()
+var _focus_changed_callable: Callable = Callable()
+var _viewport_focus_changed_callable: Callable = Callable()
+var _last_sync_result: GFVirtualListSyncResult = null
+var _emitting_sync_completed: bool = false
+
+
+# --- 公共方法 ---
+
+## 建立一个 owner-bound 虚拟列表绑定。
+##
+## `content_root` 必须是 ScrollContainer 的直接子 Control，且不能是会接管子节点位置的
+## Container。factory 返回的 Control 必须 parentless；返回后其所有权转交 Binder。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param owner: 生命周期 owner；退出 SceneTree 后 Binder 自动 dispose。
+## [br]
+## @param scroll_container: 项目持有的滚动容器；退出 SceneTree 后 Binder 自动 dispose。
+## [br]
+## @param content_root: Binder 写入主轴最小尺寸并承载活动行；退出 SceneTree 后自动 dispose。
+## [br]
+## @param layout_model: 条目 count、extent、offset 和范围模型。
+## [br]
+## @param item_factory: Callable() -> Control。
+## [br]
+## @param bind_callback: Callable(control: Control, item_index: int, item_id: Variant) -> bool。
+## [br]
+## @param unbind_callback: Callable(control: Control, item_index: int, item_id: Variant) -> void。
+## [br]
+## @param identity_callback: Callable(item_index: int) -> Variant；返回值必须是稳定 key。
+## [br]
+## @param focus_model: 可选虚拟焦点模型。
+## [br]
+## @param measure_callback: 可选 Callable(control, item_index, item_id) -> float。
+## [br]
+## @param focus_target_callback: 可选 Callable(control, item_index, item_id) -> Control。
+## [br]
+## @return 全部边界合法并建立连接时返回 true。
+## [br]
+## @schema item_factory: Callable() -> Control.
+## [br]
+## @schema bind_callback: Callable(Control, int, Variant) -> bool.
+## [br]
+## @schema unbind_callback: Callable(Control, int, Variant) -> void.
+## [br]
+## @schema identity_callback: Callable(int) -> stable Variant key.
+## [br]
+## @schema measure_callback: Optional Callable(Control, int, Variant) -> finite positive float.
+## [br]
+## @schema focus_target_callback: Optional Callable(Control, int, Variant) -> Control descendant.
+func bind(
+	owner: Node,
+	scroll_container: ScrollContainer,
+	content_root: Control,
+	layout_model: GFVirtualListModel,
+	item_factory: Callable,
+	bind_callback: Callable,
+	unbind_callback: Callable,
+	identity_callback: Callable,
+	focus_model: GFVirtualListFocusModel = null,
+	measure_callback: Callable = Callable(),
+	focus_target_callback: Callable = Callable()
+) -> bool:
+	if _state == _STATE_DISPOSED or _state != _STATE_UNBOUND:
+		return false
+	if not _is_valid_binding_boundary(owner, scroll_container, content_root, layout_model):
+		return false
+	if (
+		not item_factory.is_valid()
+		or not bind_callback.is_valid()
+		or not unbind_callback.is_valid()
+		or not identity_callback.is_valid()
+	):
+		return false
+
+	_lifecycle_generation += 1
+	_owner_ref = weakref(owner)
+	_scroll_ref = weakref(scroll_container)
+	_content_ref = weakref(content_root)
+	var viewport: Viewport = scroll_container.get_viewport()
+	_viewport_ref = weakref(viewport) if viewport != null else null
+	_owned_layout_axis = -1
+	_owned_layout_axis_baseline = 0.0
+	_layout_model = layout_model
+	_focus_model = focus_model
+	_item_factory = item_factory
+	_bind_callback = bind_callback
+	_unbind_callback = unbind_callback
+	_identity_callback = identity_callback
+	_measure_callback = measure_callback
+	_focus_target_callback = focus_target_callback
+	_state = _STATE_IDLE
+	_last_committed_data_revision = -1
+	_last_committed_layout_revision = -1
+	_measurement_requested = false
+	_measurement_request_revision = 0
+	if auto_measure:
+		_queue_measurement_request()
+	_connect_binding_signals(owner, scroll_container, content_root, viewport)
+	if _focus_model != null:
+		_binding_focus_initialization = true
+		var _focus_count_changed: bool = _focus_model.set_item_count(_layout_model.get_item_count())
+		_binding_focus_initialization = false
+	_update_content_extent()
+	_adopt_bound_virtual_focus()
+	return request_sync()
+
+
+## 请求一次合并到 deferred 队列的同步。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前处于有效绑定生命周期时返回 true。
+func request_sync() -> bool:
+	if not is_bound() or _state in [_STATE_UNBINDING, _STATE_DISPOSING]:
+		return false
+	_pending_sync = true
+	if _state != _STATE_SYNCING:
+		_state = _STATE_PENDING
+	_schedule_deferred_sync()
+	return true
+
+
+## 立即执行一轮同步；callback 内的再次请求会合并为下一轮。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return typed 同步结果。
+func sync_now() -> GFVirtualListSyncResult:
+	if _state == _STATE_DISPOSED:
+		return _store_result(_make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED))
+	if _state == _STATE_UNBOUND:
+		return _store_result(_make_terminal_result(GFVirtualListSyncResult.STATUS_UNBOUND))
+	if _sync_in_progress or _emitting_sync_completed:
+		var _requested: bool = request_sync()
+		return get_last_sync_result()
+
+	_pending_sync = false
+	_deferred_sync_scheduled = false
+	_state = _STATE_SYNCING
+	var generation: int = _lifecycle_generation
+	_sync_layout_axis = int(layout_axis)
+	_sync_fill_cross_axis = fill_cross_axis
+	_sync_max_materialized_items = max_materialized_items
+	_sync_auto_measure = auto_measure
+	_sync_measurement_requested = _measurement_requested
+	_sync_measurement_request_revision = _measurement_request_revision
+	_sync_in_progress = true
+	var result: GFVirtualListSyncResult = _synchronize(generation)
+	_sync_in_progress = false
+	_clear_sync_context()
+	if (
+		_pool_trim_requested
+		and not _dispose_requested
+		and not _unbind_requested
+		and _state not in [_STATE_DISPOSING, _STATE_UNBINDING]
+	):
+		_trim_pool_to_limit()
+		result = _copy_result_with_current_pool_count(result)
+	if _dispose_requested or _state == _STATE_DISPOSING:
+		_finish_dispose()
+		result = _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	elif _unbind_requested or _state == _STATE_UNBINDING:
+		_finish_unbind()
+		result = _make_terminal_result(GFVirtualListSyncResult.STATUS_UNBOUND)
+	elif _pending_sync:
+		_state = _STATE_PENDING
+		_schedule_deferred_sync()
+	else:
+		_state = _STATE_IDLE
+	result = _store_result(result)
+	_emitting_sync_completed = true
+	sync_completed.emit(result.duplicate_result())
+	_emitting_sync_completed = false
+	return result
+
+
+## 标记项目条目内容或 identity 已变化，并请求重新绑定当前物化范围。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前已绑定时返回 true。
+func invalidate_items() -> bool:
+	if not is_bound():
+		return false
+	_data_revision += 1
+	if auto_measure:
+		_queue_measurement_request()
+	return request_sync()
+
+
+## 请求下一轮重新测量当前活动行；即使 auto_measure 为 false 也会执行。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前已绑定时返回 true。
+func request_measurement() -> bool:
+	if not is_bound():
+		return false
+	_queue_measurement_request()
+	return request_sync()
+
+
+## 把指定条目滚入视口。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param item_index: 条目索引。
+## [br]
+## @param alignment: `ScrollAlignment` 值。
+## [br]
+## 同步 callback 内不允许直接改变当前轮滚动；先保存项目意图并请求下一轮。
+## [br]
+## @return 索引和绑定有效、当前不在同步 callback 内，且滚动操作期间 data generation、
+## 模型、视口、主轴与 Control 所有权快照保持有效并接受最终整数偏移时返回 true；
+## 否则请求下一轮同步并返回 false。
+func scroll_to_item(
+	item_index: int,
+	alignment: ScrollAlignment = ScrollAlignment.NEAREST
+) -> bool:
+	if not is_bound() or _layout_model == null:
+		return false
+	if item_index < 0 or item_index >= _layout_model.get_item_count():
+		return false
+	if not _scroll_to_item_internal(item_index, alignment):
+		return false
+	return request_sync()
+
+
+## 获取指定索引当前物化的 Control。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param item_index: 条目索引。
+## [br]
+## @return 未物化时为 null。
+func get_materialized_control(item_index: int) -> Control:
+	var token_value: Variant = _token_by_index.get(item_index)
+	if not (token_value is String):
+		return null
+	var token: String = token_value
+	return _get_record_control(_get_active_record(token))
+
+
+## 按稳定 identity 获取当前物化的 Control。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param item_id: identity callback 使用的稳定 ID。
+## [br]
+## @return ID 无效或未物化时为 null。
+## [br]
+## @schema item_id: Stable Variant key accepted by GFVariantKeyCodec.
+func get_materialized_control_by_id(item_id: Variant) -> Control:
+	var token_report: Dictionary = _make_bounded_identity_token(item_id)
+	if not GFVariantData.get_option_bool(token_report, "ok"):
+		return null
+	var token: String = GFVariantData.get_option_string(token_report, "token")
+	return _get_record_control(_get_active_record(token))
+
+
+## 获取最近同步结果的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 尚未同步时返回当前生命周期终态结果。
+func get_last_sync_result() -> GFVirtualListSyncResult:
+	if _last_sync_result != null:
+		return _last_sync_result.duplicate_result()
+	var status: StringName = GFVirtualListSyncResult.STATUS_UNBOUND
+	if _state == _STATE_DISPOSED:
+		status = GFVirtualListSyncResult.STATUS_DISPOSED
+	return _make_terminal_result(status)
+
+
+## 获取不含项目条目载荷的调试快照。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 生命周期、范围和计数摘要。
+## [br]
+## @schema return: Dictionary with state, bound, disposed, lifecycle_generation, data_revision, pending_sync, active_count, pooled_count, and last_result.
+func get_debug_snapshot() -> Dictionary:
+	return {
+		"state": _state,
+		"bound": is_bound(),
+		"disposed": is_disposed(),
+		"lifecycle_generation": _lifecycle_generation,
+		"data_revision": _data_revision,
+		"pending_sync": _pending_sync,
+		"active_count": _active_by_token.size(),
+		"pooled_count": _pool.size(),
+		"last_result": get_last_sync_result().to_dict(),
+	}
+
+
+## 检查是否处于有效绑定生命周期。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已绑定且未进入 teardown 时返回 true。
+func is_bound() -> bool:
+	return _state in [_STATE_IDLE, _STATE_PENDING, _STATE_SYNCING]
+
+
+## 检查是否进入不可复用终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return dispose 已完成时返回 true。
+func is_disposed() -> bool:
+	return _state == _STATE_DISPOSED
+
+
+## 解除当前绑定并释放全部 Binder-owned Control；实例仍可重新 bind。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func unbind() -> void:
+	if _state in [_STATE_UNBOUND, _STATE_UNBINDING, _STATE_DISPOSING, _STATE_DISPOSED]:
+		return
+	_unbind_requested = true
+	_lifecycle_generation += 1
+	_state = _STATE_UNBINDING
+	if not _is_sync_in_progress() and not _teardown_in_progress:
+		_finish_unbind()
+
+
+## 进入终态并释放行、pool、连接和 callback。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+func dispose() -> void:
+	if _state in [_STATE_DISPOSING, _STATE_DISPOSED] or _dispose_requested:
+		return
+	_dispose_requested = true
+	_lifecycle_generation += 1
+	_state = _STATE_DISPOSING
+	if not _is_sync_in_progress() and not _teardown_in_progress:
+		_finish_dispose()
+
+
+# --- 私有/辅助方法 ---
+
+func _synchronize(generation: int) -> GFVirtualListSyncResult:
+	if generation != _lifecycle_generation:
+		return _make_terminal_result(_get_interrupted_status())
+	if not _binding_objects_are_live() or not _owned_controls_are_live():
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	var scroll_container: ScrollContainer = _get_scroll_container()
+	var layout_model: GFVirtualListModel = _layout_model
+	if scroll_container == null or layout_model == null:
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+
+	# Freeze every layout value that can affect this transaction before invoking
+	# project callbacks or mutating Controls. Reentrant configuration/model writes
+	# are intentionally observed by the next synchronization round.
+	var sync_data_revision: int = _data_revision
+	var sync_layout_revision: int = layout_model.get_revision()
+	var sync_focus_intent_revision: int = _focus_intent_revision
+	var sync_item_count: int = layout_model.get_item_count()
+	_sync_layout_model = layout_model
+	_sync_expected_layout_revision = sync_layout_revision
+	_sync_content_extent = layout_model.get_content_extent()
+	var scroll_offset: float = _get_scroll_offset(scroll_container)
+	var viewport_extent: float = _get_viewport_extent(scroll_container)
+	var planned_scroll_offset: float = scroll_offset
+	var reveal_index: int = _pending_focus_reveal_index
+	var reveal_is_current: bool = (
+		reveal_index != GFVirtualListFocusModel.NO_FOCUS
+		and auto_reveal_focus
+		and _focus_model != null
+		and _focus_model.focused_index == reveal_index
+		and reveal_index >= 0
+		and reveal_index < sync_item_count
+	)
+	if reveal_is_current:
+		planned_scroll_offset = _calculate_scroll_offset_for_item(
+			layout_model,
+			reveal_index,
+			ScrollAlignment.NEAREST,
+			scroll_offset,
+			viewport_extent,
+			_sync_content_extent
+		)
+	elif reveal_index != GFVirtualListFocusModel.NO_FOCUS:
+		_clear_pending_focus_reveal()
+	planned_scroll_offset = _quantize_scroll_offset(planned_scroll_offset)
+	var viewport_range: Vector2i = layout_model.get_viewport_range(
+		planned_scroll_offset,
+		viewport_extent
+	)
+	var requested_range: Vector2i = layout_model.get_visible_range(
+		planned_scroll_offset,
+		viewport_extent
+	)
+	var selection: Dictionary = _select_target_indices(viewport_range, requested_range)
+	var target_indices: PackedInt32Array = _get_packed_indices(selection, "indices")
+	var truncated: bool = GFVariantData.get_option_bool(selection, "truncated")
+	_sync_truncated = truncated
+	_snapshot_sync_item_geometries(layout_model, target_indices)
+	_sync_context_ready = true
+
+	_update_content_extent()
+	if generation != _lifecycle_generation:
+		return _make_terminal_result(_get_interrupted_status())
+	if not _owned_controls_are_live():
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	if not _sync_data_revision_is_current(sync_data_revision):
+		return _make_deferred_sync_result(
+			viewport_range,
+			requested_range,
+			sync_layout_revision,
+			sync_data_revision
+		)
+	if reveal_is_current:
+		_applying_scroll_adjustment = true
+		_set_scroll_offset(scroll_container, planned_scroll_offset)
+		_applying_scroll_adjustment = false
+		if generation != _lifecycle_generation:
+			return _make_terminal_result(_get_interrupted_status())
+		if not _owned_controls_are_live():
+			dispose()
+			return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+		if not _sync_data_revision_is_current(sync_data_revision):
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision
+			)
+	var round_scroll_offset: float = _get_scroll_offset(scroll_container)
+	var round_viewport_extent: float = _get_viewport_extent(scroll_container)
+	var scroll_snapshot_matches: bool = is_equal_approx(
+		round_scroll_offset,
+		planned_scroll_offset
+	)
+	var viewport_snapshot_matches: bool = is_equal_approx(
+		round_viewport_extent,
+		viewport_extent
+	)
+	if not scroll_snapshot_matches or not viewport_snapshot_matches:
+		var _requested_scroll_convergence: bool = request_sync()
+		if layout_model.get_revision() != sync_layout_revision:
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision
+			)
+		viewport_range = layout_model.get_viewport_range(
+			round_scroll_offset,
+			round_viewport_extent
+		)
+		requested_range = layout_model.get_visible_range(
+			round_scroll_offset,
+			round_viewport_extent
+		)
+		selection = _select_target_indices(viewport_range, requested_range)
+		target_indices = _get_packed_indices(selection, "indices")
+		truncated = GFVariantData.get_option_bool(selection, "truncated")
+		_sync_truncated = truncated
+		_snapshot_sync_item_geometries(layout_model, target_indices)
+	if not _sync_data_revision_is_current(sync_data_revision):
+		return _make_deferred_sync_result(
+			viewport_range,
+			requested_range,
+			sync_layout_revision,
+			sync_data_revision
+		)
+	if (
+		scroll_snapshot_matches
+		and viewport_snapshot_matches
+		and _pending_focus_reveal_index == reveal_index
+		and _focus_model != null
+		and _focus_model.focused_index == reveal_index
+	):
+		_clear_pending_focus_reveal()
+	if _focus_model != null:
+		var _focus_count_changed: bool = _focus_model.set_item_count(sync_item_count)
+		if generation != _lifecycle_generation:
+			return _make_terminal_result(_get_interrupted_status())
+		if not _owned_controls_are_live():
+			dispose()
+			return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+		if not _sync_data_revision_is_current(sync_data_revision):
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision
+			)
+
+	var identity_plan: Dictionary = _build_identity_plan(
+		target_indices,
+		generation,
+		sync_data_revision
+	)
+	if generation != _lifecycle_generation:
+		return _make_terminal_result(_get_interrupted_status())
+	if not _owned_controls_are_live():
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	var identity_status: StringName = GFVariantData.get_option_string_name(identity_plan, "status")
+	if identity_status != GFVirtualListSyncResult.STATUS_SYNCED:
+		if _state == _STATE_DISPOSING:
+			return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+		if identity_status == GFVirtualListSyncResult.STATUS_DEFERRED:
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision
+			)
+		return _make_sync_result(identity_status, viewport_range, requested_range, {
+			"truncated": truncated,
+			"error_index": GFVariantData.get_option_int(identity_plan, "error_index", -1),
+			"error": GFVariantData.get_option_string(identity_plan, "error"),
+		}, sync_layout_revision, sync_data_revision)
+
+	var descriptors: Array[Dictionary] = _get_descriptor_array(identity_plan)
+	var plan: Dictionary = _stage_materialization_plan(
+		descriptors,
+		generation,
+		sync_data_revision
+	)
+	var plan_status: StringName = GFVariantData.get_option_string_name(plan, "status")
+	if plan_status != GFVirtualListSyncResult.STATUS_SYNCED:
+		_rollback_staged_records(_get_record_array(plan, "staged_records"))
+		if generation != _lifecycle_generation:
+			return _make_terminal_result(_get_interrupted_status())
+		if plan_status == GFVirtualListSyncResult.STATUS_DEFERRED:
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision,
+				{
+					"created_count": GFVariantData.get_option_int(plan, "created_count"),
+					"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+				}
+			)
+		return _make_sync_result(plan_status, viewport_range, requested_range, {
+			"truncated": truncated,
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"error_index": GFVariantData.get_option_int(plan, "error_index", -1),
+			"error": GFVariantData.get_option_string(plan, "error"),
+		}, sync_layout_revision, sync_data_revision)
+	var staged_records: Array[Dictionary] = _get_record_array(plan, "staged_records")
+	if not _owned_controls_are_live(staged_records):
+		dispose()
+		_rollback_staged_records(staged_records)
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	if not _sync_data_revision_is_current(sync_data_revision):
+		_rollback_staged_records(staged_records)
+		return _make_deferred_sync_result(
+			viewport_range,
+			requested_range,
+			sync_layout_revision,
+			sync_data_revision
+		)
+
+	var metrics: Dictionary = _commit_materialization_plan(
+		plan,
+		generation,
+		sync_data_revision
+	)
+	if generation != _lifecycle_generation or _state in [_STATE_DISPOSING, _STATE_UNBINDING]:
+		return _make_terminal_result(
+			GFVirtualListSyncResult.STATUS_DISPOSED
+			if _state == _STATE_DISPOSING
+			else GFVirtualListSyncResult.STATUS_UNBOUND
+		)
+	if not _owned_controls_are_live():
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	if GFVariantData.get_option_bool(metrics, "deferred"):
+		return _make_deferred_sync_result(
+			viewport_range,
+			requested_range,
+			sync_layout_revision,
+			sync_data_revision,
+			metrics
+		)
+
+	if not _layout_active_controls(generation, sync_data_revision):
+		if (
+			generation == _lifecycle_generation
+			and is_bound()
+			and not _sync_data_revision_is_current(sync_data_revision)
+		):
+			metrics["released_count"] = (
+				GFVariantData.get_option_int(metrics, "released_count")
+				+ _rollback_materialization_after_data_drift([], generation)
+			)
+			if generation != _lifecycle_generation:
+				return _make_terminal_result(_get_interrupted_status())
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision,
+				metrics
+			)
+		return _make_terminal_result(_get_interrupted_status())
+	if generation != _lifecycle_generation:
+		return _make_terminal_result(_get_interrupted_status())
+	if not _owned_controls_are_live():
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	var should_measure: bool = (
+		_sync_measurement_requested
+		or (
+			_sync_auto_measure
+			and (
+				GFVariantData.get_option_int(metrics, "created_count") > 0
+				or sync_data_revision != _last_committed_data_revision
+			)
+		)
+	)
+	if should_measure:
+		# Consume only the request observed by this round. A measurement callback may
+		# enqueue another request, which must remain pending for the next round.
+		if (
+			_sync_measurement_requested
+			and _measurement_request_revision == _sync_measurement_request_revision
+		):
+			_measurement_requested = false
+		var measurement_metrics: Dictionary = _measure_active_controls(
+			round_scroll_offset,
+			generation,
+			sync_data_revision
+		)
+		metrics["measured_count"] = GFVariantData.get_option_int(measurement_metrics, "measured_count")
+		metrics["anchor_adjustment"] = GFVariantData.get_option_float(measurement_metrics, "anchor_adjustment")
+		if generation != _lifecycle_generation:
+			return _make_terminal_result(
+				GFVirtualListSyncResult.STATUS_DISPOSED
+				if _state == _STATE_DISPOSING
+				else GFVirtualListSyncResult.STATUS_UNBOUND
+			)
+		if not _owned_controls_are_live():
+			dispose()
+			return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+		if GFVariantData.get_option_bool(measurement_metrics, "deferred"):
+			metrics["released_count"] = (
+				GFVariantData.get_option_int(metrics, "released_count")
+				+ _rollback_materialization_after_data_drift([], generation)
+			)
+			if generation != _lifecycle_generation:
+				return _make_terminal_result(_get_interrupted_status())
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision,
+				metrics
+			)
+	var data_revision_changed: bool = sync_data_revision != _last_committed_data_revision
+	var layout_revision_changed: bool = sync_layout_revision != _last_committed_layout_revision
+	if sync_focus_intent_revision == _focus_intent_revision:
+		var physical_focus_current: bool = _reconcile_pending_physical_focus(
+			generation,
+			sync_data_revision
+		)
+		if not physical_focus_current and generation == _lifecycle_generation:
+			metrics["released_count"] = (
+				GFVariantData.get_option_int(metrics, "released_count")
+				+ _rollback_materialization_after_data_drift([], generation)
+			)
+			if generation != _lifecycle_generation:
+				return _make_terminal_result(_get_interrupted_status())
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision,
+				metrics
+			)
+	if (
+		generation == _lifecycle_generation
+		and sync_focus_intent_revision == _focus_intent_revision
+	):
+		var focus_handoff_current: bool = _apply_pending_focus_handoff(
+			generation,
+			sync_data_revision
+		)
+		if not focus_handoff_current and generation == _lifecycle_generation:
+			metrics["released_count"] = (
+				GFVariantData.get_option_int(metrics, "released_count")
+				+ _rollback_materialization_after_data_drift([], generation)
+			)
+			if generation != _lifecycle_generation:
+				return _make_terminal_result(_get_interrupted_status())
+			return _make_deferred_sync_result(
+				viewport_range,
+				requested_range,
+				sync_layout_revision,
+				sync_data_revision,
+				metrics
+			)
+	if generation != _lifecycle_generation:
+		return _make_terminal_result(
+			GFVirtualListSyncResult.STATUS_DISPOSED
+			if _state == _STATE_DISPOSING
+			else GFVirtualListSyncResult.STATUS_UNBOUND
+		)
+	if not _owned_controls_are_live():
+		dispose()
+		return _make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	if not _sync_data_revision_is_current(sync_data_revision):
+		metrics["released_count"] = (
+			GFVariantData.get_option_int(metrics, "released_count")
+			+ _rollback_materialization_after_data_drift([], generation)
+		)
+		if generation != _lifecycle_generation:
+			return _make_terminal_result(_get_interrupted_status())
+		return _make_deferred_sync_result(
+			viewport_range,
+			requested_range,
+			sync_layout_revision,
+			sync_data_revision,
+			metrics
+		)
+	_last_committed_data_revision = sync_data_revision
+	_last_committed_layout_revision = sync_layout_revision
+
+	var status: StringName = GFVirtualListSyncResult.STATUS_SYNCED
+	if GFVariantData.get_option_bool(metrics, "bind_failed"):
+		status = GFVirtualListSyncResult.STATUS_BIND_FAILED
+		metrics["error_index"] = GFVariantData.get_option_int(metrics, "bind_error_index", -1)
+		metrics["error"] = "bind_callback rejected an item"
+	elif truncated:
+		status = GFVirtualListSyncResult.STATUS_TRUNCATED
+	elif _sync_metrics_are_unchanged(metrics, data_revision_changed, layout_revision_changed):
+		status = GFVirtualListSyncResult.STATUS_UNCHANGED
+	metrics["truncated"] = truncated
+	return _make_sync_result(
+		status,
+		viewport_range,
+		requested_range,
+		metrics,
+		sync_layout_revision,
+		sync_data_revision
+	)
+
+
+func _build_identity_plan(
+	target_indices: PackedInt32Array,
+	generation: int,
+	sync_data_revision: int
+) -> Dictionary:
+	var descriptors: Array[Dictionary] = []
+	var seen_tokens: Dictionary = {}
+	for item_index: int in target_indices:
+		if generation != _lifecycle_generation:
+			return { "status": GFVirtualListSyncResult.STATUS_DISPOSED }
+		if not _sync_data_revision_is_current(sync_data_revision):
+			return {
+				"status": GFVirtualListSyncResult.STATUS_DEFERRED,
+				"descriptors": descriptors,
+			}
+		var item_id: Variant = _identity_callback.call(item_index)
+		if generation != _lifecycle_generation:
+			return { "status": GFVirtualListSyncResult.STATUS_DISPOSED }
+		if not _owned_controls_are_live():
+			dispose()
+			return { "status": GFVirtualListSyncResult.STATUS_DISPOSED }
+		if not _sync_data_revision_is_current(sync_data_revision):
+			return {
+				"status": GFVirtualListSyncResult.STATUS_DEFERRED,
+				"descriptors": descriptors,
+			}
+		var token_report: Dictionary = _make_bounded_identity_token(item_id)
+		if not GFVariantData.get_option_bool(token_report, "ok"):
+			var token_error: String = "identity_callback returned an unstable key"
+			if GFVariantData.get_option_bool(token_report, "over_limit"):
+				token_error = "identity_callback returned a key that exceeds the bounded token limit"
+			return {
+				"status": GFVirtualListSyncResult.STATUS_INVALID_IDENTITY,
+				"error_index": item_index,
+				"error": token_error,
+				"descriptors": descriptors,
+			}
+		var token: String = GFVariantData.get_option_string(token_report, "token")
+		if seen_tokens.has(token):
+			return {
+				"status": GFVirtualListSyncResult.STATUS_DUPLICATE_IDENTITY,
+				"error_index": item_index,
+				"error": "identity_callback returned a duplicate key in the requested range",
+				"descriptors": descriptors,
+			}
+		seen_tokens[token] = true
+		descriptors.append({
+			"index": item_index,
+			"identity": GFVariantData.duplicate_variant(item_id),
+			"token": token,
+		})
+	return {
+		"status": GFVirtualListSyncResult.STATUS_SYNCED,
+		"descriptors": descriptors,
+	}
+
+
+func _make_bounded_identity_token(item_id: Variant) -> Dictionary:
+	if typeof(item_id) in [TYPE_STRING, TYPE_STRING_NAME, TYPE_NODE_PATH]:
+		var source_text: String = str(item_id)
+		if source_text.length() > ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH:
+			return {
+				"ok": false,
+				"token": "",
+				"over_limit": true,
+			}
+	var token: String = GFVariantKeyCodec.make_key_token(item_id)
+	if token.is_empty():
+		return {
+			"ok": false,
+			"token": "",
+			"over_limit": false,
+		}
+	if (
+		token.length() > ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH
+		or token.to_utf8_buffer().size() > ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH
+	):
+		return {
+			"ok": false,
+			"token": "",
+			"over_limit": true,
+		}
+	return {
+		"ok": true,
+		"token": token,
+		"over_limit": false,
+	}
+
+
+func _stage_materialization_plan(
+	descriptors: Array[Dictionary],
+	generation: int,
+	sync_data_revision: int
+) -> Dictionary:
+	var planned_records: Array[Dictionary] = []
+	var staged_records: Array[Dictionary] = []
+	var target_tokens: Dictionary = {}
+	var created_count: int = 0
+	var reused_count: int = 0
+	for descriptor: Dictionary in descriptors:
+		var target_token: String = GFVariantData.get_option_string(descriptor, "token")
+		target_tokens[target_token] = true
+	var recyclable_records: Array[Dictionary] = []
+	for token_value: Variant in _active_by_token.keys():
+		if not (token_value is String):
+			continue
+		var active_token: String = token_value
+		if target_tokens.has(active_token):
+			continue
+		var recyclable_record: Dictionary = _get_active_record(active_token)
+		if not recyclable_record.is_empty():
+			recyclable_records.append(recyclable_record)
+	var recyclable_index: int = 0
+	for descriptor: Dictionary in descriptors:
+		var token: String = GFVariantData.get_option_string(descriptor, "token")
+		var item_index: int = GFVariantData.get_option_int(descriptor, "index", -1)
+		var active_record: Dictionary = _get_active_record(token)
+		var record: Dictionary = {}
+		if not active_record.is_empty():
+			record = _make_plan_record_from_active(active_record)
+			reused_count += 1
+		elif recyclable_index < recyclable_records.size():
+			record = _make_plan_record_from_active(recyclable_records[recyclable_index])
+			recyclable_index += 1
+			reused_count += 1
+		else:
+			var acquired: Dictionary = _acquire_control(generation, staged_records)
+			if not GFVariantData.get_option_bool(acquired, "ok"):
+				if not _sync_data_revision_is_current(sync_data_revision):
+					return {
+						"status": GFVirtualListSyncResult.STATUS_DEFERRED,
+						"planned_records": planned_records,
+						"staged_records": staged_records,
+						"target_tokens": target_tokens,
+						"created_count": created_count,
+						"reused_count": reused_count,
+					}
+				return {
+					"status": GFVirtualListSyncResult.STATUS_FACTORY_FAILED,
+					"planned_records": planned_records,
+					"staged_records": staged_records,
+					"target_tokens": target_tokens,
+					"created_count": created_count,
+					"reused_count": reused_count,
+					"error_index": item_index,
+					"error": GFVariantData.get_option_string(acquired, "error"),
+				}
+			record = {
+				"control": _get_control_value(acquired, "control"),
+				"bound": false,
+				"attached_to_content": false,
+				"from_active": false,
+				"from_pool": GFVariantData.get_option_bool(acquired, "from_pool"),
+				"source_token": "",
+				"previous_index": -1,
+			}
+			if GFVariantData.get_option_bool(acquired, "created"):
+				created_count += 1
+			else:
+				reused_count += 1
+			staged_records.append(record)
+			if not _sync_data_revision_is_current(sync_data_revision):
+				return {
+					"status": GFVirtualListSyncResult.STATUS_DEFERRED,
+					"planned_records": planned_records,
+					"staged_records": staged_records,
+					"target_tokens": target_tokens,
+					"created_count": created_count,
+					"reused_count": reused_count,
+				}
+		record["index"] = item_index
+		record["identity"] = GFVariantData.get_option_value(descriptor, "identity")
+		record["token"] = token
+		record["needs_rebind"] = (
+			not GFVariantData.get_option_bool(record, "bound")
+			or GFVariantData.get_option_string(record, "source_token") != token
+			or GFVariantData.get_option_int(record, "previous_index", -1) != item_index
+			or sync_data_revision != _last_committed_data_revision
+		)
+		planned_records.append(record)
+	return {
+		"status": GFVirtualListSyncResult.STATUS_SYNCED,
+		"planned_records": planned_records,
+		"staged_records": staged_records,
+		"target_tokens": target_tokens,
+		"created_count": created_count,
+		"reused_count": reused_count,
+	}
+
+
+func _make_plan_record_from_active(active_record: Dictionary) -> Dictionary:
+	return {
+		"control": _get_record_control(active_record),
+		"bound": GFVariantData.get_option_bool(active_record, "bound"),
+		"attached_to_content": true,
+		"from_active": true,
+		"from_pool": false,
+		"source_token": GFVariantData.get_option_string(active_record, "token"),
+		"previous_index": GFVariantData.get_option_int(active_record, "index", -1),
+	}
+
+
+func _commit_materialization_plan(
+	plan: Dictionary,
+	generation: int,
+	sync_data_revision: int
+) -> Dictionary:
+	var planned_records: Array[Dictionary] = _get_record_array(plan, "planned_records")
+	var target_tokens: Dictionary = GFVariantData.get_option_dictionary(plan, "target_tokens")
+	var content_root: Control = _get_content_root()
+	var released_count: int = 0
+	var bind_failed: bool = false
+	var bind_error_index: int = -1
+	var data_drifted: bool = false
+	var next_active_by_token: Dictionary = {}
+	var next_token_by_index: Dictionary = {}
+	var rebind_by_source_token: Dictionary = {}
+	for planned_record: Dictionary in planned_records:
+		var source_token: String = GFVariantData.get_option_string(planned_record, "source_token")
+		if not source_token.is_empty() and GFVariantData.get_option_bool(planned_record, "needs_rebind"):
+			rebind_by_source_token[source_token] = true
+
+	for token_value: Variant in _active_by_token.keys():
+		if generation != _lifecycle_generation:
+			break
+		if not _sync_data_revision_is_current(sync_data_revision):
+			data_drifted = true
+			break
+		if not (token_value is String):
+			continue
+		var token: String = token_value
+		var record: Dictionary = _get_active_record(token)
+		var leaving: bool = not target_tokens.has(token)
+		var needs_rebind: bool = rebind_by_source_token.has(token)
+		if (leaving or needs_rebind) and GFVariantData.get_option_bool(record, "bound"):
+			var control: Control = _get_record_control(record)
+			var _released_commit_focus: bool = _release_control_focus_if_owned(record)
+			if generation != _lifecycle_generation:
+				break
+			if not _sync_data_revision_is_current(sync_data_revision):
+				data_drifted = true
+				break
+			if not _transaction_owned_controls_are_live(planned_records):
+				dispose()
+				break
+			_invoke_unbind(record)
+			record["bound"] = false
+			released_count += 1
+			if generation != _lifecycle_generation:
+				break
+			if not _sync_data_revision_is_current(sync_data_revision):
+				data_drifted = true
+				break
+			if not _control_has_expected_parent(control, content_root):
+				dispose()
+				break
+			if not _transaction_owned_controls_are_live(planned_records):
+				dispose()
+				break
+
+	if data_drifted:
+		released_count += _rollback_materialization_after_data_drift(
+			planned_records,
+			generation
+		)
+		return {
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"released_count": released_count,
+			"bind_failed": bind_failed,
+			"bind_error_index": bind_error_index,
+			"deferred": true,
+		}
+
+	for record: Dictionary in planned_records:
+		if generation != _lifecycle_generation:
+			break
+		if not _sync_data_revision_is_current(sync_data_revision):
+			data_drifted = true
+			break
+		var control: Control = _get_record_control(record)
+		if control == null:
+			dispose()
+			break
+		var item_index: int = GFVariantData.get_option_int(record, "index", -1)
+		var token: String = GFVariantData.get_option_string(record, "token")
+		var needs_rebind: bool = GFVariantData.get_option_bool(record, "needs_rebind")
+		if not _ensure_control_parent(
+			control,
+			GFVariantData.get_option_bool(record, "from_active")
+		):
+			break
+		record["attached_to_content"] = true
+		if generation != _lifecycle_generation:
+			break
+		if not _sync_data_revision_is_current(sync_data_revision):
+			data_drifted = true
+			break
+		if not _transaction_owned_controls_are_live(planned_records):
+			dispose()
+			break
+		if needs_rebind:
+			record["bound"] = true
+			record["bind_invoked"] = true
+			var accepted: bool = _invoke_bind(record)
+			if generation != _lifecycle_generation:
+				break
+			if not _control_has_expected_parent(control, content_root):
+				dispose()
+				break
+			if not _transaction_owned_controls_are_live(planned_records):
+				dispose()
+				break
+			if not _sync_data_revision_is_current(sync_data_revision):
+				data_drifted = true
+				break
+			if not accepted:
+				_invoke_unbind(record)
+				record["bound"] = false
+				record["bind_invoked"] = false
+				if generation != _lifecycle_generation:
+					break
+				if not _sync_data_revision_is_current(sync_data_revision):
+					data_drifted = true
+					break
+				if not _transaction_owned_controls_are_live(planned_records):
+					dispose()
+					break
+				if not _release_control_to_pool(control, content_root):
+					break
+				record["attached_to_content"] = false
+				if generation != _lifecycle_generation:
+					break
+				if not _sync_data_revision_is_current(sync_data_revision):
+					data_drifted = true
+					break
+				if not _transaction_owned_controls_are_live(planned_records):
+					dispose()
+					break
+				bind_failed = true
+				if bind_error_index < 0:
+					bind_error_index = item_index
+				continue
+		next_active_by_token[token] = record
+		next_token_by_index[item_index] = token
+
+	if data_drifted:
+		released_count += _rollback_materialization_after_data_drift(
+			planned_records,
+			generation
+		)
+		return {
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"released_count": released_count,
+			"bind_failed": bind_failed,
+			"bind_error_index": bind_error_index,
+			"deferred": true,
+		}
+	if generation != _lifecycle_generation:
+		_abort_materialization_commit(planned_records)
+		return {
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"released_count": released_count,
+			"bind_failed": bind_failed,
+			"bind_error_index": bind_error_index,
+		}
+	var next_control_ids: Dictionary = {}
+	for next_record_value: Variant in next_active_by_token.values():
+		if next_record_value is Dictionary:
+			var next_record: Dictionary = next_record_value
+			var next_control: Control = _get_record_control(next_record)
+			if next_control != null:
+				next_control_ids[next_control.get_instance_id()] = true
+	for token_value: Variant in _active_by_token.keys():
+		if not _sync_data_revision_is_current(sync_data_revision):
+			data_drifted = true
+			break
+		if not (token_value is String):
+			continue
+		var token: String = token_value
+		var record: Dictionary = _get_active_record(token)
+		var control: Control = _get_record_control(record)
+		if (
+			control != null
+			and not next_control_ids.has(control.get_instance_id())
+		):
+			if control in _pool:
+				continue
+			if not _release_control_to_pool(control, content_root):
+				break
+			if generation != _lifecycle_generation:
+				break
+			if not _sync_data_revision_is_current(sync_data_revision):
+				data_drifted = true
+				break
+			if not _transaction_owned_controls_are_live(planned_records):
+				dispose()
+				break
+	if data_drifted:
+		released_count += _rollback_materialization_after_data_drift(
+			planned_records,
+			generation
+		)
+		return {
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"released_count": released_count,
+			"bind_failed": bind_failed,
+			"bind_error_index": bind_error_index,
+			"deferred": true,
+		}
+	if generation != _lifecycle_generation:
+		_abort_materialization_commit(planned_records)
+		return {
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"released_count": released_count,
+			"bind_failed": bind_failed,
+			"bind_error_index": bind_error_index,
+		}
+	if not _sync_data_revision_is_current(sync_data_revision):
+		released_count += _rollback_materialization_after_data_drift(
+			planned_records,
+			generation
+		)
+		return {
+			"created_count": GFVariantData.get_option_int(plan, "created_count"),
+			"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+			"released_count": released_count,
+			"bind_failed": bind_failed,
+			"bind_error_index": bind_error_index,
+			"deferred": true,
+		}
+	for record: Dictionary in planned_records:
+		var _erased_needs_rebind: bool = record.erase("needs_rebind")
+		var _erased_source_token: bool = record.erase("source_token")
+		var _erased_previous_index: bool = record.erase("previous_index")
+		var _erased_from_active: bool = record.erase("from_active")
+		var _erased_from_pool: bool = record.erase("from_pool")
+		var _erased_bind_invoked: bool = record.erase("bind_invoked")
+		var _erased_attached: bool = record.erase("attached_to_content")
+	_active_by_token = next_active_by_token
+	_token_by_index = next_token_by_index
+	if generation == _lifecycle_generation and not _owned_controls_are_live():
+		dispose()
+	return {
+		"created_count": GFVariantData.get_option_int(plan, "created_count"),
+		"reused_count": GFVariantData.get_option_int(plan, "reused_count"),
+		"released_count": released_count,
+		"bind_failed": bind_failed,
+		"bind_error_index": bind_error_index,
+	}
+
+
+func _abort_materialization_commit(planned_records: Array[Dictionary]) -> void:
+	var content_root: Control = _get_content_root()
+	for record: Dictionary in planned_records:
+		var was_bound: bool = GFVariantData.get_option_bool(record, "bind_invoked")
+		var was_attached: bool = GFVariantData.get_option_bool(record, "attached_to_content")
+		if was_bound:
+			_invoke_unbind(record)
+			record["bound"] = false
+			record["bind_invoked"] = false
+		if GFVariantData.get_option_bool(record, "from_active"):
+			continue
+		var control: Control = _get_record_control(record)
+		if control == null:
+			dispose()
+			continue
+		if control in _pool:
+			record["attached_to_content"] = false
+			continue
+		var expected_parent: Node = content_root if was_attached else null
+		var _released: bool = _release_control_to_pool(control, expected_parent)
+		record["attached_to_content"] = false
+
+
+func _rollback_materialization_after_data_drift(
+	planned_records: Array[Dictionary],
+	generation: int
+) -> int:
+	var released_count: int = 0
+	_abort_materialization_commit(planned_records)
+	if generation != _lifecycle_generation or not is_bound():
+		return released_count
+	var content_root: Control = _get_content_root()
+	if content_root == null:
+		dispose()
+		return released_count
+	var seen_control_ids: Dictionary = {}
+	for token_value: Variant in _active_by_token.keys():
+		if generation != _lifecycle_generation:
+			return released_count
+		if not (token_value is String):
+			continue
+		var token: String = token_value
+		var record: Dictionary = _get_active_record(token)
+		var control: Control = _get_record_control(record)
+		if control == null:
+			dispose()
+			return released_count
+		var control_id: int = control.get_instance_id()
+		if seen_control_ids.has(control_id):
+			continue
+		seen_control_ids[control_id] = true
+		if GFVariantData.get_option_bool(record, "bound"):
+			var _released_rollback_focus: bool = _release_control_focus_if_owned(record)
+			if generation != _lifecycle_generation:
+				return released_count
+			if not _transaction_owned_controls_are_live(planned_records):
+				dispose()
+				return released_count
+			_invoke_unbind(record)
+			record["bound"] = false
+			released_count += 1
+			if generation != _lifecycle_generation:
+				return released_count
+			if not _transaction_owned_controls_are_live(planned_records):
+				dispose()
+				return released_count
+		if control in _pool:
+			_mark_planned_control_parentless(planned_records, control)
+			continue
+		if not _release_control_to_pool(control, content_root):
+			return released_count
+		_mark_planned_control_parentless(planned_records, control)
+		if generation != _lifecycle_generation:
+			return released_count
+		if not _transaction_owned_controls_are_live(planned_records):
+			dispose()
+			return released_count
+	_active_by_token.clear()
+	_token_by_index.clear()
+	return released_count
+
+
+func _mark_planned_control_parentless(
+	planned_records: Array[Dictionary],
+	control: Control
+) -> void:
+	if control == null:
+		return
+	for planned_record: Dictionary in planned_records:
+		if is_same(_get_record_control(planned_record), control):
+			planned_record["attached_to_content"] = false
+
+
+func _measure_active_controls(
+	scroll_offset: float,
+	generation: int,
+	sync_data_revision: int
+) -> Dictionary:
+	var measured_count: int = 0
+	var anchor_adjustment: float = 0.0
+	if not _sync_data_revision_is_current(sync_data_revision):
+		_queue_measurement_request()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": anchor_adjustment,
+			"deferred": true,
+		}
+	if not _sync_layout_model_is_current():
+		_queue_measurement_request()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": anchor_adjustment,
+		}
+	var active_indices: Array[int] = _get_active_indices()
+	var anchored_indices: Dictionary = {}
+	for item_index: int in active_indices:
+		var geometry: Dictionary = _get_sync_item_geometry(item_index)
+		var geometry_extent: float = GFVariantData.get_option_float(geometry, "extent")
+		if geometry_extent <= 0.0:
+			dispose()
+			break
+		var item_bottom: float = (
+			GFVariantData.get_option_float(geometry, "offset")
+			+ geometry_extent
+		)
+		if item_bottom <= scroll_offset + 0.5:
+			anchored_indices[item_index] = true
+	for item_index: int in active_indices:
+		if generation != _lifecycle_generation:
+			break
+		if not _sync_data_revision_is_current(sync_data_revision):
+			_queue_measurement_request()
+			return {
+				"measured_count": measured_count,
+				"anchor_adjustment": 0.0,
+				"deferred": true,
+			}
+		if not _sync_layout_model_is_current():
+			_queue_measurement_request()
+			break
+		var record: Dictionary = _get_record_for_index(item_index)
+		var control: Control = _get_record_control(record)
+		if control == null:
+			continue
+		var extent: float = _measure_control(record)
+		if generation != _lifecycle_generation:
+			break
+		if not _owned_controls_are_live():
+			dispose()
+			break
+		if not _sync_data_revision_is_current(sync_data_revision):
+			_queue_measurement_request()
+			return {
+				"measured_count": measured_count,
+				"anchor_adjustment": 0.0,
+				"deferred": true,
+			}
+		if not _sync_layout_model_is_current():
+			_queue_measurement_request()
+			break
+		if not is_finite(extent) or extent <= 0.0:
+			continue
+		var report: Dictionary = _sync_layout_model.set_item_extent(item_index, extent, true)
+		var report_ok: bool = GFVariantData.get_option_bool(report, "ok")
+		if report_ok:
+			measured_count += 1
+		if generation != _lifecycle_generation:
+			break
+		if not _owned_controls_are_live():
+			dispose()
+			break
+		if not _sync_data_revision_is_current(sync_data_revision):
+			_queue_measurement_request()
+			return {
+				"measured_count": measured_count,
+				"anchor_adjustment": 0.0,
+				"deferred": true,
+			}
+		var report_changed: bool = GFVariantData.get_option_bool(report, "changed")
+		var expected_revision: int = _sync_expected_layout_revision
+		if report_changed:
+			expected_revision += 1
+		if (
+			not is_same(_layout_model, _sync_layout_model)
+			or _sync_layout_model.get_revision() != expected_revision
+		):
+			_queue_measurement_request()
+			break
+		_sync_expected_layout_revision = expected_revision
+		if not report_ok:
+			continue
+		if report_changed:
+			_apply_sync_measurement_report(item_index, report)
+			if anchored_indices.has(item_index):
+				anchor_adjustment += GFVariantData.get_option_float(report, "delta")
+	if generation != _lifecycle_generation:
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+		}
+	_update_content_extent()
+	if generation != _lifecycle_generation:
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+		}
+	if not _owned_controls_are_live():
+		dispose()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+		}
+	if not _sync_data_revision_is_current(sync_data_revision):
+		_queue_measurement_request()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+			"deferred": true,
+		}
+	if not _layout_active_controls(generation, sync_data_revision):
+		var layout_data_drifted: bool = (
+			generation == _lifecycle_generation
+			and not _sync_data_revision_is_current(sync_data_revision)
+		)
+		if layout_data_drifted:
+			_queue_measurement_request()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+			"deferred": layout_data_drifted,
+		}
+	if generation != _lifecycle_generation:
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+		}
+	if not _owned_controls_are_live():
+		dispose()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+		}
+	if not _sync_data_revision_is_current(sync_data_revision):
+		_queue_measurement_request()
+		return {
+			"measured_count": measured_count,
+			"anchor_adjustment": 0.0,
+			"deferred": true,
+		}
+	if not is_zero_approx(anchor_adjustment):
+		var scroll_container: ScrollContainer = _get_scroll_container()
+		if scroll_container != null:
+			_applying_scroll_adjustment = true
+			_set_scroll_offset(scroll_container, scroll_offset + anchor_adjustment)
+			_applying_scroll_adjustment = false
+			if generation != _lifecycle_generation:
+				return {
+					"measured_count": measured_count,
+					"anchor_adjustment": 0.0,
+				}
+			if not _owned_controls_are_live():
+				dispose()
+				return {
+					"measured_count": measured_count,
+					"anchor_adjustment": 0.0,
+				}
+			if not _sync_data_revision_is_current(sync_data_revision):
+				_queue_measurement_request()
+				return {
+					"measured_count": measured_count,
+					"anchor_adjustment": anchor_adjustment,
+					"deferred": true,
+				}
+	return {
+		"measured_count": measured_count,
+		"anchor_adjustment": anchor_adjustment,
+	}
+
+
+func _layout_active_controls(generation: int, sync_data_revision: int) -> bool:
+	var content_root: Control = _get_content_root()
+	var scroll_container: ScrollContainer = _get_scroll_container()
+	if content_root == null or scroll_container == null or _layout_model == null:
+		dispose()
+		return false
+	var effective_axis: int = _get_effective_layout_axis()
+	var effective_fill_cross_axis: bool = _get_effective_fill_cross_axis()
+	var cross_extent: float = (
+		maxf(content_root.size.y, scroll_container.size.y)
+		if effective_axis == LayoutAxis.HORIZONTAL
+		else maxf(content_root.size.x, scroll_container.size.x)
+	)
+	for item_index: int in _get_active_indices():
+		if not _layout_write_barrier_is_current(generation, sync_data_revision):
+			return false
+		var control: Control = get_materialized_control(item_index)
+		if control == null:
+			continue
+		var offset: float = 0.0
+		var extent: float = 0.0
+		if _sync_context_ready:
+			var geometry: Dictionary = _get_sync_item_geometry(item_index)
+			extent = GFVariantData.get_option_float(geometry, "extent")
+			if extent <= 0.0:
+				dispose()
+				return false
+			offset = GFVariantData.get_option_float(geometry, "offset")
+		else:
+			offset = _layout_model.get_item_offset(item_index)
+			extent = _layout_model.get_item_extent(item_index)
+		var next_position: Vector2 = control.position
+		var next_size: Vector2 = control.size
+		if effective_axis == LayoutAxis.HORIZONTAL:
+			next_position.x = offset
+			next_size.x = extent
+			if effective_fill_cross_axis:
+				next_position.y = 0.0
+				next_size.y = cross_extent
+		else:
+			next_position.y = offset
+			next_size.y = extent
+			if effective_fill_cross_axis:
+				next_position.x = 0.0
+				next_size.x = cross_extent
+		control.position = next_position
+		if not _layout_write_barrier_is_current(generation, sync_data_revision):
+			return false
+		control.size = next_size
+		if not _layout_write_barrier_is_current(generation, sync_data_revision):
+			return false
+	return true
+
+
+func _layout_write_barrier_is_current(
+	generation: int,
+	sync_data_revision: int
+) -> bool:
+	if generation != _lifecycle_generation:
+		return false
+	if not _owned_controls_are_live():
+		dispose()
+		return false
+	return _sync_data_revision_is_current(sync_data_revision)
+
+
+func _update_content_extent() -> void:
+	var content_root: Control = _get_content_root()
+	if content_root == null or _layout_model == null:
+		return
+	var content_extent: float = (
+		_sync_content_extent
+		if _sync_context_ready
+		else _layout_model.get_content_extent()
+	)
+	var next_owned_axis: int = _get_effective_layout_axis()
+	_apply_content_extent_snapshot(content_root, next_owned_axis, content_extent)
+
+
+func _apply_content_extent_snapshot(
+	content_root: Control,
+	next_owned_axis: int,
+	content_extent: float
+) -> void:
+	var minimum_size: Vector2 = content_root.custom_minimum_size
+	if _owned_layout_axis != -1 and _owned_layout_axis != next_owned_axis:
+		if _owned_layout_axis == LayoutAxis.HORIZONTAL:
+			minimum_size.x = _owned_layout_axis_baseline
+		else:
+			minimum_size.y = _owned_layout_axis_baseline
+		_owned_layout_axis = -1
+	if _owned_layout_axis == -1:
+		_owned_layout_axis_baseline = (
+			minimum_size.x
+			if next_owned_axis == LayoutAxis.HORIZONTAL
+			else minimum_size.y
+		)
+		_owned_layout_axis = next_owned_axis
+	if next_owned_axis == LayoutAxis.HORIZONTAL:
+		minimum_size.x = content_extent
+	else:
+		minimum_size.y = content_extent
+	content_root.custom_minimum_size = minimum_size
+
+
+func _select_target_indices(viewport_range: Vector2i, requested_range: Vector2i) -> Dictionary:
+	var limit: int = maxi(_sync_max_materialized_items, 1)
+	var requested_count: int = maxi(requested_range.y - requested_range.x, 0)
+	var result: Array[int] = []
+	if requested_count <= limit:
+		for item_index: int in range(requested_range.x, requested_range.y):
+			result.append(item_index)
+		return {
+			"indices": PackedInt32Array(result),
+			"truncated": false,
+		}
+
+	for item_index: int in range(viewport_range.x, mini(viewport_range.y, viewport_range.x + limit)):
+		result.append(item_index)
+	var before_index: int = viewport_range.x - 1
+	var after_index: int = viewport_range.y
+	while result.size() < limit and (before_index >= requested_range.x or after_index < requested_range.y):
+		if before_index >= requested_range.x and result.size() < limit:
+			result.append(before_index)
+			before_index -= 1
+		if after_index < requested_range.y and result.size() < limit:
+			result.append(after_index)
+			after_index += 1
+	result.sort()
+	return {
+		"indices": PackedInt32Array(result),
+		"truncated": true,
+	}
+
+
+func _acquire_control(generation: int, staged_records: Array[Dictionary]) -> Dictionary:
+	if not _owned_controls_are_live(staged_records):
+		dispose()
+		return { "ok": false, "error": "owned Control boundary was violated" }
+	if not _pool.is_empty():
+		var pooled_value: Variant = _pool.pop_back()
+		var pooled: Control = _get_live_control(pooled_value)
+		if not _control_has_expected_parent(pooled, null):
+			dispose()
+			return { "ok": false, "error": "pooled Control boundary was violated" }
+		return {
+			"ok": true,
+			"control": pooled,
+			"from_pool": true,
+			"created": false,
+		}
+	if generation != _lifecycle_generation:
+		return { "ok": false, "error": "binding generation ended" }
+	var value: Variant = _item_factory.call()
+	if generation != _lifecycle_generation:
+		if value is Control:
+			var abandoned_control: Control = value
+			if (
+				is_instance_valid(abandoned_control)
+				and not abandoned_control.is_queued_for_deletion()
+				and abandoned_control.get_parent() == null
+			):
+				abandoned_control.queue_free()
+		return { "ok": false, "error": "binding generation ended" }
+	if not _owned_controls_are_live(staged_records):
+		if value is Control:
+			var abandoned_control: Control = value
+			if (
+				is_instance_valid(abandoned_control)
+				and not abandoned_control.is_queued_for_deletion()
+				and abandoned_control.get_parent() == null
+			):
+				abandoned_control.queue_free()
+		dispose()
+		return { "ok": false, "error": "owned Control boundary was violated" }
+	if not (value is Control):
+		return { "ok": false, "error": "item_factory did not return Control" }
+	var control: Control = value
+	if not is_instance_valid(control) or control.is_queued_for_deletion() or control.get_parent() != null:
+		return { "ok": false, "error": "item_factory returned an invalid or parented Control" }
+	var control_id: int = control.get_instance_id()
+	if _known_control_ids.has(control_id):
+		return { "ok": false, "error": "item_factory returned a Control already owned by this Binder" }
+	_known_control_ids[control_id] = true
+	return {
+		"ok": true,
+		"control": control,
+		"from_pool": false,
+		"created": true,
+	}
+
+
+func _rollback_staged_records(records: Array[Dictionary]) -> void:
+	for record: Dictionary in records:
+		var control: Control = _get_record_control(record)
+		if control == null:
+			dispose()
+			continue
+		var _released: bool = _release_control_to_pool(control, null)
+
+
+func _release_control_to_pool(control: Control, expected_parent: Node) -> bool:
+	if control == null or not is_instance_valid(control) or control.is_queued_for_deletion():
+		dispose()
+		return false
+	if _state in [_STATE_DISPOSING, _STATE_DISPOSED]:
+		_queue_free_owned_control(control)
+		return true
+	var parent: Node = control.get_parent()
+	if parent != expected_parent:
+		dispose()
+		_queue_free_owned_control(control)
+		return false
+	if parent != null:
+		parent.remove_child(control)
+	if _state not in [_STATE_DISPOSING, _STATE_DISPOSED]:
+		_pool.append(control)
+		_pool_trim_requested = true
+		return true
+	_queue_free_owned_control(control)
+	return true
+
+
+func _trim_pool_to_limit() -> void:
+	_pool_trim_requested = false
+	if not _pool_controls_are_live():
+		dispose()
+		return
+	var limit: int = clampi(max_pooled_items, 0, ABSOLUTE_MAX_POOLED_ITEMS)
+	while _pool.size() > limit:
+		var control_value: Variant = _pool.pop_back()
+		var control: Control = _get_live_control(control_value)
+		if control != null:
+			_queue_free_owned_control(control)
+
+
+func _queue_free_owned_control(control: Control) -> void:
+	if control == null or not is_instance_valid(control):
+		return
+	var control_id: int = control.get_instance_id()
+	var _known_erased: bool = _known_control_ids.erase(control_id)
+	var parent: Node = control.get_parent()
+	if parent != null:
+		parent.remove_child(control)
+	if not control.is_queued_for_deletion():
+		control.queue_free()
+
+
+func _ensure_control_parent(control: Control, from_active: bool) -> bool:
+	var content_root: Control = _get_content_root()
+	if (
+		content_root == null
+		or control == null
+		or not is_instance_valid(control)
+		or control.is_queued_for_deletion()
+	):
+		dispose()
+		return false
+	var expected_parent: Node = content_root if from_active else null
+	if not _control_has_expected_parent(control, expected_parent):
+		dispose()
+		return false
+	if from_active:
+		return true
+	content_root.add_child(control)
+	if not _control_has_expected_parent(control, content_root):
+		dispose()
+		return false
+	return true
+
+
+func _invoke_bind(record: Dictionary) -> bool:
+	var control: Control = _get_record_control(record)
+	if control == null:
+		return false
+	var result: Variant = _bind_callback.call(
+		control,
+		GFVariantData.get_option_int(record, "index", -1),
+		GFVariantData.get_option_value(record, "identity")
+	)
+	if result is bool:
+		var accepted: bool = result
+		return accepted
+	return false
+
+
+func _invoke_unbind(record: Dictionary) -> void:
+	var control: Control = _get_record_control(record)
+	if control == null or not _unbind_callback.is_valid():
+		return
+	var _result: Variant = _unbind_callback.call(
+		control,
+		GFVariantData.get_option_int(record, "index", -1),
+		GFVariantData.get_option_value(record, "identity")
+	)
+
+
+func _measure_control(record: Dictionary) -> float:
+	var control: Control = _get_record_control(record)
+	if control == null:
+		return 0.0
+	if _measure_callback.is_valid():
+		var value: Variant = _measure_callback.call(
+			control,
+			GFVariantData.get_option_int(record, "index", -1),
+			GFVariantData.get_option_value(record, "identity")
+		)
+		if value is float:
+			var measured_float: float = value
+			return measured_float
+		if value is int:
+			var measured_int: int = value
+			return float(measured_int)
+	var minimum_size: Vector2 = control.get_combined_minimum_size()
+	var effective_axis: int = _get_effective_layout_axis()
+	var extent: float = (
+		minimum_size.x
+		if effective_axis == LayoutAxis.HORIZONTAL
+		else minimum_size.y
+	)
+	if extent <= 0.0:
+		extent = control.size.x if effective_axis == LayoutAxis.HORIZONTAL else control.size.y
+	return extent
+
+
+func _scroll_to_item_internal(item_index: int, alignment: ScrollAlignment) -> bool:
+	if _sync_in_progress and _sync_context_ready:
+		return false
+	var generation: int = _lifecycle_generation
+	var layout_model: GFVirtualListModel = _layout_model
+	var scroll_container: ScrollContainer = _get_scroll_container()
+	var content_root: Control = _get_content_root()
+	if (
+		not is_bound()
+		or scroll_container == null
+		or content_root == null
+		or layout_model == null
+		or item_index < 0
+		or item_index >= layout_model.get_item_count()
+	):
+		return false
+	# Freeze the complete public operation before custom_minimum_size or scroll
+	# writes can synchronously invoke project listeners.
+	var operation_axis: int = int(layout_axis)
+	var operation_data_revision: int = _data_revision
+	var operation_layout_revision: int = layout_model.get_revision()
+	var operation_content_extent: float = layout_model.get_content_extent()
+	var item_start: float = layout_model.get_item_offset(item_index)
+	var item_extent: float = layout_model.get_item_extent(item_index)
+	var viewport_extent: float = _get_viewport_extent_for_axis(
+		scroll_container,
+		operation_axis
+	)
+	var scroll_offset: float = _get_scroll_offset_for_axis(scroll_container, operation_axis)
+	var next_offset: float = _calculate_scroll_offset_for_geometry(
+		item_start,
+		item_extent,
+		alignment,
+		scroll_offset,
+		viewport_extent,
+		operation_content_extent
+	)
+	next_offset = _quantize_scroll_offset(next_offset)
+	_apply_content_extent_snapshot(
+		content_root,
+		operation_axis,
+		operation_content_extent
+	)
+	if not _scroll_operation_is_current(
+		generation,
+		operation_data_revision,
+		layout_model,
+		operation_layout_revision,
+		operation_axis,
+		viewport_extent,
+		scroll_container,
+		content_root
+	):
+		_request_sync_after_scroll_drift()
+		return false
+	_set_scroll_offset_for_axis(scroll_container, next_offset, operation_axis)
+	var operation_is_current: bool = _scroll_operation_is_current(
+		generation,
+		operation_data_revision,
+		layout_model,
+		operation_layout_revision,
+		operation_axis,
+		viewport_extent,
+		scroll_container,
+		content_root
+	)
+	operation_is_current = (
+		operation_is_current
+		and is_equal_approx(
+			_get_scroll_offset_for_axis(scroll_container, operation_axis),
+			next_offset
+		)
+	)
+	if not operation_is_current:
+		_request_sync_after_scroll_drift()
+	return operation_is_current
+
+
+func _scroll_operation_is_current(
+	generation: int,
+	data_revision: int,
+	layout_model: GFVirtualListModel,
+	layout_revision: int,
+	operation_axis: int,
+	viewport_extent: float,
+	scroll_container: ScrollContainer,
+	content_root: Control
+) -> bool:
+	var binding_is_current: bool = (
+		generation == _lifecycle_generation
+		and _data_revision == data_revision
+		and is_bound()
+		and is_same(_layout_model, layout_model)
+		and layout_model.get_revision() == layout_revision
+		and int(layout_axis) == operation_axis
+		and is_equal_approx(
+			_get_viewport_extent_for_axis(scroll_container, operation_axis),
+			viewport_extent
+		)
+		and is_same(_get_scroll_container(), scroll_container)
+		and is_same(_get_content_root(), content_root)
+		and _binding_objects_are_live()
+	)
+	if not binding_is_current:
+		return false
+	if not _owned_controls_are_live():
+		dispose()
+		return false
+	return true
+
+
+func _request_sync_after_scroll_drift() -> void:
+	if is_bound() and _state not in [_STATE_UNBINDING, _STATE_DISPOSING]:
+		var _requested: bool = request_sync()
+
+
+func _calculate_scroll_offset_for_item(
+	layout_model: GFVirtualListModel,
+	item_index: int,
+	alignment: ScrollAlignment,
+	scroll_offset: float,
+	viewport_extent: float,
+	content_extent: float
+) -> float:
+	var item_start: float = layout_model.get_item_offset(item_index)
+	var item_extent: float = layout_model.get_item_extent(item_index)
+	return _calculate_scroll_offset_for_geometry(
+		item_start,
+		item_extent,
+		alignment,
+		scroll_offset,
+		viewport_extent,
+		content_extent
+	)
+
+
+func _calculate_scroll_offset_for_geometry(
+	item_start: float,
+	item_extent: float,
+	alignment: ScrollAlignment,
+	scroll_offset: float,
+	viewport_extent: float,
+	content_extent: float
+) -> float:
+	var item_end: float = item_start + item_extent
+	var next_offset: float = scroll_offset
+	match alignment:
+		ScrollAlignment.START:
+			next_offset = item_start
+		ScrollAlignment.CENTER:
+			next_offset = item_start - (viewport_extent - item_extent) * 0.5
+		ScrollAlignment.END:
+			next_offset = item_end - viewport_extent
+		_:
+			if item_start < scroll_offset:
+				next_offset = item_start
+			elif item_end > scroll_offset + viewport_extent:
+				next_offset = item_end - viewport_extent
+	var max_offset: float = maxf(content_extent - viewport_extent, 0.0)
+	return clampf(next_offset, 0.0, max_offset)
+
+
+func _reconcile_pending_physical_focus(
+	generation: int,
+	sync_data_revision: int
+) -> bool:
+	if not _sync_data_revision_is_current(sync_data_revision):
+		return false
+	if not _pending_physical_focus_reconciliation:
+		return true
+	_pending_physical_focus_reconciliation = false
+	var viewport: Viewport = _get_viewport()
+	var focus_owner: Control = viewport.gui_get_focus_owner() if viewport != null else null
+	if focus_owner == null:
+		return true
+	var focused_index: int = (
+		_focus_model.focused_index
+		if _focus_model != null
+		else GFVirtualListFocusModel.NO_FOCUS
+	)
+	for item_index: int in _get_active_indices():
+		var record: Dictionary = _get_record_for_index(item_index)
+		var control: Control = _get_record_control(record)
+		if (
+			control == null
+			or (
+				focus_owner != control
+				and not _node_is_descendant_of(focus_owner, control)
+			)
+		):
+			continue
+		if item_index != focused_index:
+			var project_focus_replaced_release: bool = _release_control_focus_if_owned(record)
+			if generation != _lifecycle_generation:
+				return false
+			if not _owned_controls_are_live():
+				dispose()
+				return false
+			if not _sync_data_revision_is_current(sync_data_revision):
+				return false
+			if project_focus_replaced_release:
+				_clear_pending_focus_handoff()
+		return true
+	return true
+
+
+func _apply_pending_focus_handoff(
+	generation: int,
+	sync_data_revision: int
+) -> bool:
+	if not _sync_data_revision_is_current(sync_data_revision):
+		return false
+	if not _pending_focus_handoff or _focus_model == null:
+		return true
+	var handoff_index: int = _pending_focus_index
+	if handoff_index != _focus_model.focused_index:
+		_clear_pending_focus_handoff()
+		return true
+	var viewport: Viewport = _get_viewport()
+	if _pending_focus_started_with_owner and (
+		viewport == null or viewport.gui_get_focus_owner() == null
+	):
+		_clear_pending_focus_handoff()
+		return true
+	var record: Dictionary = _get_record_for_index(handoff_index)
+	var control: Control = _get_record_control(record)
+	if control == null:
+		return true
+	var focus_target: Control = control
+	if _focus_target_callback.is_valid():
+		var value: Variant = _focus_target_callback.call(
+			control,
+			handoff_index,
+			GFVariantData.get_option_value(record, "identity")
+		)
+		if generation != _lifecycle_generation:
+			return false
+		if not _owned_controls_are_live():
+			dispose()
+			return false
+		if not _sync_data_revision_is_current(sync_data_revision):
+			return false
+		if not _focus_handoff_is_current(generation, handoff_index):
+			return true
+		if value is Control and is_instance_valid(value):
+			var candidate: Control = value
+			if (
+				not candidate.is_queued_for_deletion()
+				and (candidate == control or _node_is_descendant_of(candidate, control))
+			):
+				focus_target = candidate
+	if not _focus_handoff_is_current(generation, handoff_index):
+		return true
+	if (
+		not is_instance_valid(focus_target)
+		or focus_target.is_queued_for_deletion()
+		or focus_target.focus_mode == Control.FOCUS_NONE
+		or not focus_target.is_inside_tree()
+		or not focus_target.is_visible_in_tree()
+	):
+		return true
+	_focus_handoff_in_progress = true
+	_focus_handoff_index = handoff_index
+	_focus_handoff_observed_target = false
+	focus_target.grab_focus()
+	var observed_target: bool = _focus_handoff_observed_target
+	_focus_handoff_in_progress = false
+	_focus_handoff_index = GFVirtualListFocusModel.NO_FOCUS
+	_focus_handoff_observed_target = false
+	if generation != _lifecycle_generation:
+		return false
+	if not _owned_controls_are_live():
+		dispose()
+		return false
+	if not _sync_data_revision_is_current(sync_data_revision):
+		return false
+	var focus_owner: Control = viewport.gui_get_focus_owner() if viewport != null else null
+	if (
+		_focus_handoff_is_current(generation, handoff_index)
+		and (
+			(
+				focus_owner != null
+				and (focus_owner == control or _node_is_descendant_of(focus_owner, control))
+			)
+			or (observed_target and focus_owner == null)
+		)
+	):
+		_clear_pending_focus_handoff()
+	return true
+
+
+func _focus_handoff_is_current(generation: int, handoff_index: int) -> bool:
+	return (
+		generation == _lifecycle_generation
+		and _pending_focus_handoff
+		and _pending_focus_index == handoff_index
+		and _focus_model != null
+		and _focus_model.focused_index == handoff_index
+	)
+
+
+func _arm_pending_focus_handoff(item_index: int) -> void:
+	_pending_focus_index = item_index
+	_pending_focus_handoff = item_index != GFVirtualListFocusModel.NO_FOCUS
+	_pending_focus_started_with_owner = false
+	if not _pending_focus_handoff:
+		return
+	var viewport: Viewport = _get_viewport()
+	_pending_focus_started_with_owner = (
+		viewport != null and viewport.gui_get_focus_owner() != null
+	)
+
+
+func _clear_pending_focus_handoff() -> void:
+	_pending_focus_handoff = false
+	_pending_focus_index = GFVirtualListFocusModel.NO_FOCUS
+	_pending_focus_started_with_owner = false
+
+
+func _arm_pending_focus_reveal(item_index: int) -> void:
+	if not auto_reveal_focus or item_index == GFVirtualListFocusModel.NO_FOCUS:
+		_clear_pending_focus_reveal()
+		return
+	_pending_focus_reveal_index = item_index
+
+
+func _clear_pending_focus_reveal() -> void:
+	_pending_focus_reveal_index = GFVirtualListFocusModel.NO_FOCUS
+
+
+func _adopt_bound_virtual_focus() -> void:
+	_clear_pending_focus_handoff()
+	_clear_pending_focus_reveal()
+	if _focus_model == null:
+		return
+	var focused_index: int = _focus_model.focused_index
+	if focused_index == GFVirtualListFocusModel.NO_FOCUS:
+		return
+	if auto_reveal_focus:
+		_arm_pending_focus_reveal(focused_index)
+		var _revealed: bool = _scroll_to_item_internal(focused_index, ScrollAlignment.NEAREST)
+	var viewport: Viewport = _get_viewport()
+	if viewport != null and viewport.gui_get_focus_owner() == null:
+		_arm_pending_focus_handoff(focused_index)
+
+
+func _release_control_focus_if_owned(record: Dictionary) -> bool:
+	var control: Control = _get_record_control(record)
+	var viewport: Viewport = _get_viewport()
+	if control == null or viewport == null:
+		return false
+	var focus_owner: Control = viewport.gui_get_focus_owner()
+	if focus_owner == null:
+		return false
+	if focus_owner != control and not _node_is_descendant_of(focus_owner, control):
+		return false
+	focus_owner.release_focus()
+	if viewport.gui_get_focus_owner() != null:
+		return true
+	if (
+		_focus_model != null
+		and _focus_model.focused_index == GFVariantData.get_option_int(record, "index", -1)
+	):
+		_arm_pending_focus_handoff(_focus_model.focused_index)
+	return false
+
+
+func _connect_binding_signals(
+	owner: Node,
+	scroll_container: ScrollContainer,
+	content_root: Control,
+	viewport: Viewport
+) -> void:
+	_binding_tree_exited_callable = Callable(self, "_on_binding_tree_exited")
+	_scroll_resized_callable = Callable(self, "_on_scroll_resized")
+	_content_resized_callable = Callable(self, "_on_content_resized")
+	_vertical_scroll_callable = Callable(self, "_on_scroll_value_changed")
+	_horizontal_scroll_callable = Callable(self, "_on_scroll_value_changed")
+	_layout_changed_callable = Callable(self, "_on_layout_changed")
+	_focus_changed_callable = Callable(self, "_on_focus_changed")
+	_viewport_focus_changed_callable = Callable(self, "_on_viewport_focus_changed")
+	var lifecycle_nodes: Array[Node] = [owner, scroll_container, content_root]
+	var connected_node_ids: Dictionary = {}
+	_binding_tree_exit_refs.clear()
+	for lifecycle_node: Node in lifecycle_nodes:
+		var node_id: int = lifecycle_node.get_instance_id()
+		if connected_node_ids.has(node_id):
+			continue
+		connected_node_ids[node_id] = true
+		var connect_result: Error = OK
+		if not lifecycle_node.tree_exited.is_connected(_binding_tree_exited_callable):
+			connect_result = lifecycle_node.tree_exited.connect(
+				_binding_tree_exited_callable,
+				CONNECT_ONE_SHOT
+			) as Error
+		if connect_result == OK:
+			_binding_tree_exit_refs.append(weakref(lifecycle_node))
+	var _scroll_resized_connected: Error = scroll_container.resized.connect(_scroll_resized_callable) as Error
+	var _content_resized_connected: Error = content_root.resized.connect(_content_resized_callable) as Error
+	var _vertical_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(_vertical_scroll_callable) as Error
+	var _horizontal_connected: Error = scroll_container.get_h_scroll_bar().value_changed.connect(_horizontal_scroll_callable) as Error
+	var _layout_connected: Error = _layout_model.layout_changed.connect(_layout_changed_callable) as Error
+	if _focus_model != null:
+		var _focus_connected: Error = _focus_model.focused_index_changed.connect(_focus_changed_callable) as Error
+	if viewport != null:
+		var _viewport_connected: Error = viewport.gui_focus_changed.connect(_viewport_focus_changed_callable) as Error
+
+
+func _disconnect_binding_signals() -> void:
+	for node_ref: WeakRef in _binding_tree_exit_refs:
+		var value: Variant = node_ref.get_ref()
+		if typeof(value) != TYPE_OBJECT or not is_instance_valid(value):
+			continue
+		if value is Node:
+			var lifecycle_node: Node = value
+			if (
+				_binding_tree_exited_callable.is_valid()
+				and lifecycle_node.tree_exited.is_connected(_binding_tree_exited_callable)
+			):
+				lifecycle_node.tree_exited.disconnect(_binding_tree_exited_callable)
+	_binding_tree_exit_refs.clear()
+	var scroll_container: ScrollContainer = _get_scroll_container()
+	if scroll_container != null:
+		if _scroll_resized_callable.is_valid() and scroll_container.resized.is_connected(_scroll_resized_callable):
+			scroll_container.resized.disconnect(_scroll_resized_callable)
+		var vertical_bar: VScrollBar = scroll_container.get_v_scroll_bar()
+		if _vertical_scroll_callable.is_valid() and vertical_bar.value_changed.is_connected(_vertical_scroll_callable):
+			vertical_bar.value_changed.disconnect(_vertical_scroll_callable)
+		var horizontal_bar: HScrollBar = scroll_container.get_h_scroll_bar()
+		if _horizontal_scroll_callable.is_valid() and horizontal_bar.value_changed.is_connected(_horizontal_scroll_callable):
+			horizontal_bar.value_changed.disconnect(_horizontal_scroll_callable)
+	var content_root: Control = _get_content_root()
+	if content_root != null and _content_resized_callable.is_valid() and content_root.resized.is_connected(_content_resized_callable):
+		content_root.resized.disconnect(_content_resized_callable)
+	if _layout_model != null and _layout_changed_callable.is_valid() and _layout_model.layout_changed.is_connected(_layout_changed_callable):
+		_layout_model.layout_changed.disconnect(_layout_changed_callable)
+	if _focus_model != null and _focus_changed_callable.is_valid() and _focus_model.focused_index_changed.is_connected(_focus_changed_callable):
+		_focus_model.focused_index_changed.disconnect(_focus_changed_callable)
+	var viewport: Viewport = _get_viewport()
+	if viewport != null and _viewport_focus_changed_callable.is_valid() and viewport.gui_focus_changed.is_connected(_viewport_focus_changed_callable):
+		viewport.gui_focus_changed.disconnect(_viewport_focus_changed_callable)
+
+
+func _finish_unbind() -> void:
+	if _teardown_in_progress:
+		return
+	_teardown_in_progress = true
+	_state = _STATE_UNBINDING
+	_disconnect_binding_signals()
+	_release_all_controls()
+	_restore_content_minimum_size()
+	_clear_binding_references()
+	var escalated_to_dispose: bool = _dispose_requested
+	_unbind_requested = false
+	_dispose_requested = false
+	_state = _STATE_DISPOSED if escalated_to_dispose else _STATE_UNBOUND
+	var terminal_status: StringName = (
+		GFVirtualListSyncResult.STATUS_DISPOSED
+		if escalated_to_dispose
+		else GFVirtualListSyncResult.STATUS_UNBOUND
+	)
+	var _stored_unbind_result: GFVirtualListSyncResult = _store_result(_make_terminal_result(terminal_status))
+	_teardown_in_progress = false
+
+
+func _finish_dispose() -> void:
+	if _teardown_in_progress:
+		return
+	_teardown_in_progress = true
+	_state = _STATE_DISPOSING
+	_disconnect_binding_signals()
+	_release_all_controls()
+	_restore_content_minimum_size()
+	_clear_binding_references()
+	_unbind_requested = false
+	_dispose_requested = false
+	_state = _STATE_DISPOSED
+	var _stored_disposed_result: GFVirtualListSyncResult = _store_result(
+		_make_terminal_result(GFVirtualListSyncResult.STATUS_DISPOSED)
+	)
+	_teardown_in_progress = false
+
+
+func _release_all_controls() -> void:
+	for item_index: int in _get_active_indices():
+		var record: Dictionary = _get_record_for_index(item_index)
+		if GFVariantData.get_option_bool(record, "bound"):
+			var _released_teardown_focus: bool = _release_control_focus_if_owned(record)
+			_invoke_unbind(record)
+			record["bound"] = false
+		var control: Control = _get_record_control(record)
+		if control != null:
+			_queue_free_owned_control(control)
+	_active_by_token.clear()
+	_token_by_index.clear()
+	for control_value: Variant in _pool:
+		var control: Control = _get_live_control(control_value)
+		if control != null:
+			_queue_free_owned_control(control)
+	_pool.clear()
+	_known_control_ids.clear()
+
+
+func _restore_content_minimum_size() -> void:
+	var content_root: Control = _get_content_root()
+	if content_root != null:
+		var minimum_size: Vector2 = content_root.custom_minimum_size
+		if _owned_layout_axis == LayoutAxis.HORIZONTAL:
+			minimum_size.x = _owned_layout_axis_baseline
+		elif _owned_layout_axis == LayoutAxis.VERTICAL:
+			minimum_size.y = _owned_layout_axis_baseline
+		content_root.custom_minimum_size = minimum_size
+	_owned_layout_axis = -1
+	_owned_layout_axis_baseline = 0.0
+
+
+func _clear_binding_references() -> void:
+	_pending_sync = false
+	_deferred_sync_scheduled = false
+	_measurement_requested = false
+	_measurement_request_revision = 0
+	_pool_trim_requested = false
+	_binding_focus_initialization = false
+	_clear_sync_context()
+	_clear_pending_focus_handoff()
+	_clear_pending_focus_reveal()
+	_pending_physical_focus_reconciliation = false
+	_focus_intent_revision = 0
+	_focus_handoff_in_progress = false
+	_focus_handoff_index = GFVirtualListFocusModel.NO_FOCUS
+	_focus_handoff_observed_target = false
+	_owner_ref = null
+	_scroll_ref = null
+	_content_ref = null
+	_viewport_ref = null
+	_layout_model = null
+	_focus_model = null
+	_item_factory = Callable()
+	_bind_callback = Callable()
+	_unbind_callback = Callable()
+	_identity_callback = Callable()
+	_measure_callback = Callable()
+	_focus_target_callback = Callable()
+
+
+func _schedule_deferred_sync() -> void:
+	if _deferred_sync_scheduled or _state == _STATE_SYNCING:
+		return
+	_deferred_sync_scheduled = true
+	var _deferred_result: Variant = call_deferred("_run_deferred_sync", _lifecycle_generation)
+
+
+func _run_deferred_sync(generation: int) -> void:
+	_deferred_sync_scheduled = false
+	if generation != _lifecycle_generation or not _pending_sync or not is_bound():
+		return
+	var _result: GFVirtualListSyncResult = sync_now()
+
+
+func _make_sync_result(
+	status: StringName,
+	viewport_range: Vector2i,
+	requested_range: Vector2i,
+	metrics: Dictionary = {},
+	layout_revision: int = -1,
+	data_revision: int = -1
+) -> GFVirtualListSyncResult:
+	var result: GFVirtualListSyncResult = GFVirtualListSyncResult.new()
+	var resolved_layout_revision: int = layout_revision
+	if resolved_layout_revision < 0:
+		resolved_layout_revision = _layout_model.get_revision() if _layout_model != null else 0
+	var resolved_data_revision: int = data_revision if data_revision >= 0 else _data_revision
+	var _configured: bool = result.configure_for_framework({
+		"status": status,
+		"layout_revision": resolved_layout_revision,
+		"data_revision": resolved_data_revision,
+		"viewport_range": viewport_range,
+		"requested_range": requested_range,
+		"materialized_indices": PackedInt32Array(_get_active_indices()),
+		"pooled_count": _pool.size(),
+		"created_count": GFVariantData.get_option_int(metrics, "created_count"),
+		"reused_count": GFVariantData.get_option_int(metrics, "reused_count"),
+		"released_count": GFVariantData.get_option_int(metrics, "released_count"),
+		"measured_count": GFVariantData.get_option_int(metrics, "measured_count"),
+		"anchor_adjustment": GFVariantData.get_option_float(metrics, "anchor_adjustment"),
+		"truncated": GFVariantData.get_option_bool(metrics, "truncated"),
+		"error_index": GFVariantData.get_option_int(metrics, "error_index", -1),
+		"error": GFVariantData.get_option_string(metrics, "error"),
+	})
+	return result
+
+
+func _make_terminal_result(status: StringName) -> GFVirtualListSyncResult:
+	return _make_sync_result(status, Vector2i.ZERO, Vector2i.ZERO)
+
+
+func _make_deferred_sync_result(
+	viewport_range: Vector2i,
+	requested_range: Vector2i,
+	layout_revision: int,
+	data_revision: int,
+	metrics: Dictionary = {}
+) -> GFVirtualListSyncResult:
+	if is_bound() and _state not in [_STATE_UNBINDING, _STATE_DISPOSING]:
+		var _requested_deferred_round: bool = request_sync()
+	var result_metrics: Dictionary = metrics.duplicate()
+	result_metrics["truncated"] = _sync_truncated
+	return _make_sync_result(
+		GFVirtualListSyncResult.STATUS_DEFERRED,
+		viewport_range,
+		requested_range,
+		result_metrics,
+		layout_revision,
+		data_revision
+	)
+
+
+func _copy_result_with_current_pool_count(
+	source: GFVirtualListSyncResult
+) -> GFVirtualListSyncResult:
+	if source == null:
+		return _make_terminal_result(_get_interrupted_status())
+	var snapshot: Dictionary = source.to_dict()
+	snapshot["pooled_count"] = _pool.size()
+	var result: GFVirtualListSyncResult = GFVirtualListSyncResult.new()
+	var _configured: bool = result.configure_for_framework(snapshot)
+	return result
+
+
+func _get_interrupted_status() -> StringName:
+	if _state in [_STATE_UNBOUND, _STATE_UNBINDING]:
+		return GFVirtualListSyncResult.STATUS_UNBOUND
+	return GFVirtualListSyncResult.STATUS_DISPOSED
+
+
+func _store_result(result: GFVirtualListSyncResult) -> GFVirtualListSyncResult:
+	_last_sync_result = result.duplicate_result()
+	return result
+
+
+func _sync_metrics_are_unchanged(
+	metrics: Dictionary,
+	data_revision_changed: bool,
+	layout_revision_changed: bool
+) -> bool:
+	return (
+		GFVariantData.get_option_int(metrics, "created_count") == 0
+		and GFVariantData.get_option_int(metrics, "released_count") == 0
+		and GFVariantData.get_option_int(metrics, "measured_count") == 0
+		and is_zero_approx(GFVariantData.get_option_float(metrics, "anchor_adjustment"))
+		and not data_revision_changed
+		and not layout_revision_changed
+	)
+
+
+func _get_active_indices() -> Array[int]:
+	var indices: Array[int] = []
+	for index_value: Variant in _token_by_index.keys():
+		if index_value is int:
+			var item_index: int = index_value
+			indices.append(item_index)
+	indices.sort()
+	return indices
+
+
+func _get_active_record(token: String) -> Dictionary:
+	var value: Variant = _active_by_token.get(token)
+	if value is Dictionary:
+		var record: Dictionary = value
+		return record
+	return {}
+
+
+func _get_record_for_index(item_index: int) -> Dictionary:
+	var token_value: Variant = _token_by_index.get(item_index)
+	if token_value is String:
+		var token: String = token_value
+		return _get_active_record(token)
+	return {}
+
+
+func _get_record_control(record: Dictionary) -> Control:
+	return _get_control_value(record, "control")
+
+
+func _get_control_value(data: Dictionary, key: String) -> Control:
+	var value: Variant = GFVariantData.get_option_value(data, key)
+	return _get_live_control(value)
+
+
+func _get_live_control(value: Variant) -> Control:
+	if typeof(value) != TYPE_OBJECT or not is_instance_valid(value):
+		return null
+	if value is Control:
+		var control: Control = value
+		if not control.is_queued_for_deletion():
+			return control
+	return null
+
+
+func _get_descriptor_array(data: Dictionary) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for value: Variant in GFVariantData.get_option_array(data, "descriptors"):
+		if value is Dictionary:
+			var descriptor: Dictionary = value
+			result.append(descriptor)
+	return result
+
+
+func _get_record_array(data: Dictionary, key: String) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for value: Variant in GFVariantData.get_option_array(data, key):
+		if value is Dictionary:
+			var record: Dictionary = value
+			result.append(record)
+	return result
+
+
+func _get_packed_indices(data: Dictionary, key: String) -> PackedInt32Array:
+	var value: Variant = GFVariantData.get_option_value(data, key, PackedInt32Array())
+	if value is PackedInt32Array:
+		var indices: PackedInt32Array = value
+		return indices
+	return PackedInt32Array()
+
+
+func _get_effective_layout_axis() -> int:
+	if _sync_in_progress and _sync_layout_axis in [LayoutAxis.VERTICAL, LayoutAxis.HORIZONTAL]:
+		return _sync_layout_axis
+	return int(layout_axis)
+
+
+func _get_effective_fill_cross_axis() -> bool:
+	if _sync_in_progress:
+		return _sync_fill_cross_axis
+	return fill_cross_axis
+
+
+func _sync_layout_model_is_current() -> bool:
+	return (
+		_sync_context_ready
+		and _sync_layout_model != null
+		and is_same(_layout_model, _sync_layout_model)
+		and _sync_layout_model.get_revision() == _sync_expected_layout_revision
+	)
+
+
+func _sync_data_revision_is_current(sync_data_revision: int) -> bool:
+	return _sync_in_progress and _data_revision == sync_data_revision
+
+
+func _get_sync_item_geometry(item_index: int) -> Dictionary:
+	var value: Variant = _sync_item_geometries.get(item_index)
+	if value is Dictionary:
+		var geometry: Dictionary = value
+		return geometry.duplicate()
+	return {}
+
+
+func _snapshot_sync_item_geometries(
+	layout_model: GFVirtualListModel,
+	target_indices: PackedInt32Array
+) -> void:
+	_sync_item_geometries.clear()
+	for item_index: int in target_indices:
+		_sync_item_geometries[item_index] = {
+			"offset": layout_model.get_item_offset(item_index),
+			"extent": layout_model.get_item_extent(item_index),
+		}
+
+
+func _apply_sync_measurement_report(item_index: int, report: Dictionary) -> void:
+	var geometry: Dictionary = _get_sync_item_geometry(item_index)
+	var previous_extent: float = GFVariantData.get_option_float(geometry, "extent")
+	if previous_extent <= 0.0:
+		dispose()
+		return
+	var delta: float = GFVariantData.get_option_float(report, "delta")
+	geometry["extent"] = GFVariantData.get_option_float(report, "extent", previous_extent)
+	_sync_item_geometries[item_index] = geometry
+	if not is_zero_approx(delta):
+		for key: Variant in _sync_item_geometries.keys():
+			if key is int:
+				var geometry_index: int = key
+				if geometry_index > item_index:
+					var shifted_geometry: Dictionary = _get_sync_item_geometry(geometry_index)
+					shifted_geometry["offset"] = (
+						GFVariantData.get_option_float(shifted_geometry, "offset")
+						+ delta
+					)
+					_sync_item_geometries[geometry_index] = shifted_geometry
+		_sync_content_extent = maxf(_sync_content_extent + delta, 0.0)
+
+
+func _clear_sync_context() -> void:
+	_sync_layout_axis = -1
+	_sync_fill_cross_axis = false
+	_sync_max_materialized_items = DEFAULT_MAX_MATERIALIZED_ITEMS
+	_sync_auto_measure = true
+	_sync_measurement_requested = false
+	_sync_measurement_request_revision = 0
+	_sync_truncated = false
+	_sync_layout_model = null
+	_sync_expected_layout_revision = -1
+	_sync_content_extent = 0.0
+	_sync_item_geometries.clear()
+	_sync_context_ready = false
+
+
+func _get_scroll_offset(scroll_container: ScrollContainer) -> float:
+	return _get_scroll_offset_for_axis(scroll_container, _get_effective_layout_axis())
+
+
+func _get_scroll_offset_for_axis(scroll_container: ScrollContainer, axis: int) -> float:
+	if axis == LayoutAxis.HORIZONTAL:
+		return float(scroll_container.scroll_horizontal)
+	return float(scroll_container.scroll_vertical)
+
+
+func _set_scroll_offset(scroll_container: ScrollContainer, value: float) -> void:
+	_set_scroll_offset_for_axis(scroll_container, value, _get_effective_layout_axis())
+
+
+func _set_scroll_offset_for_axis(
+	scroll_container: ScrollContainer,
+	value: float,
+	axis: int
+) -> void:
+	var safe_value: int = int(_quantize_scroll_offset(value))
+	if axis == LayoutAxis.HORIZONTAL:
+		scroll_container.scroll_horizontal = safe_value
+	else:
+		scroll_container.scroll_vertical = safe_value
+
+
+func _quantize_scroll_offset(value: float) -> float:
+	return float(maxi(roundi(value), 0))
+
+
+func _get_viewport_extent(scroll_container: ScrollContainer) -> float:
+	return _get_viewport_extent_for_axis(scroll_container, _get_effective_layout_axis())
+
+
+func _get_viewport_extent_for_axis(scroll_container: ScrollContainer, axis: int) -> float:
+	var container_extent: float = (
+		scroll_container.size.x
+		if axis == LayoutAxis.HORIZONTAL
+		else scroll_container.size.y
+	)
+	var scroll_page: float = (
+		scroll_container.get_h_scroll_bar().page
+		if axis == LayoutAxis.HORIZONTAL
+		else scroll_container.get_v_scroll_bar().page
+	)
+	if is_finite(scroll_page) and scroll_page > 0.0:
+		return minf(scroll_page, maxf(container_extent, 0.0))
+	return maxf(container_extent, 0.0)
+
+
+func _is_valid_binding_boundary(
+	owner: Node,
+	scroll_container: ScrollContainer,
+	content_root: Control,
+	layout_model: GFVirtualListModel
+) -> bool:
+	return (
+		owner != null
+		and is_instance_valid(owner)
+		and owner.is_inside_tree()
+		and scroll_container != null
+		and is_instance_valid(scroll_container)
+		and scroll_container.is_inside_tree()
+		and content_root != null
+		and is_instance_valid(content_root)
+		and content_root.get_parent() == scroll_container
+		and not (content_root is Container)
+		and layout_model != null
+	)
+
+
+func _binding_objects_are_live() -> bool:
+	var owner: Node = _get_owner_node()
+	var scroll_container: ScrollContainer = _get_scroll_container()
+	var content_root: Control = _get_content_root()
+	return (
+		owner != null
+		and owner.is_inside_tree()
+		and scroll_container != null
+		and scroll_container.is_inside_tree()
+		and content_root != null
+		and content_root.is_inside_tree()
+		and content_root.get_parent() == scroll_container
+	)
+
+
+func _owned_controls_are_live(additional_parentless_records: Array[Dictionary] = []) -> bool:
+	var content_root: Control = _get_content_root()
+	if content_root == null:
+		return false
+	var observed_control_ids: Dictionary = {}
+	if _token_by_index.size() != _active_by_token.size():
+		return false
+	for token_value: Variant in _active_by_token.keys():
+		if not (token_value is String):
+			return false
+		var token: String = token_value
+		var record_value: Variant = _active_by_token.get(token)
+		if not (record_value is Dictionary):
+			return false
+		var record: Dictionary = record_value
+		var item_index: int = GFVariantData.get_option_int(record, "index", -1)
+		if (
+			item_index < 0
+			or GFVariantData.get_option_string(record, "token") != token
+			or not GFVariantData.get_option_bool(record, "bound")
+			or _token_by_index.get(item_index) != token
+		):
+			return false
+		var control: Control = _get_record_control(record)
+		if not _register_owned_control(control, content_root, observed_control_ids):
+			return false
+	for index_value: Variant in _token_by_index.keys():
+		if not (index_value is int):
+			return false
+		var item_index: int = index_value
+		var token_value: Variant = _token_by_index.get(item_index)
+		if not (token_value is String):
+			return false
+		var token: String = token_value
+		var record_value: Variant = _active_by_token.get(token)
+		if not (record_value is Dictionary):
+			return false
+		var record: Dictionary = record_value
+		if GFVariantData.get_option_int(record, "index", -1) != item_index:
+			return false
+	for control_value: Variant in _pool:
+		var control: Control = _get_live_control(control_value)
+		if not _register_owned_control(control, null, observed_control_ids):
+			return false
+	for record: Dictionary in additional_parentless_records:
+		var control: Control = _get_record_control(record)
+		if not _register_owned_control(control, null, observed_control_ids):
+			return false
+	if observed_control_ids.size() != _known_control_ids.size():
+		return false
+	for control_id_value: Variant in _known_control_ids.keys():
+		if not (control_id_value is int) or not observed_control_ids.has(control_id_value):
+			return false
+	return true
+
+
+func _transaction_owned_controls_are_live(planned_records: Array[Dictionary]) -> bool:
+	var content_root: Control = _get_content_root()
+	if content_root == null or _token_by_index.size() != _active_by_token.size():
+		return false
+	var controls_by_id: Dictionary = {}
+	var active_control_ids: Dictionary = {}
+	for token_value: Variant in _active_by_token.keys():
+		if not (token_value is String):
+			return false
+		var token: String = token_value
+		var record_value: Variant = _active_by_token.get(token)
+		if not (record_value is Dictionary):
+			return false
+		var record: Dictionary = record_value
+		var item_index: int = GFVariantData.get_option_int(record, "index", -1)
+		if (
+			item_index < 0
+			or GFVariantData.get_option_string(record, "token") != token
+			or _token_by_index.get(item_index) != token
+		):
+			return false
+		var control: Control = _get_record_control(record)
+		if not _register_transaction_control(control, controls_by_id):
+			return false
+		active_control_ids[control.get_instance_id()] = true
+	for index_value: Variant in _token_by_index.keys():
+		if not (index_value is int):
+			return false
+		var item_index: int = index_value
+		var token_value: Variant = _token_by_index.get(item_index)
+		if not (token_value is String):
+			return false
+		var record_value: Variant = _active_by_token.get(token_value)
+		if not (record_value is Dictionary):
+			return false
+		var record: Dictionary = record_value
+		if GFVariantData.get_option_int(record, "index", -1) != item_index:
+			return false
+
+	var expected_parents: Dictionary = {}
+	var planned_control_ids: Dictionary = {}
+	for record: Dictionary in planned_records:
+		var control: Control = _get_record_control(record)
+		if not _register_transaction_control(control, controls_by_id):
+			return false
+		var control_id: int = control.get_instance_id()
+		if planned_control_ids.has(control_id):
+			return false
+		planned_control_ids[control_id] = true
+		expected_parents[control_id] = (
+			content_root
+			if GFVariantData.get_option_bool(record, "attached_to_content")
+			else null
+		)
+
+	var pooled_control_ids: Dictionary = {}
+	for control_value: Variant in _pool:
+		var control: Control = _get_live_control(control_value)
+		if not _register_transaction_control(control, controls_by_id):
+			return false
+		var control_id: int = control.get_instance_id()
+		if pooled_control_ids.has(control_id):
+			return false
+		pooled_control_ids[control_id] = true
+		if expected_parents.has(control_id) and expected_parents.get(control_id) != null:
+			return false
+		expected_parents[control_id] = null
+
+	for control_id_value: Variant in active_control_ids.keys():
+		if not expected_parents.has(control_id_value):
+			expected_parents[control_id_value] = content_root
+	if controls_by_id.size() != _known_control_ids.size():
+		return false
+	for control_id_value: Variant in _known_control_ids.keys():
+		if not (control_id_value is int) or not controls_by_id.has(control_id_value):
+			return false
+	for control_id_value: Variant in controls_by_id.keys():
+		if not expected_parents.has(control_id_value):
+			return false
+		var control_value: Variant = controls_by_id.get(control_id_value)
+		if not (control_value is Control):
+			return false
+		var control: Control = control_value
+		var expected_value: Variant = expected_parents.get(control_id_value)
+		var expected_parent: Node = expected_value if expected_value is Node else null
+		if not _control_has_expected_parent(control, expected_parent):
+			return false
+	return true
+
+
+func _register_transaction_control(control: Control, controls_by_id: Dictionary) -> bool:
+	if control == null or not is_instance_valid(control) or control.is_queued_for_deletion():
+		return false
+	var control_id: int = control.get_instance_id()
+	if not _known_control_ids.has(control_id):
+		return false
+	if controls_by_id.has(control_id):
+		return is_same(controls_by_id.get(control_id), control)
+	controls_by_id[control_id] = control
+	return true
+
+
+func _pool_controls_are_live() -> bool:
+	var observed_control_ids: Dictionary = {}
+	for control_value: Variant in _pool:
+		var control: Control = _get_live_control(control_value)
+		if not _register_owned_control(control, null, observed_control_ids):
+			return false
+	return true
+
+
+func _register_owned_control(
+	control: Control,
+	expected_parent: Node,
+	observed_control_ids: Dictionary
+) -> bool:
+	if not _control_has_expected_parent(control, expected_parent):
+		return false
+	var control_id: int = control.get_instance_id()
+	if observed_control_ids.has(control_id) or not _known_control_ids.has(control_id):
+		return false
+	observed_control_ids[control_id] = true
+	return true
+
+
+func _control_has_expected_parent(control: Control, expected_parent: Node) -> bool:
+	return (
+		control != null
+		and is_instance_valid(control)
+		and not control.is_queued_for_deletion()
+		and control.get_parent() == expected_parent
+	)
+
+
+func _get_owner_node() -> Node:
+	return _get_live_node(_owner_ref)
+
+
+func _get_scroll_container() -> ScrollContainer:
+	var node: Node = _get_live_node(_scroll_ref)
+	if node is ScrollContainer:
+		var scroll_container: ScrollContainer = node
+		return scroll_container
+	return null
+
+
+func _get_content_root() -> Control:
+	var node: Node = _get_live_node(_content_ref)
+	if node is Control:
+		var control: Control = node
+		return control
+	return null
+
+
+func _get_viewport() -> Viewport:
+	if _viewport_ref == null:
+		return null
+	var value: Variant = _viewport_ref.get_ref()
+	if value is Viewport:
+		var viewport: Viewport = value
+		if is_instance_valid(viewport):
+			return viewport
+	return null
+
+
+func _get_live_node(node_ref: WeakRef) -> Node:
+	if node_ref == null:
+		return null
+	var value: Variant = node_ref.get_ref()
+	if value is Node:
+		var node: Node = value
+		if is_instance_valid(node) and not node.is_queued_for_deletion():
+			return node
+	return null
+
+
+func _node_is_descendant_of(node: Node, ancestor: Node) -> bool:
+	var current: Node = node
+	while current != null:
+		if current == ancestor:
+			return true
+		current = current.get_parent()
+	return false
+
+
+func _is_sync_in_progress() -> bool:
+	return _sync_in_progress
+
+
+func _queue_measurement_request() -> void:
+	_measurement_requested = true
+	_measurement_request_revision += 1
+
+
+# --- 信号处理函数 ---
+
+func _on_binding_tree_exited() -> void:
+	dispose()
+
+
+func _on_scroll_resized() -> void:
+	var _requested: bool = request_sync()
+
+
+func _on_content_resized() -> void:
+	if _get_effective_fill_cross_axis():
+		var _requested: bool = request_sync()
+
+
+func _on_scroll_value_changed(_value: float) -> void:
+	if _applying_scroll_adjustment:
+		return
+	var _requested: bool = request_sync()
+
+
+func _on_layout_changed(_revision: int) -> void:
+	var _requested: bool = request_sync()
+
+
+func _on_focus_changed(previous_index: int, focused_index: int) -> void:
+	if _binding_focus_initialization:
+		return
+	_focus_intent_revision += 1
+	if _sync_in_progress:
+		_pending_physical_focus_reconciliation = (
+			_pending_physical_focus_reconciliation
+			or previous_index != GFVirtualListFocusModel.NO_FOCUS
+		)
+		if focused_index == GFVirtualListFocusModel.NO_FOCUS:
+			_clear_pending_focus_handoff()
+			_clear_pending_focus_reveal()
+		else:
+			_arm_pending_focus_handoff(focused_index)
+			_arm_pending_focus_reveal(focused_index)
+		var _requested_next_focus_round: bool = request_sync()
+		return
+	var generation: int = _lifecycle_generation
+	var focus_model: GFVirtualListFocusModel = _focus_model
+	var project_focus_replaced_release: bool = false
+	if previous_index != GFVirtualListFocusModel.NO_FOCUS:
+		project_focus_replaced_release = _release_control_focus_if_owned(
+			_get_record_for_index(previous_index)
+		)
+	if (
+		generation != _lifecycle_generation
+		or not is_bound()
+		or not is_same(_focus_model, focus_model)
+		or _focus_model == null
+		or _focus_model.focused_index != focused_index
+	):
+		return
+	if not _owned_controls_are_live():
+		dispose()
+		return
+	var viewport: Viewport = _get_viewport()
+	var physical_focus_owner: Control = viewport.gui_get_focus_owner() if viewport != null else null
+	if project_focus_replaced_release or physical_focus_owner != null:
+		_clear_pending_focus_handoff()
+		_arm_pending_focus_reveal(focused_index)
+		if _pending_focus_reveal_index != GFVirtualListFocusModel.NO_FOCUS:
+			var _revealed_after_project_focus: bool = _scroll_to_item_internal(
+				focused_index,
+				ScrollAlignment.NEAREST
+			)
+		var _requested_after_project_focus: bool = request_sync()
+		return
+	_arm_pending_focus_handoff(focused_index)
+	_arm_pending_focus_reveal(focused_index)
+	if _pending_focus_reveal_index != GFVirtualListFocusModel.NO_FOCUS:
+		var _revealed: bool = _scroll_to_item_internal(focused_index, ScrollAlignment.NEAREST)
+	var _requested: bool = request_sync()
+
+
+func _on_viewport_focus_changed(control: Control) -> void:
+	if _focus_handoff_in_progress:
+		if control == null:
+			return
+		var handoff_record: Dictionary = _get_record_for_index(_focus_handoff_index)
+		var handoff_control: Control = _get_record_control(handoff_record)
+		if (
+			handoff_control != null
+			and (control == handoff_control or _node_is_descendant_of(control, handoff_control))
+		):
+			_focus_handoff_observed_target = true
+			return
+	if not _pending_focus_handoff:
+		return
+	if control == null:
+		_clear_pending_focus_handoff()
+		return
+	var pending_record: Dictionary = _get_record_for_index(_pending_focus_index)
+	var pending_control: Control = _get_record_control(pending_record)
+	if (
+		pending_control != null
+		and (control == pending_control or _node_is_descendant_of(control, pending_control))
+	):
+		return
+	_clear_pending_focus_handoff()

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd
@@ -694,10 +694,7 @@ func _synchronize(generation: int) -> GFVirtualListSyncResult:
 			)
 	var round_scroll_offset: float = _get_scroll_offset(scroll_container)
 	var round_viewport_extent: float = _get_viewport_extent(scroll_container)
-	var scroll_snapshot_matches: bool = is_equal_approx(
-		round_scroll_offset,
-		planned_scroll_offset
-	)
+	var scroll_snapshot_matches: bool = round_scroll_offset == planned_scroll_offset
 	var viewport_snapshot_matches: bool = is_equal_approx(
 		round_viewport_extent,
 		viewport_extent
@@ -2137,10 +2134,7 @@ func _scroll_to_item_internal(item_index: int, alignment: ScrollAlignment) -> bo
 	)
 	operation_is_current = (
 		operation_is_current
-		and is_equal_approx(
-			_get_scroll_offset_for_axis(scroll_container, operation_axis),
-			next_offset
-		)
+		and _get_scroll_offset_for_axis(scroll_container, operation_axis) == next_offset
 	)
 	if not operation_is_current:
 		_request_sync_after_scroll_drift()

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd.uid
@@ -1,0 +1,1 @@
+uid://d3rwra63klcdm

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_model.gd
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_model.gd
@@ -13,6 +13,20 @@ class_name GFVirtualListModel
 extends RefCounted
 
 
+# --- 信号 ---
+
+## 布局状态实际变化后发出。
+##
+## 一次公开写操作无论影响多少条目都只推进一次 revision；无变化或被拒绝的写入不发出。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param revision: 变更后的单调递增布局版本号。
+signal layout_changed(revision: int)
+
+
 # --- 常量 ---
 
 ## 默认条目估算尺寸。
@@ -56,7 +70,11 @@ var overscan_items: int:
 	get:
 		return _overscan_items
 	set(value):
-		_overscan_items = maxi(value, 0)
+		var _next_overscan_items: int = maxi(value, 0)
+		if _overscan_items == _next_overscan_items:
+			return
+		_overscan_items = _next_overscan_items
+		_notify_layout_changed()
 
 ## 列表末尾额外报告的滚动尺寸。
 ## [br]
@@ -65,8 +83,13 @@ var trailing_padding: float:
 	get:
 		return _trailing_padding
 	set(value):
-		if is_finite(value):
-			_trailing_padding = clampf(value, 0.0, MAX_ITEM_EXTENT)
+		if not is_finite(value):
+			return
+		var _next_trailing_padding: float = clampf(value, 0.0, MAX_ITEM_EXTENT)
+		if is_equal_approx(_trailing_padding, _next_trailing_padding):
+			return
+		_trailing_padding = _next_trailing_padding
+		_notify_layout_changed()
 
 
 # --- 私有变量 ---
@@ -79,6 +102,7 @@ var _measured: PackedByteArray = PackedByteArray()
 var _offsets: PackedFloat64Array = PackedFloat64Array()
 var _offsets_dirty: bool = true
 var _content_extent: float = 0.0
+var _revision: int = 0
 
 
 # --- 公共方法 ---
@@ -87,11 +111,14 @@ var _content_extent: float = 0.0
 ## [br]
 ## @api public
 func clear() -> void:
+	var had_items: bool = not _extents.is_empty()
 	var _extents_resize_result: int = _extents.resize(0)
 	var _measured_resize_result: int = _measured.resize(0)
 	var _offsets_resize_result: int = _offsets.resize(0)
 	_offsets_dirty = false
 	_content_extent = 0.0
+	if had_items:
+		_notify_layout_changed()
 
 
 ## 设置条目数量，并为新增条目填入估算尺寸。
@@ -102,6 +129,8 @@ func clear() -> void:
 func set_item_count(item_count: int) -> void:
 	var next_count: int = maxi(item_count, 0)
 	var previous_count: int = _extents.size()
+	if next_count == previous_count:
+		return
 	var _extents_resize_result: int = _extents.resize(next_count)
 	var _measured_resize_result: int = _measured.resize(next_count)
 	if next_count > previous_count:
@@ -109,6 +138,7 @@ func set_item_count(item_count: int) -> void:
 			_extents[index] = _estimated_item_extent
 			_measured[index] = 0
 	_offsets_dirty = true
+	_notify_layout_changed()
 
 
 ## 追加一个条目。
@@ -132,6 +162,7 @@ func append_item(extent: float = -1.0, measured: bool = false) -> int:
 		measured_flag = 1
 	var _measured_appended: bool = _measured.append(measured_flag)
 	_offsets_dirty = true
+	_notify_layout_changed()
 	return next_index
 
 
@@ -148,6 +179,7 @@ func remove_item(item_index: int) -> bool:
 	_extents.remove_at(item_index)
 	_measured.remove_at(item_index)
 	_offsets_dirty = true
+	_notify_layout_changed()
 	return true
 
 
@@ -216,6 +248,7 @@ func set_item_extent(
 	_measured[item_index] = measured_flag
 	_offsets_dirty = true
 	report["changed"] = true
+	_notify_layout_changed()
 	return report
 
 
@@ -229,9 +262,12 @@ func set_item_extent(
 func reset_item_extent(item_index: int) -> bool:
 	if not _is_valid_index(item_index):
 		return false
+	if is_equal_approx(_extents[item_index], _estimated_item_extent) and _measured[item_index] == 0:
+		return true
 	_extents[item_index] = _estimated_item_extent
 	_measured[item_index] = 0
 	_offsets_dirty = true
+	_notify_layout_changed()
 	return true
 
 
@@ -242,6 +278,17 @@ func reset_item_extent(item_index: int) -> bool:
 ## @return 当前条目数量。
 func get_item_count() -> int:
 	return _extents.size()
+
+
+## 获取布局状态的当前版本号。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 从 0 开始、只在布局实际变化时递增的版本号。
+func get_revision() -> int:
+	return _revision
 
 
 ## 获取条目尺寸。
@@ -299,16 +346,18 @@ func get_content_extent(include_trailing_padding: bool = true) -> float:
 	return _content_extent + extra_extent
 
 
-## 计算当前滚动窗口内应被物化的条目范围。
+## 计算当前滚动窗口直接命中的条目范围，不包含 overscan。
 ## [br]
 ## @api public
+## [br]
+## @since unreleased
 ## [br]
 ## @param scroll_offset: 当前滚动偏移。
 ## [br]
 ## @param viewport_extent: 视口尺寸。
 ## [br]
 ## @return Vector2i(start, end)，end 为不包含的结束索引。
-func get_visible_range(scroll_offset: float, viewport_extent: float) -> Vector2i:
+func get_viewport_range(scroll_offset: float, viewport_extent: float) -> Vector2i:
 	if _extents.is_empty():
 		return Vector2i.ZERO
 	_ensure_offsets()
@@ -317,10 +366,30 @@ func get_visible_range(scroll_offset: float, viewport_extent: float) -> Vector2i
 	var scroll_bottom: float = minf(scroll_top + visible_extent, _content_extent)
 	var start_index: int = _search_first_bottom_after(scroll_top)
 	var end_index: int = _search_first_top_at_or_after(scroll_bottom)
-	start_index = maxi(start_index - _overscan_items, 0)
-	end_index = mini(end_index + _overscan_items, _extents.size())
 	if end_index < start_index:
 		end_index = start_index
+	return Vector2i(start_index, end_index)
+
+
+## 计算当前滚动窗口内应被物化的条目范围。
+## [br]
+## @api public
+## [br]
+## @since 4.4.0
+## [br]
+## @param scroll_offset: 当前滚动偏移。
+## [br]
+## @param viewport_extent: 视口尺寸。
+## [br]
+## @return Vector2i(start, end)，end 为不包含的结束索引。
+func get_visible_range(scroll_offset: float, viewport_extent: float) -> Vector2i:
+	var viewport_range: Vector2i = get_viewport_range(scroll_offset, viewport_extent)
+	if viewport_range == Vector2i.ZERO and _extents.is_empty():
+		return viewport_range
+	var start_index: int = viewport_range.x
+	var end_index: int = viewport_range.y
+	start_index = maxi(start_index - _overscan_items, 0)
+	end_index = mini(end_index + _overscan_items, _extents.size())
 	return Vector2i(start_index, end_index)
 
 
@@ -361,6 +430,12 @@ func _set_estimated_item_extent(value: float) -> void:
 		if _measured[item_index] == 0:
 			_extents[item_index] = next_extent
 	_offsets_dirty = true
+	_notify_layout_changed()
+
+
+func _notify_layout_changed() -> void:
+	_revision += 1
+	layout_changed.emit(_revision)
 
 
 func _ensure_offsets() -> void:

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_model.gd
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_model.gd
@@ -86,7 +86,7 @@ var trailing_padding: float:
 		if not is_finite(value):
 			return
 		var _next_trailing_padding: float = clampf(value, 0.0, MAX_ITEM_EXTENT)
-		if is_equal_approx(_trailing_padding, _next_trailing_padding):
+		if _trailing_padding == _next_trailing_padding:
 			return
 		_trailing_padding = _next_trailing_padding
 		_notify_layout_changed()
@@ -262,7 +262,7 @@ func set_item_extent(
 func reset_item_extent(item_index: int) -> bool:
 	if not _is_valid_index(item_index):
 		return false
-	if is_equal_approx(_extents[item_index], _estimated_item_extent) and _measured[item_index] == 0:
+	if _extents[item_index] == _estimated_item_extent and _measured[item_index] == 0:
 		return true
 	_extents[item_index] = _estimated_item_extent
 	_measured[item_index] = 0
@@ -423,7 +423,7 @@ func _set_estimated_item_extent(value: float) -> void:
 	if not is_finite(value):
 		return
 	var next_extent: float = _normalize_item_extent(value)
-	if is_equal_approx(_estimated_item_extent, next_extent):
+	if _estimated_item_extent == next_extent:
 		return
 	_estimated_item_extent = next_extent
 	for item_index: int in range(_extents.size()):

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd
@@ -1,0 +1,482 @@
+## GFVirtualListSyncResult: 虚拟列表同步的不可变诊断结果。
+##
+## 只保存范围、计数、版本和稳定错误信息，不保存项目条目数据或原始稳定 ID。
+## [br]
+## @api public
+## [br]
+## @category value_object
+## [br]
+## @since unreleased
+class_name GFVirtualListSyncResult
+extends RefCounted
+
+
+# --- 常量 ---
+
+## 目标范围已完整同步。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_SYNCED: StringName = &"synced"
+
+## 当前 materialization 已满足目标且没有结构变化。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_UNCHANGED: StringName = &"unchanged"
+
+## 当前轮冻结快照在完成提交前或项目绑定副作用期间失效；Binder 已保留后续同步请求。
+## [br]
+## 该状态不表示同步成功。若漂移发生在绑定副作用前，Binder 保留最近一次可信
+## materialization；若已调用 bind/unbind、测量、布局或焦点副作用，则对称解绑并清空
+## 不可信 materialization。调用方应以结果中的当前索引为准并等待下一轮结果。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_DEFERRED: StringName = &"deferred"
+
+## 目标范围超过显式节点预算，已优先物化真实视口范围。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_TRUNCATED: StringName = &"truncated"
+
+## Binder 当前没有有效绑定。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_UNBOUND: StringName = &"unbound"
+
+## Binder 已进入不可复用的终态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_DISPOSED: StringName = &"disposed"
+
+## identity callback 返回了不可稳定编码的值。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_INVALID_IDENTITY: StringName = &"invalid_identity"
+
+## 当前请求范围包含重复稳定 identity。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_DUPLICATE_IDENTITY: StringName = &"duplicate_identity"
+
+## item factory 没有返回可接管的 parentless Control。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_FACTORY_FAILED: StringName = &"factory_failed"
+
+## 项目 bind callback 拒绝了一个条目。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_BIND_FAILED: StringName = &"bind_failed"
+
+# JSON number 可以无损表达的最大整数。
+# 所有写入诊断摘要的 revision、count 与 error_index 都必须位于对应语义范围内。
+const _MAX_JSON_SAFE_INTEGER: int = 9_007_199_254_740_991
+const _MAX_ERROR_LENGTH: int = 512
+
+
+# --- 私有变量 ---
+
+var _configured: bool = false
+var _status: StringName = STATUS_UNBOUND
+var _layout_revision: int = 0
+var _data_revision: int = 0
+var _viewport_range: Vector2i = Vector2i.ZERO
+var _requested_range: Vector2i = Vector2i.ZERO
+var _materialized_indices: PackedInt32Array = PackedInt32Array()
+var _pooled_count: int = 0
+var _created_count: int = 0
+var _reused_count: int = 0
+var _released_count: int = 0
+var _measured_count: int = 0
+var _anchor_adjustment: float = 0.0
+var _truncated: bool = false
+var _error_index: int = -1
+var _error: String = ""
+
+
+# --- 公共方法 ---
+
+## 检查同步是否提交了内部一致的目标状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 完整、无变化或按显式预算截断完成时返回 true。
+func is_successful() -> bool:
+	return _status in [STATUS_SYNCED, STATUS_UNCHANGED, STATUS_TRUNCATED]
+
+
+## 获取稳定同步状态。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `STATUS_*` 常量之一。
+func get_status() -> StringName:
+	return _status
+
+
+## 获取本轮计算范围前冻结的布局版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return `GFVirtualListModel` revision。
+func get_layout_revision() -> int:
+	return _layout_revision
+
+
+## 获取本轮开始时冻结的 Binder 数据失效版本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 从 0 开始的 data revision。
+func get_data_revision() -> int:
+	return _data_revision
+
+
+## 获取未加入 overscan 的真实视口范围。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Vector2i(start, end)，end 不包含。
+func get_viewport_range() -> Vector2i:
+	return _viewport_range
+
+
+## 获取加入 overscan、应用预算前的请求范围。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return Vector2i(start, end)，end 不包含。
+func get_requested_range() -> Vector2i:
+	return _requested_range
+
+
+## 获取实际物化索引副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 升序物化索引。
+func get_materialized_indices() -> PackedInt32Array:
+	return _materialized_indices.duplicate()
+
+
+## 获取实际物化数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 当前活动 Control 数量。
+func get_materialized_count() -> int:
+	return _materialized_indices.size()
+
+
+## 获取当前池内可复用 Control 数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return parentless 池节点数量。
+func get_pooled_count() -> int:
+	return _pooled_count
+
+
+## 获取本轮新建 Control 数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return factory 成功创建数量。
+func get_created_count() -> int:
+	return _created_count
+
+
+## 获取本轮从旧 active 或 pool 复用数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 复用数量。
+func get_reused_count() -> int:
+	return _reused_count
+
+
+## 获取本轮离开旧绑定的数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 已执行 unbind 的旧绑定数量。
+func get_released_count() -> int:
+	return _released_count
+
+
+## 获取本轮成功测量的行数量。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 测量数量。
+func get_measured_count() -> int:
+	return _measured_count
+
+
+## 获取本轮一次性应用的滚动锚点修正。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 主轴滚动调整量。
+func get_anchor_adjustment() -> float:
+	return _anchor_adjustment
+
+
+## 检查是否因 materialization 上限截断。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 目标范围未完整物化时返回 true。
+func was_truncated() -> bool:
+	return _truncated
+
+
+## 获取首个失败条目索引。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 没有索引错误时为 -1。
+func get_error_index() -> int:
+	return _error_index
+
+
+## 获取有界稳定错误说明。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 成功时为空。
+func get_error() -> String:
+	return _error
+
+
+## 创建结果的隔离副本。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 新结果对象。
+func duplicate_result() -> GFVirtualListSyncResult:
+	var result: GFVirtualListSyncResult = GFVirtualListSyncResult.new()
+	var _configured_result: bool = result.configure_for_framework(to_dict())
+	return result
+
+
+## 转换为不含项目数据的诊断字典。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return JSON-safe 同步摘要；状态使用 String，范围与索引只使用 JSON 原生容器和整数。
+## [br]
+## @schema return: Dictionary with String status; viewport_range and requested_range Dictionaries containing start and end_exclusive ints; materialized_indices Array[int]; revisions and counts in 0..9007199254740991; finite anchor_adjustment; truncated; error_index in -1..9007199254740991; and error.
+func to_dict() -> Dictionary:
+	var materialized_indices: Array[int] = []
+	for item_index: int in _materialized_indices:
+		materialized_indices.append(item_index)
+	return {
+		"status": String(_status),
+		"layout_revision": _layout_revision,
+		"data_revision": _data_revision,
+		"viewport_range": _range_to_json_dictionary(_viewport_range),
+		"requested_range": _range_to_json_dictionary(_requested_range),
+		"materialized_indices": materialized_indices,
+		"pooled_count": _pooled_count,
+		"created_count": _created_count,
+		"reused_count": _reused_count,
+		"released_count": _released_count,
+		"measured_count": _measured_count,
+		"anchor_adjustment": _anchor_adjustment,
+		"truncated": _truncated,
+		"error_index": _error_index,
+		"error": _error,
+	}
+
+
+# --- 框架内部方法 ---
+
+## 由 VirtualList Binder 一次性配置结果。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param data: 同步诊断字段。
+## [br]
+## @return 首次配置、状态有效且所有 revision/count/error_index 位于 JSON 安全整数范围时返回 true。
+## [br]
+## @schema data: Dictionary accepting String or StringName status; typed Vector2i or JSON range Dictionaries with start and end_exclusive; PackedInt32Array or JSON Array materialized_indices; layout_revision, data_revision and count fields in 0..9007199254740991; error_index in -1..9007199254740991; and the remaining scalar fields emitted by to_dict().
+func configure_for_framework(data: Dictionary) -> bool:
+	if _configured:
+		return false
+	var status: StringName = GFVariantData.get_option_string_name(data, "status", STATUS_UNBOUND)
+	if not _is_known_status(status):
+		return false
+	if (
+		not _has_bounded_json_integer(data, "layout_revision", 0, 0)
+		or not _has_bounded_json_integer(data, "data_revision", 0, 0)
+		or not _has_bounded_json_integer(data, "pooled_count", 0, 0)
+		or not _has_bounded_json_integer(data, "created_count", 0, 0)
+		or not _has_bounded_json_integer(data, "reused_count", 0, 0)
+		or not _has_bounded_json_integer(data, "released_count", 0, 0)
+		or not _has_bounded_json_integer(data, "measured_count", 0, 0)
+		or not _has_bounded_json_integer(data, "error_index", -1, -1)
+	):
+		return false
+	_configured = true
+	_status = status
+	_layout_revision = GFVariantData.get_option_int(data, "layout_revision")
+	_data_revision = GFVariantData.get_option_int(data, "data_revision")
+	_viewport_range = _get_vector_2i(data, "viewport_range")
+	_requested_range = _get_vector_2i(data, "requested_range")
+	_materialized_indices = _get_packed_int_32_array(data, "materialized_indices")
+	_pooled_count = GFVariantData.get_option_int(data, "pooled_count")
+	_created_count = GFVariantData.get_option_int(data, "created_count")
+	_reused_count = GFVariantData.get_option_int(data, "reused_count")
+	_released_count = GFVariantData.get_option_int(data, "released_count")
+	_measured_count = GFVariantData.get_option_int(data, "measured_count")
+	var anchor_adjustment: float = GFVariantData.get_option_float(data, "anchor_adjustment")
+	_anchor_adjustment = anchor_adjustment if is_finite(anchor_adjustment) else 0.0
+	_truncated = GFVariantData.get_option_bool(data, "truncated")
+	_error_index = GFVariantData.get_option_int(data, "error_index", -1)
+	_error = GFVariantData.get_option_string(data, "error").left(_MAX_ERROR_LENGTH)
+	return true
+
+
+# --- 私有/辅助方法 ---
+
+func _is_known_status(status: StringName) -> bool:
+	return status in [
+		STATUS_SYNCED,
+		STATUS_UNCHANGED,
+		STATUS_DEFERRED,
+		STATUS_TRUNCATED,
+		STATUS_UNBOUND,
+		STATUS_DISPOSED,
+		STATUS_INVALID_IDENTITY,
+		STATUS_DUPLICATE_IDENTITY,
+		STATUS_FACTORY_FAILED,
+		STATUS_BIND_FAILED,
+	]
+
+
+func _has_bounded_json_integer(
+	data: Dictionary,
+	key: String,
+	default_value: int,
+	minimum_value: int
+) -> bool:
+	var value: Variant = GFVariantData.get_option_value(data, key, default_value)
+	if value is int:
+		var integer_value: int = value
+		return integer_value >= minimum_value and integer_value <= _MAX_JSON_SAFE_INTEGER
+	if value is float:
+		var json_number: float = value
+		return (
+			is_finite(json_number)
+			and json_number == floor(json_number)
+			and json_number >= float(minimum_value)
+			and json_number <= float(_MAX_JSON_SAFE_INTEGER)
+		)
+	return false
+
+
+func _get_vector_2i(data: Dictionary, key: String) -> Vector2i:
+	var value: Variant = GFVariantData.get_option_value(data, key, Vector2i.ZERO)
+	if value is Vector2i:
+		var vector: Vector2i = value
+		return vector
+	if value is Dictionary:
+		var range_data: Dictionary = value
+		return Vector2i(
+			GFVariantData.get_option_int(range_data, "start"),
+			GFVariantData.get_option_int(range_data, "end_exclusive")
+		)
+	return Vector2i.ZERO
+
+
+func _get_packed_int_32_array(data: Dictionary, key: String) -> PackedInt32Array:
+	var value: Variant = GFVariantData.get_option_value(data, key, PackedInt32Array())
+	if value is PackedInt32Array:
+		var packed_values: PackedInt32Array = value
+		return packed_values.duplicate()
+	if value is Array:
+		var result: PackedInt32Array = PackedInt32Array()
+		var array_values: Array = value
+		for item: Variant in array_values:
+			if item is int:
+				var item_index: int = item
+				if item_index >= -2_147_483_648 and item_index <= 2_147_483_647:
+					var _append_int_result: bool = result.append(item_index)
+			elif item is float:
+				var numeric_index: float = item
+				if (
+					is_finite(numeric_index)
+					and numeric_index == floor(numeric_index)
+					and numeric_index >= -2_147_483_648.0
+					and numeric_index <= 2_147_483_647.0
+				):
+					var _append_float_result: bool = result.append(int(numeric_index))
+		return result
+	return PackedInt32Array()
+
+
+func _range_to_json_dictionary(range_value: Vector2i) -> Dictionary:
+	return {
+		"start": range_value.x,
+		"end_exclusive": range_value.y,
+	}

--- a/addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd.uid
+++ b/addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd.uid
@@ -1,0 +1,1 @@
+uid://b5denewiutxe3

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "de285031e86ff6421bf561a34dcc42fa84fa2a2b45644b040a7823faf02875b6",
-  "class_count": 780,
+  "source_digest": "95a9d6eaa1332964197ad119a48cb090ab1855446abee23c2cc8d041c4f2a4ae",
+  "class_count": 789,
   "package_count": 52,
   "packages": [
     {
@@ -415,7 +415,7 @@
         "gf.standard.input",
         "gf.standard.spatial"
       ],
-      "description": "Bounded runtime Control for 2D world navigation, grid snapping, stable item selection, and project-validated placement sessions.",
+      "description": "Bounded runtime Control for 2D world navigation, configurable input and parent-scroll arbitration, grid snapping, stable item selection, and project-validated placement sessions.",
       "representative_path": "addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd"
     },
     {
@@ -488,7 +488,7 @@
         "gf.kernel",
         "gf.standard.base"
       ],
-      "description": "Core UI value adapters, form/list/table helpers, modal value objects, text fitting, and virtual list models.",
+      "description": "Core UI value adapters, form/list/table projection helpers, modal value objects, text fitting, and bounded virtual list binding.",
       "representative_path": "addons/gf/standard/utilities/ui/gf_control_focus_utility.gd"
     },
     {
@@ -77623,6 +77623,13 @@
           "visibility": "public"
         },
         {
+          "kind": "enum",
+          "name": "InputDisposition",
+          "signature": "enum InputDisposition {\n\t## 事件未被画布识别或当前策略要求继续交给其他接收者。\n\tIGNORED,\n\t## 事件已更新画布，但仍允许 GUI 冒泡。\n\tHANDLED,\n\t## 事件已更新画布，并应在 GUI 边界停止传播。\n\tCONSUMED,\n}",
+          "summary": "输入处理结果。",
+          "visibility": "public"
+        },
+        {
           "kind": "const",
           "name": "ABSOLUTE_MAX_ITEMS",
           "signature": "const ABSOLUTE_MAX_ITEMS: int = 65536",
@@ -77849,21 +77856,21 @@
         {
           "kind": "func",
           "name": "set_selection",
-          "signature": "func set_selection( item_ids: PackedStringArray, mode: int = SelectionMode.REPLACE ) -> PackedStringArray",
+          "signature": "func set_selection( item_ids: PackedStringArray, mode: SelectionMode = SelectionMode.REPLACE ) -> PackedStringArray",
           "summary": "按模式更新选择。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "select_point",
-          "signature": "func select_point( canvas_position: Vector2, mode: int = SelectionMode.REPLACE ) -> PackedStringArray",
+          "signature": "func select_point( canvas_position: Vector2, mode: SelectionMode = SelectionMode.REPLACE ) -> PackedStringArray",
           "summary": "在画布坐标点选最高优先级条目。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "select_rect",
-          "signature": "func select_rect( canvas_rect: Rect2, mode: int = SelectionMode.REPLACE, fully_contained: bool = false ) -> PackedStringArray",
+          "signature": "func select_rect( canvas_rect: Rect2, mode: SelectionMode = SelectionMode.REPLACE, fully_contained: bool = false ) -> PackedStringArray",
           "summary": "在画布坐标框选条目。",
           "visibility": "public"
         },
@@ -77939,15 +77946,29 @@
         },
         {
           "kind": "func",
+          "name": "set_input_policy",
+          "signature": "func set_input_policy(policy: GFSpatialCanvasInputPolicy) -> bool",
+          "summary": "原子替换输入解释策略。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_input_policy",
+          "signature": "func get_input_policy() -> GFSpatialCanvasInputPolicy",
+          "summary": "获取当前输入策略的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "handle_input_event",
-          "signature": "func handle_input_event(event: InputEvent) -> bool",
+          "signature": "func handle_input_event(event: InputEvent) -> InputDisposition",
           "summary": "处理一个项目转发的输入事件。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "handle_screen_input_event",
-          "signature": "func handle_screen_input_event(event: InputEvent) -> bool",
+          "signature": "func handle_screen_input_event(event: InputEvent) -> InputDisposition",
           "summary": "处理一个使用 Viewport 屏幕坐标的输入事件。",
           "visibility": "public"
         },
@@ -77963,6 +77984,254 @@
           "name": "get_debug_snapshot",
           "signature": "func get_debug_snapshot() -> Dictionary",
           "summary": "获取 JSON-safe 调试快照。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSpatialCanvasInputPolicy": {
+      "extends": "Resource",
+      "module": "standard",
+      "package_id": "gf.standard.spatial.canvas",
+      "path": "addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd",
+      "summary": "GFSpatialCanvasInputPolicy: 空间画布输入解释策略。 以数据方式声明平移、选择、滚轮、触摸和取消输入。策略不持有节点、 Viewport 或父容器引用；[code]GFSpatialCanvas2D[/code] 只接受完整校验通过的隔离副本。",
+      "visibility": "public",
+      "category": "resource_definition",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "enum",
+          "name": "ModifierMask",
+          "signature": "enum ModifierMask {\n\t## 不要求修饰键。\n\tNONE = 0,\n\t## Shift 修饰键。\n\tSHIFT = 1,\n\t## Ctrl 修饰键。\n\tCTRL = 2,\n\t## Alt 修饰键。\n\tALT = 4,\n\t## Meta 修饰键。\n\tMETA = 8,\n}",
+          "summary": "输入修饰键位掩码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "WheelAxis",
+          "signature": "enum WheelAxis {\n\t## 使用向上/向下滚轮事件。\n\tVERTICAL,\n\t## 使用向左/向右滚轮事件。\n\tHORIZONTAL,\n}",
+          "summary": "滚轮缩放使用的物理轴。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "WheelRouting",
+          "signature": "enum WheelRouting {\n\t## 画布处理目标轴上的所有滚轮事件。\n\tCANVAS,\n\t## 只有修饰键掩码精确匹配时由画布处理。\n\tMODIFIER_GATED,\n\t## 画布始终忽略滚轮，让 GUI 祖先继续处理。\n\tPARENT_ONLY,\n}",
+          "summary": "滚轮事件的画布路由策略。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "TouchPrimaryBehavior",
+          "signature": "enum TouchPrimaryBehavior {\n\t## 单指不执行画布行为；若启用任一多指行为，首触点仍会被捕获以等待后续触点。\n\tNONE,\n\t## 单指拖动平移画布。\n\tPAN,\n\t## 单指执行点选、框选或放置确认。\n\tSELECT,\n}",
+          "summary": "单指触摸的主行为。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS",
+          "signature": "const ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS: int = 15",
+          "summary": "单份策略允许声明的选择修饰键绑定绝对上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ABSOLUTE_MAX_ACTION_EVENTS",
+          "signature": "const ABSOLUTE_MAX_ACTION_EVENTS: int = 64",
+          "summary": "校验单个 InputMap action 时允许扫描的事件绝对上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "pan_mouse_button",
+          "signature": "var pan_mouse_button: MouseButton = MOUSE_BUTTON_MIDDLE",
+          "summary": "直接触发平移捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "pan_action",
+          "signature": "var pan_action: StringName = &\"\"",
+          "summary": "通过 InputMap 触发平移捕获的动作；空名称表示禁用动作绑定。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "pan_modifier_mask",
+          "signature": "var pan_modifier_mask: int = ModifierMask.NONE",
+          "summary": "直接平移按钮必须精确匹配的修饰键掩码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "selection_mouse_button",
+          "signature": "var selection_mouse_button: MouseButton = MOUSE_BUTTON_LEFT",
+          "summary": "直接触发选择捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "selection_action",
+          "signature": "var selection_action: StringName = &\"\"",
+          "summary": "通过 InputMap 触发选择捕获的动作；空名称表示禁用动作绑定。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "selection_default_mode",
+          "signature": "var selection_default_mode: GFSpatialCanvas2D.SelectionMode = (",
+          "summary": "没有选择修饰键绑定精确匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code]。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "selection_modifier_bindings",
+          "signature": "var selection_modifier_bindings: Array[GFSpatialCanvasSelectionModeBinding] = []",
+          "summary": "修饰键到选择模式的精确匹配表；重复掩码会使策略校验失败。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "drag_threshold",
+          "signature": "var drag_threshold: float = 4.0",
+          "summary": "区分点选和框选的局部画布像素阈值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "wheel_axis",
+          "signature": "var wheel_axis: WheelAxis = WheelAxis.VERTICAL",
+          "summary": "用于画布缩放的滚轮轴。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "wheel_routing",
+          "signature": "var wheel_routing: WheelRouting = WheelRouting.CANVAS",
+          "summary": "滚轮缩放路由策略。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "wheel_modifier_mask",
+          "signature": "var wheel_modifier_mask: int = ModifierMask.NONE",
+          "summary": "[constant WheelRouting.MODIFIER_GATED] 下必须精确匹配的修饰键掩码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "wheel_zoom_factor",
+          "signature": "var wheel_zoom_factor: float = 1.1",
+          "summary": "每个滚轮刻度的缩放倍率，必须为有限且大于 1 的值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "touch_enabled",
+          "signature": "var touch_enabled: bool = true",
+          "summary": "是否处理原始 ScreenTouch / ScreenDrag 事件。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "touch_primary_behavior",
+          "signature": "var touch_primary_behavior: TouchPrimaryBehavior = TouchPrimaryBehavior.PAN",
+          "summary": "单指触摸的主行为。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "touch_multi_pan_enabled",
+          "signature": "var touch_multi_pan_enabled: bool = true",
+          "summary": "是否允许双指及以上触点驱动平移。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "touch_multi_zoom_enabled",
+          "signature": "var touch_multi_zoom_enabled: bool = true",
+          "summary": "是否允许双指及以上触点驱动捏合缩放。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "system_pan_gesture_enabled",
+          "signature": "var system_pan_gesture_enabled: bool = true",
+          "summary": "是否处理 Godot 的系统 PanGesture 事件。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "system_magnify_gesture_enabled",
+          "signature": "var system_magnify_gesture_enabled: bool = true",
+          "summary": "是否处理 Godot 的系统 MagnifyGesture 事件。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "placement_cancel_action",
+          "signature": "var placement_cancel_action: StringName = &\"ui_cancel\"",
+          "summary": "取消活动放置或瞬态选择的非指针 InputMap 动作；空名称表示禁用取消输入。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "consume_handled_events",
+          "signature": "var consume_handled_events: bool = true",
+          "summary": "一般已处理事件是否由 Canvas GUI 边界消费。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "consume_wheel_events",
+          "signature": "var consume_wheel_events: bool = true",
+          "summary": "已处理滚轮事件是否由 Canvas GUI 边界消费。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_policy",
+          "signature": "func validate_policy() -> Dictionary",
+          "summary": "校验完整策略。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_policy",
+          "signature": "func duplicate_policy() -> GFSpatialCanvasInputPolicy",
+          "summary": "创建策略及嵌套选择绑定的隔离副本。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFSpatialCanvasSelectionModeBinding": {
+      "extends": "Resource",
+      "module": "standard",
+      "package_id": "gf.standard.spatial.canvas",
+      "path": "addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd",
+      "summary": "GFSpatialCanvasSelectionModeBinding: 空间画布选择修饰键绑定。 只描述修饰键掩码到 [code]GFSpatialCanvas2D.SelectionMode[/code] 的映射， 不读取设备状态，也不拥有输入生命周期。",
+      "visibility": "public",
+      "category": "resource_definition",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "var",
+          "name": "modifier_mask",
+          "signature": "var modifier_mask: int = 0",
+          "summary": "需要精确匹配的 [code]GFSpatialCanvasInputPolicy.ModifierMask[/code] 掩码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "selection_mode",
+          "signature": "var selection_mode: GFSpatialCanvas2D.SelectionMode = (",
+          "summary": "匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code] 值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_binding",
+          "signature": "func duplicate_binding() -> GFSpatialCanvasSelectionModeBinding",
+          "summary": "创建隔离副本。",
           "visibility": "public"
         }
       ]
@@ -82313,8 +82582,15 @@
         {
           "kind": "signal",
           "name": "view_changed",
-          "signature": "signal view_changed(visible_count: int)",
-          "summary": "可见行集合变化后发出。",
+          "signature": "signal view_changed(view_revision: int, visible_count: int)",
+          "summary": "可见行集合成功提交后发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "signal",
+          "name": "view_rebuild_failed",
+          "signature": "signal view_rebuild_failed(result: GFTableViewRebuildResult)",
+          "summary": "候选投影未提交时发出。",
           "visibility": "public"
         },
         {
@@ -82339,30 +82615,58 @@
           "visibility": "public"
         },
         {
-          "kind": "var",
-          "name": "row_id_column",
-          "signature": "var row_id_column: StringName = &\"id\"",
-          "summary": "用作稳定行 ID 的字段键。为空时使用源行索引。",
+          "kind": "const",
+          "name": "MAX_ROW_PREDICATE_COUNT",
+          "signature": "const MAX_ROW_PREDICATE_COUNT: int = 64",
+          "summary": "单个表格允许注册的命名行谓词上限。",
           "visibility": "public"
         },
         {
-          "kind": "var",
-          "name": "case_sensitive_filter",
-          "signature": "var case_sensitive_filter: bool = false",
-          "summary": "过滤时是否区分大小写。",
+          "kind": "func",
+          "name": "set_row_id_column",
+          "signature": "func set_row_id_column(column_id: StringName) -> GFTableViewRebuildResult",
+          "summary": "事务式设置稳定行 ID 字段键。",
           "visibility": "public"
         },
         {
-          "kind": "var",
-          "name": "selection_model",
-          "signature": "var selection_model: GFTableSelectionModel = GFTableSelectionModel.new()",
-          "summary": "该视图使用的选择模型。",
+          "kind": "func",
+          "name": "get_row_id_column",
+          "signature": "func get_row_id_column() -> StringName",
+          "summary": "获取稳定行 ID 字段键。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_filter_case_sensitive",
+          "signature": "func set_filter_case_sensitive(case_sensitive: bool) -> GFTableViewRebuildResult",
+          "summary": "事务式设置文本过滤是否区分大小写。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_filter_case_sensitive",
+          "signature": "func is_filter_case_sensitive() -> bool",
+          "summary": "查询文本过滤是否区分大小写。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_selection_model",
+          "signature": "func set_selection_model(model: GFTableSelectionModel) -> GFTableViewRebuildResult",
+          "summary": "事务式替换该视图使用的选择模型。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_selection_model",
+          "signature": "func get_selection_model() -> GFTableSelectionModel",
+          "summary": "获取该视图使用的选择模型。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "set_columns",
-          "signature": "func set_columns(column_definitions: Array[GFTableColumnDefinition]) -> void",
+          "signature": "func set_columns( column_definitions: Array[GFTableColumnDefinition] ) -> GFTableViewRebuildResult",
           "summary": "设置列定义列表。",
           "visibility": "public"
         },
@@ -82390,7 +82694,7 @@
         {
           "kind": "func",
           "name": "set_rows",
-          "signature": "func set_rows(row_values: Array, duplicate_rows: bool = false) -> void",
+          "signature": "func set_rows( row_values: Array, duplicate_rows: bool = false ) -> GFTableViewRebuildResult",
           "summary": "设置源行数据。",
           "visibility": "public"
         },
@@ -82488,7 +82792,7 @@
         {
           "kind": "func",
           "name": "set_filter_query",
-          "signature": "func set_filter_query(query: String) -> void",
+          "signature": "func set_filter_query(query: String) -> GFTableViewRebuildResult",
           "summary": "设置过滤文本。",
           "visibility": "public"
         },
@@ -82497,6 +82801,76 @@
           "name": "get_filter_query",
           "signature": "func get_filter_query() -> String",
           "summary": "获取当前过滤文本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_row_predicates",
+          "signature": "func set_row_predicates( registrations: Array[GFTableRowPredicateRegistration] ) -> GFTableViewRebuildResult",
+          "summary": "事务式替换全部命名行谓词。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "register_row_predicate",
+          "signature": "func register_row_predicate( registration: GFTableRowPredicateRegistration ) -> GFTableViewRebuildResult",
+          "summary": "事务式注册一个命名行谓词。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unregister_row_predicate",
+          "signature": "func unregister_row_predicate(predicate_id: StringName) -> GFTableViewRebuildResult",
+          "summary": "事务式移除一个命名行谓词。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_row_predicate_enabled",
+          "signature": "func set_row_predicate_enabled( predicate_id: StringName, enabled: bool ) -> GFTableViewRebuildResult",
+          "summary": "事务式设置命名行谓词的启用状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_row_predicate_order",
+          "signature": "func set_row_predicate_order( predicate_id: StringName, order: int ) -> GFTableViewRebuildResult",
+          "summary": "事务式设置命名行谓词的执行顺序。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_row_predicate",
+          "signature": "func get_row_predicate(predicate_id: StringName) -> GFTableRowPredicateRegistration",
+          "summary": "获取一个命名行谓词注册值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_row_predicates",
+          "signature": "func get_row_predicates() -> Array[GFTableRowPredicateRegistration]",
+          "summary": "获取按确定顺序排列的命名行谓词注册值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_row_predicate_ids",
+          "signature": "func get_row_predicate_ids() -> Array[StringName]",
+          "summary": "获取按确定顺序排列的命名行谓词 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_view_revision",
+          "signature": "func get_view_revision() -> int",
+          "summary": "获取当前已提交投影 revision。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_last_view_rebuild_result",
+          "signature": "func get_last_view_rebuild_result() -> GFTableViewRebuildResult",
+          "summary": "获取最近一次投影事务结果。",
           "visibility": "public"
         },
         {
@@ -82530,7 +82904,7 @@
         {
           "kind": "func",
           "name": "refresh_view",
-          "signature": "func refresh_view() -> void",
+          "signature": "func refresh_view() -> GFTableViewRebuildResult",
           "summary": "重新构建可见行索引。",
           "visibility": "public"
         },
@@ -82545,14 +82919,14 @@
           "kind": "func",
           "name": "commit_cell_value",
           "signature": "func commit_cell_value(row_index: int, column_id: StringName, new_value: Variant) -> bool",
-          "summary": "提交源行单元格值。",
+          "summary": "事务式提交源行单元格值。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "commit_visible_cell_value",
           "signature": "func commit_visible_cell_value( visible_row_index: int, column_id: StringName, new_value: Variant ) -> bool",
-          "summary": "提交可见行单元格值。",
+          "summary": "事务式提交可见行单元格值。",
           "visibility": "public"
         },
         {
@@ -82602,6 +82976,194 @@
           "name": "get_debug_snapshot",
           "signature": "func get_debug_snapshot() -> Dictionary",
           "summary": "获取调试快照。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFTableRowPredicate": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_table_row_predicate.gd",
+      "summary": "GFTableRowPredicate: 表格结构化行过滤协议。 项目通过子类实现同步、只读、有界且无副作用的行判断。 GFTableDataView 按注册顺序契约组合多个谓词，并把显式失败视为整次投影失败。",
+      "visibility": "public",
+      "category": "protocol",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "evaluate",
+          "signature": "func evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult",
+          "summary": "求值一个隔离行视图。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "_evaluate",
+          "signature": "func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult",
+          "summary": "实现一次同步、只读且有界的行判断。",
+          "visibility": "protected"
+        }
+      ]
+    },
+    "GFTableRowPredicateRegistration": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd",
+      "summary": "GFTableRowPredicateRegistration: 命名行谓词的注册定义值。 把项目谓词与稳定 ID、启用状态和显式顺序组合成一次注册定义。 GFTableDataView 会复制数组并以 order 升序、predicate_id 字典序稳定执行。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "create",
+          "signature": "static func create( predicate_id: StringName, predicate: GFTableRowPredicate, order: int = 0, enabled: bool = true ) -> GFTableRowPredicateRegistration",
+          "summary": "创建注册定义值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_predicate_id",
+          "signature": "func get_predicate_id() -> StringName",
+          "summary": "获取稳定谓词 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_predicate",
+          "signature": "func get_predicate() -> GFTableRowPredicate",
+          "summary": "获取类型化谓词。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_order",
+          "signature": "func get_order() -> int",
+          "summary": "获取显式执行顺序。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_enabled",
+          "signature": "func is_enabled() -> bool",
+          "summary": "查询注册是否启用。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "validate_registration",
+          "signature": "func validate_registration() -> Dictionary",
+          "summary": "校验注册定义。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFTableRowPredicateResult": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd",
+      "summary": "GFTableRowPredicateResult: 类型化行谓词求值结果。 成功结果明确表示包含或排除当前行；失败结果携带稳定错误码和有界说明， 供 GFTableDataView 中止候选投影并保留上一份已提交视图。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "included",
+          "signature": "static func included() -> GFTableRowPredicateResult",
+          "summary": "创建包含当前行的成功结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "excluded",
+          "signature": "static func excluded() -> GFTableRowPredicateResult",
+          "summary": "创建排除当前行的成功结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "failed",
+          "signature": "static func failed( error_code: StringName, error_message: String = \"\" ) -> GFTableRowPredicateResult",
+          "summary": "创建求值失败结果。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "查询求值是否成功。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "should_include",
+          "signature": "func should_include() -> bool",
+          "summary": "查询成功结果是否包含当前行。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_code",
+          "signature": "func get_error_code() -> StringName",
+          "summary": "获取稳定错误码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_message",
+          "signature": "func get_error_message() -> String",
+          "summary": "获取有界错误说明。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFTableRowView": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_table_row_view.gd",
+      "summary": "GFTableRowView: 表格行谓词使用的隔离只读视图。 只公开稳定行 ID、源索引和已配置列的复制值，不公开源行容器。 项目谓词可以读取隐藏列，但不能通过该视图修改权威表格数据。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "get_row_id",
+          "signature": "func get_row_id() -> Variant",
+          "summary": "获取稳定行 ID 副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_row_index",
+          "signature": "func get_source_row_index() -> int",
+          "summary": "获取源行索引。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "has_value",
+          "signature": "func has_value(column_id: StringName) -> bool",
+          "summary": "判断是否包含指定列值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_value",
+          "signature": "func get_value(column_id: StringName, default_value: Variant = null) -> Variant",
+          "summary": "获取指定列的隔离值副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_values",
+          "signature": "func get_values() -> Dictionary",
+          "summary": "获取全部列值副本。",
           "visibility": "public"
         }
       ]
@@ -82681,6 +83243,13 @@
         },
         {
           "kind": "func",
+          "name": "replace_selection_with_anchor",
+          "signature": "func replace_selection_with_anchor( row_ids: Array, selection_anchor: Variant ) -> bool",
+          "summary": "用一组行 ID 与显式锚点原子替换当前选择。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "select_range",
           "signature": "func select_range( ordered_row_ids: Array, from_row_id: Variant, to_row_id: Variant, additive: bool = false ) -> bool",
           "summary": "在有序行 ID 列表中选择范围。",
@@ -82726,6 +83295,102 @@
           "name": "get_debug_snapshot",
           "signature": "func get_debug_snapshot() -> Dictionary",
           "summary": "获取调试快照。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFTableViewRebuildResult": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd",
+      "summary": "GFTableViewRebuildResult: 表格投影事务的类型化结果。 成功结果描述一次提交或 no-op；失败结果描述未提交的阶段、谓词和行身份。 结果不携带源 row，从而可安全交给 UI 诊断层。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "查询事务是否成功。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "was_committed",
+          "signature": "func was_committed() -> bool",
+          "summary": "查询事务是否提交了新 revision。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_view_revision",
+          "signature": "func get_view_revision() -> int",
+          "summary": "获取结果对应的已提交 revision。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_visible_count",
+          "signature": "func get_visible_count() -> int",
+          "summary": "获取当前已提交可见行数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_scanned_row_count",
+          "signature": "func get_scanned_row_count() -> int",
+          "summary": "获取本次候选扫描的源行数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_predicate_evaluation_count",
+          "signature": "func get_predicate_evaluation_count() -> int",
+          "summary": "获取本次候选执行的谓词次数。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_code",
+          "signature": "func get_error_code() -> StringName",
+          "summary": "获取稳定错误码。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_message",
+          "signature": "func get_error_message() -> String",
+          "summary": "获取有界错误说明。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_failed_predicate_id",
+          "signature": "func get_failed_predicate_id() -> StringName",
+          "summary": "获取失败谓词 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_failed_source_row_index",
+          "signature": "func get_failed_source_row_index() -> int",
+          "summary": "获取失败源行索引。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_failed_row_id",
+          "signature": "func get_failed_row_id() -> Variant",
+          "summary": "获取失败行 ID 副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_result",
+          "signature": "func duplicate_result() -> GFTableViewRebuildResult",
+          "summary": "创建结果的隔离副本。",
           "visibility": "public"
         }
       ]
@@ -90948,6 +91613,214 @@
         }
       ]
     },
+    "GFVirtualListBinder": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd",
+      "summary": "GFVirtualListBinder: owner-bound 虚拟列表 Control 物化与回收协调器。 连接项目提供的 `ScrollContainer`、绝对布局 content root、`GFVirtualListModel` 与行回调，只物化真实视口及 overscan 范围。项目继续拥有条目数据、稳定 ID、",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "signal",
+          "name": "sync_completed",
+          "signature": "signal sync_completed(result: GFVirtualListSyncResult)",
+          "summary": "一轮同步完成后发出。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "LayoutAxis",
+          "signature": "enum LayoutAxis {\n\t## 以 Y 轴和垂直滚动条组织条目。\n\tVERTICAL,\n\t## 以 X 轴和水平滚动条组织条目。\n\tHORIZONTAL,\n}",
+          "summary": "列表滚动和尺寸测量使用的主轴。",
+          "visibility": "public"
+        },
+        {
+          "kind": "enum",
+          "name": "ScrollAlignment",
+          "signature": "enum ScrollAlignment {\n\t## 已可见时不滚动，否则移动到最近边界。\n\tNEAREST,\n\t## 条目起点对齐视口起点。\n\tSTART,\n\t## 条目中心对齐视口中心。\n\tCENTER,\n\t## 条目终点对齐视口终点。\n\tEND,\n}",
+          "summary": "把条目滚入视口时使用的对齐方式。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DEFAULT_MAX_MATERIALIZED_ITEMS",
+          "signature": "const DEFAULT_MAX_MATERIALIZED_ITEMS: int = 512",
+          "summary": "默认活动 Control 硬上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "DEFAULT_MAX_POOLED_ITEMS",
+          "signature": "const DEFAULT_MAX_POOLED_ITEMS: int = 64",
+          "summary": "默认 parentless pool Control 上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ABSOLUTE_MAX_MATERIALIZED_ITEMS",
+          "signature": "const ABSOLUTE_MAX_MATERIALIZED_ITEMS: int = 4096",
+          "summary": "活动物化 Control 的框架级绝对硬上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ABSOLUTE_MAX_POOLED_ITEMS",
+          "signature": "const ABSOLUTE_MAX_POOLED_ITEMS: int = 1024",
+          "summary": "parentless pool 的框架级绝对硬上限。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH",
+          "signature": "const ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH: int = 1024",
+          "summary": "稳定 identity token 允许的最大 UTF-8 字节数。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "layout_axis",
+          "signature": "var layout_axis: LayoutAxis = LayoutAxis.VERTICAL",
+          "summary": "布局主轴。只接受 VERTICAL/HORIZONTAL；绑定期间修改后调用 request_sync() 使其生效。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "max_materialized_items",
+          "signature": "var max_materialized_items: int = DEFAULT_MAX_MATERIALIZED_ITEMS",
+          "summary": "活动物化 Control 硬上限；运行时按至少 1 处理。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "max_pooled_items",
+          "signature": "var max_pooled_items: int = DEFAULT_MAX_POOLED_ITEMS",
+          "summary": "parentless pool 最多保留的 Control 数量；小于 0 时按 0 处理。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "auto_measure",
+          "signature": "var auto_measure: bool = true",
+          "summary": "是否在新绑定或数据失效后自动测量活动行；不影响显式 request_measurement()。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "auto_reveal_focus",
+          "signature": "var auto_reveal_focus: bool = true",
+          "summary": "虚拟焦点变化后是否按最近边界自动滚入视口。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "fill_cross_axis",
+          "signature": "var fill_cross_axis: bool = true",
+          "summary": "是否让行 Control 填满 content root 的交叉轴。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "bind",
+          "signature": "func bind( owner: Node, scroll_container: ScrollContainer, content_root: Control, layout_model: GFVirtualListModel, item_factory: Callable, bind_callback: Callable, unbind_callback: Callable, identity_callback: Callable, focus_model: GFVirtualListFocusModel = null, measure_callback: Callable = Callable(), focus_target_callback: Callable = Callable() ) -> bool",
+          "summary": "建立一个 owner-bound 虚拟列表绑定。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "request_sync",
+          "signature": "func request_sync() -> bool",
+          "summary": "请求一次合并到 deferred 队列的同步。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "sync_now",
+          "signature": "func sync_now() -> GFVirtualListSyncResult",
+          "summary": "立即执行一轮同步；callback 内的再次请求会合并为下一轮。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "invalidate_items",
+          "signature": "func invalidate_items() -> bool",
+          "summary": "标记项目条目内容或 identity 已变化，并请求重新绑定当前物化范围。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "request_measurement",
+          "signature": "func request_measurement() -> bool",
+          "summary": "请求下一轮重新测量当前活动行；即使 auto_measure 为 false 也会执行。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "scroll_to_item",
+          "signature": "func scroll_to_item( item_index: int, alignment: ScrollAlignment = ScrollAlignment.NEAREST ) -> bool",
+          "summary": "把指定条目滚入视口。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_materialized_control",
+          "signature": "func get_materialized_control(item_index: int) -> Control",
+          "summary": "获取指定索引当前物化的 Control。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_materialized_control_by_id",
+          "signature": "func get_materialized_control_by_id(item_id: Variant) -> Control",
+          "summary": "按稳定 identity 获取当前物化的 Control。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_last_sync_result",
+          "signature": "func get_last_sync_result() -> GFVirtualListSyncResult",
+          "summary": "获取最近同步结果的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_debug_snapshot",
+          "signature": "func get_debug_snapshot() -> Dictionary",
+          "summary": "获取不含项目条目载荷的调试快照。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_bound",
+          "signature": "func is_bound() -> bool",
+          "summary": "检查是否处于有效绑定生命周期。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_disposed",
+          "signature": "func is_disposed() -> bool",
+          "summary": "检查是否进入不可复用终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "unbind",
+          "signature": "func unbind() -> void",
+          "summary": "解除当前绑定并释放全部 Binder-owned Control；实例仍可重新 bind。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "dispose",
+          "signature": "func dispose() -> void",
+          "summary": "进入终态并释放行、pool、连接和 callback。",
+          "visibility": "public"
+        }
+      ]
+    },
     "GFVirtualListFocusModel": {
       "extends": "RefCounted",
       "module": "standard",
@@ -91111,6 +91984,13 @@
       "since": "4.4.0",
       "members": [
         {
+          "kind": "signal",
+          "name": "layout_changed",
+          "signature": "signal layout_changed(revision: int)",
+          "summary": "布局状态实际变化后发出。",
+          "visibility": "public"
+        },
+        {
           "kind": "const",
           "name": "DEFAULT_ESTIMATED_ITEM_EXTENT",
           "signature": "const DEFAULT_ESTIMATED_ITEM_EXTENT: float = 60.0",
@@ -91210,6 +92090,13 @@
         },
         {
           "kind": "func",
+          "name": "get_revision",
+          "signature": "func get_revision() -> int",
+          "summary": "获取布局状态的当前版本号。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "get_item_extent",
           "signature": "func get_item_extent(item_index: int) -> float",
           "summary": "获取条目尺寸。",
@@ -91238,6 +92125,13 @@
         },
         {
           "kind": "func",
+          "name": "get_viewport_range",
+          "signature": "func get_viewport_range(scroll_offset: float, viewport_extent: float) -> Vector2i",
+          "summary": "计算当前滚动窗口直接命中的条目范围，不包含 overscan。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "get_visible_range",
           "signature": "func get_visible_range(scroll_offset: float, viewport_extent: float) -> Vector2i",
           "summary": "计算当前滚动窗口内应被物化的条目范围。",
@@ -91248,6 +92142,221 @@
           "name": "get_visible_items",
           "signature": "func get_visible_items(scroll_offset: float, viewport_extent: float) -> Array[Dictionary]",
           "summary": "获取当前滚动窗口内的条目布局记录。",
+          "visibility": "public"
+        }
+      ]
+    },
+    "GFVirtualListSyncResult": {
+      "extends": "RefCounted",
+      "module": "standard",
+      "package_id": "gf.standard.ui",
+      "path": "addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd",
+      "summary": "GFVirtualListSyncResult: 虚拟列表同步的不可变诊断结果。 只保存范围、计数、版本和稳定错误信息，不保存项目条目数据或原始稳定 ID。",
+      "visibility": "public",
+      "category": "value_object",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "const",
+          "name": "STATUS_SYNCED",
+          "signature": "const STATUS_SYNCED: StringName = &\"synced\"",
+          "summary": "目标范围已完整同步。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_UNCHANGED",
+          "signature": "const STATUS_UNCHANGED: StringName = &\"unchanged\"",
+          "summary": "当前 materialization 已满足目标且没有结构变化。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_DEFERRED",
+          "signature": "const STATUS_DEFERRED: StringName = &\"deferred\"",
+          "summary": "当前轮冻结快照在完成提交前或项目绑定副作用期间失效；Binder 已保留后续同步请求。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_TRUNCATED",
+          "signature": "const STATUS_TRUNCATED: StringName = &\"truncated\"",
+          "summary": "目标范围超过显式节点预算，已优先物化真实视口范围。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_UNBOUND",
+          "signature": "const STATUS_UNBOUND: StringName = &\"unbound\"",
+          "summary": "Binder 当前没有有效绑定。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_DISPOSED",
+          "signature": "const STATUS_DISPOSED: StringName = &\"disposed\"",
+          "summary": "Binder 已进入不可复用的终态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_INVALID_IDENTITY",
+          "signature": "const STATUS_INVALID_IDENTITY: StringName = &\"invalid_identity\"",
+          "summary": "identity callback 返回了不可稳定编码的值。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_DUPLICATE_IDENTITY",
+          "signature": "const STATUS_DUPLICATE_IDENTITY: StringName = &\"duplicate_identity\"",
+          "summary": "当前请求范围包含重复稳定 identity。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_FACTORY_FAILED",
+          "signature": "const STATUS_FACTORY_FAILED: StringName = &\"factory_failed\"",
+          "summary": "item factory 没有返回可接管的 parentless Control。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_BIND_FAILED",
+          "signature": "const STATUS_BIND_FAILED: StringName = &\"bind_failed\"",
+          "summary": "项目 bind callback 拒绝了一个条目。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_successful",
+          "signature": "func is_successful() -> bool",
+          "summary": "检查同步是否提交了内部一致的目标状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_status",
+          "signature": "func get_status() -> StringName",
+          "summary": "获取稳定同步状态。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_layout_revision",
+          "signature": "func get_layout_revision() -> int",
+          "summary": "获取本轮计算范围前冻结的布局版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_data_revision",
+          "signature": "func get_data_revision() -> int",
+          "summary": "获取本轮开始时冻结的 Binder 数据失效版本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_viewport_range",
+          "signature": "func get_viewport_range() -> Vector2i",
+          "summary": "获取未加入 overscan 的真实视口范围。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_requested_range",
+          "signature": "func get_requested_range() -> Vector2i",
+          "summary": "获取加入 overscan、应用预算前的请求范围。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_materialized_indices",
+          "signature": "func get_materialized_indices() -> PackedInt32Array",
+          "summary": "获取实际物化索引副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_materialized_count",
+          "signature": "func get_materialized_count() -> int",
+          "summary": "获取实际物化数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_pooled_count",
+          "signature": "func get_pooled_count() -> int",
+          "summary": "获取当前池内可复用 Control 数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_created_count",
+          "signature": "func get_created_count() -> int",
+          "summary": "获取本轮新建 Control 数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_reused_count",
+          "signature": "func get_reused_count() -> int",
+          "summary": "获取本轮从旧 active 或 pool 复用数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_released_count",
+          "signature": "func get_released_count() -> int",
+          "summary": "获取本轮离开旧绑定的数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_measured_count",
+          "signature": "func get_measured_count() -> int",
+          "summary": "获取本轮成功测量的行数量。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_anchor_adjustment",
+          "signature": "func get_anchor_adjustment() -> float",
+          "summary": "获取本轮一次性应用的滚动锚点修正。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "was_truncated",
+          "signature": "func was_truncated() -> bool",
+          "summary": "检查是否因 materialization 上限截断。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error_index",
+          "signature": "func get_error_index() -> int",
+          "summary": "获取首个失败条目索引。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_error",
+          "signature": "func get_error() -> String",
+          "summary": "获取有界稳定错误说明。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "duplicate_result",
+          "signature": "func duplicate_result() -> GFVirtualListSyncResult",
+          "summary": "创建结果的隔离副本。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "to_dict",
+          "signature": "func to_dict() -> Dictionary",
+          "summary": "转换为不含项目数据的诊断字典。",
           "visibility": "public"
         }
       ]

--- a/addons/gf/tools/ai_developer/knowledge/capabilities.json
+++ b/addons/gf/tools/ai_developer/knowledge/capabilities.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.8.0",
+  "catalog_version": "1.9.0",
   "capabilities": [
     {
       "id": "architecture",
@@ -85,12 +85,18 @@
     {
       "id": "ui-scalability",
       "title": "Scalable and virtualized UI collections",
-      "summary": "Bounded virtual-list windows, stable item identity, focus projection, repeater binding, and large collection presentation.",
-      "keywords": ["virtual list", "virtualized list", "large list", "recycled rows", "recycler", "repeater", "repeater binding", "focus model", "focus projection", "windowed ui", "scroll performance"],
+      "summary": "Bounded virtual-list materialization, stable item identity and focus, transactional table predicates, repeater binding, and large collection presentation.",
+      "keywords": ["virtual list", "virtualized list", "large list", "recycled rows", "recycler", "table predicate", "structured filter", "repeater", "repeater binding", "focus model", "focus projection", "windowed ui", "scroll performance"],
       "packages": ["gf.standard.ui", "gf.standard.ui.state"],
-      "primary_classes": ["GFVirtualListModel", "GFVirtualListFocusModel", "GFRepeaterBinder"],
+      "primary_classes": ["GFVirtualListModel", "GFVirtualListBinder", "GFVirtualListFocusModel", "GFTableDataView", "GFTableRowPredicate", "GFRepeaterBinder"],
+      "required_api_members": [
+        {
+          "class_name": "GFVirtualListBinder",
+          "members": ["bind", "sync_now", "invalidate_items"]
+        }
+      ],
       "recipes": ["scalable-ui-collection"],
-      "boundary": "GF owns bounded visible windows, stable identity and focus projection, and reusable binder lifecycle mechanics; projects own authoritative item identity, sorting, filtering, row visuals, input, accessibility, and product semantics."
+      "boundary": "GF owns bounded visible windows, recycler lifecycle, focus projection, and transactional predicate execution; projects own authoritative data and identity, domain predicate construction, row visuals, input, accessibility, and product semantics."
     },
     {
       "id": "audio",
@@ -221,12 +227,18 @@
     {
       "id": "spatial-physics",
       "title": "Spatial math and physics mechanisms",
-      "summary": "Grid/path math, spatial queries, bounded 2D canvas orchestration, camera mechanisms, hit detection, buoyancy sampling, and physics-independent policies.",
-      "keywords": ["spatial", "grid", "path", "grid path", "path preview", "grid path preview", "pathfinding", "canvas", "selection", "placement", "physics", "camera", "hitbox", "buoyancy", "2d", "3d"],
+      "summary": "Grid/path math, spatial queries, policy-driven bounded 2D canvas orchestration, camera mechanisms, hit detection, buoyancy sampling, and physics-independent policies.",
+      "keywords": ["spatial", "grid", "path", "grid path", "path preview", "grid path preview", "pathfinding", "canvas", "input policy", "gesture arbitration", "parent scroll", "selection", "placement", "physics", "camera", "hitbox", "buoyancy", "2d", "3d"],
       "packages": ["gf.standard.spatial", "gf.standard.spatial.canvas", "gf.extension.physics", "gf.extension.camera", "gf.extension.combat"],
-      "primary_classes": ["GFSpatialQueryIndex2D", "GFGridPathMath2D", "GFGraphPathSearchState", "GFSpatialCanvas2D", "GFBuoyancyField3D", "GFCameraOrbitRig3D", "GFHitBox2D"],
+      "primary_classes": ["GFSpatialQueryIndex2D", "GFGridPathMath2D", "GFGraphPathSearchState", "GFSpatialCanvas2D", "GFSpatialCanvasInputPolicy", "GFBuoyancyField3D", "GFCameraOrbitRig3D", "GFHitBox2D"],
+      "required_api_members": [
+        {
+          "class_name": "GFSpatialCanvasInputPolicy",
+          "members": ["validate_policy", "duplicate_policy"]
+        }
+      ],
       "recipes": ["spatial-policy", "asset-catalog-spatial-placement"],
-      "boundary": "GFSpatialCanvas2D orchestrates view, selection, and placement operation records only; projects own TileMap or scene mutation, business legality, persistence, UGC, collision layers, world semantics, authority, and force application policy."
+      "boundary": "GFSpatialCanvas2D orchestrates view, validated input routing, selection, and placement operation records only; projects own action naming, TileMap or scene mutation, business legality, persistence, UGC, collision layers, world semantics, authority, and force application policy."
     },
     {
       "id": "project-tooling",

--- a/addons/gf/tools/ai_developer/knowledge/recipes.json
+++ b/addons/gf/tools/ai_developer/knowledge/recipes.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.8.0",
+  "catalog_version": "1.9.0",
   "recipes": [
     {
       "id": "project-feature",
@@ -397,17 +397,23 @@
     {
       "id": "scalable-ui-collection",
       "title": "Present a scalable UI collection",
-      "package_requirements": {"all_of": [], "any_of": [["gf.standard.ui", "gf.standard.ui.state"]]},
-      "primary_classes": ["GFVirtualListModel", "GFVirtualListFocusModel", "GFRepeaterBinder"],
+      "package_requirements": {"all_of": ["gf.standard.ui"], "any_of": []},
+      "primary_classes": ["GFVirtualListModel", "GFVirtualListBinder", "GFVirtualListFocusModel", "GFTableDataView", "GFTableRowPredicate"],
+      "required_api_members": [
+        {
+          "class_name": "GFTableDataView",
+          "members": ["set_row_predicates", "get_view_revision"]
+        }
+      ],
       "steps": [
         "Keep authoritative item identity, sorting, filtering, selection, and accessibility semantics in project state.",
-        "Configure GFVirtualListModel with the item count and measured or estimated extents, then request only the visible range for the current viewport.",
-        "Recycle project-owned row views by stable item identity and feed measured extent changes back into the layout model.",
-        "Use GFVirtualListFocusModel to preserve logical focus independently from the currently materialized row nodes.",
-        "When reactive repeater binding is needed, install gf.standard.ui.state and bind only the currently materialized visible slice to GFRepeaterBinder; never pass the complete large collection, and keep template and teardown ownership explicit.",
-        "Test empty and very large collections, variable extents, reorder and filter changes, focus repair, container disposal, and repeated bind and unbind cycles."
+        "Use GFTableDataView when one canonical dataset needs text filtering, deterministic project-defined row predicates, sorting, and stable-ID selection; react only to committed view changes.",
+        "Configure GFVirtualListModel with the committed visible count and measured or estimated extents, then bind a project-owned ScrollContainer, content root, row factory, and callbacks through GFVirtualListBinder.",
+        "Invalidate binder identities after a committed reorder or filter, let the binder recycle its owned Controls by stable scalar identity while project callbacks only reset visual state, and feed measured extents plus one anchor correction back into the layout model.",
+        "Use GFVirtualListFocusModel to preserve logical focus independently from currently materialized row nodes; keep focus distinct from selection.",
+        "Test empty and very large collections, predicate failure and reentrancy, variable extents, reorder and filter changes, focus repair, owner disposal, and repeated bind and unbind cycles."
       ],
-      "avoid": ["One Control node permanently allocated per large item", "Row node identity used as authoritative item identity", "Sorting or filtering hidden inside the framework binder"]
+      "avoid": ["One Control node permanently allocated per large item", "Row node identity used as authoritative item identity", "Domain predicates or sorting hidden inside the visual binder", "Failed predicate rebuilds replacing the last committed projection"]
     },
     {
       "id": "ui-route-operation",
@@ -606,17 +612,18 @@
       "id": "spatial-policy",
       "title": "Apply spatial or physics mechanisms",
       "package_requirements": {"all_of": [], "any_of": [["gf.standard.spatial", "gf.standard.spatial.canvas", "gf.extension.physics", "gf.extension.camera"]]},
-      "primary_classes": ["GFSpatialQueryIndex2D", "GFGridPathMath2D", "GFSpatialCanvas2D", "GFBuoyancyField3D", "GFCameraOrbitRig3D"],
+      "primary_classes": ["GFSpatialQueryIndex2D", "GFGridPathMath2D", "GFSpatialCanvas2D", "GFSpatialCanvasInputPolicy", "GFBuoyancyField3D", "GFCameraOrbitRig3D"],
       "steps": [
         "Separate pure spatial math or sampling from world ownership and node mutation.",
         "Declare coordinate, units, layer, update cadence, and authority contracts.",
         "Use GFGridPathMath2D for bounded path or flow-field data, while project code owns cell legality, movement cost, authority, and preview rendering.",
-        "Use GFSpatialCanvas2D only to coordinate bounded view transforms, selection, and project-validated placement operation records.",
+        "Use GFSpatialCanvas2D only to coordinate bounded view transforms, selection, and project-validated placement operation records; apply one validated GFSpatialCanvasInputPolicy to choose pointer chords, modifiers, gestures, cancel action, and propagation.",
+        "For a canvas nested in scrolling UI, leave unmatched wheel input to normal GUI propagation and consume only the gestures the policy assigns to the canvas; manual routers must honor the returned input disposition.",
         "Let the project choose candidates, validate placement, mutate TileMap or scene content, persist history or UGC, apply forces, and define collision policy.",
         "Bound queries and incremental work.",
         "Test empty worlds, invalid values, large coordinates, frame-rate variation, and disposal."
       ],
-      "avoid": ["Physics ownership hidden inside a math helper", "Treating GFSpatialCanvas2D as a TileMap editor, business-rule authority, save system, or UGC store", "Unbounded world scans on frame callbacks"]
+      "avoid": ["Physics ownership hidden inside a math helper", "Treating GFSpatialCanvas2D as a TileMap editor, business-rule authority, save system, or UGC store", "Canvas code scanning or commanding parent ScrollContainers", "Unbounded world scans on frame callbacks"]
     }
   ]
 }

--- a/docs/api_catalog/classes/GFSpatialCanvas2D.xml
+++ b/docs/api_catalog/classes/GFSpatialCanvas2D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSpatialCanvas2D" path="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd" module="standard" extends="Control" classDigest="0cbf7f32f886a0cdeb35d935526c10d08b3c9b647f91a5eab446ba9bcf59d8b3">
+<class name="GFSpatialCanvas2D" path="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd" module="standard" extends="Control" classDigest="f137ae89b3ab2ebb85a973dff1f0d1e242c93ef990e949226f9466001cf7c462">
 	<description>GFSpatialCanvas2D: 有界运行时 2D 空间交互画布。
 统一管理画布视图、世界/画布/格子坐标转换、显式条目查询、稳定选择和项目校验的
 放置会话。项目仍拥有内容节点、占位与权限规则、业务命令、存档和网络同步。</description>
@@ -95,6 +95,23 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">10.0.0</tag>
+			</tags>
+		</member>
+		<member kind="enum" name="InputDisposition">
+			<signature>enum InputDisposition {
+	## 事件未被画布识别或当前策略要求继续交给其他接收者。
+	IGNORED,
+	## 事件已更新画布，但仍允许 GUI 冒泡。
+	HANDLED,
+	## 事件已更新画布，并应在 GUI 边界停止传播。
+	CONSUMED,
+}</signature>
+			<description>输入处理结果。
+手工转发调用只观察该返回值；只有 [constant InputDisposition.CONSUMED]
+会让画布自身的 [code]_gui_input()[/code] 调用 [method Control.accept_event]。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 	</enums>
@@ -430,35 +447,35 @@ GF 只更新该节点的位置与缩放，不扫描、重挂或主动释放项�
 			</tags>
 		</member>
 		<member kind="method" name="set_selection">
-			<signature>func set_selection( item_ids: PackedStringArray, mode: int = SelectionMode.REPLACE ) -&gt; PackedStringArray:</signature>
+			<signature>func set_selection( item_ids: PackedStringArray, mode: SelectionMode = SelectionMode.REPLACE ) -&gt; PackedStringArray:</signature>
 			<description>按模式更新选择。
 只接受已登记且可选的稳定 ID；容量只限制替换或新增，不截断减去候选。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">item_ids: 候选条目 ID。</tag>
-				<tag name="param">mode: SelectionMode 值。</tag>
+				<tag name="param">mode: [enum SelectionMode] 值。</tag>
 				<tag name="return">更新后的隔离选择副本。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="select_point">
-			<signature>func select_point( canvas_position: Vector2, mode: int = SelectionMode.REPLACE ) -&gt; PackedStringArray:</signature>
+			<signature>func select_point( canvas_position: Vector2, mode: SelectionMode = SelectionMode.REPLACE ) -&gt; PackedStringArray:</signature>
 			<description>在画布坐标点选最高优先级条目。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">canvas_position: 本 Control 的画布坐标。</tag>
-				<tag name="param">mode: SelectionMode 值。</tag>
+				<tag name="param">mode: [enum SelectionMode] 值。</tag>
 				<tag name="return">更新后的选择。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="select_rect">
-			<signature>func select_rect( canvas_rect: Rect2, mode: int = SelectionMode.REPLACE, fully_contained: bool = false ) -&gt; PackedStringArray:</signature>
+			<signature>func select_rect( canvas_rect: Rect2, mode: SelectionMode = SelectionMode.REPLACE, fully_contained: bool = false ) -&gt; PackedStringArray:</signature>
 			<description>在画布坐标框选条目。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">canvas_rect: 画布选择矩形。</tag>
-				<tag name="param">mode: SelectionMode 值。</tag>
+				<tag name="param">mode: [enum SelectionMode] 值。</tag>
 				<tag name="param">fully_contained: 为 true 时只选择完全位于矩形内的条目。</tag>
 				<tag name="return">更新后的选择。</tag>
 				<tag name="since">10.0.0</tag>
@@ -572,27 +589,51 @@ GF 只更新该节点的位置与缩放，不扫描、重挂或主动释放项�
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
+		<member kind="method" name="set_input_policy">
+			<signature>func set_input_policy(policy: GFSpatialCanvasInputPolicy) -&gt; bool:</signature>
+			<description>原子替换输入解释策略。
+方法先完整校验并深拷贝候选策略；失败时保留当前策略和所有瞬态状态。
+成功切换会释放当前指针捕获，但不会清除选择集合或活动放置会话。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">policy: 候选输入策略。</tag>
+				<tag name="return">策略有效并完成替换时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_input_policy">
+			<signature>func get_input_policy() -&gt; GFSpatialCanvasInputPolicy:</signature>
+			<description>获取当前输入策略的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前策略的深拷贝。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="handle_input_event">
-			<signature>func handle_input_event(event: InputEvent) -&gt; bool:</signature>
+			<signature>func handle_input_event(event: InputEvent) -&gt; InputDisposition:</signature>
 			<description>处理一个项目转发的输入事件。
-中键/单指拖动用于平移，滚轮/捏合用于焦点缩放，左键用于点选、框选或活动放置。
-只有实际识别和消费的事件返回 true。</description>
+事件按当前 [GFSpatialCanvasInputPolicy] 解释。方法不会调用 Viewport 的 handled API；
+手工路由方应根据 [enum InputDisposition] 决定是否继续传播。
+鼠标与原始触摸只允许一个来源持有瞬态捕获；冲突来源及系统手势在物理释放或
+显式取消前返回 [constant InputDisposition.IGNORED] 且不修改画布状态。
+系统标记为 canceled 的当前捕获事件只释放瞬态状态，不提交选择或放置。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">event: Godot 输入事件。</tag>
-				<tag name="return">事件被画布消费时返回 true。</tag>
+				<tag name="return">[enum InputDisposition] 值。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="handle_screen_input_event">
-			<signature>func handle_screen_input_event(event: InputEvent) -&gt; bool:</signature>
+			<signature>func handle_screen_input_event(event: InputEvent) -&gt; InputDisposition:</signature>
 			<description>处理一个使用 Viewport 屏幕坐标的输入事件。
 适合从 `_input()` 或自定义全局路由转发事件；事件会先复制并转换到本 Control
 的局部画布坐标。`_gui_input()` 已提供局部事件，应直接使用 handle_input_event()。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">event: 使用 Viewport 屏幕坐标的 Godot 输入事件。</tag>
-				<tag name="return">事件被画布消费时返回 true；变换不可逆时返回 false。</tag>
+				<tag name="return">[enum InputDisposition] 值；变换不可逆时返回 [constant InputDisposition.IGNORED]。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFSpatialCanvasInputPolicy.xml
+++ b/docs/api_catalog/classes/GFSpatialCanvasInputPolicy.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSpatialCanvasInputPolicy" path="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd" module="standard" extends="Resource" classDigest="1d2a057342c915fc4736ed4d59719cbbd99eebb17ba37af2eba8b7837e96f145">
+	<description>GFSpatialCanvasInputPolicy: 空间画布输入解释策略。
+以数据方式声明平移、选择、滚轮、触摸和取消输入。策略不持有节点、
+Viewport 或父容器引用；[code]GFSpatialCanvas2D[/code] 只接受完整校验通过的隔离副本。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">resource_definition</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums>
+		<member kind="enum" name="ModifierMask">
+			<signature>enum ModifierMask {
+	## 不要求修饰键。
+	NONE = 0,
+	## Shift 修饰键。
+	SHIFT = 1,
+	## Ctrl 修饰键。
+	CTRL = 2,
+	## Alt 修饰键。
+	ALT = 4,
+	## Meta 修饰键。
+	META = 8,
+}</signature>
+			<description>输入修饰键位掩码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="enum" name="WheelAxis">
+			<signature>enum WheelAxis {
+	## 使用向上/向下滚轮事件。
+	VERTICAL,
+	## 使用向左/向右滚轮事件。
+	HORIZONTAL,
+}</signature>
+			<description>滚轮缩放使用的物理轴。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="enum" name="WheelRouting">
+			<signature>enum WheelRouting {
+	## 画布处理目标轴上的所有滚轮事件。
+	CANVAS,
+	## 只有修饰键掩码精确匹配时由画布处理。
+	MODIFIER_GATED,
+	## 画布始终忽略滚轮，让 GUI 祖先继续处理。
+	PARENT_ONLY,
+}</signature>
+			<description>滚轮事件的画布路由策略。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="enum" name="TouchPrimaryBehavior">
+			<signature>enum TouchPrimaryBehavior {
+	## 单指不执行画布行为；若启用任一多指行为，首触点仍会被捕获以等待后续触点。
+	NONE,
+	## 单指拖动平移画布。
+	PAN,
+	## 单指执行点选、框选或放置确认。
+	SELECT,
+}</signature>
+			<description>单指触摸的主行为。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
+	<constants>
+		<member kind="const" name="ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS">
+			<signature>const ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS: int = 15</signature>
+			<description>单份策略允许声明的选择修饰键绑定绝对上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ABSOLUTE_MAX_ACTION_EVENTS">
+			<signature>const ABSOLUTE_MAX_ACTION_EVENTS: int = 64</signature>
+			<description>校验单个 InputMap action 时允许扫描的事件绝对上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties>
+		<member kind="property" name="pan_mouse_button" decorators="@export">
+			<signature>var pan_mouse_button: MouseButton = MOUSE_BUTTON_MIDDLE</signature>
+			<description>直接触发平移捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="pan_action" decorators="@export">
+			<signature>var pan_action: StringName = &amp;""</signature>
+			<description>通过 InputMap 触发平移捕获的动作；空名称表示禁用动作绑定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="pan_modifier_mask" decorators="@export_flags(&quot;Shift:1&quot;, &quot;Ctrl:2&quot;, &quot;Alt:4&quot;, &quot;Meta:8&quot;)">
+			<signature>var pan_modifier_mask: int = ModifierMask.NONE</signature>
+			<description>直接平移按钮必须精确匹配的修饰键掩码。
+使用 [member pan_action] 时修饰键由 InputMap action 精确声明，本字段必须为 NONE。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="selection_mouse_button" decorators="@export">
+			<signature>var selection_mouse_button: MouseButton = MOUSE_BUTTON_LEFT</signature>
+			<description>直接触发选择捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="selection_action" decorators="@export">
+			<signature>var selection_action: StringName = &amp;""</signature>
+			<description>通过 InputMap 触发选择捕获的动作；空名称表示禁用动作绑定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="selection_default_mode" decorators="@export">
+			<signature>var selection_default_mode: GFSpatialCanvas2D.SelectionMode = (</signature>
+			<description>没有选择修饰键绑定精确匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code]。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="selection_modifier_bindings" decorators="@export">
+			<signature>var selection_modifier_bindings: Array[GFSpatialCanvasSelectionModeBinding] = []</signature>
+			<description>修饰键到选择模式的精确匹配表；重复掩码会使策略校验失败。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="drag_threshold" decorators="@export">
+			<signature>var drag_threshold: float = 4.0</signature>
+			<description>区分点选和框选的局部画布像素阈值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="wheel_axis" decorators="@export">
+			<signature>var wheel_axis: WheelAxis = WheelAxis.VERTICAL</signature>
+			<description>用于画布缩放的滚轮轴。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="wheel_routing" decorators="@export">
+			<signature>var wheel_routing: WheelRouting = WheelRouting.CANVAS</signature>
+			<description>滚轮缩放路由策略。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="wheel_modifier_mask" decorators="@export_flags(&quot;Shift:1&quot;, &quot;Ctrl:2&quot;, &quot;Alt:4&quot;, &quot;Meta:8&quot;)">
+			<signature>var wheel_modifier_mask: int = ModifierMask.NONE</signature>
+			<description>[constant WheelRouting.MODIFIER_GATED] 下必须精确匹配的修饰键掩码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="wheel_zoom_factor" decorators="@export">
+			<signature>var wheel_zoom_factor: float = 1.1</signature>
+			<description>每个滚轮刻度的缩放倍率，必须为有限且大于 1 的值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="touch_enabled" decorators="@export">
+			<signature>var touch_enabled: bool = true</signature>
+			<description>是否处理原始 ScreenTouch / ScreenDrag 事件。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="touch_primary_behavior" decorators="@export">
+			<signature>var touch_primary_behavior: TouchPrimaryBehavior = TouchPrimaryBehavior.PAN</signature>
+			<description>单指触摸的主行为。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="touch_multi_pan_enabled" decorators="@export">
+			<signature>var touch_multi_pan_enabled: bool = true</signature>
+			<description>是否允许双指及以上触点驱动平移。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="touch_multi_zoom_enabled" decorators="@export">
+			<signature>var touch_multi_zoom_enabled: bool = true</signature>
+			<description>是否允许双指及以上触点驱动捏合缩放。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="system_pan_gesture_enabled" decorators="@export">
+			<signature>var system_pan_gesture_enabled: bool = true</signature>
+			<description>是否处理 Godot 的系统 PanGesture 事件。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="system_magnify_gesture_enabled" decorators="@export">
+			<signature>var system_magnify_gesture_enabled: bool = true</signature>
+			<description>是否处理 Godot 的系统 MagnifyGesture 事件。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="placement_cancel_action" decorators="@export">
+			<signature>var placement_cancel_action: StringName = &amp;"ui_cancel"</signature>
+			<description>取消活动放置或瞬态选择的非指针 InputMap 动作；空名称表示禁用取消输入。
+动作不得包含鼠标、触摸或位置手势事件，避免取消优先级饿死画布指针行为。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="consume_handled_events" decorators="@export">
+			<signature>var consume_handled_events: bool = true</signature>
+			<description>一般已处理事件是否由 Canvas GUI 边界消费。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="consume_wheel_events" decorators="@export">
+			<signature>var consume_wheel_events: bool = true</signature>
+			<description>已处理滚轮事件是否由 Canvas GUI 边界消费。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</properties>
+	<methods>
+		<member kind="method" name="validate_policy">
+			<signature>func validate_policy() -&gt; Dictionary:</signature>
+			<description>校验完整策略。
+校验失败时调用方必须保留上一份有效策略；报告遵循
+[code]GFValidationReportDictionary[/code] 结构。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">策略校验报告。</tag>
+				<tag name="schema">return: GFValidationReportDictionary-compatible report with issues describing invalid fields.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_policy">
+			<signature>func duplicate_policy() -&gt; GFSpatialCanvasInputPolicy:</signature>
+			<description>创建策略及嵌套选择绑定的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新策略。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFSpatialCanvasSelectionModeBinding.xml
+++ b/docs/api_catalog/classes/GFSpatialCanvasSelectionModeBinding.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFSpatialCanvasSelectionModeBinding" path="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd" module="standard" extends="Resource" classDigest="2ac15e345d0c9308e80d303c98c31af26d423c3664ecf8f23564ab1c864ca3ee">
+	<description>GFSpatialCanvasSelectionModeBinding: 空间画布选择修饰键绑定。
+只描述修饰键掩码到 [code]GFSpatialCanvas2D.SelectionMode[/code] 的映射，
+不读取设备状态，也不拥有输入生命周期。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">resource_definition</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties>
+		<member kind="property" name="modifier_mask" decorators="@export_flags(&quot;Shift:1&quot;, &quot;Ctrl:2&quot;, &quot;Alt:4&quot;, &quot;Meta:8&quot;)">
+			<signature>var modifier_mask: int = 0</signature>
+			<description>需要精确匹配的 [code]GFSpatialCanvasInputPolicy.ModifierMask[/code] 掩码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="selection_mode" decorators="@export">
+			<signature>var selection_mode: GFSpatialCanvas2D.SelectionMode = (</signature>
+			<description>匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code] 值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</properties>
+	<methods>
+		<member kind="method" name="duplicate_binding">
+			<signature>func duplicate_binding() -&gt; GFSpatialCanvasSelectionModeBinding:</signature>
+			<description>创建隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新绑定。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFTableDataView.xml
+++ b/docs/api_catalog/classes/GFTableDataView.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTableDataView" path="addons/gf/standard/utilities/ui/gf_table_data_view.gd" module="standard" extends="RefCounted" classDigest="76c200643b4da0c9715ad084ba95e8a03e6dbbaef295500feff635f47629950d">
+<class name="GFTableDataView" path="addons/gf/standard/utilities/ui/gf_table_data_view.gd" module="standard" extends="RefCounted" classDigest="fb29dd169a1056d372deefef6b02c6f0c9ce3322ac493d2e3e88ba5a2f9b82d4">
 	<description>GFTableDataView: 通用表格数据视图模型。
 维护行数据、列定义、可见行索引、排序、过滤和单元格提交，
 供运行时 UI、编辑器 Dock、资源表或配置表工具自行选择渲染方式。
@@ -20,12 +20,22 @@
 			</tags>
 		</member>
 		<member kind="signal" name="view_changed">
-			<signature>signal view_changed(visible_count: int)</signature>
-			<description>可见行集合变化后发出。</description>
+			<signature>signal view_changed(view_revision: int, visible_count: int)</signature>
+			<description>可见行集合成功提交后发出。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="param">view_revision: 单调递增的已提交投影 revision。</tag>
 				<tag name="param">visible_count: 当前可见行数量。</tag>
 				<tag name="since">5.2.0</tag>
+			</tags>
+		</member>
+		<member kind="signal" name="view_rebuild_failed">
+			<signature>signal view_rebuild_failed(result: GFTableViewRebuildResult)</signature>
+			<description>候选投影未提交时发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">result: 保留 prior projection 的类型化失败结果。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="signal" name="filter_changed">
@@ -66,40 +76,87 @@
 		</member>
 	</signals>
 	<enums />
-	<constants />
-	<properties>
-		<member kind="property" name="row_id_column">
-			<signature>var row_id_column: StringName = &amp;"id"</signature>
-			<description>用作稳定行 ID 的字段键。为空时使用源行索引。</description>
+	<constants>
+		<member kind="const" name="MAX_ROW_PREDICATE_COUNT">
+			<signature>const MAX_ROW_PREDICATE_COUNT: int = 64</signature>
+			<description>单个表格允许注册的命名行谓词上限。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="since">5.2.0</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
-		<member kind="property" name="case_sensitive_filter">
-			<signature>var case_sensitive_filter: bool = false</signature>
-			<description>过滤时是否区分大小写。</description>
-			<tags>
-				<tag name="api">public</tag>
-				<tag name="since">5.2.0</tag>
-			</tags>
-		</member>
-		<member kind="property" name="selection_model">
-			<signature>var selection_model: GFTableSelectionModel = GFTableSelectionModel.new()</signature>
-			<description>该视图使用的选择模型。</description>
-			<tags>
-				<tag name="api">public</tag>
-				<tag name="since">5.2.0</tag>
-			</tags>
-		</member>
-	</properties>
+	</constants>
+	<properties />
 	<methods>
+		<member kind="method" name="set_row_id_column">
+			<signature>func set_row_id_column(column_id: StringName) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式设置稳定行 ID 字段键。
+新字段键会先参与完整候选投影；失败时保留旧字段键、投影、选择模型与 revision。
+成功时按同一源行迁移稳定选择和范围锚点。空字段键表示使用源行索引。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">column_id: 新的稳定行 ID 字段键；为空时使用源行索引。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_row_id_column">
+			<signature>func get_row_id_column() -&gt; StringName:</signature>
+			<description>获取稳定行 ID 字段键。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前稳定行 ID 字段键；为空时使用源行索引。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_filter_case_sensitive">
+			<signature>func set_filter_case_sensitive(case_sensitive: bool) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式设置文本过滤是否区分大小写。
+新设置会先参与完整候选投影；失败时保留旧设置、投影、选择模型与 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">case_sensitive: 为 true 时区分大小写。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_filter_case_sensitive">
+			<signature>func is_filter_case_sensitive() -&gt; bool:</signature>
+			<description>查询文本过滤是否区分大小写。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">区分大小写时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_selection_model">
+			<signature>func set_selection_model(model: GFTableSelectionModel) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式替换该视图使用的选择模型。
+新模型只会在完整候选投影成功后成为权威选择模型，并在提交态中按当前行 ID 修剪。
+失败时不会修改旧模型、新模型、投影或 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">model: 非空选择模型。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_selection_model">
+			<signature>func get_selection_model() -&gt; GFTableSelectionModel:</signature>
+			<description>获取该视图使用的选择模型。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前非空选择模型。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="set_columns">
-			<signature>func set_columns(column_definitions: Array[GFTableColumnDefinition]) -&gt; void:</signature>
+			<signature>func set_columns( column_definitions: Array[GFTableColumnDefinition] ) -&gt; GFTableViewRebuildResult:</signature>
 			<description>设置列定义列表。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">column_definitions: 列定义列表；null 项会被忽略。</tag>
+				<tag name="return">类型化投影重建结果；失败时保留原列与 prior projection。</tag>
 				<tag name="schema">column_definitions: Array，包含 GFTableColumnDefinition。</tag>
 				<tag name="since">5.2.0</tag>
 			</tags>
@@ -135,12 +192,13 @@
 			</tags>
 		</member>
 		<member kind="method" name="set_rows">
-			<signature>func set_rows(row_values: Array, duplicate_rows: bool = false) -&gt; void:</signature>
+			<signature>func set_rows( row_values: Array, duplicate_rows: bool = false ) -&gt; GFTableViewRebuildResult:</signature>
 			<description>设置源行数据。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">row_values: 行数据列表。</tag>
 				<tag name="param">duplicate_rows: 是否复制 Dictionary / Array 行数据。</tag>
+				<tag name="return">类型化投影重建结果；失败时保留原 source、projection 与 selection。</tag>
 				<tag name="schema">row_values: Array，调用方保存的行数据。</tag>
 				<tag name="since">5.2.0</tag>
 			</tags>
@@ -277,11 +335,12 @@
 			</tags>
 		</member>
 		<member kind="method" name="set_filter_query">
-			<signature>func set_filter_query(query: String) -&gt; void:</signature>
+			<signature>func set_filter_query(query: String) -&gt; GFTableViewRebuildResult:</signature>
 			<description>设置过滤文本。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">query: 过滤文本；空字符串显示全部行。</tag>
+				<tag name="return">类型化投影重建结果；失败时保留旧 query 与 prior projection。</tag>
 				<tag name="since">5.2.0</tag>
 			</tags>
 		</member>
@@ -292,6 +351,110 @@
 				<tag name="api">public</tag>
 				<tag name="return">过滤文本。</tag>
 				<tag name="since">5.2.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_row_predicates">
+			<signature>func set_row_predicates( registrations: Array[GFTableRowPredicateRegistration] ) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式替换全部命名行谓词。
+注册会先完整校验并按 order 升序、predicate_id 字典序排序，再构建一个候选投影。
+GFTableDataView 保存 predicate_id、order、enabled 与 predicate 引用的框架自有
+metadata 快照；调用方后续修改注册对象不会改变已提交 registry。
+任一失败都会保留当前 registry、projection、revision 与 selection。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">registrations: 谓词注册定义；提交时复制 metadata。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="schema">registrations: Array of GFTableRowPredicateRegistration values.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="register_row_predicate">
+			<signature>func register_row_predicate( registration: GFTableRowPredicateRegistration ) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式注册一个命名行谓词。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">registration: 谓词注册定义；提交时复制 metadata。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unregister_row_predicate">
+			<signature>func unregister_row_predicate(predicate_id: StringName) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式移除一个命名行谓词。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">predicate_id: 要移除的稳定谓词 ID。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_row_predicate_enabled">
+			<signature>func set_row_predicate_enabled( predicate_id: StringName, enabled: bool ) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式设置命名行谓词的启用状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">predicate_id: 稳定谓词 ID。</tag>
+				<tag name="param">enabled: 是否参与候选投影。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_row_predicate_order">
+			<signature>func set_row_predicate_order( predicate_id: StringName, order: int ) -&gt; GFTableViewRebuildResult:</signature>
+			<description>事务式设置命名行谓词的执行顺序。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">predicate_id: 稳定谓词 ID。</tag>
+				<tag name="param">order: 新顺序；数值越小越早执行。</tag>
+				<tag name="return">类型化投影重建结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_row_predicate">
+			<signature>func get_row_predicate(predicate_id: StringName) -&gt; GFTableRowPredicateRegistration:</signature>
+			<description>获取一个命名行谓词注册值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">predicate_id: 稳定谓词 ID。</tag>
+				<tag name="return">独立 metadata 快照；predicate 协议实例保持同一引用，不存在时返回 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_row_predicates">
+			<signature>func get_row_predicates() -&gt; Array[GFTableRowPredicateRegistration]:</signature>
+			<description>获取按确定顺序排列的命名行谓词注册值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">独立 metadata 快照数组；predicate 协议实例保持同一引用。</tag>
+				<tag name="schema">return: Array of GFTableRowPredicateRegistration values.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_row_predicate_ids">
+			<signature>func get_row_predicate_ids() -&gt; Array[StringName]:</signature>
+			<description>获取按确定顺序排列的命名行谓词 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">稳定谓词 ID 数组。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_view_revision">
+			<signature>func get_view_revision() -&gt; int:</signature>
+			<description>获取当前已提交投影 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">单调递增 revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_last_view_rebuild_result">
+			<signature>func get_last_view_rebuild_result() -&gt; GFTableViewRebuildResult:</signature>
+			<description>获取最近一次投影事务结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">最近结果的隔离副本；尚未执行时返回 revision 0 的成功 no-op。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="sort_by_column">
@@ -333,10 +496,11 @@
 			</tags>
 		</member>
 		<member kind="method" name="refresh_view">
-			<signature>func refresh_view() -&gt; void:</signature>
+			<signature>func refresh_view() -&gt; GFTableViewRebuildResult:</signature>
 			<description>重新构建可见行索引。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="return">类型化投影重建结果；失败时保留 prior projection。</tag>
 				<tag name="since">5.2.0</tag>
 			</tags>
 		</member>
@@ -354,7 +518,9 @@
 		</member>
 		<member kind="method" name="commit_cell_value">
 			<signature>func commit_cell_value(row_index: int, column_id: StringName, new_value: Variant) -&gt; bool:</signature>
-			<description>提交源行单元格值。</description>
+			<description>事务式提交源行单元格值。
+写入先发生在隔离候选行上，完整投影成功后才交换权威 source；自定义
+value_setter 与不可隔离的 Object / 脚本 Resource 会在调用任何 setter 前失败关闭。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">row_index: 源行索引。</tag>
@@ -367,7 +533,9 @@
 		</member>
 		<member kind="method" name="commit_visible_cell_value">
 			<signature>func commit_visible_cell_value( visible_row_index: int, column_id: StringName, new_value: Variant ) -&gt; bool:</signature>
-			<description>提交可见行单元格值。</description>
+			<description>事务式提交可见行单元格值。
+写入先发生在隔离候选行上，完整投影成功后才交换权威 source；自定义
+value_setter 与不可隔离的 Object / 脚本 Resource 会在调用任何 setter 前失败关闭。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">visible_row_index: 可见行索引。</tag>
@@ -381,8 +549,8 @@
 		<member kind="method" name="commit_cell_values">
 			<signature>func commit_cell_values(changes: Array[Dictionary]) -&gt; Dictionary:</signature>
 			<description>批量提交源行单元格值。
-该方法会先处理所有变更，再在有实际写入时统一刷新视图并发送单元格提交信号；
-它不是事务，部分失败不会回滚已成功的变更。</description>
+该方法先在隔离候选 rows 上完成全部写入与投影，成功后统一交换并发送信号。
+任一输入、隔离、写入或投影失败都会回滚整批候选变更。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">changes: 单元格变更数组；每项包含 row_index、column_id 与 new_value。</tag>
@@ -396,7 +564,7 @@
 			<signature>func commit_visible_cell_values(changes: Array[Dictionary]) -&gt; Dictionary:</signature>
 			<description>批量提交可见行单元格值。
 可见行索引会在任何写入发生前解析为源行索引，避免排序或过滤重建导致同一批变更漂移。
-该方法不是事务，部分失败不会回滚已成功的变更。</description>
+任一输入、隔离、写入或投影失败都会回滚整批候选变更。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">changes: 单元格变更数组；每项包含 visible_row_index、column_id 与 new_value。</tag>
@@ -440,7 +608,7 @@
 				<tag name="param">options: 描述选项。</tag>
 				<tag name="return">视图摘要。</tag>
 				<tag name="schema">options: Dictionary，可包含 visible_only: bool、include_values: bool、include_columns: bool、include_hidden_columns: bool、include_row_data: bool、copy_values: bool。</tag>
-				<tag name="schema">return: Dictionary，包含 row_count、visible_count、column_count、filter_query、sort_column_id、sort_ascending、visible_only、columns 和 rows。</tag>
+				<tag name="schema">return: Dictionary，包含 view_revision、row_count、visible_count、column_count、predicate_count、filter_query、sort_column_id、sort_ascending、visible_only、columns 和 rows。</tag>
 				<tag name="since">7.0.0</tag>
 			</tags>
 		</member>
@@ -460,7 +628,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">数据视图状态字典。</tag>
-				<tag name="schema">return: Dictionary，包含 row_count、visible_count、column_count、filter_query、sort_column_id 和 sort_ascending。</tag>
+				<tag name="schema">return: Dictionary，包含 view_revision、row_count、visible_count、column_count、predicate_count、enabled_predicate_count、filter_query、sort_column_id、sort_ascending、last_rebuild_ok 和 last_rebuild_error_code。</tag>
 				<tag name="since">5.2.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFTableRowPredicate.xml
+++ b/docs/api_catalog/classes/GFTableRowPredicate.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTableRowPredicate" path="addons/gf/standard/utilities/ui/gf_table_row_predicate.gd" module="standard" extends="RefCounted" classDigest="5351313336a5124b365fdffc7cb5734fc4ad13071000ebcabfaa2684f28f873c">
+	<description>GFTableRowPredicate: 表格结构化行过滤协议。
+项目通过子类实现同步、只读、有界且无副作用的行判断。
+GFTableDataView 按注册顺序契约组合多个谓词，并把显式失败视为整次投影失败。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">protocol</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="evaluate">
+			<signature>func evaluate(row_view: GFTableRowView) -&gt; GFTableRowPredicateResult:</signature>
+			<description>求值一个隔离行视图。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">row_view: 不暴露源 row 的隔离只读视图。</tag>
+				<tag name="return">类型化包含、排除或失败结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="_evaluate">
+			<signature>func _evaluate(_row_view: GFTableRowView) -&gt; GFTableRowPredicateResult:</signature>
+			<description>实现一次同步、只读且有界的行判断。</description>
+			<tags>
+				<tag name="api">protected</tag>
+				<tag name="param">_row_view: 当前行的隔离只读视图。</tag>
+				<tag name="return">类型化包含、排除或失败结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFTableRowPredicateRegistration.xml
+++ b/docs/api_catalog/classes/GFTableRowPredicateRegistration.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTableRowPredicateRegistration" path="addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd" module="standard" extends="RefCounted" classDigest="d255e5cc925d23270662ce0928c32371a66322e7e7b6ab510c92336839d01844">
+	<description>GFTableRowPredicateRegistration: 命名行谓词的注册定义值。
+把项目谓词与稳定 ID、启用状态和显式顺序组合成一次注册定义。
+GFTableDataView 会复制数组并以 order 升序、predicate_id 字典序稳定执行。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="create">
+			<signature>static func create( predicate_id: StringName, predicate: GFTableRowPredicate, order: int = 0, enabled: bool = true ) -&gt; GFTableRowPredicateRegistration:</signature>
+			<description>创建注册定义值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">predicate_id: 非空、无首尾空白且 UTF-8 编码不超过 128 字节的稳定 ID。</tag>
+				<tag name="param">predicate: 项目提供的类型化行谓词。</tag>
+				<tag name="param">order: 执行顺序；数值越小越早执行。</tag>
+				<tag name="param">enabled: 是否参与投影。</tag>
+				<tag name="return">新的注册值；调用方仍应检查 validate_registration()。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_predicate_id">
+			<signature>func get_predicate_id() -&gt; StringName:</signature>
+			<description>获取稳定谓词 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">稳定谓词 ID。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_predicate">
+			<signature>func get_predicate() -&gt; GFTableRowPredicate:</signature>
+			<description>获取类型化谓词。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">注册的谓词。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_order">
+			<signature>func get_order() -&gt; int:</signature>
+			<description>获取显式执行顺序。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">order；数值越小越早执行。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_enabled">
+			<signature>func is_enabled() -&gt; bool:</signature>
+			<description>查询注册是否启用。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">启用时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="validate_registration">
+			<signature>func validate_registration() -&gt; Dictionary:</signature>
+			<description>校验注册定义。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">GFValidationReportDictionary 兼容报告。</tag>
+				<tag name="schema">return: Dictionary with ok, issues, counts, summary, and next_actions.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFTableRowPredicateResult.xml
+++ b/docs/api_catalog/classes/GFTableRowPredicateResult.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTableRowPredicateResult" path="addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd" module="standard" extends="RefCounted" classDigest="7f8a3d3690005b66bd76d4a5a595b8689402d9b25814ffe405dedec9c8bc3a85">
+	<description>GFTableRowPredicateResult: 类型化行谓词求值结果。
+成功结果明确表示包含或排除当前行；失败结果携带稳定错误码和有界说明，
+供 GFTableDataView 中止候选投影并保留上一份已提交视图。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="included">
+			<signature>static func included() -&gt; GFTableRowPredicateResult:</signature>
+			<description>创建包含当前行的成功结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新的包含结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="excluded">
+			<signature>static func excluded() -&gt; GFTableRowPredicateResult:</signature>
+			<description>创建排除当前行的成功结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新的排除结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="failed">
+			<signature>static func failed( error_code: StringName, error_message: String = "" ) -&gt; GFTableRowPredicateResult:</signature>
+			<description>创建求值失败结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">error_code: 非空、无首尾空白且 UTF-8 编码不超过 128 字节的稳定错误码。</tag>
+				<tag name="param">error_message: 面向维护者的失败说明；最多保留 1024 个 UTF-8 字节。</tag>
+				<tag name="return">新的失败结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>查询求值是否成功。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="should_include">
+			<signature>func should_include() -&gt; bool:</signature>
+			<description>查询成功结果是否包含当前行。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功且应包含当前行时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_code">
+			<signature>func get_error_code() -&gt; StringName:</signature>
+			<description>获取稳定错误码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败错误码；成功时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_message">
+			<signature>func get_error_message() -&gt; String:</signature>
+			<description>获取有界错误说明。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败说明；成功时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFTableRowView.xml
+++ b/docs/api_catalog/classes/GFTableRowView.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTableRowView" path="addons/gf/standard/utilities/ui/gf_table_row_view.gd" module="standard" extends="RefCounted" classDigest="d3fb369088a2ad84fe0ab9ed357541342db8945fc8bcc80d24a3306326f0b4a9">
+	<description>GFTableRowView: 表格行谓词使用的隔离只读视图。
+只公开稳定行 ID、源索引和已配置列的复制值，不公开源行容器。
+项目谓词可以读取隐藏列，但不能通过该视图修改权威表格数据。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="get_row_id">
+			<signature>func get_row_id() -&gt; Variant:</signature>
+			<description>获取稳定行 ID 副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">稳定行 ID 副本。</tag>
+				<tag name="schema">return: Variant stable row identity copy.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_row_index">
+			<signature>func get_source_row_index() -&gt; int:</signature>
+			<description>获取源行索引。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">构建该视图时的源行索引。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="has_value">
+			<signature>func has_value(column_id: StringName) -&gt; bool:</signature>
+			<description>判断是否包含指定列值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">column_id: 稳定列 ID。</tag>
+				<tag name="return">存在列值时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_value">
+			<signature>func get_value(column_id: StringName, default_value: Variant = null) -&gt; Variant:</signature>
+			<description>获取指定列的隔离值副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">column_id: 稳定列 ID。</tag>
+				<tag name="param">default_value: 列不存在时返回的默认值。</tag>
+				<tag name="return">列值或默认值的副本。</tag>
+				<tag name="schema">default_value: Variant fallback copied before return.</tag>
+				<tag name="schema">return: Variant isolated column value copy.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_values">
+			<signature>func get_values() -&gt; Dictionary:</signature>
+			<description>获取全部列值副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">以列 ID 为键的隔离值副本。</tag>
+				<tag name="schema">return: Dictionary keyed by StringName column IDs with copied Variant values.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFTableSelectionModel.xml
+++ b/docs/api_catalog/classes/GFTableSelectionModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTableSelectionModel" path="addons/gf/standard/utilities/ui/gf_table_selection_model.gd" module="standard" extends="RefCounted" classDigest="6da5e9675ade4beff18b7a5cd8559445bbb689956d7005bc9a271d13f1c7f509">
+<class name="GFTableSelectionModel" path="addons/gf/standard/utilities/ui/gf_table_selection_model.gd" module="standard" extends="RefCounted" classDigest="25f437d3dc6130f372369f7a076a2a45bddd39f7968d0c929035b8e491c3e263">
 	<description>GFTableSelectionModel: 稳定行 ID 驱动的表格选择模型。
 只维护选中行 ID、锚点和选择模式，不关心行如何渲染、排序或过滤。
 表格视图排序、过滤或重建可见行时，只要 row_id 稳定，选择状态就能保留。</description>
@@ -109,6 +109,20 @@
 				<tag name="return">状态发生变化时返回 true。</tag>
 				<tag name="schema">row_ids: Array，调用方提供的稳定行 ID。</tag>
 				<tag name="since">5.2.0</tag>
+			</tags>
+		</member>
+		<member kind="method" name="replace_selection_with_anchor">
+			<signature>func replace_selection_with_anchor( row_ids: Array, selection_anchor: Variant ) -&gt; bool:</signature>
+			<description>用一组行 ID 与显式锚点原子替换当前选择。
+选择集合和锚点会在发出 selection_changed 前同时完成更新；锚点不在最终选择中时归一为空。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">row_ids: 稳定行 ID 列表。</tag>
+				<tag name="param">selection_anchor: 最终范围选择锚点；null 表示没有锚点。</tag>
+				<tag name="return">选择集合或锚点发生变化时返回 true。</tag>
+				<tag name="schema">row_ids: Array，调用方提供的稳定行 ID。</tag>
+				<tag name="schema">selection_anchor: Variant，最终选择中的稳定行 ID，或 null。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="select_range">

--- a/docs/api_catalog/classes/GFTableViewRebuildResult.xml
+++ b/docs/api_catalog/classes/GFTableViewRebuildResult.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTableViewRebuildResult" path="addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd" module="standard" extends="RefCounted" classDigest="f5d0fc0dc7d8c5be36169746ddd1182426c463ecbfb3e4d408e9da39e9fcf14e">
+	<description>GFTableViewRebuildResult: 表格投影事务的类型化结果。
+成功结果描述一次提交或 no-op；失败结果描述未提交的阶段、谓词和行身份。
+结果不携带源 row，从而可安全交给 UI 诊断层。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>查询事务是否成功。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="was_committed">
+			<signature>func was_committed() -&gt; bool:</signature>
+			<description>查询事务是否提交了新 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">提交时返回 true；成功 no-op 返回 false。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_view_revision">
+			<signature>func get_view_revision() -&gt; int:</signature>
+			<description>获取结果对应的已提交 revision。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前已提交 revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_visible_count">
+			<signature>func get_visible_count() -&gt; int:</signature>
+			<description>获取当前已提交可见行数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">可见行数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_scanned_row_count">
+			<signature>func get_scanned_row_count() -&gt; int:</signature>
+			<description>获取本次候选扫描的源行数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已扫描行数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_predicate_evaluation_count">
+			<signature>func get_predicate_evaluation_count() -&gt; int:</signature>
+			<description>获取本次候选执行的谓词次数。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">谓词求值次数。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_code">
+			<signature>func get_error_code() -&gt; StringName:</signature>
+			<description>获取稳定错误码。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败错误码；成功时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_message">
+			<signature>func get_error_message() -&gt; String:</signature>
+			<description>获取有界错误说明。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败说明；成功时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_failed_predicate_id">
+			<signature>func get_failed_predicate_id() -&gt; StringName:</signature>
+			<description>获取失败谓词 ID。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败谓词 ID；非谓词失败时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_failed_source_row_index">
+			<signature>func get_failed_source_row_index() -&gt; int:</signature>
+			<description>获取失败源行索引。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败行索引；非行失败时为 -1。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_failed_row_id">
+			<signature>func get_failed_row_id() -&gt; Variant:</signature>
+			<description>获取失败行 ID 副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">失败行 ID；非行失败时为 null。</tag>
+				<tag name="schema">return: Variant stable row identity copy, or null.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_result">
+			<signature>func duplicate_result() -&gt; GFTableViewRebuildResult:</signature>
+			<description>创建结果的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新结果对象；未配置实例返回新的未配置实例。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFVirtualListBinder.xml
+++ b/docs/api_catalog/classes/GFVirtualListBinder.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFVirtualListBinder" path="addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd" module="standard" extends="RefCounted" classDigest="c1f0a45a0b8d9d81acb80cb32c937f176a39e946759f99972f0092b8e9c417b6">
+	<description>GFVirtualListBinder: owner-bound 虚拟列表 Control 物化与回收协调器。
+连接项目提供的 `ScrollContainer`、绝对布局 content root、`GFVirtualListModel`
+与行回调，只物化真实视口及 overscan 范围。项目继续拥有条目数据、稳定 ID、
+行视觉、选择、激活、输入和无障碍语义；Binder 拥有 factory 成功交付的 Control，
+并在 unbind、任一绑定节点退出或 dispose 时确定性解除回调和节点引用。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals>
+		<member kind="signal" name="sync_completed">
+			<signature>signal sync_completed(result: GFVirtualListSyncResult)</signature>
+			<description>一轮同步完成后发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">result: 不含项目条目载荷的 typed 同步结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
+	<enums>
+		<member kind="enum" name="LayoutAxis">
+			<signature>enum LayoutAxis {
+	## 以 Y 轴和垂直滚动条组织条目。
+	VERTICAL,
+	## 以 X 轴和水平滚动条组织条目。
+	HORIZONTAL,
+}</signature>
+			<description>列表滚动和尺寸测量使用的主轴。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="enum" name="ScrollAlignment">
+			<signature>enum ScrollAlignment {
+	## 已可见时不滚动，否则移动到最近边界。
+	NEAREST,
+	## 条目起点对齐视口起点。
+	START,
+	## 条目中心对齐视口中心。
+	CENTER,
+	## 条目终点对齐视口终点。
+	END,
+}</signature>
+			<description>把条目滚入视口时使用的对齐方式。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
+	<constants>
+		<member kind="const" name="DEFAULT_MAX_MATERIALIZED_ITEMS">
+			<signature>const DEFAULT_MAX_MATERIALIZED_ITEMS: int = 512</signature>
+			<description>默认活动 Control 硬上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="DEFAULT_MAX_POOLED_ITEMS">
+			<signature>const DEFAULT_MAX_POOLED_ITEMS: int = 64</signature>
+			<description>默认 parentless pool Control 上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ABSOLUTE_MAX_MATERIALIZED_ITEMS">
+			<signature>const ABSOLUTE_MAX_MATERIALIZED_ITEMS: int = 4096</signature>
+			<description>活动物化 Control 的框架级绝对硬上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ABSOLUTE_MAX_POOLED_ITEMS">
+			<signature>const ABSOLUTE_MAX_POOLED_ITEMS: int = 1024</signature>
+			<description>parentless pool 的框架级绝对硬上限。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH">
+			<signature>const ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH: int = 1024</signature>
+			<description>稳定 identity token 允许的最大 UTF-8 字节数。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties>
+		<member kind="property" name="layout_axis">
+			<signature>var layout_axis: LayoutAxis = LayoutAxis.VERTICAL:</signature>
+			<description>布局主轴。只接受 VERTICAL/HORIZONTAL；绑定期间修改后调用 request_sync() 使其生效。
+同步 callback 内修改时，当前轮继续使用入口快照，下一轮才采用新值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="max_materialized_items">
+			<signature>var max_materialized_items: int = DEFAULT_MAX_MATERIALIZED_ITEMS:</signature>
+			<description>活动物化 Control 硬上限；运行时按至少 1 处理。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="max_pooled_items">
+			<signature>var max_pooled_items: int = DEFAULT_MAX_POOLED_ITEMS:</signature>
+			<description>parentless pool 最多保留的 Control 数量；小于 0 时按 0 处理。
+同步事务内收紧预算时，会在候选提交或回滚完成后统一裁剪。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="auto_measure">
+			<signature>var auto_measure: bool = true</signature>
+			<description>是否在新绑定或数据失效后自动测量活动行；不影响显式 request_measurement()。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="auto_reveal_focus">
+			<signature>var auto_reveal_focus: bool = true</signature>
+			<description>虚拟焦点变化后是否按最近边界自动滚入视口。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="fill_cross_axis">
+			<signature>var fill_cross_axis: bool = true</signature>
+			<description>是否让行 Control 填满 content root 的交叉轴。
+同步 callback 内修改时，当前轮继续使用入口快照，下一轮才采用新值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</properties>
+	<methods>
+		<member kind="method" name="bind">
+			<signature>func bind( owner: Node, scroll_container: ScrollContainer, content_root: Control, layout_model: GFVirtualListModel, item_factory: Callable, bind_callback: Callable, unbind_callback: Callable, identity_callback: Callable, focus_model: GFVirtualListFocusModel = null, measure_callback: Callable = Callable(), focus_target_callback: Callable = Callable() ) -&gt; bool:</signature>
+			<description>建立一个 owner-bound 虚拟列表绑定。
+`content_root` 必须是 ScrollContainer 的直接子 Control，且不能是会接管子节点位置的
+Container。factory 返回的 Control 必须 parentless；返回后其所有权转交 Binder。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">owner: 生命周期 owner；退出 SceneTree 后 Binder 自动 dispose。</tag>
+				<tag name="param">scroll_container: 项目持有的滚动容器；退出 SceneTree 后 Binder 自动 dispose。</tag>
+				<tag name="param">content_root: Binder 写入主轴最小尺寸并承载活动行；退出 SceneTree 后自动 dispose。</tag>
+				<tag name="param">layout_model: 条目 count、extent、offset 和范围模型。</tag>
+				<tag name="param">item_factory: Callable() -&gt; Control。</tag>
+				<tag name="param">bind_callback: Callable(control: Control, item_index: int, item_id: Variant) -&gt; bool。</tag>
+				<tag name="param">unbind_callback: Callable(control: Control, item_index: int, item_id: Variant) -&gt; void。</tag>
+				<tag name="param">identity_callback: Callable(item_index: int) -&gt; Variant；返回值必须是稳定 key。</tag>
+				<tag name="param">focus_model: 可选虚拟焦点模型。</tag>
+				<tag name="param">measure_callback: 可选 Callable(control, item_index, item_id) -&gt; float。</tag>
+				<tag name="param">focus_target_callback: 可选 Callable(control, item_index, item_id) -&gt; Control。</tag>
+				<tag name="return">全部边界合法并建立连接时返回 true。</tag>
+				<tag name="schema">item_factory: Callable() -&gt; Control.</tag>
+				<tag name="schema">bind_callback: Callable(Control, int, Variant) -&gt; bool.</tag>
+				<tag name="schema">unbind_callback: Callable(Control, int, Variant) -&gt; void.</tag>
+				<tag name="schema">identity_callback: Callable(int) -&gt; stable Variant key.</tag>
+				<tag name="schema">measure_callback: Optional Callable(Control, int, Variant) -&gt; finite positive float.</tag>
+				<tag name="schema">focus_target_callback: Optional Callable(Control, int, Variant) -&gt; Control descendant.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="request_sync">
+			<signature>func request_sync() -&gt; bool:</signature>
+			<description>请求一次合并到 deferred 队列的同步。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前处于有效绑定生命周期时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="sync_now">
+			<signature>func sync_now() -&gt; GFVirtualListSyncResult:</signature>
+			<description>立即执行一轮同步；callback 内的再次请求会合并为下一轮。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">typed 同步结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="invalidate_items">
+			<signature>func invalidate_items() -&gt; bool:</signature>
+			<description>标记项目条目内容或 identity 已变化，并请求重新绑定当前物化范围。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前已绑定时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="request_measurement">
+			<signature>func request_measurement() -&gt; bool:</signature>
+			<description>请求下一轮重新测量当前活动行；即使 auto_measure 为 false 也会执行。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前已绑定时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="scroll_to_item">
+			<signature>func scroll_to_item( item_index: int, alignment: ScrollAlignment = ScrollAlignment.NEAREST ) -&gt; bool:</signature>
+			<description>把指定条目滚入视口。
+同步 callback 内不允许直接改变当前轮滚动；先保存项目意图并请求下一轮。
+模型、视口、主轴与 Control 所有权快照保持有效并接受最终整数偏移时返回 true；
+否则请求下一轮同步并返回 false。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">item_index: 条目索引。</tag>
+				<tag name="param">alignment: `ScrollAlignment` 值。</tag>
+				<tag name="return">索引和绑定有效、当前不在同步 callback 内，且滚动操作期间 data generation、</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_materialized_control">
+			<signature>func get_materialized_control(item_index: int) -&gt; Control:</signature>
+			<description>获取指定索引当前物化的 Control。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">item_index: 条目索引。</tag>
+				<tag name="return">未物化时为 null。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_materialized_control_by_id">
+			<signature>func get_materialized_control_by_id(item_id: Variant) -&gt; Control:</signature>
+			<description>按稳定 identity 获取当前物化的 Control。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">item_id: identity callback 使用的稳定 ID。</tag>
+				<tag name="return">ID 无效或未物化时为 null。</tag>
+				<tag name="schema">item_id: Stable Variant key accepted by GFVariantKeyCodec.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_last_sync_result">
+			<signature>func get_last_sync_result() -&gt; GFVirtualListSyncResult:</signature>
+			<description>获取最近同步结果的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">尚未同步时返回当前生命周期终态结果。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_debug_snapshot">
+			<signature>func get_debug_snapshot() -&gt; Dictionary:</signature>
+			<description>获取不含项目条目载荷的调试快照。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">生命周期、范围和计数摘要。</tag>
+				<tag name="schema">return: Dictionary with state, bound, disposed, lifecycle_generation, data_revision, pending_sync, active_count, pooled_count, and last_result.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_bound">
+			<signature>func is_bound() -&gt; bool:</signature>
+			<description>检查是否处于有效绑定生命周期。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已绑定且未进入 teardown 时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_disposed">
+			<signature>func is_disposed() -&gt; bool:</signature>
+			<description>检查是否进入不可复用终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">dispose 已完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="unbind">
+			<signature>func unbind() -&gt; void:</signature>
+			<description>解除当前绑定并释放全部 Binder-owned Control；实例仍可重新 bind。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="dispose">
+			<signature>func dispose() -&gt; void:</signature>
+			<description>进入终态并释放行、pool、连接和 callback。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/classes/GFVirtualListModel.xml
+++ b/docs/api_catalog/classes/GFVirtualListModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFVirtualListModel" path="addons/gf/standard/utilities/ui/gf_virtual_list_model.gd" module="standard" extends="RefCounted" classDigest="b2ae80471a5d7f9f642d6dc2b4200e5730a4969c3071420550e782146faeb443">
+<class name="GFVirtualListModel" path="addons/gf/standard/utilities/ui/gf_virtual_list_model.gd" module="standard" extends="RefCounted" classDigest="23e87f7039a51a34e13ddc7b810dc865758bd4bf05b109760a3ea882446f3ac3">
 	<description>GFVirtualListModel: 可变尺寸虚拟列表布局模型。
 维护条目数量、估算尺寸、实测尺寸、累计偏移和可见范围，供聊天流、
 日志面板、资源列表或编辑器 Dock 自行渲染可见 Control。它不创建 UI 节点，
@@ -9,7 +9,18 @@
 		<tag name="category">runtime_service</tag>
 		<tag name="since">4.4.0</tag>
 	</tags>
-	<signals />
+	<signals>
+		<member kind="signal" name="layout_changed">
+			<signature>signal layout_changed(revision: int)</signature>
+			<description>布局状态实际变化后发出。
+一次公开写操作无论影响多少条目都只推进一次 revision；无变化或被拒绝的写入不发出。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">revision: 变更后的单调递增布局版本号。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</signals>
 	<enums />
 	<constants>
 		<member kind="const" name="DEFAULT_ESTIMATED_ITEM_EXTENT">
@@ -133,6 +144,15 @@ scroll_offset 之前时，调用方可把当前滚动偏移加上该值。</desc
 				<tag name="return">当前条目数量。</tag>
 			</tags>
 		</member>
+		<member kind="method" name="get_revision">
+			<signature>func get_revision() -&gt; int:</signature>
+			<description>获取布局状态的当前版本号。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">从 0 开始、只在布局实际变化时递增的版本号。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="get_item_extent">
 			<signature>func get_item_extent(item_index: int) -&gt; float:</signature>
 			<description>获取条目尺寸。</description>
@@ -169,6 +189,17 @@ scroll_offset 之前时，调用方可把当前滚动偏移加上该值。</desc
 				<tag name="return">内容总尺寸。</tag>
 			</tags>
 		</member>
+		<member kind="method" name="get_viewport_range">
+			<signature>func get_viewport_range(scroll_offset: float, viewport_extent: float) -&gt; Vector2i:</signature>
+			<description>计算当前滚动窗口直接命中的条目范围，不包含 overscan。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">scroll_offset: 当前滚动偏移。</tag>
+				<tag name="param">viewport_extent: 视口尺寸。</tag>
+				<tag name="return">Vector2i(start, end)，end 为不包含的结束索引。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="method" name="get_visible_range">
 			<signature>func get_visible_range(scroll_offset: float, viewport_extent: float) -&gt; Vector2i:</signature>
 			<description>计算当前滚动窗口内应被物化的条目范围。</description>
@@ -177,6 +208,7 @@ scroll_offset 之前时，调用方可把当前滚动偏移加上该值。</desc
 				<tag name="param">scroll_offset: 当前滚动偏移。</tag>
 				<tag name="param">viewport_extent: 视口尺寸。</tag>
 				<tag name="return">Vector2i(start, end)，end 为不包含的结束索引。</tag>
+				<tag name="since">4.4.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_visible_items">

--- a/docs/api_catalog/classes/GFVirtualListSyncResult.xml
+++ b/docs/api_catalog/classes/GFVirtualListSyncResult.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFVirtualListSyncResult" path="addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd" module="standard" extends="RefCounted" classDigest="7d9d7279518d8d1adf0710ba67deb5db7f240bf269cec65fa750a7b9f410b414">
+	<description>GFVirtualListSyncResult: 虚拟列表同步的不可变诊断结果。
+只保存范围、计数、版本和稳定错误信息，不保存项目条目数据或原始稳定 ID。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">value_object</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants>
+		<member kind="const" name="STATUS_SYNCED">
+			<signature>const STATUS_SYNCED: StringName = &amp;"synced"</signature>
+			<description>目标范围已完整同步。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_UNCHANGED">
+			<signature>const STATUS_UNCHANGED: StringName = &amp;"unchanged"</signature>
+			<description>当前 materialization 已满足目标且没有结构变化。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_DEFERRED">
+			<signature>const STATUS_DEFERRED: StringName = &amp;"deferred"</signature>
+			<description>当前轮冻结快照在完成提交前或项目绑定副作用期间失效；Binder 已保留后续同步请求。
+该状态不表示同步成功。若漂移发生在绑定副作用前，Binder 保留最近一次可信
+materialization；若已调用 bind/unbind、测量、布局或焦点副作用，则对称解绑并清空
+不可信 materialization。调用方应以结果中的当前索引为准并等待下一轮结果。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_TRUNCATED">
+			<signature>const STATUS_TRUNCATED: StringName = &amp;"truncated"</signature>
+			<description>目标范围超过显式节点预算，已优先物化真实视口范围。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_UNBOUND">
+			<signature>const STATUS_UNBOUND: StringName = &amp;"unbound"</signature>
+			<description>Binder 当前没有有效绑定。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_DISPOSED">
+			<signature>const STATUS_DISPOSED: StringName = &amp;"disposed"</signature>
+			<description>Binder 已进入不可复用的终态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_INVALID_IDENTITY">
+			<signature>const STATUS_INVALID_IDENTITY: StringName = &amp;"invalid_identity"</signature>
+			<description>identity callback 返回了不可稳定编码的值。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_DUPLICATE_IDENTITY">
+			<signature>const STATUS_DUPLICATE_IDENTITY: StringName = &amp;"duplicate_identity"</signature>
+			<description>当前请求范围包含重复稳定 identity。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_FACTORY_FAILED">
+			<signature>const STATUS_FACTORY_FAILED: StringName = &amp;"factory_failed"</signature>
+			<description>item factory 没有返回可接管的 parentless Control。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_BIND_FAILED">
+			<signature>const STATUS_BIND_FAILED: StringName = &amp;"bind_failed"</signature>
+			<description>项目 bind callback 拒绝了一个条目。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</constants>
+	<properties />
+	<methods>
+		<member kind="method" name="is_successful">
+			<signature>func is_successful() -&gt; bool:</signature>
+			<description>检查同步是否提交了内部一致的目标状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">完整、无变化或按显式预算截断完成时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_status">
+			<signature>func get_status() -&gt; StringName:</signature>
+			<description>获取稳定同步状态。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`STATUS_*` 常量之一。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_layout_revision">
+			<signature>func get_layout_revision() -&gt; int:</signature>
+			<description>获取本轮计算范围前冻结的布局版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">`GFVirtualListModel` revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_data_revision">
+			<signature>func get_data_revision() -&gt; int:</signature>
+			<description>获取本轮开始时冻结的 Binder 数据失效版本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">从 0 开始的 data revision。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_viewport_range">
+			<signature>func get_viewport_range() -&gt; Vector2i:</signature>
+			<description>获取未加入 overscan 的真实视口范围。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Vector2i(start, end)，end 不包含。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_requested_range">
+			<signature>func get_requested_range() -&gt; Vector2i:</signature>
+			<description>获取加入 overscan、应用预算前的请求范围。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">Vector2i(start, end)，end 不包含。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_materialized_indices">
+			<signature>func get_materialized_indices() -&gt; PackedInt32Array:</signature>
+			<description>获取实际物化索引副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">升序物化索引。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_materialized_count">
+			<signature>func get_materialized_count() -&gt; int:</signature>
+			<description>获取实际物化数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前活动 Control 数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_pooled_count">
+			<signature>func get_pooled_count() -&gt; int:</signature>
+			<description>获取当前池内可复用 Control 数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">parentless 池节点数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_created_count">
+			<signature>func get_created_count() -&gt; int:</signature>
+			<description>获取本轮新建 Control 数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">factory 成功创建数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_reused_count">
+			<signature>func get_reused_count() -&gt; int:</signature>
+			<description>获取本轮从旧 active 或 pool 复用数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">复用数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_released_count">
+			<signature>func get_released_count() -&gt; int:</signature>
+			<description>获取本轮离开旧绑定的数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">已执行 unbind 的旧绑定数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_measured_count">
+			<signature>func get_measured_count() -&gt; int:</signature>
+			<description>获取本轮成功测量的行数量。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">测量数量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_anchor_adjustment">
+			<signature>func get_anchor_adjustment() -&gt; float:</signature>
+			<description>获取本轮一次性应用的滚动锚点修正。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">主轴滚动调整量。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="was_truncated">
+			<signature>func was_truncated() -&gt; bool:</signature>
+			<description>检查是否因 materialization 上限截断。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">目标范围未完整物化时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error_index">
+			<signature>func get_error_index() -&gt; int:</signature>
+			<description>获取首个失败条目索引。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">没有索引错误时为 -1。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_error">
+			<signature>func get_error() -&gt; String:</signature>
+			<description>获取有界稳定错误说明。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">成功时为空。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="duplicate_result">
+			<signature>func duplicate_result() -&gt; GFVirtualListSyncResult:</signature>
+			<description>创建结果的隔离副本。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">新结果对象。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="to_dict">
+			<signature>func to_dict() -&gt; Dictionary:</signature>
+			<description>转换为不含项目数据的诊断字典。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">JSON-safe 同步摘要；状态使用 String，范围与索引只使用 JSON 原生容器和整数。</tag>
+				<tag name="schema">return: Dictionary with String status; viewport_range and requested_range Dictionaries containing start and end_exclusive ints; materialized_indices Array[int]; revisions and counts in 0..9007199254740991; finite anchor_adjustment; truncated; error_index in -1..9007199254740991; and error.</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="cab721c60c4bbbd57b0bb2e664fd538696903620585f73a376637c59a2b56124" classCount="804" methodCount="7316">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="2052010d7f0b391cd32994d97b3f012fe7240124999eaa77b7f83c4800db76ba" classCount="813" methodCount="7405">
 	<module id="kernel" label="Kernel" classCount="74" methodCount="793">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -76,7 +76,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="445" methodCount="4493">
+	<module id="standard" label="Standard" classCount="454" methodCount="4582">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />
@@ -430,6 +430,8 @@
 		<class name="GFSourceTextLoader" path="classes/GFSourceTextLoader.xml" sourcePath="addons/gf/standard/utilities/io/gf_source_text_loader.gd" extends="RefCounted" />
 		<class name="GFSourceTextPatchTools" path="classes/GFSourceTextPatchTools.xml" sourcePath="addons/gf/standard/foundation/text/gf_source_text_patch_tools.gd" extends="RefCounted" />
 		<class name="GFSpatialCanvas2D" path="classes/GFSpatialCanvas2D.xml" sourcePath="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd" extends="Control" />
+		<class name="GFSpatialCanvasInputPolicy" path="classes/GFSpatialCanvasInputPolicy.xml" sourcePath="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd" extends="Resource" />
+		<class name="GFSpatialCanvasSelectionModeBinding" path="classes/GFSpatialCanvasSelectionModeBinding.xml" sourcePath="addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd" extends="Resource" />
 		<class name="GFSpatialHash3D" path="classes/GFSpatialHash3D.xml" sourcePath="addons/gf/standard/foundation/math/gf_spatial_hash_3d.gd" extends="RefCounted" />
 		<class name="GFSpatialQueryIdentity" path="classes/GFSpatialQueryIdentity.xml" sourcePath="addons/gf/standard/foundation/math/gf_spatial_query_identity.gd" extends="RefCounted" />
 		<class name="GFSpatialQueryIndex2D" path="classes/GFSpatialQueryIndex2D.xml" sourcePath="addons/gf/standard/utilities/spatial/gf_spatial_query_index_2d.gd" extends="RefCounted" />
@@ -460,7 +462,12 @@
 		<class name="GFSurfaceUtility" path="classes/GFSurfaceUtility.xml" sourcePath="addons/gf/standard/utilities/display/gf_surface_utility.gd" extends="GFUtility" />
 		<class name="GFTableColumnDefinition" path="classes/GFTableColumnDefinition.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_column_definition.gd" extends="Resource" />
 		<class name="GFTableDataView" path="classes/GFTableDataView.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_data_view.gd" extends="RefCounted" />
+		<class name="GFTableRowPredicate" path="classes/GFTableRowPredicate.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_row_predicate.gd" extends="RefCounted" />
+		<class name="GFTableRowPredicateRegistration" path="classes/GFTableRowPredicateRegistration.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd" extends="RefCounted" />
+		<class name="GFTableRowPredicateResult" path="classes/GFTableRowPredicateResult.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd" extends="RefCounted" />
+		<class name="GFTableRowView" path="classes/GFTableRowView.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_row_view.gd" extends="RefCounted" />
 		<class name="GFTableSelectionModel" path="classes/GFTableSelectionModel.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_selection_model.gd" extends="RefCounted" />
+		<class name="GFTableViewRebuildResult" path="classes/GFTableViewRebuildResult.xml" sourcePath="addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd" extends="RefCounted" />
 		<class name="GFTagCatalog" path="classes/GFTagCatalog.xml" sourcePath="addons/gf/standard/foundation/tags/gf_tag_catalog.gd" extends="Resource" />
 		<class name="GFTagExpression" path="classes/GFTagExpression.xml" sourcePath="addons/gf/standard/foundation/tags/gf_tag_expression.gd" extends="Resource" />
 		<class name="GFTagQuery" path="classes/GFTagQuery.xml" sourcePath="addons/gf/standard/foundation/tags/gf_tag_query.gd" extends="Resource" />
@@ -515,8 +522,10 @@
 		<class name="GFVirtualInputBridge" path="classes/GFVirtualInputBridge.xml" sourcePath="addons/gf/standard/input/common/gf_virtual_input_bridge.gd" extends="RefCounted" />
 		<class name="GFVirtualInputPulseOperation" path="classes/GFVirtualInputPulseOperation.xml" sourcePath="addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd" extends="RefCounted" />
 		<class name="GFVirtualInputSource" path="classes/GFVirtualInputSource.xml" sourcePath="addons/gf/standard/input/sources/gf_virtual_input_source.gd" extends="RefCounted" />
+		<class name="GFVirtualListBinder" path="classes/GFVirtualListBinder.xml" sourcePath="addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd" extends="RefCounted" />
 		<class name="GFVirtualListFocusModel" path="classes/GFVirtualListFocusModel.xml" sourcePath="addons/gf/standard/utilities/ui/gf_virtual_list_focus_model.gd" extends="RefCounted" />
 		<class name="GFVirtualListModel" path="classes/GFVirtualListModel.xml" sourcePath="addons/gf/standard/utilities/ui/gf_virtual_list_model.gd" extends="RefCounted" />
+		<class name="GFVirtualListSyncResult" path="classes/GFVirtualListSyncResult.xml" sourcePath="addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd" extends="RefCounted" />
 		<class name="GFVoronoi2D" path="classes/GFVoronoi2D.xml" sourcePath="addons/gf/standard/foundation/math/gf_voronoi_2d.gd" extends="RefCounted" />
 		<class name="GFWaitSequenceStep" path="classes/GFWaitSequenceStep.xml" sourcePath="addons/gf/standard/sequence/gf_wait_sequence_step.gd" extends="GFSequenceStep" />
 		<class name="GFWaveFunctionCollapse2D" path="classes/GFWaveFunctionCollapse2D.xml" sourcePath="addons/gf/standard/foundation/math/gf_wave_function_collapse_2d.gd" extends="RefCounted" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -24,7 +24,7 @@
 
 ## [未发布]
 
-**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，为 Save Profile 增加精确 provider domain、活动身份与显式恢复/对账事务，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；此外加入冻结模块访问策略、Route 请求生命周期和类型化虚拟输入 Pulse，使生成访问、异步 UI 与定时输入都具备明确的身份、终态与所有权边界；框架只提供可验证的通用机制，不内置项目启动、存档业务、部署协议、环境模型或轮询式音频模拟。
+**版本概述**：本轮新增类型化音频播放区间与循环点和共享资源 admission Broker，把 Architecture 启动升级为依赖 DAG 驱动的四阶段激活并增加类型化异步关闭，为 Save Profile 增加精确 provider domain、活动身份与显式恢复/对账事务，补充 Headless 服务探针和周期环境表现的项目组合配方，修复并加固 AI Developer 的项目 Adapter 依赖边界，同时把 Changelog 与安全扫描抑制约束转为可执行维护门禁，并收紧热模块事务、Save Profile 准备、可选依赖、后台回调所有权、按 key 并发、场景邻居稳定帧、渲染预热和音频释放契约；此外加入冻结模块访问策略、Route 请求生命周期、类型化虚拟输入 Pulse，以及有界虚拟列表 Binder、事务式表格谓词和可验证的 Spatial Canvas 输入策略，使生成访问、异步 UI、定时输入和大型交互界面都具备明确的身份、终态、传播与所有权边界；框架只提供可验证的通用机制，不内置项目启动、存档业务、部署协议、领域过滤器、行视觉、环境模型或轮询式音频模拟。
 
 ### 🚀 新增特性 (Added)
 
@@ -33,7 +33,7 @@
 - `GFAudioBackendCapability` 新增播放区间协议发现能力，`GFAudioBackend.evaluate_playback_region()` 提供无副作用的逐片段、逐通道协商；粗粒度能力声明不能替代具体请求评估。
 - 新增 Headless 服务健康/探针组合配方：组合惰性诊断 Provider、有界会话字段与类型化传输指标，由项目 Adapter 决定 liveness/readiness、传输协议、鉴权和部署政策；Backend 指标补充使用通用执行预算，并对总指标、自定义指标和 ID 长度设置绝对上限。
 - 新增周期环境表现组合配方：组合可注入时钟、项目环境样本、Shader Profile、接口快照与 Binder；周期、天气、天文、时区和持久化策略继续由项目负责。
-- AI Developer Capability / Recipe 知识目录升级到 `1.8.0`，加入两份组合配方的可搜索边界，并让音频能力目录认识类型化播放区间与循环点。
+- AI Developer Capability / Recipe 知识目录升级到 `1.9.0`，加入两份环境组合配方，并让目录认识类型化播放区间、虚拟列表 Binder、事务式表格谓词和 Spatial Canvas 输入策略的可搜索组合边界。
 - `GFModel`、`GFSystem` 与 `GFUtility` 新增 `begin_activation(scope)` / `begin_quiesce(scope)`；`GFArchitecture` 新增 activation/shutdown deadline、激活与 quiescing 状态查询，以及依赖 DAG 驱动的第四阶段 bootstrap。
 - 新增 `GFArchitectureShutdownResult`：类型化区分正常完成、失败、取消、超时、强制释放与幂等重复关闭，并以有界模块条目保存 quiesce 证据；并发 `shutdown_async()` 调用共享同一关闭流程。
 - 新增 Save Profile bootstrap 组合配方：项目 System 声明依赖 `GFSaveProfileUtility`，在 `begin_activation()` 中把 `load_profile()` / `flush_profile()` Operation 桥接到一次性完成源；框架不新增项目存档业务类。
@@ -58,6 +58,9 @@
 - `GFArchitecture` 新增统一的 `resolve_module_access()`、模块类型与查询作用域枚举；Access Generator 可按精确模块脚本路径冻结 inherited/local、required 与 require-ready 策略，生成结果不再依赖运行时隐式选择。
 - 新增 `GFUIPanelAsyncOperation`：为每次底层异步 push/replace 冻结单调 serial、路径、层级和操作类型，并以弱面板引用暴露唯一终态；`GFUIRouterUtility` 的异步打开选项新增 owner 与 `GFAsyncScope` 生命周期锚点。
 - 新增 `GFVirtualInputPulseOperation` 与 `GFVirtualInputSource.PulseReplacementPolicy`：以类型化句柄表达有界虚拟动作脉冲、OR 生命周期取消、原子替换/拒绝策略、单调 generation 和匹配释放证明。
+- 新增 `GFVirtualListBinder` 与 `GFVirtualListSyncResult`：把项目持有的 `ScrollContainer`、绝对布局内容根、行工厂和绑定回调组合为 owner-bound 的有界回收句柄，按稳定 identity 物化 visible + overscan 窗口，统一处理测量回写、单次锚点修正、虚拟焦点交接、重入合并和确定性释放；数据、视觉、选择、激活与输入继续由项目负责。
+- 新增 `GFTableRowView`、`GFTableRowPredicate`、`GFTableRowPredicateResult`、`GFTableRowPredicateRegistration` 与 `GFTableViewRebuildResult`：以稳定 ID、启用状态和确定顺序组合项目谓词，并以隔离行视图和类型化结果表达包含、排除或失败。
+- 新增 `GFSpatialCanvasInputPolicy` 与 `GFSpatialCanvasSelectionModeBinding`；`GFSpatialCanvas2D.InputDisposition` 显式区分 ignored、handled 和 consumed，使鼠标 chord、选择修饰键、滚轮父级仲裁、可禁用单指行为、独立多指 pan/zoom、系统手势和取消 action 可以在不继承 Canvas 的前提下原子配置。
 
 ### 🔄 机制更改 (Changed)
 
@@ -97,6 +100,9 @@
 - Access Generator 在调用扩展或构建源码前事务式验证整批策略，统一 String/StringName 字段键并拒绝等价重复、未知、失配或错误类型配置；失败报告固定为零写入且不会覆盖既有产物。生成的 Model/System/Utility 访问器统一委托 Architecture 共享解析原语。
 - `GFUIUtility.push_panel_async*()` / `replace_layer_async*()` 改为返回精确请求句柄并可预绑定完成回调；Router 只关联返回句柄，不再把无请求身份的全局完成信号当作协议。Route 在 UI 提交前接受 owner/scope 任一终止，提交后则保持结果未知边界，不尝试撤销已提交 UI 工作。
 - 虚拟输入 Pulse 由 Source 持有操作 generation、Mapping 持有稳定输入键的权威 lease；同键替换和手动写入在单次原子边界交接，不发出中间 inactive 状态，清理、重建与 dispose 只释放仍匹配的当前贡献。
+- `GFVirtualListModel` 增加单调布局 revision、`layout_changed` 与不含 overscan 的 viewport range；Binder 先保证真实视口，再在硬预算内补充 overscan，按本地 pool 复用 Control，并按测量前整数锚点合并同一轮全部滚动修正。每轮同步在任何项目回调前冻结 data/layout revision、条目数量、范围、目标 geometry、content extent、布局主轴、交叉轴尺寸/填充策略、活动预算与测量请求 revision；布局/轴/填充/预算变化、显式重测与新焦点意图只进入下一轮。callback 内 `invalidate_items()` 会以非成功 `STATUS_DEFERRED` 中止旧 data generation：绑定副作用前保留旧 active，副作用开始后则按 Control 身份去重、对称解绑并清空不可信 materialization，且不推进 committed revision。callback 内收紧 pool 预算也延迟到候选提交或回滚后裁剪，结果报告最终 pool 数量。公开 reveal 只有在模型、视口、主轴、精确 Control 所有权和最终整数偏移全部保持一致时才成功，否则保留意图并请求下一轮。Binder 只恢复自己实际拥有的内容轴，切轴不会覆盖项目对另一轴的修改；owner、滚动容器、内容根或活动 Control 失效都会进入确定性释放，三类生命周期节点任一退出树都会立即 dispose。`GFVirtualListSyncResult.to_dict()` 只输出 JSON 原生 String、Dictionary、Array、数字和布尔值。数据或 identity 变化必须由项目显式失效，不能伪装成布局变化。
+- `GFTableDataView` 的投影管线收敛为“文本过滤 → 启用谓词 AND 短路 → 排序 → 单次候选交换”；注册校验、谓词失败、非法结果和经 `GFTableDataView` API 发起的回调重入都保留上一份 registry、source、projection、revision 与选择。谓词数量先执行 raw admission，超限时不遍历或调用候选；每个谓词接收独占 `GFTableRowView`，框架只经静态入口调用受保护 `_evaluate()`，并直接从继承基类存储归一化结果，候选覆写公开 evaluate/getter 不能参与协议。注册 metadata 同样按 inherited 基类存储隔离为纯 GF 值；查询只返回独立快照，调用方不能绕过 revision 静默修改 ID、顺序、启用态或谓词引用。谓词实例参数变化必须显式 `refresh_view()`。行快照中的 PackedVector 按 double-precision 构建上界计费。单格和批量写入先在可隔离候选行上完成写入与完整投影，再一次提交 source、selection 和 projection；稳定行 ID 变化会同时迁移选择集合与原范围锚点。不可安全复制的行值或带任意 setter 的写入失败关闭，不再留下部分写入，所有外部信号只在一致状态完成后发布。
+- `GFSpatialCanvas2D` 不再把“已处理”和“停止传播”混为布尔值；输入策略先逐字段复制到纯 GF 基类实例再校验，不能由 Resource 子类覆写复制或校验绕过。拖动开始时冻结实际按钮与选择模式，普通滚轮可以留给父级 `ScrollContainer`，手工转发不隐式修改 Viewport handled 状态；取消 action 只允许非指针事件，并在每次匹配前重新执行有界检查，InputMap 运行时漂移会失败关闭而不会抢占平移或选择。鼠标与原始触摸现在由唯一物理输入 owner 串行化：冲突来源（含 wheel）和系统手势在匹配 release 或显式 cancel 前保持 `IGNORED` 且不修改 Canvas 状态，输入禁用、策略替换、Control/应用失焦、应用暂停、Canvas 隐藏和生命周期退出会完整释放 owner 与指针追踪。单指 `NONE` 且全部 raw 多指行为关闭时不会建立隐式捕获；多指 pan 与 pinch zoom 分别门控，同一手势只应用明确启用的视图分量。Godot canceled 鼠标/touch 只释放匹配捕获，不再被当作正常 release 提交选择或放置。
 
 ### 🐛 Bug 修复 (Fixed)
 
@@ -137,6 +143,7 @@
 - 移除 `GFSaveSectionProvider.gather_section()`、`_gather_section()`、`GFSaveProfileUtility.STATE_GATHERING` 及读取回滚对保存采集的隐式回退；保存 Provider 必须采用 Snapshot Operation，启用读取的 Provider 必须显式实现 `_capture_section()`。
 - 移除 `GFArchitecture.fail_on_missing_declared_dependencies` 与 `module_lifecycle_max_stage_passes`；声明依赖现在始终是强契约，生命周期计划只编译一个确定性候选 DAG，不保留 warning-only 或初始化期多轮补注册路径。
 - 移除 `GFArchitecture.HOOK_GET_REQUIRED_DEPENDENCIES`、`HOOK_GET_REQUIRED_MODELS`、`HOOK_GET_REQUIRED_SYSTEMS`、`HOOK_GET_REQUIRED_UTILITIES` 与 `HOOK_GET_REQUIRED_FACTORIES`；依赖声明只通过 `GFModel`、`GFSystem`、`GFUtility` 的类型化虚方法表达，不再暴露字符串 Hook 常量。
+- 移除 `GFSpatialCanvas2D.handle_input_event()` / `handle_screen_input_event()` 的 `bool` 返回契约，以及内置 raw Escape、中键、左键和固定 modifier 判断；调用方改用 `InputDisposition` 与显式 `GFSpatialCanvasInputPolicy`，不保留双轨解释路径。
 
 ### 🔧 API 变动说明 (API Changes)
 
@@ -171,6 +178,9 @@
 - `GFArchitecture.ModuleKind`、`ModuleLookupScope` 与 `resolve_module_access(module_kind, script_cls, lookup_scope, required, require_ready)` 是新的公开共享模块解析 API；`GFAccessGenerator.ACCESS_SCOPE_*`、`ACCESS_POLICIES_SETTING` 和 `gf/codegen/access_policies` 是新的生成期策略契约。
 - `GFUIUtility.push_panel_async()`、`push_panel_async_with_options()`、`replace_layer_async()` 与 `replace_layer_async_with_options()` 现在返回 `GFUIPanelAsyncOperation`，并在末尾接收可选完成回调；`GFUIRouterUtility.push_route_async()` / `replace_route_async()` 的 `async_options` 支持 `owner` 与 `scope`，`GFUIRouteResult` 新增 `STATUS_INVALID_LIFECYCLE`。
 - `GFVirtualInputSource.configure()` 新增可选 `GFTimerUtility`，并新增 `set_timer_utility()`、`get_timer_utility()`、`pulse_action()` 与不可逆 `dispose()`；`GFVirtualInputPulseOperation` 公开冻结身份、状态、取消、调试快照和匹配释放计数。
+- `GFVirtualListModel.layout_changed(revision)`、`get_revision()` 与 `get_viewport_range()` 是新的公开布局观察 API；`GFVirtualListBinder.bind()` / `sync_now()` / `invalidate_items()` / `request_measurement()` / `scroll_to_item()`、生命周期入口和 `GFVirtualListSyncResult` 构成新的可回收 Control 组合契约；`GFVirtualListSyncResult.to_dict()` 的范围编码为 `{start, end_exclusive}`，物化索引编码为 `Array[int]`。
+- `GFTableDataView.view_changed` 从单个 `visible_count` 参数改为 `(view_revision, visible_count)`；`set_columns()`、`set_rows()`、`set_filter_query()` 与 `refresh_view()` 现在返回 `GFTableViewRebuildResult`。移除可绕过事务的 `row_id_column`、`case_sensitive_filter` 与 `selection_model` 公共字段，改为类型化 setter/getter；新增命名谓词注册、启停、排序、查询和 revision/result API。`GFTableSelectionModel` 新增原子替换选择集合与锚点的入口；`commit_cell_value()` 与两种批量提交改为候选行事务，不再允许不可隔离行或任意 `value_setter` 走先写后刷新的部分提交路径。命名谓词不保留 Callable-only 或裸 Dictionary 入口。
+- `GFSpatialCanvas2D.handle_input_event()` 与 `handle_screen_input_event()` 的返回类型从 `bool` 改为命名的 `InputDisposition` 枚举；新增 `set_input_policy()` / `get_input_policy()`、`GFSpatialCanvasInputPolicy` 与 `GFSpatialCanvasSelectionModeBinding`。滚轮轴、滚轮路由、触摸主行为分别使用各自的命名枚举；`TouchPrimaryBehavior.NONE` 显式关闭单指行为，`touch_multi_pan_enabled` 与 `touch_multi_zoom_enabled` 独立控制 raw 多指视图分量。策略默认选择、嵌套 modifier binding、公开选择入口和捕获状态共同使用唯一的 `GFSpatialCanvas2D.SelectionMode` 类型。
 
 ### 📘 升级指南 (Migration Guide)
 
@@ -213,6 +223,9 @@
 26. 若项目依赖生成访问器的本地/父级、必需性或 ready 语义，在 `gf/codegen/access_policies` 中按精确 `res://` 模块脚本路径声明策略并重新生成；删除未知、重复或已失配路径，生成器会整批失败关闭而不保留部分源码。
 27. 把依赖全局 `panel_async_load_finished` 识别单次请求的代码迁移到异步 UI 方法返回的 `GFUIPanelAsyncOperation` 或完成回调；全局信号只用于无身份遥测。Route 调用若需要生命周期绑定，在 options 中传有效 owner 和/或未完成的 `GFAsyncScope`。
 28. 需要短时虚拟动作时，为 `GFVirtualInputSource` 注入共享 `GFTimerUtility` 并调用 `pulse_action()`；用返回句柄观察终态，不自行安排延迟 `clear_action()`。同键覆盖语义应显式选择 REPLACE 或 REJECT_NEW，Source 与 Mapping 关闭后不得复用。
+29. 大型列表把项目 `ScrollContainer` 的直接子内容根、行工厂、bind/unbind、稳定 identity 和 owner 交给 `GFVirtualListBinder`；内容根不能是接管子节点位置的 `Container`。排序、过滤或数据内容提交后显式调用 `invalidate_items()`，只使用稳定且有界的标量 identity；若在 Binder callback 内失效，当前结果会是非成功 `STATUS_DEFERRED`，副作用已开始时 active 可被安全清空，调用方应以结果索引为准等待下一轮重建。需要切换 `layout_axis`、`fill_cross_axis`、`auto_measure` 或 callback 内的预算时，先更新配置并调用 `request_sync()`，当前同步轮仍使用入口快照，下一轮才采用新值。`scroll_to_item()` 返回 `false` 表示操作快照或最终整数偏移未能完整提交，调用方不要把它当作部分成功。Binder 会按每段轴所有权恢复接管前的最小尺寸。owner 退出前让 Binder 自动或显式 `dispose()`，不得重挂载或释放 Binder-owned Control。
+30. 表格结构化过滤改为继承 `GFTableRowPredicate`，返回 `GFTableRowPredicateResult`，再用 `GFTableRowPredicateRegistration.create()` 批量事务注册。将 `row_id_column`、`case_sensitive_filter` 与 `selection_model` 直接赋值迁移到 `set_row_id_column()`、`set_filter_case_sensitive()` 与 `set_selection_model()`，并通过 getter 读取已提交配置。更新所有 `view_changed` 连接以接收 revision 与 visible count；只有 rebuild result 成功且 committed，或收到 `view_changed` 时，才更新 VirtualList count 与 Binder identity，失败时继续展示上一份已提交投影。谓词实例的项目参数改变后显式调用 `refresh_view()`，不要依赖框架观察任意成员写入。经 `GFTableDataView.commit_cell_value()` 或批量入口写入的行必须可安全隔离；把带任意副作用的 `value_setter` 移到项目事务层，提交完成后再用新的 source 行调用 `set_rows()`。
+31. Spatial Canvas 输入转发改为检查 `InputDisposition`：只有 `CONSUMED` 才停止项目路由。创建并校验 `GFSpatialCanvasInputPolicy` 来替代硬编码按键；嵌套滚动界面用 modifier-gated 或 parent-only wheel，让未匹配滚轮继续 GUI 冒泡。需要禁用单指时使用 `TouchPrimaryBehavior.NONE`，并分别决定 raw 多指 pan 与 pinch zoom；若二者也都关闭，首触点不会被 Canvas 捕获。取消行为使用只含非指针事件的项目 InputMap action，不得与鼠标、触摸或位置手势复用；项目运行时修改 InputMap 后，超出事件预算或变成指针映射的取消 action 会失败关闭。
 
 ### 📁 核心受影响文件 (Affected Files)
 
@@ -248,6 +261,18 @@
 - `addons/gf/standard/utilities/ui/gf_ui_route_result.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_router_utility.gd`
 - `addons/gf/standard/utilities/ui/gf_ui_utility.gd`
+- `addons/gf/standard/utilities/ui/gf_virtual_list_model.gd`
+- `addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd`
+- `addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd`
+- `addons/gf/standard/utilities/ui/gf_table_data_view.gd`
+- `addons/gf/standard/utilities/ui/gf_table_row_predicate.gd`
+- `addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd`
+- `addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd`
+- `addons/gf/standard/utilities/ui/gf_table_row_view.gd`
+- `addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd`
+- `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd`
+- `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd`
+- `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd`
 - `addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd`
 - `addons/gf/standard/input/sources/gf_virtual_input_source.gd`
 - `addons/gf/standard/input/runtime/gf_input_mapping_utility.gd`
@@ -275,6 +300,8 @@
 - `addons/gf/extensions/save/profile/gf_save_profile_mutation_request.gd`
 - `addons/gf/extensions/save/gf_extension.json`
 - `packages/standard/gf.standard.storage.json`
+- `packages/standard/gf.standard.ui.json`
+- `packages/standard/gf.standard.spatial.canvas.json`
 - `addons/gf/extensions/network/backends/gf_network_backend.gd`
 - `addons/gf/extensions/network/runtime/gf_network_transport_metrics.gd`
 - `addons/gf/extensions/network/gf_extension.json`
@@ -282,6 +309,7 @@
 - `addons/gf/tools/ai_developer/gf_ai/contract.py`
 - `addons/gf/tools/ai_developer/gf_ai/dependencies.py`
 - `addons/gf/tools/ai_developer/gf_ai/snapshot.py`
+- `addons/gf/tools/ai_developer/knowledge/capabilities.json`
 - `addons/gf/tools/ai_developer/knowledge/recipes.json`
 - `tools/gdscript_api_parser.py`
 - `tools/gf_maintenance.py`
@@ -297,6 +325,9 @@
 - `docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md`
 - `docs/zh/standard/utilities/io/assets-jobs-warmup/resource-broker.md`
 - `docs/zh/standard/utilities/runtime/settings-ui-scene/scene-flow/preload-cache-map.md`
+- `docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/virtual-list-model.md`
+- `docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/table-data-view.md`
+- `docs/zh/standard/input-flow/spatial-canvas-2d.md`
 - `docs/zh/standard/utilities/runtime/audio/backend-events.md`
 - `docs/zh/standard/utilities/runtime/settings-ui-scene/shader-parameter-profile.md`
 - `tests/gf_core/extensions/network/test_gf_network_extension.gd`
@@ -313,6 +344,9 @@
 - `tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd`
 - `tests/gf_core/standard/utilities/assets/test_gf_resource_broker.gd`
 - `tests/gf_core/standard/utilities/scene/test_gf_scene_preload_map.gd`
+- `tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd`
+- `tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd`
+- `tests/gf_core/standard/utilities/spatial_canvas/test_gf_spatial_canvas_2d.gd`
 - `tests/gf_core/package_focused_gut_mapping.json`
 - `tests/gf_core/standard/utilities/audio/test_gf_audio_utility.gd`
 - `tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py`

--- a/docs/zh/reference/api/classes/GFSpatialCanvas2D.md
+++ b/docs/zh/reference/api/classes/GFSpatialCanvas2D.md
@@ -23,6 +23,7 @@
 | 信号 | [`placement_cancelled`](#member-gfspatialcanvas2d-signals-placement_cancelled) | `signal placement_cancelled(report: Dictionary)` |
 | 信号 | [`history_operation_requested`](#member-gfspatialcanvas2d-signals-history_operation_requested) | `signal history_operation_requested(operation: Dictionary)` |
 | 枚举 | [`SelectionMode`](#member-gfspatialcanvas2d-enums-selectionmode) | `enum SelectionMode` |
+| 枚举 | [`InputDisposition`](#member-gfspatialcanvas2d-enums-inputdisposition) | `enum InputDisposition` |
 | 常量 | [`ABSOLUTE_MAX_ITEMS`](#member-gfspatialcanvas2d-constants-absolute_max_items) | `const ABSOLUTE_MAX_ITEMS: int = 65536` |
 | 常量 | [`ABSOLUTE_MAX_SELECTION`](#member-gfspatialcanvas2d-constants-absolute_max_selection) | `const ABSOLUTE_MAX_SELECTION: int = 16384` |
 | 常量 | [`ABSOLUTE_MAX_QUERY_CANDIDATES`](#member-gfspatialcanvas2d-constants-absolute_max_query_candidates) | `const ABSOLUTE_MAX_QUERY_CANDIDATES: int = 16384` |
@@ -55,9 +56,9 @@
 | 方法 | [`get_item`](#member-gfspatialcanvas2d-methods-get_item) | `func get_item(item_id: StringName) -> Dictionary:` |
 | 方法 | [`query_items_at`](#member-gfspatialcanvas2d-methods-query_items_at) | `func query_items_at(world_position: Vector2) -> PackedStringArray:` |
 | 方法 | [`query_items_in_rect`](#member-gfspatialcanvas2d-methods-query_items_in_rect) | `func query_items_in_rect( world_rect: Rect2, fully_contained: bool = false ) -> PackedStringArray:` |
-| 方法 | [`set_selection`](#member-gfspatialcanvas2d-methods-set_selection) | `func set_selection( item_ids: PackedStringArray, mode: int = SelectionMode.REPLACE ) -> PackedStringArray:` |
-| 方法 | [`select_point`](#member-gfspatialcanvas2d-methods-select_point) | `func select_point( canvas_position: Vector2, mode: int = SelectionMode.REPLACE ) -> PackedStringArray:` |
-| 方法 | [`select_rect`](#member-gfspatialcanvas2d-methods-select_rect) | `func select_rect( canvas_rect: Rect2, mode: int = SelectionMode.REPLACE, fully_contained: bool = false ) -> PackedStringArray:` |
+| 方法 | [`set_selection`](#member-gfspatialcanvas2d-methods-set_selection) | `func set_selection( item_ids: PackedStringArray, mode: SelectionMode = SelectionMode.REPLACE ) -> PackedStringArray:` |
+| 方法 | [`select_point`](#member-gfspatialcanvas2d-methods-select_point) | `func select_point( canvas_position: Vector2, mode: SelectionMode = SelectionMode.REPLACE ) -> PackedStringArray:` |
+| 方法 | [`select_rect`](#member-gfspatialcanvas2d-methods-select_rect) | `func select_rect( canvas_rect: Rect2, mode: SelectionMode = SelectionMode.REPLACE, fully_contained: bool = false ) -> PackedStringArray:` |
 | 方法 | [`clear_selection`](#member-gfspatialcanvas2d-methods-clear_selection) | `func clear_selection() -> void:` |
 | 方法 | [`get_selection`](#member-gfspatialcanvas2d-methods-get_selection) | `func get_selection() -> PackedStringArray:` |
 | 方法 | [`set_placement_validator`](#member-gfspatialcanvas2d-methods-set_placement_validator) | `func set_placement_validator(callback: Callable) -> void:` |
@@ -68,8 +69,10 @@
 | 方法 | [`cancel_placement`](#member-gfspatialcanvas2d-methods-cancel_placement) | `func cancel_placement(reason: StringName = &"cancelled") -> Dictionary:` |
 | 方法 | [`has_active_placement`](#member-gfspatialcanvas2d-methods-has_active_placement) | `func has_active_placement() -> bool:` |
 | 方法 | [`get_placement_snapshot`](#member-gfspatialcanvas2d-methods-get_placement_snapshot) | `func get_placement_snapshot() -> Dictionary:` |
-| 方法 | [`handle_input_event`](#member-gfspatialcanvas2d-methods-handle_input_event) | `func handle_input_event(event: InputEvent) -> bool:` |
-| 方法 | [`handle_screen_input_event`](#member-gfspatialcanvas2d-methods-handle_screen_input_event) | `func handle_screen_input_event(event: InputEvent) -> bool:` |
+| 方法 | [`set_input_policy`](#member-gfspatialcanvas2d-methods-set_input_policy) | `func set_input_policy(policy: GFSpatialCanvasInputPolicy) -> bool:` |
+| 方法 | [`get_input_policy`](#member-gfspatialcanvas2d-methods-get_input_policy) | `func get_input_policy() -> GFSpatialCanvasInputPolicy:` |
+| 方法 | [`handle_input_event`](#member-gfspatialcanvas2d-methods-handle_input_event) | `func handle_input_event(event: InputEvent) -> InputDisposition:` |
+| 方法 | [`handle_screen_input_event`](#member-gfspatialcanvas2d-methods-handle_screen_input_event) | `func handle_screen_input_event(event: InputEvent) -> InputDisposition:` |
 | 方法 | [`set_input_enabled`](#member-gfspatialcanvas2d-methods-set_input_enabled) | `func set_input_enabled(enabled: bool) -> void:` |
 | 方法 | [`get_debug_snapshot`](#member-gfspatialcanvas2d-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
 
@@ -255,6 +258,26 @@ enum SelectionMode {
 ```
 
 选择集合更新模式。
+
+<a id="member-gfspatialcanvas2d-enums-inputdisposition"></a>
+
+### `InputDisposition`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum InputDisposition {
+	## 事件未被画布识别或当前策略要求继续交给其他接收者。
+	IGNORED,
+	## 事件已更新画布，但仍允许 GUI 冒泡。
+	HANDLED,
+	## 事件已更新画布，并应在 GUI 边界停止传播。
+	CONSUMED,
+}
+```
+
+输入处理结果。 手工转发调用只观察该返回值；只有 [constant InputDisposition.CONSUMED] 会让画布自身的 [code]_gui_input()[/code] 调用 [method Control.accept_event]。
 
 ## 常量
 
@@ -891,7 +914,7 @@ func query_items_in_rect( world_rect: Rect2, fully_contained: bool = false ) -> 
 - 首次版本：`10.0.0`
 
 ```gdscript
-func set_selection( item_ids: PackedStringArray, mode: int = SelectionMode.REPLACE ) -> PackedStringArray:
+func set_selection( item_ids: PackedStringArray, mode: SelectionMode = SelectionMode.REPLACE ) -> PackedStringArray:
 ```
 
 按模式更新选择。 只接受已登记且可选的稳定 ID；容量只限制替换或新增，不截断减去候选。
@@ -901,7 +924,7 @@ func set_selection( item_ids: PackedStringArray, mode: int = SelectionMode.REPLA
 | 名称 | 说明 |
 |---|---|
 | `item_ids` | 候选条目 ID。 |
-| `mode` | SelectionMode 值。 |
+| `mode` | [enum SelectionMode] 值。 |
 
 返回：更新后的隔离选择副本。
 
@@ -913,7 +936,7 @@ func set_selection( item_ids: PackedStringArray, mode: int = SelectionMode.REPLA
 - 首次版本：`10.0.0`
 
 ```gdscript
-func select_point( canvas_position: Vector2, mode: int = SelectionMode.REPLACE ) -> PackedStringArray:
+func select_point( canvas_position: Vector2, mode: SelectionMode = SelectionMode.REPLACE ) -> PackedStringArray:
 ```
 
 在画布坐标点选最高优先级条目。
@@ -923,7 +946,7 @@ func select_point( canvas_position: Vector2, mode: int = SelectionMode.REPLACE )
 | 名称 | 说明 |
 |---|---|
 | `canvas_position` | 本 Control 的画布坐标。 |
-| `mode` | SelectionMode 值。 |
+| `mode` | [enum SelectionMode] 值。 |
 
 返回：更新后的选择。
 
@@ -935,7 +958,7 @@ func select_point( canvas_position: Vector2, mode: int = SelectionMode.REPLACE )
 - 首次版本：`10.0.0`
 
 ```gdscript
-func select_rect( canvas_rect: Rect2, mode: int = SelectionMode.REPLACE, fully_contained: bool = false ) -> PackedStringArray:
+func select_rect( canvas_rect: Rect2, mode: SelectionMode = SelectionMode.REPLACE, fully_contained: bool = false ) -> PackedStringArray:
 ```
 
 在画布坐标框选条目。
@@ -945,7 +968,7 @@ func select_rect( canvas_rect: Rect2, mode: int = SelectionMode.REPLACE, fully_c
 | 名称 | 说明 |
 |---|---|
 | `canvas_rect` | 画布选择矩形。 |
-| `mode` | SelectionMode 值。 |
+| `mode` | [enum SelectionMode] 值。 |
 | `fully_contained` | 为 true 时只选择完全位于矩形内的条目。 |
 
 返回：更新后的选择。
@@ -1151,6 +1174,42 @@ func get_placement_snapshot() -> Dictionary:
 
 - `return`: Dictionary，包含 session_id、type_id、footprint、world_position、rotation_radians、world_bounds、snap_to_grid 和 snap_rotation。
 
+<a id="member-gfspatialcanvas2d-methods-set_input_policy"></a>
+
+### `set_input_policy`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_input_policy(policy: GFSpatialCanvasInputPolicy) -> bool:
+```
+
+原子替换输入解释策略。 方法先完整校验并深拷贝候选策略；失败时保留当前策略和所有瞬态状态。 成功切换会释放当前指针捕获，但不会清除选择集合或活动放置会话。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `policy` | 候选输入策略。 |
+
+返回：策略有效并完成替换时返回 true。
+
+<a id="member-gfspatialcanvas2d-methods-get_input_policy"></a>
+
+### `get_input_policy`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_input_policy() -> GFSpatialCanvasInputPolicy:
+```
+
+获取当前输入策略的隔离副本。
+
+返回：当前策略的深拷贝。
+
 <a id="member-gfspatialcanvas2d-methods-handle_input_event"></a>
 
 ### `handle_input_event`
@@ -1159,10 +1218,10 @@ func get_placement_snapshot() -> Dictionary:
 - 首次版本：`10.0.0`
 
 ```gdscript
-func handle_input_event(event: InputEvent) -> bool:
+func handle_input_event(event: InputEvent) -> InputDisposition:
 ```
 
-处理一个项目转发的输入事件。 中键/单指拖动用于平移，滚轮/捏合用于焦点缩放，左键用于点选、框选或活动放置。 只有实际识别和消费的事件返回 true。
+处理一个项目转发的输入事件。 事件按当前 [GFSpatialCanvasInputPolicy] 解释。方法不会调用 Viewport 的 handled API； 手工路由方应根据 [enum InputDisposition] 决定是否继续传播。 鼠标与原始触摸只允许一个来源持有瞬态捕获；冲突来源及系统手势在物理释放或 显式取消前返回 [constant InputDisposition.IGNORED] 且不修改画布状态。 系统标记为 canceled 的当前捕获事件只释放瞬态状态，不提交选择或放置。
 
 参数：
 
@@ -1170,7 +1229,7 @@ func handle_input_event(event: InputEvent) -> bool:
 |---|---|
 | `event` | Godot 输入事件。 |
 
-返回：事件被画布消费时返回 true。
+返回：[enum InputDisposition] 值。
 
 <a id="member-gfspatialcanvas2d-methods-handle_screen_input_event"></a>
 
@@ -1180,7 +1239,7 @@ func handle_input_event(event: InputEvent) -> bool:
 - 首次版本：`10.0.0`
 
 ```gdscript
-func handle_screen_input_event(event: InputEvent) -> bool:
+func handle_screen_input_event(event: InputEvent) -> InputDisposition:
 ```
 
 处理一个使用 Viewport 屏幕坐标的输入事件。 适合从 `_input()` 或自定义全局路由转发事件；事件会先复制并转换到本 Control 的局部画布坐标。`_gui_input()` 已提供局部事件，应直接使用 handle_input_event()。
@@ -1191,7 +1250,7 @@ func handle_screen_input_event(event: InputEvent) -> bool:
 |---|---|
 | `event` | 使用 Viewport 屏幕坐标的 Godot 输入事件。 |
 
-返回：事件被画布消费时返回 true；变换不可逆时返回 false。
+返回：[enum InputDisposition] 值；变换不可逆时返回 [constant InputDisposition.IGNORED]。
 
 <a id="member-gfspatialcanvas2d-methods-set_input_enabled"></a>
 

--- a/docs/zh/reference/api/classes/GFSpatialCanvasInputPolicy.md
+++ b/docs/zh/reference/api/classes/GFSpatialCanvasInputPolicy.md
@@ -1,0 +1,469 @@
+# GFSpatialCanvasInputPolicy
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd`
+- 模块：`Standard`
+- 继承：`Resource`
+- API：`public`
+- 类别：资源定义 (`resource_definition`)
+- 首次版本：`unreleased`
+
+空间画布输入解释策略。 以数据方式声明平移、选择、滚轮、触摸和取消输入。策略不持有节点、 Viewport 或父容器引用；[code]GFSpatialCanvas2D[/code] 只接受完整校验通过的隔离副本。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 枚举 | [`ModifierMask`](#member-gfspatialcanvasinputpolicy-enums-modifiermask) | `enum ModifierMask` |
+| 枚举 | [`WheelAxis`](#member-gfspatialcanvasinputpolicy-enums-wheelaxis) | `enum WheelAxis` |
+| 枚举 | [`WheelRouting`](#member-gfspatialcanvasinputpolicy-enums-wheelrouting) | `enum WheelRouting` |
+| 枚举 | [`TouchPrimaryBehavior`](#member-gfspatialcanvasinputpolicy-enums-touchprimarybehavior) | `enum TouchPrimaryBehavior` |
+| 常量 | [`ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS`](#member-gfspatialcanvasinputpolicy-constants-absolute_max_selection_modifier_bindings) | `const ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS: int = 15` |
+| 常量 | [`ABSOLUTE_MAX_ACTION_EVENTS`](#member-gfspatialcanvasinputpolicy-constants-absolute_max_action_events) | `const ABSOLUTE_MAX_ACTION_EVENTS: int = 64` |
+| 属性 | [`pan_mouse_button`](#member-gfspatialcanvasinputpolicy-properties-pan_mouse_button) | `var pan_mouse_button: MouseButton = MOUSE_BUTTON_MIDDLE` |
+| 属性 | [`pan_action`](#member-gfspatialcanvasinputpolicy-properties-pan_action) | `var pan_action: StringName = &""` |
+| 属性 | [`pan_modifier_mask`](#member-gfspatialcanvasinputpolicy-properties-pan_modifier_mask) | `var pan_modifier_mask: int = ModifierMask.NONE` |
+| 属性 | [`selection_mouse_button`](#member-gfspatialcanvasinputpolicy-properties-selection_mouse_button) | `var selection_mouse_button: MouseButton = MOUSE_BUTTON_LEFT` |
+| 属性 | [`selection_action`](#member-gfspatialcanvasinputpolicy-properties-selection_action) | `var selection_action: StringName = &""` |
+| 属性 | [`selection_default_mode`](#member-gfspatialcanvasinputpolicy-properties-selection_default_mode) | `var selection_default_mode: GFSpatialCanvas2D.SelectionMode = (` |
+| 属性 | [`selection_modifier_bindings`](#member-gfspatialcanvasinputpolicy-properties-selection_modifier_bindings) | `var selection_modifier_bindings: Array[GFSpatialCanvasSelectionModeBinding] = []` |
+| 属性 | [`drag_threshold`](#member-gfspatialcanvasinputpolicy-properties-drag_threshold) | `var drag_threshold: float = 4.0` |
+| 属性 | [`wheel_axis`](#member-gfspatialcanvasinputpolicy-properties-wheel_axis) | `var wheel_axis: WheelAxis = WheelAxis.VERTICAL` |
+| 属性 | [`wheel_routing`](#member-gfspatialcanvasinputpolicy-properties-wheel_routing) | `var wheel_routing: WheelRouting = WheelRouting.CANVAS` |
+| 属性 | [`wheel_modifier_mask`](#member-gfspatialcanvasinputpolicy-properties-wheel_modifier_mask) | `var wheel_modifier_mask: int = ModifierMask.NONE` |
+| 属性 | [`wheel_zoom_factor`](#member-gfspatialcanvasinputpolicy-properties-wheel_zoom_factor) | `var wheel_zoom_factor: float = 1.1` |
+| 属性 | [`touch_enabled`](#member-gfspatialcanvasinputpolicy-properties-touch_enabled) | `var touch_enabled: bool = true` |
+| 属性 | [`touch_primary_behavior`](#member-gfspatialcanvasinputpolicy-properties-touch_primary_behavior) | `var touch_primary_behavior: TouchPrimaryBehavior = TouchPrimaryBehavior.PAN` |
+| 属性 | [`touch_multi_pan_enabled`](#member-gfspatialcanvasinputpolicy-properties-touch_multi_pan_enabled) | `var touch_multi_pan_enabled: bool = true` |
+| 属性 | [`touch_multi_zoom_enabled`](#member-gfspatialcanvasinputpolicy-properties-touch_multi_zoom_enabled) | `var touch_multi_zoom_enabled: bool = true` |
+| 属性 | [`system_pan_gesture_enabled`](#member-gfspatialcanvasinputpolicy-properties-system_pan_gesture_enabled) | `var system_pan_gesture_enabled: bool = true` |
+| 属性 | [`system_magnify_gesture_enabled`](#member-gfspatialcanvasinputpolicy-properties-system_magnify_gesture_enabled) | `var system_magnify_gesture_enabled: bool = true` |
+| 属性 | [`placement_cancel_action`](#member-gfspatialcanvasinputpolicy-properties-placement_cancel_action) | `var placement_cancel_action: StringName = &"ui_cancel"` |
+| 属性 | [`consume_handled_events`](#member-gfspatialcanvasinputpolicy-properties-consume_handled_events) | `var consume_handled_events: bool = true` |
+| 属性 | [`consume_wheel_events`](#member-gfspatialcanvasinputpolicy-properties-consume_wheel_events) | `var consume_wheel_events: bool = true` |
+| 方法 | [`validate_policy`](#member-gfspatialcanvasinputpolicy-methods-validate_policy) | `func validate_policy() -> Dictionary:` |
+| 方法 | [`duplicate_policy`](#member-gfspatialcanvasinputpolicy-methods-duplicate_policy) | `func duplicate_policy() -> GFSpatialCanvasInputPolicy:` |
+
+## 枚举
+
+<a id="member-gfspatialcanvasinputpolicy-enums-modifiermask"></a>
+
+### `ModifierMask`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum ModifierMask {
+	## 不要求修饰键。
+	NONE = 0,
+	## Shift 修饰键。
+	SHIFT = 1,
+	## Ctrl 修饰键。
+	CTRL = 2,
+	## Alt 修饰键。
+	ALT = 4,
+	## Meta 修饰键。
+	META = 8,
+}
+```
+
+输入修饰键位掩码。
+
+<a id="member-gfspatialcanvasinputpolicy-enums-wheelaxis"></a>
+
+### `WheelAxis`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum WheelAxis {
+	## 使用向上/向下滚轮事件。
+	VERTICAL,
+	## 使用向左/向右滚轮事件。
+	HORIZONTAL,
+}
+```
+
+滚轮缩放使用的物理轴。
+
+<a id="member-gfspatialcanvasinputpolicy-enums-wheelrouting"></a>
+
+### `WheelRouting`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum WheelRouting {
+	## 画布处理目标轴上的所有滚轮事件。
+	CANVAS,
+	## 只有修饰键掩码精确匹配时由画布处理。
+	MODIFIER_GATED,
+	## 画布始终忽略滚轮，让 GUI 祖先继续处理。
+	PARENT_ONLY,
+}
+```
+
+滚轮事件的画布路由策略。
+
+<a id="member-gfspatialcanvasinputpolicy-enums-touchprimarybehavior"></a>
+
+### `TouchPrimaryBehavior`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum TouchPrimaryBehavior {
+	## 单指不执行画布行为；若启用任一多指行为，首触点仍会被捕获以等待后续触点。
+	NONE,
+	## 单指拖动平移画布。
+	PAN,
+	## 单指执行点选、框选或放置确认。
+	SELECT,
+}
+```
+
+单指触摸的主行为。
+
+## 常量
+
+<a id="member-gfspatialcanvasinputpolicy-constants-absolute_max_selection_modifier_bindings"></a>
+
+### `ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS: int = 15
+```
+
+单份策略允许声明的选择修饰键绑定绝对上限。
+
+<a id="member-gfspatialcanvasinputpolicy-constants-absolute_max_action_events"></a>
+
+### `ABSOLUTE_MAX_ACTION_EVENTS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ABSOLUTE_MAX_ACTION_EVENTS: int = 64
+```
+
+校验单个 InputMap action 时允许扫描的事件绝对上限。
+
+## 属性
+
+<a id="member-gfspatialcanvasinputpolicy-properties-pan_mouse_button"></a>
+
+### `pan_mouse_button`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var pan_mouse_button: MouseButton = MOUSE_BUTTON_MIDDLE
+```
+
+直接触发平移捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-pan_action"></a>
+
+### `pan_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var pan_action: StringName = &""
+```
+
+通过 InputMap 触发平移捕获的动作；空名称表示禁用动作绑定。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-pan_modifier_mask"></a>
+
+### `pan_modifier_mask`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var pan_modifier_mask: int = ModifierMask.NONE
+```
+
+直接平移按钮必须精确匹配的修饰键掩码。 使用 [member pan_action] 时修饰键由 InputMap action 精确声明，本字段必须为 NONE。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-selection_mouse_button"></a>
+
+### `selection_mouse_button`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var selection_mouse_button: MouseButton = MOUSE_BUTTON_LEFT
+```
+
+直接触发选择捕获的鼠标按钮；[constant MOUSE_BUTTON_NONE] 表示禁用直接按钮。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-selection_action"></a>
+
+### `selection_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var selection_action: StringName = &""
+```
+
+通过 InputMap 触发选择捕获的动作；空名称表示禁用动作绑定。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-selection_default_mode"></a>
+
+### `selection_default_mode`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var selection_default_mode: GFSpatialCanvas2D.SelectionMode = (
+```
+
+没有选择修饰键绑定精确匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code]。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-selection_modifier_bindings"></a>
+
+### `selection_modifier_bindings`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var selection_modifier_bindings: Array[GFSpatialCanvasSelectionModeBinding] = []
+```
+
+修饰键到选择模式的精确匹配表；重复掩码会使策略校验失败。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-drag_threshold"></a>
+
+### `drag_threshold`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var drag_threshold: float = 4.0
+```
+
+区分点选和框选的局部画布像素阈值。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-wheel_axis"></a>
+
+### `wheel_axis`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var wheel_axis: WheelAxis = WheelAxis.VERTICAL
+```
+
+用于画布缩放的滚轮轴。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-wheel_routing"></a>
+
+### `wheel_routing`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var wheel_routing: WheelRouting = WheelRouting.CANVAS
+```
+
+滚轮缩放路由策略。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-wheel_modifier_mask"></a>
+
+### `wheel_modifier_mask`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var wheel_modifier_mask: int = ModifierMask.NONE
+```
+
+[constant WheelRouting.MODIFIER_GATED] 下必须精确匹配的修饰键掩码。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-wheel_zoom_factor"></a>
+
+### `wheel_zoom_factor`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var wheel_zoom_factor: float = 1.1
+```
+
+每个滚轮刻度的缩放倍率，必须为有限且大于 1 的值。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-touch_enabled"></a>
+
+### `touch_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var touch_enabled: bool = true
+```
+
+是否处理原始 ScreenTouch / ScreenDrag 事件。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-touch_primary_behavior"></a>
+
+### `touch_primary_behavior`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var touch_primary_behavior: TouchPrimaryBehavior = TouchPrimaryBehavior.PAN
+```
+
+单指触摸的主行为。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-touch_multi_pan_enabled"></a>
+
+### `touch_multi_pan_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var touch_multi_pan_enabled: bool = true
+```
+
+是否允许双指及以上触点驱动平移。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-touch_multi_zoom_enabled"></a>
+
+### `touch_multi_zoom_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var touch_multi_zoom_enabled: bool = true
+```
+
+是否允许双指及以上触点驱动捏合缩放。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-system_pan_gesture_enabled"></a>
+
+### `system_pan_gesture_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var system_pan_gesture_enabled: bool = true
+```
+
+是否处理 Godot 的系统 PanGesture 事件。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-system_magnify_gesture_enabled"></a>
+
+### `system_magnify_gesture_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var system_magnify_gesture_enabled: bool = true
+```
+
+是否处理 Godot 的系统 MagnifyGesture 事件。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-placement_cancel_action"></a>
+
+### `placement_cancel_action`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var placement_cancel_action: StringName = &"ui_cancel"
+```
+
+取消活动放置或瞬态选择的非指针 InputMap 动作；空名称表示禁用取消输入。 动作不得包含鼠标、触摸或位置手势事件，避免取消优先级饿死画布指针行为。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-consume_handled_events"></a>
+
+### `consume_handled_events`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var consume_handled_events: bool = true
+```
+
+一般已处理事件是否由 Canvas GUI 边界消费。
+
+<a id="member-gfspatialcanvasinputpolicy-properties-consume_wheel_events"></a>
+
+### `consume_wheel_events`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var consume_wheel_events: bool = true
+```
+
+已处理滚轮事件是否由 Canvas GUI 边界消费。
+
+## 方法
+
+<a id="member-gfspatialcanvasinputpolicy-methods-validate_policy"></a>
+
+### `validate_policy`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_policy() -> Dictionary:
+```
+
+校验完整策略。 校验失败时调用方必须保留上一份有效策略；报告遵循 [code]GFValidationReportDictionary[/code] 结构。
+
+返回：策略校验报告。
+
+结构：
+
+- `return`: GFValidationReportDictionary-compatible report with issues describing invalid fields.
+
+<a id="member-gfspatialcanvasinputpolicy-methods-duplicate_policy"></a>
+
+### `duplicate_policy`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_policy() -> GFSpatialCanvasInputPolicy:
+```
+
+创建策略及嵌套选择绑定的隔离副本。
+
+返回：新策略。

--- a/docs/zh/reference/api/classes/GFSpatialCanvasSelectionModeBinding.md
+++ b/docs/zh/reference/api/classes/GFSpatialCanvasSelectionModeBinding.md
@@ -1,0 +1,65 @@
+# GFSpatialCanvasSelectionModeBinding
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd`
+- 模块：`Standard`
+- 继承：`Resource`
+- API：`public`
+- 类别：资源定义 (`resource_definition`)
+- 首次版本：`unreleased`
+
+空间画布选择修饰键绑定。 只描述修饰键掩码到 [code]GFSpatialCanvas2D.SelectionMode[/code] 的映射， 不读取设备状态，也不拥有输入生命周期。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 属性 | [`modifier_mask`](#member-gfspatialcanvasselectionmodebinding-properties-modifier_mask) | `var modifier_mask: int = 0` |
+| 属性 | [`selection_mode`](#member-gfspatialcanvasselectionmodebinding-properties-selection_mode) | `var selection_mode: GFSpatialCanvas2D.SelectionMode = (` |
+| 方法 | [`duplicate_binding`](#member-gfspatialcanvasselectionmodebinding-methods-duplicate_binding) | `func duplicate_binding() -> GFSpatialCanvasSelectionModeBinding:` |
+
+## 属性
+
+<a id="member-gfspatialcanvasselectionmodebinding-properties-modifier_mask"></a>
+
+### `modifier_mask`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var modifier_mask: int = 0
+```
+
+需要精确匹配的 [code]GFSpatialCanvasInputPolicy.ModifierMask[/code] 掩码。
+
+<a id="member-gfspatialcanvasselectionmodebinding-properties-selection_mode"></a>
+
+### `selection_mode`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var selection_mode: GFSpatialCanvas2D.SelectionMode = (
+```
+
+匹配时使用的 [code]GFSpatialCanvas2D.SelectionMode[/code] 值。
+
+## 方法
+
+<a id="member-gfspatialcanvasselectionmodebinding-methods-duplicate_binding"></a>
+
+### `duplicate_binding`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_binding() -> GFSpatialCanvasSelectionModeBinding:
+```
+
+创建隔离副本。
+
+返回：新绑定。

--- a/docs/zh/reference/api/classes/GFTableDataView.md
+++ b/docs/zh/reference/api/classes/GFTableDataView.md
@@ -16,18 +16,23 @@
 | 类型 | 名称 | 签名 |
 |---|---|---|
 | 信号 | [`rows_changed`](#member-gftabledataview-signals-rows_changed) | `signal rows_changed(row_count: int)` |
-| 信号 | [`view_changed`](#member-gftabledataview-signals-view_changed) | `signal view_changed(visible_count: int)` |
+| 信号 | [`view_changed`](#member-gftabledataview-signals-view_changed) | `signal view_changed(view_revision: int, visible_count: int)` |
+| 信号 | [`view_rebuild_failed`](#member-gftabledataview-signals-view_rebuild_failed) | `signal view_rebuild_failed(result: GFTableViewRebuildResult)` |
 | 信号 | [`filter_changed`](#member-gftabledataview-signals-filter_changed) | `signal filter_changed(query: String, visible_count: int)` |
 | 信号 | [`sort_changed`](#member-gftabledataview-signals-sort_changed) | `signal sort_changed(column_id: StringName, ascending: bool)` |
 | 信号 | [`cell_value_committed`](#member-gftabledataview-signals-cell_value_committed) | `signal cell_value_committed(` |
-| 属性 | [`row_id_column`](#member-gftabledataview-properties-row_id_column) | `var row_id_column: StringName = &"id"` |
-| 属性 | [`case_sensitive_filter`](#member-gftabledataview-properties-case_sensitive_filter) | `var case_sensitive_filter: bool = false` |
-| 属性 | [`selection_model`](#member-gftabledataview-properties-selection_model) | `var selection_model: GFTableSelectionModel = GFTableSelectionModel.new()` |
-| 方法 | [`set_columns`](#member-gftabledataview-methods-set_columns) | `func set_columns(column_definitions: Array[GFTableColumnDefinition]) -> void:` |
+| 常量 | [`MAX_ROW_PREDICATE_COUNT`](#member-gftabledataview-constants-max_row_predicate_count) | `const MAX_ROW_PREDICATE_COUNT: int = 64` |
+| 方法 | [`set_row_id_column`](#member-gftabledataview-methods-set_row_id_column) | `func set_row_id_column(column_id: StringName) -> GFTableViewRebuildResult:` |
+| 方法 | [`get_row_id_column`](#member-gftabledataview-methods-get_row_id_column) | `func get_row_id_column() -> StringName:` |
+| 方法 | [`set_filter_case_sensitive`](#member-gftabledataview-methods-set_filter_case_sensitive) | `func set_filter_case_sensitive(case_sensitive: bool) -> GFTableViewRebuildResult:` |
+| 方法 | [`is_filter_case_sensitive`](#member-gftabledataview-methods-is_filter_case_sensitive) | `func is_filter_case_sensitive() -> bool:` |
+| 方法 | [`set_selection_model`](#member-gftabledataview-methods-set_selection_model) | `func set_selection_model(model: GFTableSelectionModel) -> GFTableViewRebuildResult:` |
+| 方法 | [`get_selection_model`](#member-gftabledataview-methods-get_selection_model) | `func get_selection_model() -> GFTableSelectionModel:` |
+| 方法 | [`set_columns`](#member-gftabledataview-methods-set_columns) | `func set_columns( column_definitions: Array[GFTableColumnDefinition] ) -> GFTableViewRebuildResult:` |
 | 方法 | [`add_column`](#member-gftabledataview-methods-add_column) | `func add_column(column: GFTableColumnDefinition) -> bool:` |
 | 方法 | [`get_columns`](#member-gftabledataview-methods-get_columns) | `func get_columns() -> Array[GFTableColumnDefinition]:` |
 | 方法 | [`get_column`](#member-gftabledataview-methods-get_column) | `func get_column(column_id: StringName) -> GFTableColumnDefinition:` |
-| 方法 | [`set_rows`](#member-gftabledataview-methods-set_rows) | `func set_rows(row_values: Array, duplicate_rows: bool = false) -> void:` |
+| 方法 | [`set_rows`](#member-gftabledataview-methods-set_rows) | `func set_rows( row_values: Array, duplicate_rows: bool = false ) -> GFTableViewRebuildResult:` |
 | 方法 | [`append_row`](#member-gftabledataview-methods-append_row) | `func append_row(row_data: Variant) -> int:` |
 | 方法 | [`remove_row`](#member-gftabledataview-methods-remove_row) | `func remove_row(row_index: int, should_prune_selection: bool = true) -> bool:` |
 | 方法 | [`clear_rows`](#member-gftabledataview-methods-clear_rows) | `func clear_rows() -> void:` |
@@ -41,13 +46,23 @@
 | 方法 | [`get_visible_row_id`](#member-gftabledataview-methods-get_visible_row_id) | `func get_visible_row_id(visible_row_index: int) -> Variant:` |
 | 方法 | [`get_row_ids`](#member-gftabledataview-methods-get_row_ids) | `func get_row_ids() -> Array:` |
 | 方法 | [`get_visible_row_ids`](#member-gftabledataview-methods-get_visible_row_ids) | `func get_visible_row_ids() -> Array:` |
-| 方法 | [`set_filter_query`](#member-gftabledataview-methods-set_filter_query) | `func set_filter_query(query: String) -> void:` |
+| 方法 | [`set_filter_query`](#member-gftabledataview-methods-set_filter_query) | `func set_filter_query(query: String) -> GFTableViewRebuildResult:` |
 | 方法 | [`get_filter_query`](#member-gftabledataview-methods-get_filter_query) | `func get_filter_query() -> String:` |
+| 方法 | [`set_row_predicates`](#member-gftabledataview-methods-set_row_predicates) | `func set_row_predicates( registrations: Array[GFTableRowPredicateRegistration] ) -> GFTableViewRebuildResult:` |
+| 方法 | [`register_row_predicate`](#member-gftabledataview-methods-register_row_predicate) | `func register_row_predicate( registration: GFTableRowPredicateRegistration ) -> GFTableViewRebuildResult:` |
+| 方法 | [`unregister_row_predicate`](#member-gftabledataview-methods-unregister_row_predicate) | `func unregister_row_predicate(predicate_id: StringName) -> GFTableViewRebuildResult:` |
+| 方法 | [`set_row_predicate_enabled`](#member-gftabledataview-methods-set_row_predicate_enabled) | `func set_row_predicate_enabled( predicate_id: StringName, enabled: bool ) -> GFTableViewRebuildResult:` |
+| 方法 | [`set_row_predicate_order`](#member-gftabledataview-methods-set_row_predicate_order) | `func set_row_predicate_order( predicate_id: StringName, order: int ) -> GFTableViewRebuildResult:` |
+| 方法 | [`get_row_predicate`](#member-gftabledataview-methods-get_row_predicate) | `func get_row_predicate(predicate_id: StringName) -> GFTableRowPredicateRegistration:` |
+| 方法 | [`get_row_predicates`](#member-gftabledataview-methods-get_row_predicates) | `func get_row_predicates() -> Array[GFTableRowPredicateRegistration]:` |
+| 方法 | [`get_row_predicate_ids`](#member-gftabledataview-methods-get_row_predicate_ids) | `func get_row_predicate_ids() -> Array[StringName]:` |
+| 方法 | [`get_view_revision`](#member-gftabledataview-methods-get_view_revision) | `func get_view_revision() -> int:` |
+| 方法 | [`get_last_view_rebuild_result`](#member-gftabledataview-methods-get_last_view_rebuild_result) | `func get_last_view_rebuild_result() -> GFTableViewRebuildResult:` |
 | 方法 | [`sort_by_column`](#member-gftabledataview-methods-sort_by_column) | `func sort_by_column(column_id: StringName, ascending: bool = true) -> bool:` |
 | 方法 | [`clear_sort`](#member-gftabledataview-methods-clear_sort) | `func clear_sort() -> bool:` |
 | 方法 | [`get_sort_column_id`](#member-gftabledataview-methods-get_sort_column_id) | `func get_sort_column_id() -> StringName:` |
 | 方法 | [`is_sort_ascending`](#member-gftabledataview-methods-is_sort_ascending) | `func is_sort_ascending() -> bool:` |
-| 方法 | [`refresh_view`](#member-gftabledataview-methods-refresh_view) | `func refresh_view() -> void:` |
+| 方法 | [`refresh_view`](#member-gftabledataview-methods-refresh_view) | `func refresh_view() -> GFTableViewRebuildResult:` |
 | 方法 | [`get_cell_value`](#member-gftabledataview-methods-get_cell_value) | `func get_cell_value(row_index: int, column_id: StringName) -> Variant:` |
 | 方法 | [`commit_cell_value`](#member-gftabledataview-methods-commit_cell_value) | `func commit_cell_value(row_index: int, column_id: StringName, new_value: Variant) -> bool:` |
 | 方法 | [`commit_visible_cell_value`](#member-gftabledataview-methods-commit_visible_cell_value) | `func commit_visible_cell_value( visible_row_index: int, column_id: StringName, new_value: Variant ) -> bool:` |
@@ -88,16 +103,36 @@ signal rows_changed(row_count: int)
 - 首次版本：`5.2.0`
 
 ```gdscript
-signal view_changed(visible_count: int)
+signal view_changed(view_revision: int, visible_count: int)
 ```
 
-可见行集合变化后发出。
+可见行集合成功提交后发出。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
+| `view_revision` | 单调递增的已提交投影 revision。 |
 | `visible_count` | 当前可见行数量。 |
+
+<a id="member-gftabledataview-signals-view_rebuild_failed"></a>
+
+### `view_rebuild_failed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal view_rebuild_failed(result: GFTableViewRebuildResult)
+```
+
+候选投影未提交时发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `result` | 保留 prior projection 的类型化失败结果。 |
 
 <a id="member-gftabledataview-signals-filter_changed"></a>
 
@@ -168,48 +203,130 @@ signal cell_value_committed(
 - `old_value`: Variant，提交前的列值。
 - `new_value`: Variant，提交后的列值。
 
-## 属性
+## 常量
 
-<a id="member-gftabledataview-properties-row_id_column"></a>
+<a id="member-gftabledataview-constants-max_row_predicate_count"></a>
 
-### `row_id_column`
-
-- API：`public`
-- 首次版本：`5.2.0`
-
-```gdscript
-var row_id_column: StringName = &"id"
-```
-
-用作稳定行 ID 的字段键。为空时使用源行索引。
-
-<a id="member-gftabledataview-properties-case_sensitive_filter"></a>
-
-### `case_sensitive_filter`
+### `MAX_ROW_PREDICATE_COUNT`
 
 - API：`public`
-- 首次版本：`5.2.0`
+- 首次版本：`unreleased`
 
 ```gdscript
-var case_sensitive_filter: bool = false
+const MAX_ROW_PREDICATE_COUNT: int = 64
 ```
 
-过滤时是否区分大小写。
-
-<a id="member-gftabledataview-properties-selection_model"></a>
-
-### `selection_model`
-
-- API：`public`
-- 首次版本：`5.2.0`
-
-```gdscript
-var selection_model: GFTableSelectionModel = GFTableSelectionModel.new()
-```
-
-该视图使用的选择模型。
+单个表格允许注册的命名行谓词上限。
 
 ## 方法
+
+<a id="member-gftabledataview-methods-set_row_id_column"></a>
+
+### `set_row_id_column`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_row_id_column(column_id: StringName) -> GFTableViewRebuildResult:
+```
+
+事务式设置稳定行 ID 字段键。 新字段键会先参与完整候选投影；失败时保留旧字段键、投影、选择模型与 revision。 成功时按同一源行迁移稳定选择和范围锚点。空字段键表示使用源行索引。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `column_id` | 新的稳定行 ID 字段键；为空时使用源行索引。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-get_row_id_column"></a>
+
+### `get_row_id_column`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_row_id_column() -> StringName:
+```
+
+获取稳定行 ID 字段键。
+
+返回：当前稳定行 ID 字段键；为空时使用源行索引。
+
+<a id="member-gftabledataview-methods-set_filter_case_sensitive"></a>
+
+### `set_filter_case_sensitive`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_filter_case_sensitive(case_sensitive: bool) -> GFTableViewRebuildResult:
+```
+
+事务式设置文本过滤是否区分大小写。 新设置会先参与完整候选投影；失败时保留旧设置、投影、选择模型与 revision。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `case_sensitive` | 为 true 时区分大小写。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-is_filter_case_sensitive"></a>
+
+### `is_filter_case_sensitive`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_filter_case_sensitive() -> bool:
+```
+
+查询文本过滤是否区分大小写。
+
+返回：区分大小写时返回 true。
+
+<a id="member-gftabledataview-methods-set_selection_model"></a>
+
+### `set_selection_model`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_selection_model(model: GFTableSelectionModel) -> GFTableViewRebuildResult:
+```
+
+事务式替换该视图使用的选择模型。 新模型只会在完整候选投影成功后成为权威选择模型，并在提交态中按当前行 ID 修剪。 失败时不会修改旧模型、新模型、投影或 revision。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `model` | 非空选择模型。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-get_selection_model"></a>
+
+### `get_selection_model`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_selection_model() -> GFTableSelectionModel:
+```
+
+获取该视图使用的选择模型。
+
+返回：当前非空选择模型。
 
 <a id="member-gftabledataview-methods-set_columns"></a>
 
@@ -219,7 +336,7 @@ var selection_model: GFTableSelectionModel = GFTableSelectionModel.new()
 - 首次版本：`5.2.0`
 
 ```gdscript
-func set_columns(column_definitions: Array[GFTableColumnDefinition]) -> void:
+func set_columns( column_definitions: Array[GFTableColumnDefinition] ) -> GFTableViewRebuildResult:
 ```
 
 设置列定义列表。
@@ -229,6 +346,8 @@ func set_columns(column_definitions: Array[GFTableColumnDefinition]) -> void:
 | 名称 | 说明 |
 |---|---|
 | `column_definitions` | 列定义列表；null 项会被忽略。 |
+
+返回：类型化投影重建结果；失败时保留原列与 prior projection。
 
 结构：
 
@@ -303,7 +422,7 @@ func get_column(column_id: StringName) -> GFTableColumnDefinition:
 - 首次版本：`5.2.0`
 
 ```gdscript
-func set_rows(row_values: Array, duplicate_rows: bool = false) -> void:
+func set_rows( row_values: Array, duplicate_rows: bool = false ) -> GFTableViewRebuildResult:
 ```
 
 设置源行数据。
@@ -314,6 +433,8 @@ func set_rows(row_values: Array, duplicate_rows: bool = false) -> void:
 |---|---|
 | `row_values` | 行数据列表。 |
 | `duplicate_rows` | 是否复制 Dictionary / Array 行数据。 |
+
+返回：类型化投影重建结果；失败时保留原 source、projection 与 selection。
 
 结构：
 
@@ -591,7 +712,7 @@ func get_visible_row_ids() -> Array:
 - 首次版本：`5.2.0`
 
 ```gdscript
-func set_filter_query(query: String) -> void:
+func set_filter_query(query: String) -> GFTableViewRebuildResult:
 ```
 
 设置过滤文本。
@@ -601,6 +722,8 @@ func set_filter_query(query: String) -> void:
 | 名称 | 说明 |
 |---|---|
 | `query` | 过滤文本；空字符串显示全部行。 |
+
+返回：类型化投影重建结果；失败时保留旧 query 与 prior projection。
 
 <a id="member-gftabledataview-methods-get_filter_query"></a>
 
@@ -616,6 +739,202 @@ func get_filter_query() -> String:
 获取当前过滤文本。
 
 返回：过滤文本。
+
+<a id="member-gftabledataview-methods-set_row_predicates"></a>
+
+### `set_row_predicates`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_row_predicates( registrations: Array[GFTableRowPredicateRegistration] ) -> GFTableViewRebuildResult:
+```
+
+事务式替换全部命名行谓词。 注册会先完整校验并按 order 升序、predicate_id 字典序排序，再构建一个候选投影。 GFTableDataView 保存 predicate_id、order、enabled 与 predicate 引用的框架自有 metadata 快照；调用方后续修改注册对象不会改变已提交 registry。 任一失败都会保留当前 registry、projection、revision 与 selection。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `registrations` | 谓词注册定义；提交时复制 metadata。 |
+
+返回：类型化投影重建结果。
+
+结构：
+
+- `registrations`: Array of GFTableRowPredicateRegistration values.
+
+<a id="member-gftabledataview-methods-register_row_predicate"></a>
+
+### `register_row_predicate`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func register_row_predicate( registration: GFTableRowPredicateRegistration ) -> GFTableViewRebuildResult:
+```
+
+事务式注册一个命名行谓词。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `registration` | 谓词注册定义；提交时复制 metadata。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-unregister_row_predicate"></a>
+
+### `unregister_row_predicate`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unregister_row_predicate(predicate_id: StringName) -> GFTableViewRebuildResult:
+```
+
+事务式移除一个命名行谓词。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `predicate_id` | 要移除的稳定谓词 ID。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-set_row_predicate_enabled"></a>
+
+### `set_row_predicate_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_row_predicate_enabled( predicate_id: StringName, enabled: bool ) -> GFTableViewRebuildResult:
+```
+
+事务式设置命名行谓词的启用状态。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `predicate_id` | 稳定谓词 ID。 |
+| `enabled` | 是否参与候选投影。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-set_row_predicate_order"></a>
+
+### `set_row_predicate_order`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_row_predicate_order( predicate_id: StringName, order: int ) -> GFTableViewRebuildResult:
+```
+
+事务式设置命名行谓词的执行顺序。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `predicate_id` | 稳定谓词 ID。 |
+| `order` | 新顺序；数值越小越早执行。 |
+
+返回：类型化投影重建结果。
+
+<a id="member-gftabledataview-methods-get_row_predicate"></a>
+
+### `get_row_predicate`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_row_predicate(predicate_id: StringName) -> GFTableRowPredicateRegistration:
+```
+
+获取一个命名行谓词注册值。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `predicate_id` | 稳定谓词 ID。 |
+
+返回：独立 metadata 快照；predicate 协议实例保持同一引用，不存在时返回 null。
+
+<a id="member-gftabledataview-methods-get_row_predicates"></a>
+
+### `get_row_predicates`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_row_predicates() -> Array[GFTableRowPredicateRegistration]:
+```
+
+获取按确定顺序排列的命名行谓词注册值。
+
+返回：独立 metadata 快照数组；predicate 协议实例保持同一引用。
+
+结构：
+
+- `return`: Array of GFTableRowPredicateRegistration values.
+
+<a id="member-gftabledataview-methods-get_row_predicate_ids"></a>
+
+### `get_row_predicate_ids`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_row_predicate_ids() -> Array[StringName]:
+```
+
+获取按确定顺序排列的命名行谓词 ID。
+
+返回：稳定谓词 ID 数组。
+
+<a id="member-gftabledataview-methods-get_view_revision"></a>
+
+### `get_view_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_view_revision() -> int:
+```
+
+获取当前已提交投影 revision。
+
+返回：单调递增 revision。
+
+<a id="member-gftabledataview-methods-get_last_view_rebuild_result"></a>
+
+### `get_last_view_rebuild_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_last_view_rebuild_result() -> GFTableViewRebuildResult:
+```
+
+获取最近一次投影事务结果。
+
+返回：最近结果的隔离副本；尚未执行时返回 revision 0 的成功 no-op。
 
 <a id="member-gftabledataview-methods-sort_by_column"></a>
 
@@ -692,10 +1011,12 @@ func is_sort_ascending() -> bool:
 - 首次版本：`5.2.0`
 
 ```gdscript
-func refresh_view() -> void:
+func refresh_view() -> GFTableViewRebuildResult:
 ```
 
 重新构建可见行索引。
+
+返回：类型化投影重建结果；失败时保留 prior projection。
 
 <a id="member-gftabledataview-methods-get_cell_value"></a>
 
@@ -734,7 +1055,7 @@ func get_cell_value(row_index: int, column_id: StringName) -> Variant:
 func commit_cell_value(row_index: int, column_id: StringName, new_value: Variant) -> bool:
 ```
 
-提交源行单元格值。
+事务式提交源行单元格值。 写入先发生在隔离候选行上，完整投影成功后才交换权威 source；自定义 value_setter 与不可隔离的 Object / 脚本 Resource 会在调用任何 setter 前失败关闭。
 
 参数：
 
@@ -761,7 +1082,7 @@ func commit_cell_value(row_index: int, column_id: StringName, new_value: Variant
 func commit_visible_cell_value( visible_row_index: int, column_id: StringName, new_value: Variant ) -> bool:
 ```
 
-提交可见行单元格值。
+事务式提交可见行单元格值。 写入先发生在隔离候选行上，完整投影成功后才交换权威 source；自定义 value_setter 与不可隔离的 Object / 脚本 Resource 会在调用任何 setter 前失败关闭。
 
 参数：
 
@@ -788,7 +1109,7 @@ func commit_visible_cell_value( visible_row_index: int, column_id: StringName, n
 func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ```
 
-批量提交源行单元格值。 该方法会先处理所有变更，再在有实际写入时统一刷新视图并发送单元格提交信号； 它不是事务，部分失败不会回滚已成功的变更。
+批量提交源行单元格值。 该方法先在隔离候选 rows 上完成全部写入与投影，成功后统一交换并发送信号。 任一输入、隔离、写入或投影失败都会回滚整批候选变更。
 
 参数：
 
@@ -814,7 +1135,7 @@ func commit_cell_values(changes: Array[Dictionary]) -> Dictionary:
 func commit_visible_cell_values(changes: Array[Dictionary]) -> Dictionary:
 ```
 
-批量提交可见行单元格值。 可见行索引会在任何写入发生前解析为源行索引，避免排序或过滤重建导致同一批变更漂移。 该方法不是事务，部分失败不会回滚已成功的变更。
+批量提交可见行单元格值。 可见行索引会在任何写入发生前解析为源行索引，避免排序或过滤重建导致同一批变更漂移。 任一输入、隔离、写入或投影失败都会回滚整批候选变更。
 
 参数：
 
@@ -905,7 +1226,7 @@ func describe_view(options: Dictionary = {}) -> Dictionary:
 结构：
 
 - `options`: Dictionary，可包含 visible_only: bool、include_values: bool、include_columns: bool、include_hidden_columns: bool、include_row_data: bool、copy_values: bool。
-- `return`: Dictionary，包含 row_count、visible_count、column_count、filter_query、sort_column_id、sort_ascending、visible_only、columns 和 rows。
+- `return`: Dictionary，包含 view_revision、row_count、visible_count、column_count、predicate_count、filter_query、sort_column_id、sort_ascending、visible_only、columns 和 rows。
 
 <a id="member-gftabledataview-methods-prune_selection"></a>
 
@@ -945,4 +1266,4 @@ func get_debug_snapshot() -> Dictionary:
 
 结构：
 
-- `return`: Dictionary，包含 row_count、visible_count、column_count、filter_query、sort_column_id 和 sort_ascending。
+- `return`: Dictionary，包含 view_revision、row_count、visible_count、column_count、predicate_count、enabled_predicate_count、filter_query、sort_column_id、sort_ascending、last_rebuild_ok 和 last_rebuild_error_code。

--- a/docs/zh/reference/api/classes/GFTableRowPredicate.md
+++ b/docs/zh/reference/api/classes/GFTableRowPredicate.md
@@ -1,0 +1,63 @@
+# GFTableRowPredicate
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_table_row_predicate.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：协议与扩展点 (`protocol`)
+- 首次版本：`unreleased`
+
+表格结构化行过滤协议。 项目通过子类实现同步、只读、有界且无副作用的行判断。 GFTableDataView 按注册顺序契约组合多个谓词，并把显式失败视为整次投影失败。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`evaluate`](#member-gftablerowpredicate-methods-evaluate) | `func evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:` |
+| 方法 | [`_evaluate`](#member-gftablerowpredicate-methods-_evaluate) | `func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:` |
+
+## 方法
+
+<a id="member-gftablerowpredicate-methods-evaluate"></a>
+
+### `evaluate`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+```
+
+求值一个隔离行视图。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `row_view` | 不暴露源 row 的隔离只读视图。 |
+
+返回：类型化包含、排除或失败结果。
+
+<a id="member-gftablerowpredicate-methods-_evaluate"></a>
+
+### `_evaluate`
+
+- API：`protected`
+- 首次版本：`unreleased`
+
+```gdscript
+func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+```
+
+实现一次同步、只读且有界的行判断。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `_row_view` | 当前行的隔离只读视图。 |
+
+返回：类型化包含、排除或失败结果。

--- a/docs/zh/reference/api/classes/GFTableRowPredicateRegistration.md
+++ b/docs/zh/reference/api/classes/GFTableRowPredicateRegistration.md
@@ -1,0 +1,128 @@
+# GFTableRowPredicateRegistration
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+命名行谓词的注册定义值。 把项目谓词与稳定 ID、启用状态和显式顺序组合成一次注册定义。 GFTableDataView 会复制数组并以 order 升序、predicate_id 字典序稳定执行。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`create`](#member-gftablerowpredicateregistration-methods-create) | `static func create( predicate_id: StringName, predicate: GFTableRowPredicate, order: int = 0, enabled: bool = true ) -> GFTableRowPredicateRegistration:` |
+| 方法 | [`get_predicate_id`](#member-gftablerowpredicateregistration-methods-get_predicate_id) | `func get_predicate_id() -> StringName:` |
+| 方法 | [`get_predicate`](#member-gftablerowpredicateregistration-methods-get_predicate) | `func get_predicate() -> GFTableRowPredicate:` |
+| 方法 | [`get_order`](#member-gftablerowpredicateregistration-methods-get_order) | `func get_order() -> int:` |
+| 方法 | [`is_enabled`](#member-gftablerowpredicateregistration-methods-is_enabled) | `func is_enabled() -> bool:` |
+| 方法 | [`validate_registration`](#member-gftablerowpredicateregistration-methods-validate_registration) | `func validate_registration() -> Dictionary:` |
+
+## 方法
+
+<a id="member-gftablerowpredicateregistration-methods-create"></a>
+
+### `create`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func create( predicate_id: StringName, predicate: GFTableRowPredicate, order: int = 0, enabled: bool = true ) -> GFTableRowPredicateRegistration:
+```
+
+创建注册定义值。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `predicate_id` | 非空、无首尾空白且 UTF-8 编码不超过 128 字节的稳定 ID。 |
+| `predicate` | 项目提供的类型化行谓词。 |
+| `order` | 执行顺序；数值越小越早执行。 |
+| `enabled` | 是否参与投影。 |
+
+返回：新的注册值；调用方仍应检查 validate_registration()。
+
+<a id="member-gftablerowpredicateregistration-methods-get_predicate_id"></a>
+
+### `get_predicate_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_predicate_id() -> StringName:
+```
+
+获取稳定谓词 ID。
+
+返回：稳定谓词 ID。
+
+<a id="member-gftablerowpredicateregistration-methods-get_predicate"></a>
+
+### `get_predicate`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_predicate() -> GFTableRowPredicate:
+```
+
+获取类型化谓词。
+
+返回：注册的谓词。
+
+<a id="member-gftablerowpredicateregistration-methods-get_order"></a>
+
+### `get_order`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_order() -> int:
+```
+
+获取显式执行顺序。
+
+返回：order；数值越小越早执行。
+
+<a id="member-gftablerowpredicateregistration-methods-is_enabled"></a>
+
+### `is_enabled`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_enabled() -> bool:
+```
+
+查询注册是否启用。
+
+返回：启用时返回 true。
+
+<a id="member-gftablerowpredicateregistration-methods-validate_registration"></a>
+
+### `validate_registration`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func validate_registration() -> Dictionary:
+```
+
+校验注册定义。
+
+返回：GFValidationReportDictionary 兼容报告。
+
+结构：
+
+- `return`: Dictionary with ok, issues, counts, summary, and next_actions.

--- a/docs/zh/reference/api/classes/GFTableRowPredicateResult.md
+++ b/docs/zh/reference/api/classes/GFTableRowPredicateResult.md
@@ -1,0 +1,138 @@
+# GFTableRowPredicateResult
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+类型化行谓词求值结果。 成功结果明确表示包含或排除当前行；失败结果携带稳定错误码和有界说明， 供 GFTableDataView 中止候选投影并保留上一份已提交视图。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`included`](#member-gftablerowpredicateresult-methods-included) | `static func included() -> GFTableRowPredicateResult:` |
+| 方法 | [`excluded`](#member-gftablerowpredicateresult-methods-excluded) | `static func excluded() -> GFTableRowPredicateResult:` |
+| 方法 | [`failed`](#member-gftablerowpredicateresult-methods-failed) | `static func failed( error_code: StringName, error_message: String = "" ) -> GFTableRowPredicateResult:` |
+| 方法 | [`is_successful`](#member-gftablerowpredicateresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`should_include`](#member-gftablerowpredicateresult-methods-should_include) | `func should_include() -> bool:` |
+| 方法 | [`get_error_code`](#member-gftablerowpredicateresult-methods-get_error_code) | `func get_error_code() -> StringName:` |
+| 方法 | [`get_error_message`](#member-gftablerowpredicateresult-methods-get_error_message) | `func get_error_message() -> String:` |
+
+## 方法
+
+<a id="member-gftablerowpredicateresult-methods-included"></a>
+
+### `included`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func included() -> GFTableRowPredicateResult:
+```
+
+创建包含当前行的成功结果。
+
+返回：新的包含结果。
+
+<a id="member-gftablerowpredicateresult-methods-excluded"></a>
+
+### `excluded`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func excluded() -> GFTableRowPredicateResult:
+```
+
+创建排除当前行的成功结果。
+
+返回：新的排除结果。
+
+<a id="member-gftablerowpredicateresult-methods-failed"></a>
+
+### `failed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+static func failed( error_code: StringName, error_message: String = "" ) -> GFTableRowPredicateResult:
+```
+
+创建求值失败结果。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `error_code` | 非空、无首尾空白且 UTF-8 编码不超过 128 字节的稳定错误码。 |
+| `error_message` | 面向维护者的失败说明；最多保留 1024 个 UTF-8 字节。 |
+
+返回：新的失败结果。
+
+<a id="member-gftablerowpredicateresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+查询求值是否成功。
+
+返回：成功时返回 true。
+
+<a id="member-gftablerowpredicateresult-methods-should_include"></a>
+
+### `should_include`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func should_include() -> bool:
+```
+
+查询成功结果是否包含当前行。
+
+返回：成功且应包含当前行时返回 true。
+
+<a id="member-gftablerowpredicateresult-methods-get_error_code"></a>
+
+### `get_error_code`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_code() -> StringName:
+```
+
+获取稳定错误码。
+
+返回：失败错误码；成功时为空。
+
+<a id="member-gftablerowpredicateresult-methods-get_error_message"></a>
+
+### `get_error_message`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_message() -> String:
+```
+
+获取有界错误说明。
+
+返回：失败说明；成功时为空。

--- a/docs/zh/reference/api/classes/GFTableRowView.md
+++ b/docs/zh/reference/api/classes/GFTableRowView.md
@@ -1,0 +1,125 @@
+# GFTableRowView
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_table_row_view.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+表格行谓词使用的隔离只读视图。 只公开稳定行 ID、源索引和已配置列的复制值，不公开源行容器。 项目谓词可以读取隐藏列，但不能通过该视图修改权威表格数据。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`get_row_id`](#member-gftablerowview-methods-get_row_id) | `func get_row_id() -> Variant:` |
+| 方法 | [`get_source_row_index`](#member-gftablerowview-methods-get_source_row_index) | `func get_source_row_index() -> int:` |
+| 方法 | [`has_value`](#member-gftablerowview-methods-has_value) | `func has_value(column_id: StringName) -> bool:` |
+| 方法 | [`get_value`](#member-gftablerowview-methods-get_value) | `func get_value(column_id: StringName, default_value: Variant = null) -> Variant:` |
+| 方法 | [`get_values`](#member-gftablerowview-methods-get_values) | `func get_values() -> Dictionary:` |
+
+## 方法
+
+<a id="member-gftablerowview-methods-get_row_id"></a>
+
+### `get_row_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_row_id() -> Variant:
+```
+
+获取稳定行 ID 副本。
+
+返回：稳定行 ID 副本。
+
+结构：
+
+- `return`: Variant stable row identity copy.
+
+<a id="member-gftablerowview-methods-get_source_row_index"></a>
+
+### `get_source_row_index`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_row_index() -> int:
+```
+
+获取源行索引。
+
+返回：构建该视图时的源行索引。
+
+<a id="member-gftablerowview-methods-has_value"></a>
+
+### `has_value`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func has_value(column_id: StringName) -> bool:
+```
+
+判断是否包含指定列值。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `column_id` | 稳定列 ID。 |
+
+返回：存在列值时返回 true。
+
+<a id="member-gftablerowview-methods-get_value"></a>
+
+### `get_value`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_value(column_id: StringName, default_value: Variant = null) -> Variant:
+```
+
+获取指定列的隔离值副本。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `column_id` | 稳定列 ID。 |
+| `default_value` | 列不存在时返回的默认值。 |
+
+返回：列值或默认值的副本。
+
+结构：
+
+- `default_value`: Variant fallback copied before return.
+- `return`: Variant isolated column value copy.
+
+<a id="member-gftablerowview-methods-get_values"></a>
+
+### `get_values`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_values() -> Dictionary:
+```
+
+获取全部列值副本。
+
+返回：以列 ID 为键的隔离值副本。
+
+结构：
+
+- `return`: Dictionary keyed by StringName column IDs with copied Variant values.

--- a/docs/zh/reference/api/classes/GFTableSelectionModel.md
+++ b/docs/zh/reference/api/classes/GFTableSelectionModel.md
@@ -24,6 +24,7 @@
 | 方法 | [`toggle_selected`](#member-gftableselectionmodel-methods-toggle_selected) | `func toggle_selected(row_id: Variant) -> bool:` |
 | 方法 | [`select_single`](#member-gftableselectionmodel-methods-select_single) | `func select_single(row_id: Variant) -> bool:` |
 | 方法 | [`replace_selection`](#member-gftableselectionmodel-methods-replace_selection) | `func replace_selection(row_ids: Array) -> bool:` |
+| 方法 | [`replace_selection_with_anchor`](#member-gftableselectionmodel-methods-replace_selection_with_anchor) | `func replace_selection_with_anchor( row_ids: Array, selection_anchor: Variant ) -> bool:` |
 | 方法 | [`select_range`](#member-gftableselectionmodel-methods-select_range) | `func select_range( ordered_row_ids: Array, from_row_id: Variant, to_row_id: Variant, additive: bool = false ) -> bool:` |
 | 方法 | [`prune_to_row_ids`](#member-gftableselectionmodel-methods-prune_to_row_ids) | `func prune_to_row_ids(row_ids: Array) -> bool:` |
 | 方法 | [`is_selected`](#member-gftableselectionmodel-methods-is_selected) | `func is_selected(row_id: Variant) -> bool:` |
@@ -226,6 +227,33 @@ func replace_selection(row_ids: Array) -> bool:
 结构：
 
 - `row_ids`: Array，调用方提供的稳定行 ID。
+
+<a id="member-gftableselectionmodel-methods-replace_selection_with_anchor"></a>
+
+### `replace_selection_with_anchor`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func replace_selection_with_anchor( row_ids: Array, selection_anchor: Variant ) -> bool:
+```
+
+用一组行 ID 与显式锚点原子替换当前选择。 选择集合和锚点会在发出 selection_changed 前同时完成更新；锚点不在最终选择中时归一为空。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `row_ids` | 稳定行 ID 列表。 |
+| `selection_anchor` | 最终范围选择锚点；null 表示没有锚点。 |
+
+返回：选择集合或锚点发生变化时返回 true。
+
+结构：
+
+- `row_ids`: Array，调用方提供的稳定行 ID。
+- `selection_anchor`: Variant，最终选择中的稳定行 ID，或 null。
 
 <a id="member-gftableselectionmodel-methods-select_range"></a>
 

--- a/docs/zh/reference/api/classes/GFTableViewRebuildResult.md
+++ b/docs/zh/reference/api/classes/GFTableViewRebuildResult.md
@@ -1,0 +1,215 @@
+# GFTableViewRebuildResult
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+表格投影事务的类型化结果。 成功结果描述一次提交或 no-op；失败结果描述未提交的阶段、谓词和行身份。 结果不携带源 row，从而可安全交给 UI 诊断层。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`is_successful`](#member-gftableviewrebuildresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`was_committed`](#member-gftableviewrebuildresult-methods-was_committed) | `func was_committed() -> bool:` |
+| 方法 | [`get_view_revision`](#member-gftableviewrebuildresult-methods-get_view_revision) | `func get_view_revision() -> int:` |
+| 方法 | [`get_visible_count`](#member-gftableviewrebuildresult-methods-get_visible_count) | `func get_visible_count() -> int:` |
+| 方法 | [`get_scanned_row_count`](#member-gftableviewrebuildresult-methods-get_scanned_row_count) | `func get_scanned_row_count() -> int:` |
+| 方法 | [`get_predicate_evaluation_count`](#member-gftableviewrebuildresult-methods-get_predicate_evaluation_count) | `func get_predicate_evaluation_count() -> int:` |
+| 方法 | [`get_error_code`](#member-gftableviewrebuildresult-methods-get_error_code) | `func get_error_code() -> StringName:` |
+| 方法 | [`get_error_message`](#member-gftableviewrebuildresult-methods-get_error_message) | `func get_error_message() -> String:` |
+| 方法 | [`get_failed_predicate_id`](#member-gftableviewrebuildresult-methods-get_failed_predicate_id) | `func get_failed_predicate_id() -> StringName:` |
+| 方法 | [`get_failed_source_row_index`](#member-gftableviewrebuildresult-methods-get_failed_source_row_index) | `func get_failed_source_row_index() -> int:` |
+| 方法 | [`get_failed_row_id`](#member-gftableviewrebuildresult-methods-get_failed_row_id) | `func get_failed_row_id() -> Variant:` |
+| 方法 | [`duplicate_result`](#member-gftableviewrebuildresult-methods-duplicate_result) | `func duplicate_result() -> GFTableViewRebuildResult:` |
+
+## 方法
+
+<a id="member-gftableviewrebuildresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+查询事务是否成功。
+
+返回：成功时返回 true。
+
+<a id="member-gftableviewrebuildresult-methods-was_committed"></a>
+
+### `was_committed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func was_committed() -> bool:
+```
+
+查询事务是否提交了新 revision。
+
+返回：提交时返回 true；成功 no-op 返回 false。
+
+<a id="member-gftableviewrebuildresult-methods-get_view_revision"></a>
+
+### `get_view_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_view_revision() -> int:
+```
+
+获取结果对应的已提交 revision。
+
+返回：当前已提交 revision。
+
+<a id="member-gftableviewrebuildresult-methods-get_visible_count"></a>
+
+### `get_visible_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_visible_count() -> int:
+```
+
+获取当前已提交可见行数量。
+
+返回：可见行数量。
+
+<a id="member-gftableviewrebuildresult-methods-get_scanned_row_count"></a>
+
+### `get_scanned_row_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_scanned_row_count() -> int:
+```
+
+获取本次候选扫描的源行数量。
+
+返回：已扫描行数量。
+
+<a id="member-gftableviewrebuildresult-methods-get_predicate_evaluation_count"></a>
+
+### `get_predicate_evaluation_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_predicate_evaluation_count() -> int:
+```
+
+获取本次候选执行的谓词次数。
+
+返回：谓词求值次数。
+
+<a id="member-gftableviewrebuildresult-methods-get_error_code"></a>
+
+### `get_error_code`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_code() -> StringName:
+```
+
+获取稳定错误码。
+
+返回：失败错误码；成功时为空。
+
+<a id="member-gftableviewrebuildresult-methods-get_error_message"></a>
+
+### `get_error_message`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_message() -> String:
+```
+
+获取有界错误说明。
+
+返回：失败说明；成功时为空。
+
+<a id="member-gftableviewrebuildresult-methods-get_failed_predicate_id"></a>
+
+### `get_failed_predicate_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_failed_predicate_id() -> StringName:
+```
+
+获取失败谓词 ID。
+
+返回：失败谓词 ID；非谓词失败时为空。
+
+<a id="member-gftableviewrebuildresult-methods-get_failed_source_row_index"></a>
+
+### `get_failed_source_row_index`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_failed_source_row_index() -> int:
+```
+
+获取失败源行索引。
+
+返回：失败行索引；非行失败时为 -1。
+
+<a id="member-gftableviewrebuildresult-methods-get_failed_row_id"></a>
+
+### `get_failed_row_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_failed_row_id() -> Variant:
+```
+
+获取失败行 ID 副本。
+
+返回：失败行 ID；非行失败时为 null。
+
+结构：
+
+- `return`: Variant stable row identity copy, or null.
+
+<a id="member-gftableviewrebuildresult-methods-duplicate_result"></a>
+
+### `duplicate_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_result() -> GFTableViewRebuildResult:
+```
+
+创建结果的隔离副本。
+
+返回：新结果对象；未配置实例返回新的未配置实例。

--- a/docs/zh/reference/api/classes/GFVirtualListBinder.md
+++ b/docs/zh/reference/api/classes/GFVirtualListBinder.md
@@ -1,0 +1,515 @@
+# GFVirtualListBinder
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+owner-bound 虚拟列表 Control 物化与回收协调器。 连接项目提供的 `ScrollContainer`、绝对布局 content root、`GFVirtualListModel` 与行回调，只物化真实视口及 overscan 范围。项目继续拥有条目数据、稳定 ID、 行视觉、选择、激活、输入和无障碍语义；Binder 拥有 factory 成功交付的 Control， 并在 unbind、任一绑定节点退出或 dispose 时确定性解除回调和节点引用。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 信号 | [`sync_completed`](#member-gfvirtuallistbinder-signals-sync_completed) | `signal sync_completed(result: GFVirtualListSyncResult)` |
+| 枚举 | [`LayoutAxis`](#member-gfvirtuallistbinder-enums-layoutaxis) | `enum LayoutAxis` |
+| 枚举 | [`ScrollAlignment`](#member-gfvirtuallistbinder-enums-scrollalignment) | `enum ScrollAlignment` |
+| 常量 | [`DEFAULT_MAX_MATERIALIZED_ITEMS`](#member-gfvirtuallistbinder-constants-default_max_materialized_items) | `const DEFAULT_MAX_MATERIALIZED_ITEMS: int = 512` |
+| 常量 | [`DEFAULT_MAX_POOLED_ITEMS`](#member-gfvirtuallistbinder-constants-default_max_pooled_items) | `const DEFAULT_MAX_POOLED_ITEMS: int = 64` |
+| 常量 | [`ABSOLUTE_MAX_MATERIALIZED_ITEMS`](#member-gfvirtuallistbinder-constants-absolute_max_materialized_items) | `const ABSOLUTE_MAX_MATERIALIZED_ITEMS: int = 4096` |
+| 常量 | [`ABSOLUTE_MAX_POOLED_ITEMS`](#member-gfvirtuallistbinder-constants-absolute_max_pooled_items) | `const ABSOLUTE_MAX_POOLED_ITEMS: int = 1024` |
+| 常量 | [`ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH`](#member-gfvirtuallistbinder-constants-absolute_max_identity_token_length) | `const ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH: int = 1024` |
+| 属性 | [`layout_axis`](#member-gfvirtuallistbinder-properties-layout_axis) | `var layout_axis: LayoutAxis = LayoutAxis.VERTICAL:` |
+| 属性 | [`max_materialized_items`](#member-gfvirtuallistbinder-properties-max_materialized_items) | `var max_materialized_items: int = DEFAULT_MAX_MATERIALIZED_ITEMS:` |
+| 属性 | [`max_pooled_items`](#member-gfvirtuallistbinder-properties-max_pooled_items) | `var max_pooled_items: int = DEFAULT_MAX_POOLED_ITEMS:` |
+| 属性 | [`auto_measure`](#member-gfvirtuallistbinder-properties-auto_measure) | `var auto_measure: bool = true` |
+| 属性 | [`auto_reveal_focus`](#member-gfvirtuallistbinder-properties-auto_reveal_focus) | `var auto_reveal_focus: bool = true` |
+| 属性 | [`fill_cross_axis`](#member-gfvirtuallistbinder-properties-fill_cross_axis) | `var fill_cross_axis: bool = true` |
+| 方法 | [`bind`](#member-gfvirtuallistbinder-methods-bind) | `func bind( owner: Node, scroll_container: ScrollContainer, content_root: Control, layout_model: GFVirtualListModel, item_factory: Callable, bind_callback: Callable, unbind_callback: Callable, identity_callback: Callable, focus_model: GFVirtualListFocusModel = null, measure_callback: Callable = Callable(), focus_target_callback: Callable = Callable() ) -> bool:` |
+| 方法 | [`request_sync`](#member-gfvirtuallistbinder-methods-request_sync) | `func request_sync() -> bool:` |
+| 方法 | [`sync_now`](#member-gfvirtuallistbinder-methods-sync_now) | `func sync_now() -> GFVirtualListSyncResult:` |
+| 方法 | [`invalidate_items`](#member-gfvirtuallistbinder-methods-invalidate_items) | `func invalidate_items() -> bool:` |
+| 方法 | [`request_measurement`](#member-gfvirtuallistbinder-methods-request_measurement) | `func request_measurement() -> bool:` |
+| 方法 | [`scroll_to_item`](#member-gfvirtuallistbinder-methods-scroll_to_item) | `func scroll_to_item( item_index: int, alignment: ScrollAlignment = ScrollAlignment.NEAREST ) -> bool:` |
+| 方法 | [`get_materialized_control`](#member-gfvirtuallistbinder-methods-get_materialized_control) | `func get_materialized_control(item_index: int) -> Control:` |
+| 方法 | [`get_materialized_control_by_id`](#member-gfvirtuallistbinder-methods-get_materialized_control_by_id) | `func get_materialized_control_by_id(item_id: Variant) -> Control:` |
+| 方法 | [`get_last_sync_result`](#member-gfvirtuallistbinder-methods-get_last_sync_result) | `func get_last_sync_result() -> GFVirtualListSyncResult:` |
+| 方法 | [`get_debug_snapshot`](#member-gfvirtuallistbinder-methods-get_debug_snapshot) | `func get_debug_snapshot() -> Dictionary:` |
+| 方法 | [`is_bound`](#member-gfvirtuallistbinder-methods-is_bound) | `func is_bound() -> bool:` |
+| 方法 | [`is_disposed`](#member-gfvirtuallistbinder-methods-is_disposed) | `func is_disposed() -> bool:` |
+| 方法 | [`unbind`](#member-gfvirtuallistbinder-methods-unbind) | `func unbind() -> void:` |
+| 方法 | [`dispose`](#member-gfvirtuallistbinder-methods-dispose) | `func dispose() -> void:` |
+
+## 信号
+
+<a id="member-gfvirtuallistbinder-signals-sync_completed"></a>
+
+### `sync_completed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal sync_completed(result: GFVirtualListSyncResult)
+```
+
+一轮同步完成后发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `result` | 不含项目条目载荷的 typed 同步结果。 |
+
+## 枚举
+
+<a id="member-gfvirtuallistbinder-enums-layoutaxis"></a>
+
+### `LayoutAxis`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum LayoutAxis {
+	## 以 Y 轴和垂直滚动条组织条目。
+	VERTICAL,
+	## 以 X 轴和水平滚动条组织条目。
+	HORIZONTAL,
+}
+```
+
+列表滚动和尺寸测量使用的主轴。
+
+<a id="member-gfvirtuallistbinder-enums-scrollalignment"></a>
+
+### `ScrollAlignment`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum ScrollAlignment {
+	## 已可见时不滚动，否则移动到最近边界。
+	NEAREST,
+	## 条目起点对齐视口起点。
+	START,
+	## 条目中心对齐视口中心。
+	CENTER,
+	## 条目终点对齐视口终点。
+	END,
+}
+```
+
+把条目滚入视口时使用的对齐方式。
+
+## 常量
+
+<a id="member-gfvirtuallistbinder-constants-default_max_materialized_items"></a>
+
+### `DEFAULT_MAX_MATERIALIZED_ITEMS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DEFAULT_MAX_MATERIALIZED_ITEMS: int = 512
+```
+
+默认活动 Control 硬上限。
+
+<a id="member-gfvirtuallistbinder-constants-default_max_pooled_items"></a>
+
+### `DEFAULT_MAX_POOLED_ITEMS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const DEFAULT_MAX_POOLED_ITEMS: int = 64
+```
+
+默认 parentless pool Control 上限。
+
+<a id="member-gfvirtuallistbinder-constants-absolute_max_materialized_items"></a>
+
+### `ABSOLUTE_MAX_MATERIALIZED_ITEMS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ABSOLUTE_MAX_MATERIALIZED_ITEMS: int = 4096
+```
+
+活动物化 Control 的框架级绝对硬上限。
+
+<a id="member-gfvirtuallistbinder-constants-absolute_max_pooled_items"></a>
+
+### `ABSOLUTE_MAX_POOLED_ITEMS`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ABSOLUTE_MAX_POOLED_ITEMS: int = 1024
+```
+
+parentless pool 的框架级绝对硬上限。
+
+<a id="member-gfvirtuallistbinder-constants-absolute_max_identity_token_length"></a>
+
+### `ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH: int = 1024
+```
+
+稳定 identity token 允许的最大 UTF-8 字节数。
+
+## 属性
+
+<a id="member-gfvirtuallistbinder-properties-layout_axis"></a>
+
+### `layout_axis`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var layout_axis: LayoutAxis = LayoutAxis.VERTICAL:
+```
+
+布局主轴。只接受 VERTICAL/HORIZONTAL；绑定期间修改后调用 request_sync() 使其生效。 同步 callback 内修改时，当前轮继续使用入口快照，下一轮才采用新值。
+
+<a id="member-gfvirtuallistbinder-properties-max_materialized_items"></a>
+
+### `max_materialized_items`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var max_materialized_items: int = DEFAULT_MAX_MATERIALIZED_ITEMS:
+```
+
+活动物化 Control 硬上限；运行时按至少 1 处理。
+
+<a id="member-gfvirtuallistbinder-properties-max_pooled_items"></a>
+
+### `max_pooled_items`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var max_pooled_items: int = DEFAULT_MAX_POOLED_ITEMS:
+```
+
+parentless pool 最多保留的 Control 数量；小于 0 时按 0 处理。 同步事务内收紧预算时，会在候选提交或回滚完成后统一裁剪。
+
+<a id="member-gfvirtuallistbinder-properties-auto_measure"></a>
+
+### `auto_measure`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var auto_measure: bool = true
+```
+
+是否在新绑定或数据失效后自动测量活动行；不影响显式 request_measurement()。
+
+<a id="member-gfvirtuallistbinder-properties-auto_reveal_focus"></a>
+
+### `auto_reveal_focus`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var auto_reveal_focus: bool = true
+```
+
+虚拟焦点变化后是否按最近边界自动滚入视口。
+
+<a id="member-gfvirtuallistbinder-properties-fill_cross_axis"></a>
+
+### `fill_cross_axis`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var fill_cross_axis: bool = true
+```
+
+是否让行 Control 填满 content root 的交叉轴。 同步 callback 内修改时，当前轮继续使用入口快照，下一轮才采用新值。
+
+## 方法
+
+<a id="member-gfvirtuallistbinder-methods-bind"></a>
+
+### `bind`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func bind( owner: Node, scroll_container: ScrollContainer, content_root: Control, layout_model: GFVirtualListModel, item_factory: Callable, bind_callback: Callable, unbind_callback: Callable, identity_callback: Callable, focus_model: GFVirtualListFocusModel = null, measure_callback: Callable = Callable(), focus_target_callback: Callable = Callable() ) -> bool:
+```
+
+建立一个 owner-bound 虚拟列表绑定。 `content_root` 必须是 ScrollContainer 的直接子 Control，且不能是会接管子节点位置的 Container。factory 返回的 Control 必须 parentless；返回后其所有权转交 Binder。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `owner` | 生命周期 owner；退出 SceneTree 后 Binder 自动 dispose。 |
+| `scroll_container` | 项目持有的滚动容器；退出 SceneTree 后 Binder 自动 dispose。 |
+| `content_root` | Binder 写入主轴最小尺寸并承载活动行；退出 SceneTree 后自动 dispose。 |
+| `layout_model` | 条目 count、extent、offset 和范围模型。 |
+| `item_factory` | Callable() -> Control。 |
+| `bind_callback` | Callable(control: Control, item_index: int, item_id: Variant) -> bool。 |
+| `unbind_callback` | Callable(control: Control, item_index: int, item_id: Variant) -> void。 |
+| `identity_callback` | Callable(item_index: int) -> Variant；返回值必须是稳定 key。 |
+| `focus_model` | 可选虚拟焦点模型。 |
+| `measure_callback` | 可选 Callable(control, item_index, item_id) -> float。 |
+| `focus_target_callback` | 可选 Callable(control, item_index, item_id) -> Control。 |
+
+返回：全部边界合法并建立连接时返回 true。
+
+结构：
+
+- `item_factory`: Callable() -> Control.
+- `bind_callback`: Callable(Control, int, Variant) -> bool.
+- `unbind_callback`: Callable(Control, int, Variant) -> void.
+- `identity_callback`: Callable(int) -> stable Variant key.
+- `measure_callback`: Optional Callable(Control, int, Variant) -> finite positive float.
+- `focus_target_callback`: Optional Callable(Control, int, Variant) -> Control descendant.
+
+<a id="member-gfvirtuallistbinder-methods-request_sync"></a>
+
+### `request_sync`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func request_sync() -> bool:
+```
+
+请求一次合并到 deferred 队列的同步。
+
+返回：当前处于有效绑定生命周期时返回 true。
+
+<a id="member-gfvirtuallistbinder-methods-sync_now"></a>
+
+### `sync_now`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func sync_now() -> GFVirtualListSyncResult:
+```
+
+立即执行一轮同步；callback 内的再次请求会合并为下一轮。
+
+返回：typed 同步结果。
+
+<a id="member-gfvirtuallistbinder-methods-invalidate_items"></a>
+
+### `invalidate_items`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func invalidate_items() -> bool:
+```
+
+标记项目条目内容或 identity 已变化，并请求重新绑定当前物化范围。
+
+返回：当前已绑定时返回 true。
+
+<a id="member-gfvirtuallistbinder-methods-request_measurement"></a>
+
+### `request_measurement`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func request_measurement() -> bool:
+```
+
+请求下一轮重新测量当前活动行；即使 auto_measure 为 false 也会执行。
+
+返回：当前已绑定时返回 true。
+
+<a id="member-gfvirtuallistbinder-methods-scroll_to_item"></a>
+
+### `scroll_to_item`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func scroll_to_item( item_index: int, alignment: ScrollAlignment = ScrollAlignment.NEAREST ) -> bool:
+```
+
+把指定条目滚入视口。 同步 callback 内不允许直接改变当前轮滚动；先保存项目意图并请求下一轮。 模型、视口、主轴与 Control 所有权快照保持有效并接受最终整数偏移时返回 true； 否则请求下一轮同步并返回 false。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `item_index` | 条目索引。 |
+| `alignment` | `ScrollAlignment` 值。 |
+
+返回：索引和绑定有效、当前不在同步 callback 内，且滚动操作期间 data generation、
+
+<a id="member-gfvirtuallistbinder-methods-get_materialized_control"></a>
+
+### `get_materialized_control`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_materialized_control(item_index: int) -> Control:
+```
+
+获取指定索引当前物化的 Control。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `item_index` | 条目索引。 |
+
+返回：未物化时为 null。
+
+<a id="member-gfvirtuallistbinder-methods-get_materialized_control_by_id"></a>
+
+### `get_materialized_control_by_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_materialized_control_by_id(item_id: Variant) -> Control:
+```
+
+按稳定 identity 获取当前物化的 Control。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `item_id` | identity callback 使用的稳定 ID。 |
+
+返回：ID 无效或未物化时为 null。
+
+结构：
+
+- `item_id`: Stable Variant key accepted by GFVariantKeyCodec.
+
+<a id="member-gfvirtuallistbinder-methods-get_last_sync_result"></a>
+
+### `get_last_sync_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_last_sync_result() -> GFVirtualListSyncResult:
+```
+
+获取最近同步结果的隔离副本。
+
+返回：尚未同步时返回当前生命周期终态结果。
+
+<a id="member-gfvirtuallistbinder-methods-get_debug_snapshot"></a>
+
+### `get_debug_snapshot`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_debug_snapshot() -> Dictionary:
+```
+
+获取不含项目条目载荷的调试快照。
+
+返回：生命周期、范围和计数摘要。
+
+结构：
+
+- `return`: Dictionary with state, bound, disposed, lifecycle_generation, data_revision, pending_sync, active_count, pooled_count, and last_result.
+
+<a id="member-gfvirtuallistbinder-methods-is_bound"></a>
+
+### `is_bound`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_bound() -> bool:
+```
+
+检查是否处于有效绑定生命周期。
+
+返回：已绑定且未进入 teardown 时返回 true。
+
+<a id="member-gfvirtuallistbinder-methods-is_disposed"></a>
+
+### `is_disposed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_disposed() -> bool:
+```
+
+检查是否进入不可复用终态。
+
+返回：dispose 已完成时返回 true。
+
+<a id="member-gfvirtuallistbinder-methods-unbind"></a>
+
+### `unbind`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func unbind() -> void:
+```
+
+解除当前绑定并释放全部 Binder-owned Control；实例仍可重新 bind。
+
+<a id="member-gfvirtuallistbinder-methods-dispose"></a>
+
+### `dispose`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func dispose() -> void:
+```
+
+进入终态并释放行、pool、连接和 callback。

--- a/docs/zh/reference/api/classes/GFVirtualListModel.md
+++ b/docs/zh/reference/api/classes/GFVirtualListModel.md
@@ -15,6 +15,7 @@
 
 | 类型 | 名称 | 签名 |
 |---|---|---|
+| 信号 | [`layout_changed`](#member-gfvirtuallistmodel-signals-layout_changed) | `signal layout_changed(revision: int)` |
 | 常量 | [`DEFAULT_ESTIMATED_ITEM_EXTENT`](#member-gfvirtuallistmodel-constants-default_estimated_item_extent) | `const DEFAULT_ESTIMATED_ITEM_EXTENT: float = 60.0` |
 | 常量 | [`DEFAULT_OVERSCAN_ITEMS`](#member-gfvirtuallistmodel-constants-default_overscan_items) | `const DEFAULT_OVERSCAN_ITEMS: int = 2` |
 | 常量 | [`MIN_ITEM_EXTENT`](#member-gfvirtuallistmodel-constants-min_item_extent) | `const MIN_ITEM_EXTENT: float = 1.0` |
@@ -29,12 +30,35 @@
 | 方法 | [`set_item_extent`](#member-gfvirtuallistmodel-methods-set_item_extent) | `func set_item_extent( item_index: int, extent: float, measured: bool = true, scroll_offset: float = -1.0 ) -> Dictionary:` |
 | 方法 | [`reset_item_extent`](#member-gfvirtuallistmodel-methods-reset_item_extent) | `func reset_item_extent(item_index: int) -> bool:` |
 | 方法 | [`get_item_count`](#member-gfvirtuallistmodel-methods-get_item_count) | `func get_item_count() -> int:` |
+| 方法 | [`get_revision`](#member-gfvirtuallistmodel-methods-get_revision) | `func get_revision() -> int:` |
 | 方法 | [`get_item_extent`](#member-gfvirtuallistmodel-methods-get_item_extent) | `func get_item_extent(item_index: int) -> float:` |
 | 方法 | [`is_item_measured`](#member-gfvirtuallistmodel-methods-is_item_measured) | `func is_item_measured(item_index: int) -> bool:` |
 | 方法 | [`get_item_offset`](#member-gfvirtuallistmodel-methods-get_item_offset) | `func get_item_offset(item_index: int) -> float:` |
 | 方法 | [`get_content_extent`](#member-gfvirtuallistmodel-methods-get_content_extent) | `func get_content_extent(include_trailing_padding: bool = true) -> float:` |
+| 方法 | [`get_viewport_range`](#member-gfvirtuallistmodel-methods-get_viewport_range) | `func get_viewport_range(scroll_offset: float, viewport_extent: float) -> Vector2i:` |
 | 方法 | [`get_visible_range`](#member-gfvirtuallistmodel-methods-get_visible_range) | `func get_visible_range(scroll_offset: float, viewport_extent: float) -> Vector2i:` |
 | 方法 | [`get_visible_items`](#member-gfvirtuallistmodel-methods-get_visible_items) | `func get_visible_items(scroll_offset: float, viewport_extent: float) -> Array[Dictionary]:` |
+
+## 信号
+
+<a id="member-gfvirtuallistmodel-signals-layout_changed"></a>
+
+### `layout_changed`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+signal layout_changed(revision: int)
+```
+
+布局状态实际变化后发出。 一次公开写操作无论影响多少条目都只推进一次 revision；无变化或被拒绝的写入不发出。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `revision` | 变更后的单调递增布局版本号。 |
 
 ## 常量
 
@@ -260,6 +284,21 @@ func get_item_count() -> int:
 
 返回：当前条目数量。
 
+<a id="member-gfvirtuallistmodel-methods-get_revision"></a>
+
+### `get_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_revision() -> int:
+```
+
+获取布局状态的当前版本号。
+
+返回：从 0 开始、只在布局实际变化时递增的版本号。
+
 <a id="member-gfvirtuallistmodel-methods-get_item_extent"></a>
 
 ### `get_item_extent`
@@ -340,11 +379,34 @@ func get_content_extent(include_trailing_padding: bool = true) -> float:
 
 返回：内容总尺寸。
 
+<a id="member-gfvirtuallistmodel-methods-get_viewport_range"></a>
+
+### `get_viewport_range`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_viewport_range(scroll_offset: float, viewport_extent: float) -> Vector2i:
+```
+
+计算当前滚动窗口直接命中的条目范围，不包含 overscan。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `scroll_offset` | 当前滚动偏移。 |
+| `viewport_extent` | 视口尺寸。 |
+
+返回：Vector2i(start, end)，end 为不包含的结束索引。
+
 <a id="member-gfvirtuallistmodel-methods-get_visible_range"></a>
 
 ### `get_visible_range`
 
 - API：`public`
+- 首次版本：`4.4.0`
 
 ```gdscript
 func get_visible_range(scroll_offset: float, viewport_extent: float) -> Vector2i:

--- a/docs/zh/reference/api/classes/GFVirtualListSyncResult.md
+++ b/docs/zh/reference/api/classes/GFVirtualListSyncResult.md
@@ -1,0 +1,469 @@
+# GFVirtualListSyncResult
+
+[API Reference](../index.md) / [Standard](../standard.md) / [类索引](index.md)
+
+- 路径：`addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd`
+- 模块：`Standard`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：值对象 (`value_object`)
+- 首次版本：`unreleased`
+
+虚拟列表同步的不可变诊断结果。 只保存范围、计数、版本和稳定错误信息，不保存项目条目数据或原始稳定 ID。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 常量 | [`STATUS_SYNCED`](#member-gfvirtuallistsyncresult-constants-status_synced) | `const STATUS_SYNCED: StringName = &"synced"` |
+| 常量 | [`STATUS_UNCHANGED`](#member-gfvirtuallistsyncresult-constants-status_unchanged) | `const STATUS_UNCHANGED: StringName = &"unchanged"` |
+| 常量 | [`STATUS_DEFERRED`](#member-gfvirtuallistsyncresult-constants-status_deferred) | `const STATUS_DEFERRED: StringName = &"deferred"` |
+| 常量 | [`STATUS_TRUNCATED`](#member-gfvirtuallistsyncresult-constants-status_truncated) | `const STATUS_TRUNCATED: StringName = &"truncated"` |
+| 常量 | [`STATUS_UNBOUND`](#member-gfvirtuallistsyncresult-constants-status_unbound) | `const STATUS_UNBOUND: StringName = &"unbound"` |
+| 常量 | [`STATUS_DISPOSED`](#member-gfvirtuallistsyncresult-constants-status_disposed) | `const STATUS_DISPOSED: StringName = &"disposed"` |
+| 常量 | [`STATUS_INVALID_IDENTITY`](#member-gfvirtuallistsyncresult-constants-status_invalid_identity) | `const STATUS_INVALID_IDENTITY: StringName = &"invalid_identity"` |
+| 常量 | [`STATUS_DUPLICATE_IDENTITY`](#member-gfvirtuallistsyncresult-constants-status_duplicate_identity) | `const STATUS_DUPLICATE_IDENTITY: StringName = &"duplicate_identity"` |
+| 常量 | [`STATUS_FACTORY_FAILED`](#member-gfvirtuallistsyncresult-constants-status_factory_failed) | `const STATUS_FACTORY_FAILED: StringName = &"factory_failed"` |
+| 常量 | [`STATUS_BIND_FAILED`](#member-gfvirtuallistsyncresult-constants-status_bind_failed) | `const STATUS_BIND_FAILED: StringName = &"bind_failed"` |
+| 方法 | [`is_successful`](#member-gfvirtuallistsyncresult-methods-is_successful) | `func is_successful() -> bool:` |
+| 方法 | [`get_status`](#member-gfvirtuallistsyncresult-methods-get_status) | `func get_status() -> StringName:` |
+| 方法 | [`get_layout_revision`](#member-gfvirtuallistsyncresult-methods-get_layout_revision) | `func get_layout_revision() -> int:` |
+| 方法 | [`get_data_revision`](#member-gfvirtuallistsyncresult-methods-get_data_revision) | `func get_data_revision() -> int:` |
+| 方法 | [`get_viewport_range`](#member-gfvirtuallistsyncresult-methods-get_viewport_range) | `func get_viewport_range() -> Vector2i:` |
+| 方法 | [`get_requested_range`](#member-gfvirtuallistsyncresult-methods-get_requested_range) | `func get_requested_range() -> Vector2i:` |
+| 方法 | [`get_materialized_indices`](#member-gfvirtuallistsyncresult-methods-get_materialized_indices) | `func get_materialized_indices() -> PackedInt32Array:` |
+| 方法 | [`get_materialized_count`](#member-gfvirtuallistsyncresult-methods-get_materialized_count) | `func get_materialized_count() -> int:` |
+| 方法 | [`get_pooled_count`](#member-gfvirtuallistsyncresult-methods-get_pooled_count) | `func get_pooled_count() -> int:` |
+| 方法 | [`get_created_count`](#member-gfvirtuallistsyncresult-methods-get_created_count) | `func get_created_count() -> int:` |
+| 方法 | [`get_reused_count`](#member-gfvirtuallistsyncresult-methods-get_reused_count) | `func get_reused_count() -> int:` |
+| 方法 | [`get_released_count`](#member-gfvirtuallistsyncresult-methods-get_released_count) | `func get_released_count() -> int:` |
+| 方法 | [`get_measured_count`](#member-gfvirtuallistsyncresult-methods-get_measured_count) | `func get_measured_count() -> int:` |
+| 方法 | [`get_anchor_adjustment`](#member-gfvirtuallistsyncresult-methods-get_anchor_adjustment) | `func get_anchor_adjustment() -> float:` |
+| 方法 | [`was_truncated`](#member-gfvirtuallistsyncresult-methods-was_truncated) | `func was_truncated() -> bool:` |
+| 方法 | [`get_error_index`](#member-gfvirtuallistsyncresult-methods-get_error_index) | `func get_error_index() -> int:` |
+| 方法 | [`get_error`](#member-gfvirtuallistsyncresult-methods-get_error) | `func get_error() -> String:` |
+| 方法 | [`duplicate_result`](#member-gfvirtuallistsyncresult-methods-duplicate_result) | `func duplicate_result() -> GFVirtualListSyncResult:` |
+| 方法 | [`to_dict`](#member-gfvirtuallistsyncresult-methods-to_dict) | `func to_dict() -> Dictionary:` |
+
+## 常量
+
+<a id="member-gfvirtuallistsyncresult-constants-status_synced"></a>
+
+### `STATUS_SYNCED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_SYNCED: StringName = &"synced"
+```
+
+目标范围已完整同步。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_unchanged"></a>
+
+### `STATUS_UNCHANGED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_UNCHANGED: StringName = &"unchanged"
+```
+
+当前 materialization 已满足目标且没有结构变化。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_deferred"></a>
+
+### `STATUS_DEFERRED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_DEFERRED: StringName = &"deferred"
+```
+
+当前轮冻结快照在完成提交前或项目绑定副作用期间失效；Binder 已保留后续同步请求。 该状态不表示同步成功。若漂移发生在绑定副作用前，Binder 保留最近一次可信 materialization；若已调用 bind/unbind、测量、布局或焦点副作用，则对称解绑并清空 不可信 materialization。调用方应以结果中的当前索引为准并等待下一轮结果。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_truncated"></a>
+
+### `STATUS_TRUNCATED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_TRUNCATED: StringName = &"truncated"
+```
+
+目标范围超过显式节点预算，已优先物化真实视口范围。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_unbound"></a>
+
+### `STATUS_UNBOUND`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_UNBOUND: StringName = &"unbound"
+```
+
+Binder 当前没有有效绑定。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_disposed"></a>
+
+### `STATUS_DISPOSED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_DISPOSED: StringName = &"disposed"
+```
+
+Binder 已进入不可复用的终态。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_invalid_identity"></a>
+
+### `STATUS_INVALID_IDENTITY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_INVALID_IDENTITY: StringName = &"invalid_identity"
+```
+
+identity callback 返回了不可稳定编码的值。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_duplicate_identity"></a>
+
+### `STATUS_DUPLICATE_IDENTITY`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_DUPLICATE_IDENTITY: StringName = &"duplicate_identity"
+```
+
+当前请求范围包含重复稳定 identity。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_factory_failed"></a>
+
+### `STATUS_FACTORY_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_FACTORY_FAILED: StringName = &"factory_failed"
+```
+
+item factory 没有返回可接管的 parentless Control。
+
+<a id="member-gfvirtuallistsyncresult-constants-status_bind_failed"></a>
+
+### `STATUS_BIND_FAILED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_BIND_FAILED: StringName = &"bind_failed"
+```
+
+项目 bind callback 拒绝了一个条目。
+
+## 方法
+
+<a id="member-gfvirtuallistsyncresult-methods-is_successful"></a>
+
+### `is_successful`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_successful() -> bool:
+```
+
+检查同步是否提交了内部一致的目标状态。
+
+返回：完整、无变化或按显式预算截断完成时返回 true。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_status"></a>
+
+### `get_status`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_status() -> StringName:
+```
+
+获取稳定同步状态。
+
+返回：`STATUS_*` 常量之一。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_layout_revision"></a>
+
+### `get_layout_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_layout_revision() -> int:
+```
+
+获取本轮计算范围前冻结的布局版本。
+
+返回：`GFVirtualListModel` revision。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_data_revision"></a>
+
+### `get_data_revision`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_data_revision() -> int:
+```
+
+获取本轮开始时冻结的 Binder 数据失效版本。
+
+返回：从 0 开始的 data revision。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_viewport_range"></a>
+
+### `get_viewport_range`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_viewport_range() -> Vector2i:
+```
+
+获取未加入 overscan 的真实视口范围。
+
+返回：Vector2i(start, end)，end 不包含。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_requested_range"></a>
+
+### `get_requested_range`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_requested_range() -> Vector2i:
+```
+
+获取加入 overscan、应用预算前的请求范围。
+
+返回：Vector2i(start, end)，end 不包含。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_materialized_indices"></a>
+
+### `get_materialized_indices`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_materialized_indices() -> PackedInt32Array:
+```
+
+获取实际物化索引副本。
+
+返回：升序物化索引。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_materialized_count"></a>
+
+### `get_materialized_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_materialized_count() -> int:
+```
+
+获取实际物化数量。
+
+返回：当前活动 Control 数量。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_pooled_count"></a>
+
+### `get_pooled_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_pooled_count() -> int:
+```
+
+获取当前池内可复用 Control 数量。
+
+返回：parentless 池节点数量。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_created_count"></a>
+
+### `get_created_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_created_count() -> int:
+```
+
+获取本轮新建 Control 数量。
+
+返回：factory 成功创建数量。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_reused_count"></a>
+
+### `get_reused_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_reused_count() -> int:
+```
+
+获取本轮从旧 active 或 pool 复用数量。
+
+返回：复用数量。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_released_count"></a>
+
+### `get_released_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_released_count() -> int:
+```
+
+获取本轮离开旧绑定的数量。
+
+返回：已执行 unbind 的旧绑定数量。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_measured_count"></a>
+
+### `get_measured_count`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_measured_count() -> int:
+```
+
+获取本轮成功测量的行数量。
+
+返回：测量数量。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_anchor_adjustment"></a>
+
+### `get_anchor_adjustment`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_anchor_adjustment() -> float:
+```
+
+获取本轮一次性应用的滚动锚点修正。
+
+返回：主轴滚动调整量。
+
+<a id="member-gfvirtuallistsyncresult-methods-was_truncated"></a>
+
+### `was_truncated`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func was_truncated() -> bool:
+```
+
+检查是否因 materialization 上限截断。
+
+返回：目标范围未完整物化时返回 true。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_error_index"></a>
+
+### `get_error_index`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error_index() -> int:
+```
+
+获取首个失败条目索引。
+
+返回：没有索引错误时为 -1。
+
+<a id="member-gfvirtuallistsyncresult-methods-get_error"></a>
+
+### `get_error`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_error() -> String:
+```
+
+获取有界稳定错误说明。
+
+返回：成功时为空。
+
+<a id="member-gfvirtuallistsyncresult-methods-duplicate_result"></a>
+
+### `duplicate_result`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func duplicate_result() -> GFVirtualListSyncResult:
+```
+
+创建结果的隔离副本。
+
+返回：新结果对象。
+
+<a id="member-gfvirtuallistsyncresult-methods-to_dict"></a>
+
+### `to_dict`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func to_dict() -> Dictionary:
+```
+
+转换为不含项目数据的诊断字典。
+
+返回：JSON-safe 同步摘要；状态使用 String，范围与索引只使用 JSON 原生容器和整数。
+
+结构：
+
+- `return`: Dictionary with String status; viewport_range and requested_range Dictionaries containing start and end_exclusive ints; materialized_indices Array[int]; revisions and counts in 0..9007199254740991; finite anchor_adjustment; truncated; error_index in -1..9007199254740991; and error.

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 74 | 1094 | [Kernel](#module-kernel) |
-| Standard | 445 | 7102 | [Standard](#module-standard) |
+| Standard | 454 | 7245 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -258,7 +258,7 @@
 | [`GFSnapshotHistoryUtility`](GFSnapshotHistoryUtility.md#gfsnapshothistoryutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 21 | `addons/gf/standard/utilities/history/gf_snapshot_history_utility.gd` |
 | [`GFSourceTextLoader`](GFSourceTextLoader.md#gfsourcetextloader) | 运行时服务 (`runtime_service`) | `RefCounted` | 20 | `addons/gf/standard/utilities/io/gf_source_text_loader.gd` |
 | [`GFSourceTextPatchTools`](GFSourceTextPatchTools.md#gfsourcetextpatchtools) | 运行时服务 (`runtime_service`) | `RefCounted` | 8 | `addons/gf/standard/foundation/text/gf_source_text_patch_tools.gd` |
-| [`GFSpatialCanvas2D`](GFSpatialCanvas2D.md#gfspatialcanvas2d) | 运行时服务 (`runtime_service`) | `Control` | 57 | `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd` |
+| [`GFSpatialCanvas2D`](GFSpatialCanvas2D.md#gfspatialcanvas2d) | 运行时服务 (`runtime_service`) | `Control` | 60 | `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_2d.gd` |
 | [`GFSpatialHash3D`](GFSpatialHash3D.md#gfspatialhash3d) | 运行时服务 (`runtime_service`) | `RefCounted` | 17 | `addons/gf/standard/foundation/math/gf_spatial_hash_3d.gd` |
 | [`GFSpatialQueryIndex2D`](GFSpatialQueryIndex2D.md#gfspatialqueryindex2d) | 运行时服务 (`runtime_service`) | `RefCounted` | 29 | `addons/gf/standard/utilities/spatial/gf_spatial_query_index_2d.gd` |
 | [`GFSpatialQueryIndex3D`](GFSpatialQueryIndex3D.md#gfspatialqueryindex3d) | 运行时服务 (`runtime_service`) | `RefCounted` | 24 | `addons/gf/standard/utilities/spatial/gf_spatial_query_index_3d.gd` |
@@ -272,8 +272,8 @@
 | [`GFSupportReportWorkflow`](GFSupportReportWorkflow.md#gfsupportreportworkflow) | 运行时服务 (`runtime_service`) | `GFUtility` | 23 | `addons/gf/standard/utilities/debug/gf_support_report_workflow.gd` |
 | [`GFSurfaceScatterSampler3D`](GFSurfaceScatterSampler3D.md#gfsurfacescattersampler3d) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/foundation/math/gf_surface_scatter_sampler_3d.gd` |
 | [`GFSurfaceUtility`](GFSurfaceUtility.md#gfsurfaceutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 16 | `addons/gf/standard/utilities/display/gf_surface_utility.gd` |
-| [`GFTableDataView`](GFTableDataView.md#gftabledataview) | 运行时服务 (`runtime_service`) | `RefCounted` | 43 | `addons/gf/standard/utilities/ui/gf_table_data_view.gd` |
-| [`GFTableSelectionModel`](GFTableSelectionModel.md#gftableselectionmodel) | 运行时服务 (`runtime_service`) | `RefCounted` | 16 | `addons/gf/standard/utilities/ui/gf_table_selection_model.gd` |
+| [`GFTableDataView`](GFTableDataView.md#gftabledataview) | 运行时服务 (`runtime_service`) | `RefCounted` | 58 | `addons/gf/standard/utilities/ui/gf_table_data_view.gd` |
+| [`GFTableSelectionModel`](GFTableSelectionModel.md#gftableselectionmodel) | 运行时服务 (`runtime_service`) | `RefCounted` | 17 | `addons/gf/standard/utilities/ui/gf_table_selection_model.gd` |
 | [`GFTagSourceAdapter`](GFTagSourceAdapter.md#gftagsourceadapter) | 运行时服务 (`runtime_service`) | `RefCounted` | 9 | `addons/gf/standard/foundation/tags/gf_tag_source_adapter.gd` |
 | [`GFTextAutoFit`](GFTextAutoFit.md#gftextautofit) | 运行时服务 (`runtime_service`) | `Node` | 14 | `addons/gf/standard/utilities/ui/gf_text_auto_fit.gd` |
 | [`GFTextFitter`](GFTextFitter.md#gftextfitter) | 运行时服务 (`runtime_service`) | `RefCounted` | 8 | `addons/gf/standard/utilities/ui/gf_text_fitter.gd` |
@@ -301,7 +301,7 @@
 | [`GFViewportUtility`](GFViewportUtility.md#gfviewportutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 27 | `addons/gf/standard/utilities/display/gf_viewport_utility.gd` |
 | [`GFVirtualInputBridge`](GFVirtualInputBridge.md#gfvirtualinputbridge) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/input/common/gf_virtual_input_bridge.gd` |
 | [`GFVirtualListFocusModel`](GFVirtualListFocusModel.md#gfvirtuallistfocusmodel) | 运行时服务 (`runtime_service`) | `RefCounted` | 20 | `addons/gf/standard/utilities/ui/gf_virtual_list_focus_model.gd` |
-| [`GFVirtualListModel`](GFVirtualListModel.md#gfvirtuallistmodel) | 运行时服务 (`runtime_service`) | `RefCounted` | 20 | `addons/gf/standard/utilities/ui/gf_virtual_list_model.gd` |
+| [`GFVirtualListModel`](GFVirtualListModel.md#gfvirtuallistmodel) | 运行时服务 (`runtime_service`) | `RefCounted` | 23 | `addons/gf/standard/utilities/ui/gf_virtual_list_model.gd` |
 | [`GFVoronoi2D`](GFVoronoi2D.md#gfvoronoi2d) | 运行时服务 (`runtime_service`) | `RefCounted` | 4 | `addons/gf/standard/foundation/math/gf_voronoi_2d.gd` |
 | [`GFWaveFunctionCollapse2D`](GFWaveFunctionCollapse2D.md#gfwavefunctioncollapse2d) | 运行时服务 (`runtime_service`) | `RefCounted` | 10 | `addons/gf/standard/foundation/math/gf_wave_function_collapse_2d.gd` |
 | [`GFAssetCatalogSourceProvider`](GFAssetCatalogSourceProvider.md#gfassetcatalogsourceprovider) | 协议与扩展点 (`protocol`) | `RefCounted` | 7 | `addons/gf/standard/utilities/assets/gf_asset_catalog_source_provider.gd` |
@@ -326,6 +326,7 @@
 | [`GFSequenceStep`](GFSequenceStep.md#gfsequencestep) | 协议与扩展点 (`protocol`) | `Resource` | 4 | `addons/gf/standard/sequence/gf_sequence_step.gd` |
 | [`GFState`](GFState.md#gfstate) | 协议与扩展点 (`protocol`) | `RefCounted` | 26 | `addons/gf/standard/state_machine/pure/gf_state.gd` |
 | [`GFStorageBackend`](GFStorageBackend.md#gfstoragebackend) | 协议与扩展点 (`protocol`) | `RefCounted` | 17 | `addons/gf/standard/utilities/storage/gf_storage_backend.gd` |
+| [`GFTableRowPredicate`](GFTableRowPredicate.md#gftablerowpredicate) | 协议与扩展点 (`protocol`) | `RefCounted` | 2 | `addons/gf/standard/utilities/ui/gf_table_row_predicate.gd` |
 | [`GFUndoableCommand`](GFUndoableCommand.md#gfundoablecommand) | 协议与扩展点 (`protocol`) | `GFCommand` | 8 | `addons/gf/standard/command/gf_undoable_command.gd` |
 | [`GFValidationRule`](GFValidationRule.md#gfvalidationrule) | 协议与扩展点 (`protocol`) | `Resource` | 14 | `addons/gf/standard/foundation/validation/gf_validation_rule.gd` |
 | [`GFAnalyticsConfig`](GFAnalyticsConfig.md#gfanalyticsconfig) | 资源定义 (`resource_definition`) | `Resource` | 19 | `addons/gf/standard/utilities/analytics/gf_analytics_config.gd` |
@@ -428,6 +429,8 @@
 | [`GFShaderParameterProfile`](GFShaderParameterProfile.md#gfshaderparameterprofile) | 资源定义 (`resource_definition`) | `Resource` | 15 | `addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd` |
 | [`GFSignalBridge`](GFSignalBridge.md#gfsignalbridge) | 资源定义 (`resource_definition`) | `Resource` | 15 | `addons/gf/standard/utilities/signals/bridge/gf_signal_bridge.gd` |
 | [`GFSignalSourceRef`](GFSignalSourceRef.md#gfsignalsourceref) | 资源定义 (`resource_definition`) | `Resource` | 8 | `addons/gf/standard/utilities/signals/bridge/gf_signal_source_ref.gd` |
+| [`GFSpatialCanvasInputPolicy`](GFSpatialCanvasInputPolicy.md#gfspatialcanvasinputpolicy) | 资源定义 (`resource_definition`) | `Resource` | 29 | `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd` |
+| [`GFSpatialCanvasSelectionModeBinding`](GFSpatialCanvasSelectionModeBinding.md#gfspatialcanvasselectionmodebinding) | 资源定义 (`resource_definition`) | `Resource` | 3 | `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd` |
 | [`GFSteeringBehaviorResource`](GFSteeringBehaviorResource.md#gfsteeringbehaviorresource) | 资源定义 (`resource_definition`) | `Resource` | 20 | `addons/gf/standard/foundation/math/gf_steering_behavior_resource.gd` |
 | [`GFSteeringBehaviorStack`](GFSteeringBehaviorStack.md#gfsteeringbehaviorstack) | 资源定义 (`resource_definition`) | `Resource` | 10 | `addons/gf/standard/foundation/math/gf_steering_behavior_stack.gd` |
 | [`GFStorageCodec`](GFStorageCodec.md#gfstoragecodec) | 资源定义 (`resource_definition`) | `Resource` | 28 | `addons/gf/standard/utilities/storage/gf_storage_codec.gd` |
@@ -497,6 +500,7 @@
 | [`GFUIRouteOperation`](GFUIRouteOperation.md#gfuirouteoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 13 | `addons/gf/standard/utilities/ui/gf_ui_route_operation.gd` |
 | [`GFVirtualInputPulseOperation`](GFVirtualInputPulseOperation.md#gfvirtualinputpulseoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 14 | `addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd` |
 | [`GFVirtualInputSource`](GFVirtualInputSource.md#gfvirtualinputsource) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 19 | `addons/gf/standard/input/sources/gf_virtual_input_source.gd` |
+| [`GFVirtualListBinder`](GFVirtualListBinder.md#gfvirtuallistbinder) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 28 | `addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd` |
 | [`GFAssetLoadSessionResult`](GFAssetLoadSessionResult.md#gfassetloadsessionresult) | 值对象 (`value_object`) | `RefCounted` | 16 | `addons/gf/standard/utilities/assets/gf_asset_load_session_result.gd` |
 | [`GFAudioBackendCapability`](GFAudioBackendCapability.md#gfaudiobackendcapability) | 值对象 (`value_object`) | `Resource` | 15 | `addons/gf/standard/utilities/audio/gf_audio_backend_capability.gd` |
 | [`GFAudioPlaybackRegionResult`](GFAudioPlaybackRegionResult.md#gfaudioplaybackregionresult) | 值对象 (`value_object`) | `RefCounted` | 14 | `addons/gf/standard/utilities/audio/gf_audio_playback_region_result.gd` |
@@ -533,10 +537,15 @@
 | [`GFStorageConflictReport`](GFStorageConflictReport.md#gfstorageconflictreport) | 值对象 (`value_object`) | `Resource` | 14 | `addons/gf/standard/utilities/storage/gf_storage_conflict_report.gd` |
 | [`GFStorageReadResult`](GFStorageReadResult.md#gfstoragereadresult) | 值对象 (`value_object`) | `RefCounted` | 20 | `addons/gf/standard/utilities/storage/gf_storage_read_result.gd` |
 | [`GFStorageSectionCache`](GFStorageSectionCache.md#gfstoragesectioncache) | 值对象 (`value_object`) | `RefCounted` | 14 | `addons/gf/standard/utilities/storage/gf_storage_section_cache.gd` |
+| [`GFTableRowPredicateRegistration`](GFTableRowPredicateRegistration.md#gftablerowpredicateregistration) | 值对象 (`value_object`) | `RefCounted` | 6 | `addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd` |
+| [`GFTableRowPredicateResult`](GFTableRowPredicateResult.md#gftablerowpredicateresult) | 值对象 (`value_object`) | `RefCounted` | 7 | `addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd` |
+| [`GFTableRowView`](GFTableRowView.md#gftablerowview) | 值对象 (`value_object`) | `RefCounted` | 5 | `addons/gf/standard/utilities/ui/gf_table_row_view.gd` |
+| [`GFTableViewRebuildResult`](GFTableViewRebuildResult.md#gftableviewrebuildresult) | 值对象 (`value_object`) | `RefCounted` | 12 | `addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd` |
 | [`GFUIRouteResult`](GFUIRouteResult.md#gfuirouteresult) | 值对象 (`value_object`) | `RefCounted` | 34 | `addons/gf/standard/utilities/ui/gf_ui_route_result.gd` |
 | [`GFUuid`](GFUuid.md#gfuuid) | 值对象 (`value_object`) | `RefCounted` | 5 | `addons/gf/standard/foundation/identity/gf_uuid.gd` |
 | [`GFValidationIssue`](GFValidationIssue.md#gfvalidationissue) | 值对象 (`value_object`) | `RefCounted` | 32 | `addons/gf/standard/foundation/validation/gf_validation_issue.gd` |
 | [`GFValidationReport`](GFValidationReport.md#gfvalidationreport) | 值对象 (`value_object`) | `RefCounted` | 29 | `addons/gf/standard/foundation/validation/gf_validation_report.gd` |
+| [`GFVirtualListSyncResult`](GFVirtualListSyncResult.md#gfvirtuallistsyncresult) | 值对象 (`value_object`) | `RefCounted` | 29 | `addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd` |
 | [`GFDropZone`](GFDropZone.md#gfdropzone) | 领域模型 (`domain_model`) | `RefCounted` | 15 | `addons/gf/standard/input/drag_drop/gf_drop_zone.gd` |
 | [`GFInputDirectionHistory`](GFInputDirectionHistory.md#gfinputdirectionhistory) | 领域模型 (`domain_model`) | `RefCounted` | 9 | `addons/gf/standard/input/history/gf_input_direction_history.gd` |
 | [`GFInputRecording`](GFInputRecording.md#gfinputrecording) | 领域模型 (`domain_model`) | `RefCounted` | 14 | `addons/gf/standard/input/recording/gf_input_recording.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,16 +5,16 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`804`
-- 公开成员：`11851`
-- 公开方法：`7316`
+- 公开类：`813`
+- 公开成员：`11994`
+- 公开方法：`7405`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 74 | 1094 | 793 | [kernel.md](kernel.md) |
-| Standard | 445 | 7102 | 4493 | [standard.md](standard.md) |
+| Standard | 454 | 7245 | 4582 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,11 +6,11 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 188 | 3402 | 2292 |
-| [协议与扩展点](#category-protocol) | 24 | 338 | 267 |
-| [资源定义](#category-resource_definition) | 120 | 1538 | 792 |
-| [运行时句柄](#category-runtime_handle) | 49 | 853 | 546 |
-| [值对象](#category-value_object) | 40 | 736 | 460 |
+| [运行时服务](#category-runtime_service) | 188 | 3424 | 2313 |
+| [协议与扩展点](#category-protocol) | 25 | 340 | 269 |
+| [资源定义](#category-resource_definition) | 122 | 1570 | 795 |
+| [运行时句柄](#category-runtime_handle) | 50 | 881 | 560 |
+| [值对象](#category-value_object) | 45 | 795 | 509 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |
 | [事件契约](#category-event_contract) | 6 | 61 | 23 |
 | [编辑器 API](#category-editor_api) | 11 | 68 | 46 |
@@ -241,6 +241,7 @@
 | [`GFSequenceStep`](classes/GFSequenceStep.md#gfsequencestep) | `Resource` | `addons/gf/standard/sequence/gf_sequence_step.gd` |
 | [`GFState`](classes/GFState.md#gfstate) | `RefCounted` | `addons/gf/standard/state_machine/pure/gf_state.gd` |
 | [`GFStorageBackend`](classes/GFStorageBackend.md#gfstoragebackend) | `RefCounted` | `addons/gf/standard/utilities/storage/gf_storage_backend.gd` |
+| [`GFTableRowPredicate`](classes/GFTableRowPredicate.md#gftablerowpredicate) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_table_row_predicate.gd` |
 | [`GFUndoableCommand`](classes/GFUndoableCommand.md#gfundoablecommand) | `GFCommand` | `addons/gf/standard/command/gf_undoable_command.gd` |
 | [`GFValidationRule`](classes/GFValidationRule.md#gfvalidationrule) | `Resource` | `addons/gf/standard/foundation/validation/gf_validation_rule.gd` |
 
@@ -350,6 +351,8 @@
 | [`GFShaderParameterProfile`](classes/GFShaderParameterProfile.md#gfshaderparameterprofile) | `Resource` | `addons/gf/standard/utilities/display/gf_shader_parameter_profile.gd` |
 | [`GFSignalBridge`](classes/GFSignalBridge.md#gfsignalbridge) | `Resource` | `addons/gf/standard/utilities/signals/bridge/gf_signal_bridge.gd` |
 | [`GFSignalSourceRef`](classes/GFSignalSourceRef.md#gfsignalsourceref) | `Resource` | `addons/gf/standard/utilities/signals/bridge/gf_signal_source_ref.gd` |
+| [`GFSpatialCanvasInputPolicy`](classes/GFSpatialCanvasInputPolicy.md#gfspatialcanvasinputpolicy) | `Resource` | `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_input_policy.gd` |
+| [`GFSpatialCanvasSelectionModeBinding`](classes/GFSpatialCanvasSelectionModeBinding.md#gfspatialcanvasselectionmodebinding) | `Resource` | `addons/gf/standard/utilities/spatial_canvas/gf_spatial_canvas_selection_mode_binding.gd` |
 | [`GFSteeringBehaviorResource`](classes/GFSteeringBehaviorResource.md#gfsteeringbehaviorresource) | `Resource` | `addons/gf/standard/foundation/math/gf_steering_behavior_resource.gd` |
 | [`GFSteeringBehaviorStack`](classes/GFSteeringBehaviorStack.md#gfsteeringbehaviorstack) | `Resource` | `addons/gf/standard/foundation/math/gf_steering_behavior_stack.gd` |
 | [`GFStorageCodec`](classes/GFStorageCodec.md#gfstoragecodec) | `Resource` | `addons/gf/standard/utilities/storage/gf_storage_codec.gd` |
@@ -426,6 +429,7 @@
 | [`GFUIRouteOperation`](classes/GFUIRouteOperation.md#gfuirouteoperation) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_ui_route_operation.gd` |
 | [`GFVirtualInputPulseOperation`](classes/GFVirtualInputPulseOperation.md#gfvirtualinputpulseoperation) | `RefCounted` | `addons/gf/standard/input/sources/gf_virtual_input_pulse_operation.gd` |
 | [`GFVirtualInputSource`](classes/GFVirtualInputSource.md#gfvirtualinputsource) | `RefCounted` | `addons/gf/standard/input/sources/gf_virtual_input_source.gd` |
+| [`GFVirtualListBinder`](classes/GFVirtualListBinder.md#gfvirtuallistbinder) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd` |
 
 <a id="category-value_object"></a>
 
@@ -469,10 +473,15 @@
 | [`GFStorageConflictReport`](classes/GFStorageConflictReport.md#gfstorageconflictreport) | `Resource` | `addons/gf/standard/utilities/storage/gf_storage_conflict_report.gd` |
 | [`GFStorageReadResult`](classes/GFStorageReadResult.md#gfstoragereadresult) | `RefCounted` | `addons/gf/standard/utilities/storage/gf_storage_read_result.gd` |
 | [`GFStorageSectionCache`](classes/GFStorageSectionCache.md#gfstoragesectioncache) | `RefCounted` | `addons/gf/standard/utilities/storage/gf_storage_section_cache.gd` |
+| [`GFTableRowPredicateRegistration`](classes/GFTableRowPredicateRegistration.md#gftablerowpredicateregistration) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd` |
+| [`GFTableRowPredicateResult`](classes/GFTableRowPredicateResult.md#gftablerowpredicateresult) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd` |
+| [`GFTableRowView`](classes/GFTableRowView.md#gftablerowview) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_table_row_view.gd` |
+| [`GFTableViewRebuildResult`](classes/GFTableViewRebuildResult.md#gftableviewrebuildresult) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd` |
 | [`GFUIRouteResult`](classes/GFUIRouteResult.md#gfuirouteresult) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_ui_route_result.gd` |
 | [`GFUuid`](classes/GFUuid.md#gfuuid) | `RefCounted` | `addons/gf/standard/foundation/identity/gf_uuid.gd` |
 | [`GFValidationIssue`](classes/GFValidationIssue.md#gfvalidationissue) | `RefCounted` | `addons/gf/standard/foundation/validation/gf_validation_issue.gd` |
 | [`GFValidationReport`](classes/GFValidationReport.md#gfvalidationreport) | `RefCounted` | `addons/gf/standard/foundation/validation/gf_validation_report.gd` |
+| [`GFVirtualListSyncResult`](classes/GFVirtualListSyncResult.md#gfvirtuallistsyncresult) | `RefCounted` | `addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd` |
 
 <a id="category-domain_model"></a>
 

--- a/docs/zh/standard/input-flow/index.md
+++ b/docs/zh/standard/input-flow/index.md
@@ -10,7 +10,7 @@
 - [命令序列与撤销历史](command-sequence/index.md)：可撤销命令、命令历史、异步撤销约束和命令序列执行。
 - [输入映射与手感辅助](input-assist/index.md)：输入动作、上下文、设备席位、缓冲、修饰器、触发器、录制回放、改键和触屏控件。
 - [逻辑空间查询](spatial-query.md)：逻辑四叉树和与 GF 内置扩展空间能力的边界。
-- [2D Spatial Canvas](spatial-canvas-2d.md)：运行时世界视图、网格吸附、稳定选择和项目校验的有界放置会话。
+- [2D Spatial Canvas](spatial-canvas-2d.md)：运行时世界视图、可验证输入策略、网格吸附、稳定选择和项目校验的有界放置会话。
 
 ## 使用边界
 

--- a/docs/zh/standard/input-flow/spatial-canvas-2d.md
+++ b/docs/zh/standard/input-flow/spatial-canvas-2d.md
@@ -41,7 +41,40 @@ if configured:
 	var snapped_rotation := canvas.snap_rotation(candidate_rotation)
 ```
 
-`handle_input_event()` 接受本 `Control` 的局部画布坐标，提供最小运行时交互：中键或触摸拖动平移，滚轮或捏合围绕指针缩放。`_gui_input()` 事件可直接传入；从 `_input()` 或全局路由取得的 Viewport 坐标事件应交给 `handle_screen_input_event()`，由它复制并局部化。只有画布实际消费的事件才返回 `true`，项目不要把画布当作全局输入所有者。
+`GFSpatialCanvasInputPolicy` 以纯数据声明平移、选择、滚轮、原始触摸、系统手势和放置取消输入。默认策略保持中键平移、左键选择、垂直滚轮缩放、单指平移，以及双指平移和捏合缩放；取消只使用 InputMap 的 `ui_cancel`，没有 raw Escape 特判。项目可以替换直接按钮或改用已经存在的 InputMap action：
+
+```gdscript
+var policy := GFSpatialCanvasInputPolicy.new()
+policy.pan_mouse_button = MOUSE_BUTTON_NONE
+policy.pan_action = &"tactical_canvas_pan"
+policy.wheel_routing = GFSpatialCanvasInputPolicy.WheelRouting.MODIFIER_GATED
+policy.wheel_modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+policy.consume_wheel_events = true
+policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.NONE
+policy.touch_multi_pan_enabled = false
+policy.touch_multi_zoom_enabled = true
+
+policy.selection_modifier_bindings.clear()
+var add_binding := GFSpatialCanvasSelectionModeBinding.new()
+add_binding.modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+add_binding.selection_mode = GFSpatialCanvas2D.SelectionMode.ADD
+policy.selection_modifier_bindings.append(add_binding)
+
+if not canvas.set_input_policy(policy):
+	push_error("Invalid spatial canvas input policy")
+```
+
+`set_input_policy()` 先把候选公开字段及嵌套 `GFSpatialCanvasSelectionModeBinding` 逐字段复制到纯 GF 基类实例，再完整校验和原子替换；它不会调用候选子类可覆写的校验或复制方法。失败时保留上一份策略，`get_input_policy()` 也只返回纯基类隔离副本。直接 pan 按钮精确匹配 `pan_modifier_mask`；pan action 的完整 chord 由 InputMap 精确匹配，此时 `pan_modifier_mask` 必须为零。选择绑定同样按完整修饰键掩码精确匹配，按下时冻结选择模式，捕获后由同一物理按钮释放，期间 modifier 变化不会改写本次操作。direct 与 action、两个 action 之间的物理 chord 重叠会使策略失败；如果 InputMap 在应用策略后被改成冲突映射，运行时也会忽略该冲突事件且不修改状态。选择修饰键绑定最多 15 个，单个 action 校验和运行期匹配最多扫描 64 个事件，超限直接失败关闭。
+
+`placement_cancel_action` 必须是非指针动作：任何鼠标、触摸或位置手势事件都会让策略失败，避免取消优先级抢占 pan、selection 或 wheel。画布在每次匹配取消前都会重新执行同一 64-event 有界检查；如果项目在策略应用后修改 InputMap 使其包含指针事件或超过预算，本次取消匹配失败关闭，原指针事件仍可由正常画布行为解释。
+
+`handle_input_event()` 接受本 `Control` 的局部画布坐标，`handle_screen_input_event()` 则复制 Viewport 屏幕坐标事件并局部化。二者返回 `GFSpatialCanvas2D.InputDisposition`：`IGNORED` 表示未修改状态，`HANDLED` 表示已处理但允许继续传播，`CONSUMED` 表示 GUI 边界应停止传播。手工转发方法不会调用 Viewport handled API，调用方必须显式解释返回值。
+
+画布自身使用 `MOUSE_FILTER_PASS`。`_gui_input()` 只对 `CONSUMED` 调用 `accept_event()`；`consume_handled_events` 控制一般输入，`consume_wheel_events` 单独控制滚轮。`PARENT_ONLY` 的滚轮、`MODIFIER_GATED` 下未精确匹配 modifier 的滚轮都返回 `IGNORED`，因此能自然冒泡给父 `ScrollContainer`；被画布消费的滚轮不会被强制穿透。垂直与水平轴可独立选择，平滑滚轮的有限正 `event.factor` 作为有硬上限的指数参与缩放，非法或过大 factor 被忽略。
+
+一次被接受的鼠标平移/选择 press 或可能形成已启用行为的第一个原始触摸 press 会建立唯一的物理输入捕获所有权。raw touch 持有期间，全部 `InputEventMouse`（包括 wheel）都返回 `IGNORED`；鼠标持有期间，raw touch press/drag/release 都返回 `IGNORED`；两者都会排除系统 `PanGesture` / `MagnifyGesture`。冲突事件不更新视图、选择几何或手势追踪，只有匹配的鼠标 release、最后一个已接管触点的 release 或显式 cancel 才释放所有权。Godot 标记为 `canceled` 的当前鼠标按钮或已跟踪 touch 只释放整份瞬态捕获，绝不把取消位置解释成正常 release，也不会提交 selection 或 placement；不属于当前 owner 的取消事件仍保持 `IGNORED`。系统手势在没有物理捕获时仍可正常工作；placement 会话本身不构成物理输入捕获。
+
+原始触摸可整体关闭，单指主行为可独立设为 `NONE`、pan 或 select，多指 pan 与 pinch zoom 也各自显式开关；系统 `PanGesture` 与 `MagnifyGesture` 继续使用各自开关。单指为 `NONE` 且两个多指行为都关闭时，raw touch 全程 `IGNORED`，不会暗中建立捕获；只要任一多指行为启用，首触点必须先被捕获以确定性等待第二触点，但单指移动仍不修改视图或选择。第二触点进入允许的多指手势时会结束尚未提交的单指选择捕获，但不会取消活动 placement。禁用输入、成功替换策略、Control 失焦、应用失焦或暂停、Canvas 变为不可见以及退出场景树都会释放鼠标和触摸的瞬态捕获，同时保留条目、当前选择和 placement 会话；清理后的迟到 release 不会复活旧 owner。
 
 ## 候选、命中与选择
 

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/index.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/index.md
@@ -1,17 +1,17 @@
 # 视口、文本与节点树工具
 
-本组页面说明分屏视口、屏幕/世界坐标转换、表格数据视图、文本尺寸适配、富文本格式化、通用节点树操作、节点 group 查询缓存和自定义控件 Inspector 主题 override 辅助。
+本组页面说明分屏视口、屏幕/世界坐标转换、事务式表格投影、可回收虚拟列表、文本尺寸适配、富文本格式化、通用节点树操作、节点 group 查询缓存和自定义控件 Inspector 主题 override 辅助。
 
 ## 阅读入口
 
 - [视口与坐标转换](viewport-coordinates.md)：`GFViewportUtility`、分屏视口和 2D/3D 坐标辅助。
-- [表格数据视图模型](table-data-view.md)：`GFTableDataView`、`GFTableColumnDefinition` 和 `GFTableSelectionModel` 的排序、过滤、提交与稳定选择。
+- [表格数据视图模型](table-data-view.md)：`GFTableDataView`、类型化行谓词、`GFTableColumnDefinition` 和 `GFTableSelectionModel` 的事务式投影、提交与稳定选择。
 - [文本适配与富文本](text-richtext.md)：`GFTextFitter`、`GFTextAutoFit` 和 `GFRichTextFormatter`。
-- [虚拟列表布局与焦点模型](virtual-list-model.md)：`GFVirtualListModel` 的可变尺寸条目、可见范围、overscan、滚动锚点修正，以及 `GFVirtualListFocusModel` 的数据索引焦点。
+- [虚拟列表布局、回收与焦点](virtual-list-model.md)：`GFVirtualListModel` 的可变尺寸窗口、`GFVirtualListBinder` 的有界 Control 回收与滚动锚定，以及 `GFVirtualListFocusModel` 的数据索引焦点。
 - [通用节点树操作](node-tree-ops.md)：`GFNodeTreeOps` 的安全添加、重挂、查找、收集和释放。
 - [节点 Group 查询缓存](node-group-cache.md)：`GFNodeGroupCache` 的 group 快照、SceneTree 失效和诊断。
 - [主题 Override 属性列表](theme-override-property-list.md)：`GFThemeOverridePropertyList` 为自定义 Control 构建 Godot Inspector 可识别的 theme override 属性。
 
 ## 使用边界
 
-这些工具只提供坐标转换、表格数据视图、文本尺寸适配、富文本格式化、虚拟列表布局与虚拟焦点计算、节点树操作、group 查询缓存和 Inspector 属性描述。具体 UI 视觉、布局规范、输入绑定、Control 物化策略、主题命名规范和节点业务语义应由项目 UI 层决定。
+这些工具只提供坐标转换、事务式表格投影、文本尺寸适配、富文本格式化、虚拟列表布局与有界物化机制、节点树操作、group 查询缓存和 Inspector 属性描述。具体数据与稳定 ID、领域谓词、UI 视觉、输入与可访问性、主题命名规范和节点业务语义仍由项目 UI 层决定。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/table-data-view.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/table-data-view.md
@@ -6,7 +6,7 @@
 
 表格数据视图只维护数据和视图状态：源行数组、列定义、过滤文本、排序列、可见行索引和稳定行 ID。它不创建 `Tree`、`ItemList`、`ScrollContainer` 或自绘 Control，不规定表头交互、主题样式、键盘快捷键、拖拽、分页或业务字段含义。
 
-列定义负责描述一列如何读取值、写回值、格式化文本、参与过滤和比较排序。默认实现支持 `Dictionary` 与 `Object` / `Resource` 字段，也可以通过 `Callable` 接入项目自己的 getter、setter、formatter 或 comparator。
+列定义负责描述一列如何读取值、写回值、格式化文本、参与过滤和比较排序。默认读取支持 `Dictionary` 与 `Object` / `Resource` 字段，也可以通过 `Callable` 接入项目自己的 getter、formatter 或 comparator。数据视图的事务式单元格提交只接受默认写入路径，不执行无法证明无副作用的自定义 setter。
 
 ## 典型流程
 
@@ -18,19 +18,21 @@ score_column.sort_mode = GFTableColumnDefinition.SortMode.NUMBER
 score_column.editable = true
 
 var table := GFTableDataView.new()
-table.row_id_column = &"id"
-table.set_columns([id_column, name_column, score_column])
-table.set_rows(records)
+var identity_result := table.set_row_id_column(&"id")
+var columns_result := table.set_columns([id_column, name_column, score_column])
+var rows_result := table.set_rows(records)
 
 table.sort_by_column(&"score", false)
-table.set_filter_query("sword")
+var filter_result := table.set_filter_query("sword")
 
 for visible_index in range(table.get_visible_row_count()):
 	var row := table.describe_visible_row(visible_index)
 	# 项目在这里把 row["values"] 渲染到自己的 Control。
 ```
 
-提交单元格时，数据视图会通过列定义写回源行，并在排序或过滤可能受影响时重建可见行索引。
+提交单元格时，数据视图会先隔离被触及的候选行，在候选 source 上完成全部默认写入、过滤、结构化谓词和排序；只有完整投影成功后，才一次性交换权威 source、projection、revision 与稳定 ID 选择。任何输入、隔离、写入、投影失败或经 `GFTableDataView` API 发起的回调重入都会保留提交前状态。
+
+稳定行 ID 字段、文本过滤大小写策略与选择模型没有可直接赋值的公共字段。分别使用 `set_row_id_column()`、`set_filter_case_sensitive()` 与 `set_selection_model()` 进入同一候选投影事务，并通过对应 getter 查询已提交配置。候选失败时，旧配置、选择模型、投影与 revision 保持不变；getter、formatter、comparator、谓词或提交期信号回调若尝试重入这些 setter，内外事务都会失败关闭，不会让一次投影混用新旧语义。成功切换稳定 ID 字段或提交 ID 单元格时，选择集合与原范围锚点会按同一源行一起迁移，并在 `selection_changed` 发出前形成一致状态。
 
 ```gdscript
 table.commit_visible_cell_value(visible_index, &"score", 120)
@@ -48,7 +50,44 @@ if report["ok"]:
 	print(report["applied_count"])
 ```
 
-批量提交不是事务；部分失败不会回滚已成功的项。返回报告包含 `ok`、`requested_count`、`applied_count`、`unchanged_count`、`failed_count`、`committed` 和 `errors`，项目 UI 可以据此展示批量编辑结果。
+单格与批量入口使用同一事务边界；批量中任何一项失败都会丢弃整份候选，不会提交有效子集。返回报告包含 `ok`、`requested_count`、`applied_count`、`unchanged_count`、`failed_count`、`committed` 和 `errors`，项目 UI 可以据此展示提交结果。自定义 `value_setter` 会在调用前以 `non_transactional_value_setter` 失败关闭；需要业务命令、远端写入或撤销语义时，应在表格外先完成项目事务，再以新的 source 刷新数据视图。
+
+## 结构化行谓词
+
+复杂过滤应使用类型化行谓词，而不是把业务条件拼进搜索字符串。该协议由五个最小类型组成：
+
+- `GFTableRowView` 是进入谓词前冻结的隔离行快照，只提供稳定 row id、源索引和已配置列值的副本；隐藏列也会包含在快照中，但源 row 本身不会暴露。每个谓词都会从框架内部 canonical view 得到一份独占副本，前一个谓词即使违约修改自己收到的快照，也不能影响后一个谓词。
+- `GFTableRowPredicate` 定义同步求值协议。项目只覆写受保护的 `_evaluate()`，返回 `GFTableRowPredicateResult.included()`、`excluded()` 或 `failed()`；DataView 通过框架静态入口直接调用 `_evaluate()`，不会分派到候选子类覆写的公开 `evaluate()`。
+- `GFTableRowPredicateResult` 明确区分包含、排除与有界错误，不用 `null`、布尔值或异常文本混合表达状态。框架从继承的基类存储静态归一化结果，不调用候选结果子类可覆写的 getter；未初始化或非法结果会固定失败关闭。
+- `GFTableRowPredicateRegistration` 把谓词与稳定 ID、显式 `order` 和启用状态组合为注册定义。`GFTableDataView` 提交时直接从继承的基类存储创建纯框架 metadata 快照，不调用候选子类可覆写的 getter；调用方后续改写原注册对象，或改写 getter 返回的快照，都不会改变权威 registry。predicate 协议实例本身按引用保留，因此项目仍可显式调整该实例自己的参数；参数变化不会被框架隐式观察，修改后必须显式调用 `refresh_view()`，并只在返回的类型化结果成功时采用新投影。
+- `GFTableViewRebuildResult` 描述候选投影是否成功、是否提交、对应 revision、扫描/求值计数和失败位置。
+
+```gdscript
+class HighScorePredicate extends GFTableRowPredicate:
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		var score := int(row_view.get_value(&"score", 0))
+		return (
+			GFTableRowPredicateResult.included()
+			if score >= 100
+			else GFTableRowPredicateResult.excluded()
+		)
+
+var rebuild_result := table.set_row_predicates([
+	GFTableRowPredicateRegistration.create(
+		&"minimum_score",
+		HighScorePredicate.new(),
+		10
+	),
+])
+if not rebuild_result.is_successful():
+	push_warning(rebuild_result.get_error_message())
+```
+
+一次重建固定按“文本过滤 → 启用的结构化谓词 → 排序”执行。谓词按 `order` 升序排列；相同 `order` 使用 `predicate_id` 字典序打破平局，因此注册数组的输入顺序不会改变结果。排除会短路当前行剩余谓词，显式失败会中止整次候选投影。
+
+`set_row_predicates()`、注册、注销、启用和重排都先执行 64 项 raw count admission，再复制并校验完整候选 registry，最后在局部候选索引上执行。超限输入不会遍历条目、调用候选方法或创建逐项快照。成功只交换一次投影、推进一次 revision，并发出一次 `view_changed(view_revision, visible_count)`；候选失败、非法配置或经 `GFTableDataView` 公共 mutation API 发起的递归重入不会修改 registry、source、projection、revision 或 selection，只返回 `GFTableViewRebuildResult` 并发出 `view_rebuild_failed(result)`。`get_row_predicate()` 与 `get_row_predicates()` 返回独立 metadata 快照；`get_last_view_rebuild_result()` 和失败信号也提供隔离结果，观察者不能污染模型保存的诊断。
+
+谓词保持同步、纯读取且工作量有界，是调用方必须满足的协议前置条件。框架只保证经 `GFTableDataView` 公共 mutation API 发起的递归修改会失败关闭；如果谓词自行捕获外部 source、选择模型或其他可变对象并直接修改，项目已经违反协议，框架既无法检测全部副作用，也不能撤回此前由外部对象发出的信号。启用谓词时，row id 必须是 `GFVariantKeyCodec` 接受的稳定 key；`Object`、`Resource`、集合与其他引用身份不能作为 row id，失败结果也不会携带源对象别名。列值快照会在固定深度、节点数、集合项数与 UTF-8 字节预算内递归复制；PackedVector 按 double-precision 构建的最坏元素宽度计费。无脚本且通过复制后等价/无别名验证的内建 `Resource` 可以进入快照，脚本 `Resource`、其他 `Object`、`Callable`、`Signal`、`RID`、循环或超预算图一律失败关闭。
 
 ## 视图快照
 
@@ -75,14 +114,15 @@ var full_snapshot := table.describe_view({
 
 ## 选择状态
 
-`GFTableSelectionModel` 使用稳定 row id 维护选择集合，而不是使用当前可见行号。因此排序、过滤和可见行重建不会自动丢失选择。项目可以直接使用 `table.selection_model`，也可以把同一个选择模型共享给多个表格视图。
+`GFTableSelectionModel` 使用稳定 row id 维护选择集合，而不是使用当前可见行号。因此排序、过滤和可见行重建不会自动丢失选择。项目通过 `get_selection_model()` 访问当前模型；需要让多个表格共享模型时，以 `set_selection_model()` 事务式安装同一个实例。
 
 ```gdscript
-table.selection_model.set_selected("weapon_001", true)
+var selection := table.get_selection_model()
+selection.set_selected("weapon_001", true)
 table.sort_by_column(&"name")
 table.set_filter_query("rare")
 
-if table.selection_model.is_selected("weapon_001"):
+if selection.is_selected("weapon_001"):
 	# 即使该行当前被过滤隐藏，选择状态仍然保留。
 ```
 
@@ -92,9 +132,11 @@ if table.selection_model.is_selected("weapon_001"):
 
 `GFTableDataView` 负责回答“当前有哪些可见行、每行有哪些列值”。`GFVirtualListModel` 负责回答“大量可变尺寸行在滚动窗口中应该物化哪些索引”。`GFVirtualListFocusModel` 可用当前可见行索引维护虚拟焦点，避免焦点绑定到被回收复用的行控件。大表 UI 可以组合三者：先用 `GFTableDataView` 得到过滤/排序后的可见行顺序，再用 `GFVirtualListModel` 控制 Control 的创建和测量，用 `GFVirtualListFocusModel` 驱动键盘或手柄焦点表现。
 
+组合层只应在 `view_changed` 成功信号中先更新虚拟布局的条目数量，再让 binder 失效并同步当前窗口。投影失败不会发出 `view_changed`，因此不得清空、重排或局部覆盖已经物化的控件；保留上一 revision 的布局与选择，等待调用方处理类型化失败结果后再决定是否重试。
+
 ## 注意事项
 
-- `row_id_column` 应指向稳定字段；为空或缺失时会回退到源行索引，这适合临时表格，但不适合长期保存选择状态。
+- `set_row_id_column()` 应传入稳定字段；为空或缺失时会回退到源行索引，这适合临时表格，但不适合长期保存选择状态。
 - 列定义的 `editable` 为 false 时，`commit_cell_value()` 不会写回该列。
-- 自定义 `value_getter`、`value_setter`、`value_formatter` 和 `value_comparator` 应保持无业务副作用；真正的保存、撤销、权限和校验流程仍应在项目或编辑器工具层处理。
+- 自定义 `value_getter`、`value_formatter` 和 `value_comparator` 必须保持同步、无业务副作用且工作量有界；经 `GFTableDataView` API 发起的递归 source / selection mutation 会中止外层候选，直接修改回调捕获的外部可变对象则属于项目违约。事务式单元格入口不执行自定义 `value_setter`。真正的保存、撤销、权限和校验流程仍应在项目或编辑器工具层处理。
 - 表格模型不解析 CSV 表头、不推断业务类型、不内置 checkbox、progress bar 或日期规则。这些都应由列定义和渲染层明确表达。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/virtual-list-model.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/ui-stack-routing/viewport-text-node-tools/virtual-list-model.md
@@ -1,12 +1,12 @@
 # 虚拟列表布局与焦点模型
 
-`GFVirtualListModel` 是一个纯布局模型，用来维护大量可变尺寸条目的估算尺寸、实测尺寸、累计偏移和可见范围。`GFVirtualListFocusModel` 用数据索引维护虚拟焦点，让回收式列表不用把键盘或手柄焦点绑定到临时物化的 `Control`。
+`GFVirtualListModel` 是一个纯布局模型，用来维护大量可变尺寸条目的估算尺寸、实测尺寸、累计偏移和可见范围。`GFVirtualListFocusModel` 用数据索引维护虚拟焦点，让回收式列表不用把键盘或手柄焦点绑定到临时物化的 `Control`。需要框架接管可见行的创建、复用、测量和焦点交接时，使用 owner-bound 的 `GFVirtualListBinder`；每轮结果通过 `GFVirtualListSyncResult` 返回。
 
 ## 定位
 
-布局模型只回答四个问题：列表有多少条目、每个条目的尺寸是多少、当前滚动窗口应该显示哪些索引、尺寸变化后是否需要修正滚动偏移。焦点模型只回答当前哪个数据索引拥有虚拟焦点、前后移动应落到哪个可聚焦索引、数据数量变化后焦点应如何修正。它们都不创建 `Control`，不保存条目数据，不绑定 `ScrollContainer`，也不规定节点复用、选择、拖拽、搜索或视觉样式。
+布局模型只回答四个问题：列表有多少条目、每个条目的尺寸是多少、当前滚动窗口应该显示哪些索引、尺寸变化后是否需要修正滚动偏移。焦点模型只回答当前哪个数据索引拥有虚拟焦点、前后移动应落到哪个可聚焦索引、数据数量变化后焦点应如何修正。它们都不创建 `Control`，不保存条目数据，也不规定选择、拖拽、搜索或视觉样式。
 
-这使它可以被运行时 UI 和编辑器工具共同复用：项目或工具负责监听滚动、构建可见行、释放不可见行，并在行控件完成测量后把实际高度写回模型。
+Binder 只补齐通用的节点物化边界：监听滚动与模型版本，按稳定 identity 复用行，执行对称 bind/unbind，更新绝对布局并在 owner 退出树时确定性释放。条目数据、稳定 ID、行视觉、选择、激活、输入和无障碍语义仍由项目持有，因此运行时 UI 与编辑器工具可以使用同一套 primitive，而不把业务层写进框架。
 
 ## 布局流程
 
@@ -18,12 +18,15 @@ model.trailing_padding = 24.0
 model.set_item_count(entries.size())
 
 func refresh_visible_rows(scroll_y: float, viewport_height: float) -> void:
+	var viewport_range := model.get_viewport_range(scroll_y, viewport_height)
 	var visible_range := model.get_visible_range(scroll_y, viewport_height)
 	for index in range(visible_range.x, visible_range.y):
 		var offset := model.get_item_offset(index)
 		var extent := model.get_item_extent(index)
 		# 项目在这里创建或复用自己的 Control，并放到 offset。
 ```
+
+`get_viewport_range()` 是不含 overscan 的真实视口范围，`get_visible_range()` 是加入 overscan 后的请求范围。模型的每次有效公开写操作只推进一次 `get_revision()` 并发出一次 `layout_changed(revision)`；无变化或被拒绝的写入不会制造版本噪声。Binder 会用真实视口范围优先分配节点预算，再把剩余预算用于 overscan。
 
 当某个行控件完成布局后，把实际高度写回模型。若被修改的条目位于当前视口之前，报告会给出 `scroll_adjustment`，调用方可以把滚动偏移加上这个值来减少内容跳动。
 
@@ -32,6 +35,63 @@ var report := model.set_item_extent(row_index, measured_height, true, scroll_y)
 if report["changed"] and report["scroll_adjustment"] != 0.0:
 	scroll_container.scroll_vertical += int(report["scroll_adjustment"])
 ```
+
+## 受控节点物化
+
+`GFVirtualListBinder.bind()` 需要一个已进入 SceneTree 的生命周期 owner、`ScrollContainer`、作为其直接子节点的绝对布局 `Control`，以及布局模型和项目回调。`content_root` 不能是会重新排列子节点的 `Container`。factory 必须返回 parentless `Control`；成功返回后该节点的所有权转交 Binder。
+
+```gdscript
+var binder := GFVirtualListBinder.new()
+binder.max_materialized_items = 128
+binder.max_pooled_items = 24
+
+var bound := binder.bind(
+	self,
+	$ScrollContainer,
+	$ScrollContainer/Content,
+	model,
+	func() -> Control:
+		return row_scene.instantiate(),
+	func(row: Control, index: int, item_id: Variant) -> bool:
+		row.present(entries[index])
+		return true,
+	func(row: Control, _index: int, _item_id: Variant) -> void:
+		row.reset_presentation(),
+	func(index: int) -> Variant:
+		return entries[index].stable_id,
+	focus
+)
+
+if bound:
+	binder.request_sync()
+```
+
+四个回调遵循以下契约：
+
+- identity 回调必须为当前请求范围返回唯一、稳定且可由 `GFVariantKeyCodec` 编码的 key；不得把数组索引冒充跨排序稳定 ID。
+- bind 回调只把当前条目投影到给定 Control，并以 `bool` 明确接受或拒绝。每次已调用的 bind 都会对应一次 unbind，包括 bind 拒绝、同步中止和 dispose。
+- unbind 回调应断开项目自己建立的信号、清除条目引用和瞬态视觉状态；不得 `free()`、`queue_free()` 或重挂载 Binder 持有的 Control。该约束也适用于 callback 能间接访问的其他 active/pool Control，而不只适用于本次参数。
+- factory、identity、bind、unbind 与可选测量/焦点回调都可能触发项目代码。Binder 会在任何项目回调前冻结本轮 data/layout revision、条目数量、范围、目标 geometry、content extent、滚动主轴、交叉轴尺寸与填充策略，以及活动节点/自动测量预算；并在每次项目回调后的下一项回调、每个 Control 位置或尺寸写入、权威尺寸写入或 `grab_focus()` 前重验 generation、data revision 与完整 Control 所有权。callback 内的布局/轴/填充/预算修改、重测与 `request_sync()` 只合并到下一轮；`invalidate_items()` 使当前 data-generation 快照失效并返回非成功 `STATUS_DEFERRED`。若失效发生在绑定副作用前，旧 materialization 保持不变；若已进入 bind/unbind、测量、布局或焦点副作用，Binder 会按 Control 身份去重、对称解绑并清空不再可信的 active 集合，再由下一轮重建，不会把混代状态报告为成功。`unbind()` / `dispose()` 会使当前 lifecycle generation 失效；项目不应依赖递归同步或回调的未声明顺序。
+
+同步结果不会保存或回显条目载荷和稳定 ID。`STATUS_INVALID_IDENTITY`、`STATUS_DUPLICATE_IDENTITY`、`STATUS_FACTORY_FAILED` 等失败会通过 `get_status()`、`get_error_index()` 和有界错误说明报告；bind 拒绝会记录首个失败索引并使用固定错误说明。identity 预检与 factory staging 失败不会修改已经提交的 active materialization。`STATUS_DEFERRED` 的 `is_successful()` 固定为 `false`，revision/range 描述本次尝试的入口快照，materialized indices 与 release count 描述回滚后的当前诊断状态；调用方不得把它当作 `UNCHANGED`，应继续等待已排队的下一轮。
+
+需要把同步诊断交给日志、测试工件或外部工具时，使用 `GFVirtualListSyncResult.to_dict()`。该摘要可直接经过 `JSON.stringify()` / `JSON.parse_string()` 往返：`status` 输出为 `String`，`viewport_range` 与 `requested_range` 输出为 `{ "start": int, "end_exclusive": int }`，`materialized_indices` 输出为 `Array[int]`；它不会退回到 `Vector2i`、PackedArray 或项目载荷。所有 revision 与 count 必须位于 `0..9007199254740991`，`error_index` 必须位于 `-1..9007199254740991`，因此成功配置的结果不会越过 JSON 可精确表达的整数域；越界输入会在结果冻结前被拒绝，同一个新结果对象仍可用合法数据重试。类型化 getter 仍返回 `StringName`、`Vector2i` 与 `PackedInt32Array`，供运行时调用方使用。
+
+## 预算与回收
+
+`max_materialized_items` 和 `max_pooled_items` 是调用方预算，但不能突破 `ABSOLUTE_MAX_MATERIALIZED_ITEMS` 与 `ABSOLUTE_MAX_POOLED_ITEMS` 的框架硬上限。超大赋值会被钳制；活动预算至少为 1，pool 可以设为 0。同步轮次外缩小 pool 预算会立即释放超额 parentless Control；项目 callback 在同步事务内收紧预算时，Binder 会先完成候选提交或回滚，再按新上限统一裁剪并让同步结果报告最终 pool 数量，避免释放仍被事务引用的 Control。
+
+稳定 identity 经过编码后的 UTF-8 token 也受 `ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH` 限制。String、StringName 与 NodePath 会先做廉价文本长度 admission，再进行稳定编码、token 字符数和 UTF-8 字节数校验，避免用超大 key 在硬上限之前制造无界编码工作。超限 identity 会 fail-closed，诊断只说明违反边界，不包含 identity 值。节点上限小于 overscan 请求量时，`GFVirtualListSyncResult.STATUS_TRUNCATED` 表示 Binder 已优先覆盖真实视口；调用方可据此降低 overscan、增大合理预算或调整交互设计，而不应关闭硬上限。
+
+Binder 会先复用仍在目标范围内的稳定 identity，再复用离开范围的 active Control，然后使用 pool，最后才调用 factory。Control 不在 active 范围时保持 parentless，但所有权仍属于 Binder；active 必须直属 content root，pool 必须 parentless，内部 ID 集合必须与两者精确一致。项目释放、排队释放或重挂载任一 active/pool Control 都会 fail-closed，Binder 不会在后续同步中把它静默抢回或替换。事务内的合法 release 会先保持 parentless，候选 map 完整交换后再统一收敛 pool 预算，避免把短暂状态误判为破坏。`unbind()` 会释放当前绑定但允许实例重新绑定，`dispose()` 则进入不可复用终态。owner、ScrollContainer 或 content root 退出 SceneTree 也会确定性 dispose，因此不要让 owner 比承载 UI 的生命周期更长。
+
+## 测量与滚动锚点
+
+默认情况下，新绑定或条目失效会自动测量活动行；`auto_measure = false` 只关闭这些自动触发，不会屏蔽显式 `request_measurement()`。每轮会冻结自动测量配置与请求 revision；已经排队的显式请求不会被后续 `invalidate_items()` 清除，callback 中提出的重测只归入下一轮。项目可提供 `measure_callback`，否则 Binder 使用 Control 的组合最小尺寸或当前尺寸。Binder 在测量前固定与 ScrollContainer 相同的整数滚动锚点快照，因此多个位于原始视口上方的条目同时变化时，会累计全部尺寸差，并只在该轮末尾应用一次滚动修正。若项目 callback 已把布局模型推进到本轮预期 revision 之外，Binder 不会把旧轮测量写入新模型，而是保留重测请求到下一轮。修正量通过 `get_anchor_adjustment()` 报告。
+
+`ScrollContainer` 的滚动条范围由 Godot 布局阶段更新。Binder 的范围、锚点和 reveal 都以滚动条实际接受的同一整数偏移收敛。`scroll_to_item()` 会冻结模型 revision、主轴、视口、当前偏移和精确 Control 所有权；若同步信号回调、Godot 钳制或项目重挂载使快照漂移，则返回 `false`、保留项目意图并请求下一轮，而不会把部分滚动报告为成功。常规用法应使用 `request_sync()` 的 deferred 合并路径；测试或工具若在同一帧修改 content 最小尺寸后直接写滚动值，应先等待一次布局帧，再调用 `sync_now()`，避免让尚未结算的滚动条把值钳制为零。
+
+Binder 只拥有 content root 当前布局主轴的 `custom_minimum_size` 分量。`layout_axis` 只接受 `VERTICAL` 与 `HORIZONTAL`，非法动态整数会保持上一值，且有效修改仍需显式请求同步。切换主轴时，Binder 先恢复旧主轴在该段所有权开始前的分量，再以新主轴的当前分量建立独立 baseline；unbind/dispose 也只恢复最后实际拥有的分量。项目在任一轴未被 Binder 拥有期间写入的新值，会成为后续接管该轴时的恢复基线。`sync_completed` 监听器内再次调用 `sync_now()` 不会同步递归，而会合并到下一轮。
 
 ## 虚拟焦点
 
@@ -55,9 +115,11 @@ if focused_index != GFVirtualListFocusModel.NO_FOCUS:
 
 `GFVirtualListFocusModel` 表达的是“导航焦点”，不等于业务选中。需要保留多选、范围选择或排序/过滤后的稳定选择时，应继续使用 `GFTableSelectionModel` 或项目自己的选择状态。
 
+Binder 连接焦点模型后，会接纳 bind 前已经存在的虚拟焦点，并把远端虚拟焦点按 nearest 规则滚入视口；滚入与物理 handoff 是两个独立待办，因此 bind 前已有的外部物理焦点不会阻断 reveal，也不会被 Binder 抢走。只有当前没有其他 Viewport focus owner 时，Binder 才会在对应行物化后把 Godot 焦点交给该行或项目提供的行内目标。行离开 active 范围，或虚拟焦点清除、转移时，Binder 会先释放旧行拥有的 Godot 焦点；仍指向未物化行的虚拟焦点会保留，待目标再次物化后交接。只有可见目标实际成为 Viewport focus owner 后，handoff 才算完成；目标在 `focus_entered` 中立即释放也被视为项目显式取消，不会在连续同步中重抢。焦点目标或 `focus_exited` 回调中产生的新虚拟焦点优先于旧交接，项目把焦点交给另一活动行或外部 Control 也会取消尚未完成的旧 handoff，但不会取消本次 auto-reveal。项目仍负责决定哪些索引可聚焦以及虚拟焦点何时变化。
+
 ## 注意事项
 
-- `get_visible_range()` 返回 `Vector2i(start, end)`，其中 `end` 是不包含的结束索引。
+- `get_viewport_range()` 与 `get_visible_range()` 都返回 `Vector2i(start, end)`，其中 `end` 是不包含的结束索引。
 - `overscan_items` 只扩大计算范围，不代表必须同时创建所有条目；项目仍可按帧分批物化。
 - `trailing_padding` 只影响 `get_content_extent()` 的默认返回值，不改变条目自身偏移。
 - estimate、实测 extent、padding 和 offset 必须是有限数值；`NaN` / `Inf` 会被拒绝或回退，条目尺寸还会被限制到 `MIN_ITEM_EXTENT` 以上，维持二分查找所需的有限单调累计偏移。

--- a/packages/standard/gf.standard.spatial.canvas.json
+++ b/packages/standard/gf.standard.spatial.canvas.json
@@ -4,7 +4,7 @@
   "kind": "standard",
   "version": "unreleased",
   "display_name": "GF Standard 2D Spatial Canvas",
-  "description": "Bounded runtime Control for 2D world navigation, grid snapping, stable item selection, and project-validated placement sessions.",
+  "description": "Bounded runtime Control for 2D world navigation, configurable input and parent-scroll arbitration, grid snapping, stable item selection, and project-validated placement sessions.",
   "dependencies": [
     "gf.kernel",
     "gf.standard.base",

--- a/packages/standard/gf.standard.ui.json
+++ b/packages/standard/gf.standard.ui.json
@@ -4,7 +4,7 @@
   "kind": "standard",
   "version": "unreleased",
   "display_name": "GF Standard UI",
-  "description": "Core UI value adapters, form/list/table helpers, modal value objects, text fitting, and virtual list models.",
+  "description": "Core UI value adapters, form/list/table projection helpers, modal value objects, text fitting, and bounded virtual list binding.",
   "dependencies": [
     "gf.kernel",
     "gf.standard.base"
@@ -30,18 +30,32 @@
     "addons/gf/standard/utilities/ui/gf_table_column_definition.gd.uid",
     "addons/gf/standard/utilities/ui/gf_table_data_view.gd",
     "addons/gf/standard/utilities/ui/gf_table_data_view.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_table_row_predicate.gd",
+    "addons/gf/standard/utilities/ui/gf_table_row_predicate.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd",
+    "addons/gf/standard/utilities/ui/gf_table_row_predicate_registration.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd",
+    "addons/gf/standard/utilities/ui/gf_table_row_predicate_result.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_table_row_view.gd",
+    "addons/gf/standard/utilities/ui/gf_table_row_view.gd.uid",
     "addons/gf/standard/utilities/ui/gf_table_selection_model.gd",
     "addons/gf/standard/utilities/ui/gf_table_selection_model.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd",
+    "addons/gf/standard/utilities/ui/gf_table_view_rebuild_result.gd.uid",
     "addons/gf/standard/utilities/ui/gf_text_auto_fit.gd",
     "addons/gf/standard/utilities/ui/gf_text_auto_fit.gd.uid",
     "addons/gf/standard/utilities/ui/gf_text_fitter.gd",
     "addons/gf/standard/utilities/ui/gf_text_fitter.gd.uid",
     "addons/gf/standard/utilities/ui/gf_theme_override_property_list.gd",
     "addons/gf/standard/utilities/ui/gf_theme_override_property_list.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd",
+    "addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd.uid",
     "addons/gf/standard/utilities/ui/gf_virtual_list_focus_model.gd",
     "addons/gf/standard/utilities/ui/gf_virtual_list_focus_model.gd.uid",
     "addons/gf/standard/utilities/ui/gf_virtual_list_model.gd",
-    "addons/gf/standard/utilities/ui/gf_virtual_list_model.gd.uid"
+    "addons/gf/standard/utilities/ui/gf_virtual_list_model.gd.uid",
+    "addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd",
+    "addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd.uid"
   ],
   "metadata": {
     "stage": "standard-ui-core-split-v1"

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -280,7 +280,12 @@
       "res://tests/gf_core/standard/utilities/settings/test_gf_settings_utility.gd"
     ],
     "gf.standard.ui": [
-      "res://tests/gf_core/standard/utilities/ui/test_gf_text_fitter.gd"
+      "res://tests/gf_core/standard/utilities/ui/test_gf_table_data_view.gd",
+      "res://tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd",
+      "res://tests/gf_core/standard/utilities/ui/test_gf_text_fitter.gd",
+      "res://tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd",
+      "res://tests/gf_core/standard/utilities/ui/test_gf_virtual_list_focus_model.gd",
+      "res://tests/gf_core/standard/utilities/ui/test_gf_virtual_list_model.gd"
     ],
     "gf.standard.ui.navigation": [
       "res://tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd",

--- a/tests/gf_core/standard/utilities/spatial_canvas/test_gf_spatial_canvas_2d.gd
+++ b/tests/gf_core/standard/utilities/spatial_canvas/test_gf_spatial_canvas_2d.gd
@@ -1,7 +1,24 @@
 extends GutTest
 
 
+# --- 常量 ---
+
+const _PAN_ACTION: StringName = &"gf_test_spatial_canvas_pan"
+const _SELECTION_ACTION: StringName = &"gf_test_spatial_canvas_selection"
+const _CANCEL_ACTION: StringName = &"gf_test_spatial_canvas_cancel"
+const _TEST_ACTIONS: Array[StringName] = [
+	_PAN_ACTION,
+	_SELECTION_ACTION,
+	_CANCEL_ACTION,
+]
+
+
 # --- 测试方法 ---
+
+func after_each() -> void:
+	for action_id: StringName in _TEST_ACTIONS:
+		if InputMap.has_action(action_id):
+			InputMap.erase_action(action_id)
 
 func test_view_coordinates_round_trip_and_content_root_follow_view() -> void:
 	var canvas: GFSpatialCanvas2D = _make_canvas()
@@ -157,16 +174,18 @@ func test_finite_inputs_with_non_finite_derived_geometry_fail_closed() -> void:
 	var preview_before_invalid_input: Dictionary = canvas.get_placement_snapshot()
 	var invalid_motion: InputEventMouseMotion = InputEventMouseMotion.new()
 	invalid_motion.position = Vector2(2.0e38, 0.0)
-	assert_false(
+	assert_eq(
 		canvas.handle_input_event(invalid_motion),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
 		"无法转换的局部移动不得被当作世界原点。"
 	)
 	var invalid_release: InputEventMouseButton = InputEventMouseButton.new()
 	invalid_release.button_index = MOUSE_BUTTON_LEFT
 	invalid_release.pressed = false
 	invalid_release.position = Vector2(2.0e38, 0.0)
-	assert_false(
+	assert_eq(
 		canvas.handle_input_event(invalid_release),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
 		"无法转换的左键释放不得提交放置。"
 	)
 	assert_eq(
@@ -482,19 +501,31 @@ func test_selection_modes_rect_selection_and_item_removal_are_consistent() -> vo
 	assert_true(canvas.upsert_item(&"locked", Rect2(Vector2(50.0, 10.0), Vector2(10.0, 10.0)), { "selectable": false }))
 
 	assert_eq(
-		canvas.set_selection(PackedStringArray(["a"]), GFSpatialCanvas2D.SelectionMode.REPLACE),
+		canvas.set_selection(
+			PackedStringArray(["a"]),
+			GFSpatialCanvas2D.SelectionMode.REPLACE
+		),
 		PackedStringArray(["a"])
 	)
 	assert_eq(
-		canvas.set_selection(PackedStringArray(["b"]), GFSpatialCanvas2D.SelectionMode.ADD),
+		canvas.set_selection(
+			PackedStringArray(["b"]),
+			GFSpatialCanvas2D.SelectionMode.ADD
+		),
 		PackedStringArray(["a", "b"])
 	)
 	assert_eq(
-		canvas.set_selection(PackedStringArray(["a"]), GFSpatialCanvas2D.SelectionMode.TOGGLE),
+		canvas.set_selection(
+			PackedStringArray(["a"]),
+			GFSpatialCanvas2D.SelectionMode.TOGGLE
+		),
 		PackedStringArray(["b"])
 	)
 	assert_eq(
-		canvas.set_selection(PackedStringArray(["b"]), GFSpatialCanvas2D.SelectionMode.SUBTRACT),
+		canvas.set_selection(
+			PackedStringArray(["b"]),
+			GFSpatialCanvas2D.SelectionMode.SUBTRACT
+		),
 		PackedStringArray()
 	)
 
@@ -726,8 +757,9 @@ func test_screen_conversion_and_screen_input_respect_control_transform() -> void
 		screen_focus,
 		true
 	)
-	assert_true(
+	assert_eq(
 		canvas.handle_screen_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
 		"Viewport 坐标事件应先转换到本地画布坐标。"
 	)
 	var after_focus: Vector2 = canvas.screen_to_world(screen_focus)
@@ -757,11 +789,27 @@ func test_mouse_pan_and_wheel_zoom_are_captured_but_unrelated_input_is_not() -> 
 		true
 	)
 
-	assert_true(canvas.handle_input_event(press), "中键按下应开始捕获。")
-	assert_true(canvas.handle_input_event(motion), "捕获期间移动应平移。")
+	assert_eq(
+		canvas.handle_input_event(press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"中键按下应开始捕获。"
+	)
+	assert_eq(
+		canvas.handle_input_event(motion),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"捕获期间移动应平移。"
+	)
 	assert_eq(canvas.get_world_center(), Vector2(-20.0, 0.0), "拖动画布应反向移动世界中心。")
-	assert_true(canvas.handle_input_event(release), "中键释放应结束捕获。")
-	assert_true(canvas.handle_input_event(wheel), "滚轮应执行焦点缩放。")
+	assert_eq(
+		canvas.handle_input_event(release),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"中键释放应结束捕获。"
+	)
+	assert_eq(
+		canvas.handle_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"滚轮应执行焦点缩放。"
+	)
 	assert_gt(canvas.get_zoom(), 1.0, "向上滚轮应放大。")
 	assert_false(
 		GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"),
@@ -771,7 +819,61 @@ func test_mouse_pan_and_wheel_zoom_are_captured_but_unrelated_input_is_not() -> 
 	var key: InputEventKey = InputEventKey.new()
 	key.keycode = KEY_A
 	key.pressed = true
-	assert_false(canvas.handle_input_event(key), "无活动操作时普通按键不应被捕获。")
+	assert_eq(
+		canvas.handle_input_event(key),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"无活动操作时普通按键不应被捕获。"
+	)
+
+
+func test_public_input_and_selection_contracts_use_named_enum_types() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var policy: GFSpatialCanvasInputPolicy = canvas.get_input_policy()
+	var wheel_axis: GFSpatialCanvasInputPolicy.WheelAxis = (
+		policy.wheel_axis as GFSpatialCanvasInputPolicy.WheelAxis
+	)
+	var wheel_routing: GFSpatialCanvasInputPolicy.WheelRouting = (
+		policy.wheel_routing as GFSpatialCanvasInputPolicy.WheelRouting
+	)
+	var touch_behavior: GFSpatialCanvasInputPolicy.TouchPrimaryBehavior = (
+		policy.touch_primary_behavior as GFSpatialCanvasInputPolicy.TouchPrimaryBehavior
+	)
+	var disposition: GFSpatialCanvas2D.InputDisposition = canvas.handle_input_event(
+		_key_event(KEY_A)
+	)
+	var default_selection_mode: GFSpatialCanvas2D.SelectionMode = (
+		policy.selection_default_mode as GFSpatialCanvas2D.SelectionMode
+	)
+	var binding_selection_mode: GFSpatialCanvas2D.SelectionMode = (
+		policy.selection_modifier_bindings[0].selection_mode as GFSpatialCanvas2D.SelectionMode
+	)
+
+	assert_eq(wheel_axis, GFSpatialCanvasInputPolicy.WheelAxis.VERTICAL)
+	assert_eq(wheel_routing, GFSpatialCanvasInputPolicy.WheelRouting.CANVAS)
+	assert_eq(
+		touch_behavior,
+		GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.PAN
+	)
+	assert_eq(disposition, GFSpatialCanvas2D.InputDisposition.IGNORED)
+	assert_eq(default_selection_mode, GFSpatialCanvas2D.SelectionMode.REPLACE)
+	assert_eq(binding_selection_mode, GFSpatialCanvas2D.SelectionMode.ADD)
+
+	assert_true(canvas.upsert_item(&"typed", Rect2(Vector2(-1.0, -1.0), Vector2(2.0, 2.0))))
+	assert_eq(
+		canvas.set_selection(PackedStringArray(["typed"]), default_selection_mode),
+		PackedStringArray(["typed"])
+	)
+	var canvas_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	var toggle_mode: GFSpatialCanvas2D.SelectionMode = GFSpatialCanvas2D.SelectionMode.TOGGLE
+	assert_true(canvas.select_point(canvas_position, toggle_mode).is_empty())
+	var add_mode: GFSpatialCanvas2D.SelectionMode = GFSpatialCanvas2D.SelectionMode.ADD
+	assert_eq(
+		canvas.select_rect(
+			Rect2(canvas_position - Vector2.ONE, Vector2.ONE * 2.0),
+			add_mode
+		),
+		PackedStringArray(["typed"])
+	)
 
 
 func test_active_middle_mouse_gesture_takes_priority_over_placement_motion() -> void:
@@ -798,9 +900,18 @@ func test_active_middle_mouse_gesture_takes_priority_over_placement_motion() -> 
 		false
 	)
 
-	assert_true(canvas.handle_input_event(press))
-	assert_true(canvas.handle_input_event(motion))
-	assert_true(canvas.handle_input_event(release))
+	assert_eq(
+		canvas.handle_input_event(press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(motion),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(release),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
 	assert_eq(canvas.get_world_center(), Vector2(-20.0, 0.0))
 	assert_eq(
 		GFVariantData.get_option_vector2(
@@ -810,6 +921,1295 @@ func test_active_middle_mouse_gesture_takes_priority_over_placement_motion() -> 
 		Vector2(10.0, 10.0),
 		"已捕获的平移手势不得被放置预览 MouseMotion 抢占。"
 	)
+
+
+func test_input_policy_validation_rejects_invalid_mappings_atomically() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var original_policy: GFSpatialCanvasInputPolicy = canvas.get_input_policy()
+	var invalid_policy: GFSpatialCanvasInputPolicy = original_policy.duplicate_policy()
+	invalid_policy.pan_action = _PAN_ACTION
+	_add_mouse_action(_PAN_ACTION, MOUSE_BUTTON_RIGHT)
+
+	var report: Dictionary = invalid_policy.validate_policy()
+	assert_false(
+		GFVariantData.get_option_bool(report, "ok"),
+		"同一行为同时配置直接按钮和 action 必须失败关闭。"
+	)
+	assert_false(canvas.set_input_policy(invalid_policy), "非法策略不得部分应用。")
+	assert_eq(
+		canvas.get_input_policy().pan_mouse_button,
+		original_policy.pan_mouse_button,
+		"非法策略后必须保留上一份有效策略。"
+	)
+
+	var invalid_wheel_policy: GFSpatialCanvasInputPolicy = original_policy.duplicate_policy()
+	invalid_wheel_policy.wheel_routing = (
+		GFSpatialCanvasInputPolicy.WheelRouting.MODIFIER_GATED
+	)
+	invalid_wheel_policy.wheel_modifier_mask = (
+		GFSpatialCanvasInputPolicy.ModifierMask.NONE
+	)
+	assert_false(
+		GFVariantData.get_option_bool(invalid_wheel_policy.validate_policy(), "ok"),
+		"modifier-gated wheel 必须声明非零 modifier。"
+	)
+
+
+func test_named_policy_enums_reject_dynamic_out_of_range_values_fail_closed() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var property_names: Array[StringName] = [
+		&"wheel_axis",
+		&"wheel_routing",
+		&"touch_primary_behavior",
+		&"selection_default_mode",
+	]
+	var issue_kinds: Array[String] = [
+		"invalid_wheel_axis",
+		"invalid_wheel_routing",
+		"invalid_touch_behavior",
+		"invalid_selection_mode",
+	]
+	for property_index: int in range(property_names.size()):
+		var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+		policy.set(property_names[property_index], 99)
+		var report: Dictionary = policy.validate_policy()
+		assert_true(
+			_report_has_issue_kind(report, issue_kinds[property_index]),
+			"反射或反序列化写入的越界命名枚举必须由完整策略校验拒绝。"
+		)
+		assert_false(canvas.set_input_policy(policy), "非法动态枚举值不得部分应用。")
+
+
+func test_invalid_nested_selection_mode_binding_is_rejected_atomically() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var original_policy: GFSpatialCanvasInputPolicy = canvas.get_input_policy()
+	var invalid_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	invalid_policy.selection_modifier_bindings.clear()
+	var invalid_binding: GFSpatialCanvasSelectionModeBinding = (
+		GFSpatialCanvasSelectionModeBinding.new()
+	)
+	invalid_binding.modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	invalid_binding.set(&"selection_mode", 99)
+	invalid_policy.selection_modifier_bindings.append(invalid_binding)
+
+	var report: Dictionary = invalid_policy.validate_policy()
+	assert_true(_report_has_issue_kind(report, "invalid_selection_mode"))
+	assert_false(canvas.set_input_policy(invalid_policy))
+	var retained_policy: GFSpatialCanvasInputPolicy = canvas.get_input_policy()
+	assert_eq(retained_policy.selection_default_mode, original_policy.selection_default_mode)
+	assert_eq(
+		retained_policy.selection_modifier_bindings.size(),
+		original_policy.selection_modifier_bindings.size(),
+		"嵌套 binding 非法时不得部分替换 Canvas 策略。"
+	)
+
+
+func test_cancel_action_rejects_pointer_events_and_fixed_budget_overflow() -> void:
+	_add_mouse_action(_CANCEL_ACTION, MOUSE_BUTTON_LEFT)
+	var pointer_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	pointer_policy.placement_cancel_action = _CANCEL_ACTION
+	var pointer_report: Dictionary = pointer_policy.validate_policy()
+	assert_true(
+		_report_has_issue_kind(pointer_report, "pointer_cancel_action_event"),
+		"取消动作不得占用任何 Canvas 指针 chord。"
+	)
+
+	_add_key_action(_CANCEL_ACTION, KEY_Q)
+	for device_index: int in range(
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS + 2
+	):
+		var extra_key: InputEventKey = InputEventKey.new()
+		extra_key.keycode = KEY_Q
+		extra_key.device = device_index + 100
+		InputMap.action_add_event(_CANCEL_ACTION, extra_key)
+	assert_gt(
+		InputMap.action_get_events(_CANCEL_ACTION).size(),
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS
+	)
+	var budget_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	budget_policy.placement_cancel_action = _CANCEL_ACTION
+	var budget_report: Dictionary = budget_policy.validate_policy()
+	assert_true(
+		_report_has_issue_kind(budget_report, "too_many_action_events"),
+		"取消动作必须使用同一固定 64-event 扫描预算。"
+	)
+
+
+func test_canvas_isolates_policy_without_calling_overridable_candidate_methods() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var malicious_policy: MaliciousInputPolicy = MaliciousInputPolicy.new()
+	malicious_policy.wheel_zoom_factor = 1.0
+	assert_false(
+		canvas.set_input_policy(malicious_policy),
+		"候选 override 不得让非法字段绕过 GF 基类校验。"
+	)
+	assert_eq(malicious_policy.validate_call_count, 0)
+	assert_eq(malicious_policy.duplicate_call_count, 0)
+
+	malicious_policy.wheel_zoom_factor = 1.1
+	malicious_policy.selection_modifier_bindings.clear()
+	var malicious_binding: MaliciousSelectionBinding = MaliciousSelectionBinding.new()
+	malicious_binding.modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	malicious_binding.selection_mode = GFSpatialCanvas2D.SelectionMode.ADD
+	malicious_policy.selection_modifier_bindings.append(malicious_binding)
+	assert_true(canvas.set_input_policy(malicious_policy))
+	assert_eq(malicious_policy.validate_call_count, 0)
+	assert_eq(malicious_policy.duplicate_call_count, 0)
+	assert_eq(malicious_binding.duplicate_call_count, 0)
+
+	malicious_binding.selection_mode = GFSpatialCanvas2D.SelectionMode.SUBTRACT
+	var isolated_policy: GFSpatialCanvasInputPolicy = canvas.get_input_policy()
+	assert_false(
+		isolated_policy is MaliciousInputPolicy,
+		"Canvas 内部及 getter 必须返回纯 GF 基类策略。"
+	)
+	assert_false(
+		isolated_policy.selection_modifier_bindings[0] is MaliciousSelectionBinding,
+		"嵌套绑定也必须逐字段复制到纯 GF 基类实例。"
+	)
+	assert_eq(
+		isolated_policy.selection_modifier_bindings[0].selection_mode,
+		GFSpatialCanvas2D.SelectionMode.ADD,
+		"应用后修改调用方嵌套 Resource 不得污染 Canvas。"
+	)
+	assert_eq(malicious_policy.duplicate_call_count, 0, "getter 也不得调用候选 override。")
+	assert_eq(malicious_binding.duplicate_call_count, 0)
+
+
+func test_pan_modifier_is_exact_and_action_owns_its_modifier_chord() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var direct_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	direct_policy.pan_mouse_button = MOUSE_BUTTON_RIGHT
+	direct_policy.pan_modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	assert_true(canvas.set_input_policy(direct_policy))
+
+	var plain_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(100.0, 100.0),
+		true
+	)
+	assert_eq(
+		canvas.handle_input_event(plain_press),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	var over_modified_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(100.0, 100.0),
+		true
+	)
+	over_modified_press.shift_pressed = true
+	over_modified_press.ctrl_pressed = true
+	assert_eq(
+		canvas.handle_input_event(over_modified_press),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"直接按钮必须精确匹配 modifier，不能把额外修饰键当作同一 chord。"
+	)
+
+	var exact_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(100.0, 100.0),
+		true
+	)
+	exact_press.shift_pressed = true
+	assert_eq(
+		canvas.handle_input_event(exact_press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	var release_without_modifier: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(100.0, 100.0),
+		false
+	)
+	assert_eq(
+		canvas.handle_input_event(release_without_modifier),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"捕获后应由同一物理按钮释放，modifier 变化不能遗留捕获。"
+	)
+
+	_add_mouse_action(_PAN_ACTION, MOUSE_BUTTON_RIGHT)
+	var action_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	action_policy.pan_mouse_button = MOUSE_BUTTON_NONE
+	action_policy.pan_action = _PAN_ACTION
+	action_policy.pan_modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	var action_report: Dictionary = action_policy.validate_policy()
+	assert_false(GFVariantData.get_option_bool(action_report, "ok"))
+	assert_true(
+		_report_has_issue_kind(action_report, "action_modifier_conflict"),
+		"action 的 modifier 必须只由 InputMap 精确 chord 声明。"
+	)
+
+
+func test_policy_rejects_physical_chord_overlap_across_mapping_sources() -> void:
+	_add_mouse_action(
+		_SELECTION_ACTION,
+		MOUSE_BUTTON_MIDDLE,
+		GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	)
+	var direct_to_action: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	direct_to_action.pan_modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	direct_to_action.selection_mouse_button = MOUSE_BUTTON_NONE
+	direct_to_action.selection_action = _SELECTION_ACTION
+	var direct_action_report: Dictionary = direct_to_action.validate_policy()
+	assert_true(
+		_report_has_issue_kind(direct_action_report, "ambiguous_pointer_mapping"),
+		"direct pan 与 selection action 的同一物理 chord 必须被拒绝。"
+	)
+
+	_add_mouse_action(
+		_PAN_ACTION,
+		MOUSE_BUTTON_LEFT,
+		GFSpatialCanvasInputPolicy.ModifierMask.ALT
+	)
+	var action_to_direct: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	action_to_direct.pan_mouse_button = MOUSE_BUTTON_NONE
+	action_to_direct.pan_action = _PAN_ACTION
+	var action_direct_report: Dictionary = action_to_direct.validate_policy()
+	assert_true(
+		_report_has_issue_kind(action_direct_report, "ambiguous_pointer_mapping"),
+		"pan action 与 direct selection 的重叠必须被拒绝。"
+	)
+
+	_add_mouse_action(
+		_PAN_ACTION,
+		MOUSE_BUTTON_RIGHT,
+		GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+	)
+	_add_mouse_action(
+		_SELECTION_ACTION,
+		MOUSE_BUTTON_RIGHT,
+		GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+	)
+	var action_to_action: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	action_to_action.pan_mouse_button = MOUSE_BUTTON_NONE
+	action_to_action.pan_action = _PAN_ACTION
+	action_to_action.selection_mouse_button = MOUSE_BUTTON_NONE
+	action_to_action.selection_action = _SELECTION_ACTION
+	assert_true(
+		_report_has_issue_kind(
+			action_to_action.validate_policy(),
+			"ambiguous_pointer_mapping"
+		),
+		"两个 InputMap action 的同一物理 chord 必须被拒绝。"
+	)
+
+
+func test_runtime_input_map_conflict_is_ignored_without_state_mutation() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	_add_mouse_action(_PAN_ACTION, MOUSE_BUTTON_RIGHT)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.pan_mouse_button = MOUSE_BUTTON_NONE
+	policy.pan_action = _PAN_ACTION
+	assert_true(canvas.set_input_policy(policy))
+
+	_add_mouse_action(_PAN_ACTION, MOUSE_BUTTON_LEFT)
+	var conflict_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_LEFT,
+		Vector2(100.0, 100.0),
+		true
+	)
+	assert_eq(
+		canvas.handle_input_event(conflict_press),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"策略应用后 InputMap 产生冲突时必须逐事件失败关闭。"
+	)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+	assert_true(canvas.get_selection().is_empty())
+	assert_false(
+		GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"),
+		"冲突事件不得留下任一捕获状态。"
+	)
+
+
+func test_runtime_pointer_action_budget_drift_fails_closed() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	_add_mouse_action(_PAN_ACTION, MOUSE_BUTTON_RIGHT)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.pan_mouse_button = MOUSE_BUTTON_NONE
+	policy.pan_action = _PAN_ACTION
+	assert_true(canvas.set_input_policy(policy))
+
+	for device_index: int in range(
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS + 2
+	):
+		var extra_button: InputEventMouseButton = InputEventMouseButton.new()
+		extra_button.button_index = MOUSE_BUTTON_RIGHT
+		extra_button.device = device_index + 100
+		InputMap.action_add_event(_PAN_ACTION, extra_button)
+	assert_gt(
+		InputMap.action_get_events(_PAN_ACTION).size(),
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS
+	)
+	var press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(100.0, 100.0),
+		true
+	)
+	assert_eq(
+		canvas.handle_input_event(press),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"应用后膨胀的 InputMap action 不得进入无界匹配或建立捕获。"
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_policy_validation_budgets_bindings_and_action_event_scans() -> void:
+	var binding_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	binding_policy.selection_modifier_bindings.clear()
+	for mask: int in range(
+		1,
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_SELECTION_MODIFIER_BINDINGS + 2
+	):
+		var binding: GFSpatialCanvasSelectionModeBinding = (
+			GFSpatialCanvasSelectionModeBinding.new()
+		)
+		binding.modifier_mask = mask
+		binding_policy.selection_modifier_bindings.append(binding)
+	var binding_report: Dictionary = binding_policy.validate_policy()
+	assert_true(
+		_report_has_issue_kind(binding_report, "too_many_selection_bindings"),
+		"选择绑定校验必须受 15 个非零组合的硬上限约束。"
+	)
+
+	if InputMap.has_action(_PAN_ACTION):
+		InputMap.erase_action(_PAN_ACTION)
+	InputMap.add_action(_PAN_ACTION)
+	for event_index: int in range(
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS + 1
+	):
+		var action_event: InputEventMouseButton = InputEventMouseButton.new()
+		var button_slot: int = event_index % 5
+		var buttons: Array[MouseButton] = [
+			MOUSE_BUTTON_LEFT,
+			MOUSE_BUTTON_RIGHT,
+			MOUSE_BUTTON_MIDDLE,
+			MOUSE_BUTTON_XBUTTON1,
+			MOUSE_BUTTON_XBUTTON2,
+		]
+		action_event.button_index = buttons[button_slot]
+		_apply_modifier_mask(action_event, floori(float(event_index) / 5.0))
+		action_event.device = event_index
+		InputMap.action_add_event(_PAN_ACTION, action_event)
+	assert_gt(
+		InputMap.action_get_events(_PAN_ACTION).size(),
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS,
+		"测试前置条件：InputMap action 应超过事件预算。"
+	)
+	var action_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	action_policy.pan_mouse_button = MOUSE_BUTTON_NONE
+	action_policy.pan_action = _PAN_ACTION
+	action_policy.selection_mouse_button = MOUSE_BUTTON_NONE
+	var action_report: Dictionary = action_policy.validate_policy()
+	assert_true(
+		_report_has_issue_kind(action_report, "too_many_action_events"),
+		"超大 InputMap action 必须直接报告预算错误并停止扫描。"
+	)
+
+
+func test_policy_actions_buttons_and_modifier_selection_are_explicit() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	_add_mouse_action(_PAN_ACTION, MOUSE_BUTTON_RIGHT)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.pan_mouse_button = MOUSE_BUTTON_NONE
+	policy.pan_action = _PAN_ACTION
+	policy.selection_modifier_bindings.clear()
+	var subtract_binding: GFSpatialCanvasSelectionModeBinding = (
+		GFSpatialCanvasSelectionModeBinding.new()
+	)
+	subtract_binding.modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	subtract_binding.selection_mode = GFSpatialCanvas2D.SelectionMode.SUBTRACT
+	policy.selection_modifier_bindings.append(subtract_binding)
+	assert_true(canvas.set_input_policy(policy))
+
+	var middle_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_MIDDLE,
+		Vector2(100.0, 100.0),
+		true
+	)
+	assert_eq(
+		canvas.handle_input_event(middle_press),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"替换 pan 绑定后不得保留内置中键 fallback。"
+	)
+
+	var right_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(100.0, 100.0),
+		true
+	)
+	var right_motion: InputEventMouseMotion = InputEventMouseMotion.new()
+	right_motion.position = Vector2(120.0, 100.0)
+	right_motion.relative = Vector2(20.0, 0.0)
+	var right_release: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_RIGHT,
+		Vector2(120.0, 100.0),
+		false
+	)
+	assert_eq(
+		canvas.handle_input_event(right_press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(right_motion),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(right_release),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_world_center(), Vector2(-20.0, 0.0))
+
+	assert_true(
+		canvas.upsert_item(&"target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var _initial_selection: PackedStringArray = canvas.set_selection(
+		PackedStringArray(["target"])
+	)
+	var selection_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	var select_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_LEFT,
+		selection_position,
+		true
+	)
+	select_press.shift_pressed = true
+	var select_release: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_LEFT,
+		selection_position,
+		false
+	)
+	assert_eq(
+		canvas.handle_input_event(select_press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(select_release),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(canvas.get_selection().is_empty(), "Shift mapping 应按 policy 执行 subtract。")
+
+
+func test_wheel_uses_bounded_smooth_event_factor() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.wheel_zoom_factor = 4.0
+	assert_true(canvas.set_input_policy(policy))
+	var wheel: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_WHEEL_UP,
+		Vector2(400.0, 300.0),
+		true
+	)
+	wheel.factor = 0.5
+	assert_eq(
+		canvas.handle_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_almost_eq(canvas.get_zoom(), 2.0, 0.001, "0.5 格应使用倍率的平方根。")
+
+	var zoom_before_invalid: float = canvas.get_zoom()
+	wheel.factor = 0.0
+	assert_eq(
+		canvas.handle_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	wheel.factor = 65.0
+	assert_eq(
+		canvas.handle_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"超出固定指数预算的 wheel factor 必须失败关闭。"
+	)
+	wheel.factor = NAN
+	assert_eq(
+		canvas.handle_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"非有限 wheel factor 必须失败关闭。"
+	)
+	assert_eq(canvas.get_zoom(), zoom_before_invalid)
+
+
+func test_cancel_uses_input_map_action_instead_of_raw_escape() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	_add_key_action(_CANCEL_ACTION, KEY_Q)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.placement_cancel_action = _CANCEL_ACTION
+	assert_true(canvas.set_input_policy(policy))
+	assert_gt(canvas.begin_placement(&"marker", Rect2(Vector2.ZERO, Vector2.ONE)), 0)
+
+	var escape_event: InputEventKey = _key_event(KEY_ESCAPE)
+	assert_eq(
+		canvas.handle_input_event(escape_event),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"Canvas 不得保留 raw Escape 特判。"
+	)
+	assert_true(canvas.has_active_placement())
+
+	var cancel_event: InputEventKey = _key_event(KEY_Q)
+	assert_eq(
+		canvas.handle_input_event(cancel_event),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_false(canvas.has_active_placement())
+
+
+func test_cancel_action_runtime_drift_cannot_starve_pointer_or_bypass_budget() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	_add_key_action(_CANCEL_ACTION, KEY_Q)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.placement_cancel_action = _CANCEL_ACTION
+	assert_true(canvas.set_input_policy(policy))
+	assert_gt(canvas.begin_placement(&"marker", Rect2(Vector2.ZERO, Vector2.ONE)), 0)
+
+	_add_mouse_action(_CANCEL_ACTION, MOUSE_BUTTON_MIDDLE)
+	var pan_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_MIDDLE,
+		Vector2(100.0, 100.0),
+		true
+	)
+	var pan_release: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_MIDDLE,
+		Vector2(100.0, 100.0),
+		false
+	)
+	assert_eq(
+		canvas.handle_input_event(pan_press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"漂移为 pointer 的 cancel action 必须失败关闭并把事件留给 pan。"
+	)
+	assert_eq(
+		canvas.handle_input_event(pan_release),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(canvas.has_active_placement(), "pointer 漂移不得取消 placement。")
+
+	_add_key_action(_CANCEL_ACTION, KEY_Q)
+	for device_index: int in range(
+		GFSpatialCanvasInputPolicy.ABSOLUTE_MAX_ACTION_EVENTS + 2
+	):
+		var extra_key: InputEventKey = InputEventKey.new()
+		extra_key.keycode = KEY_Q
+		extra_key.device = device_index + 100
+		InputMap.action_add_event(_CANCEL_ACTION, extra_key)
+	assert_eq(
+		canvas.handle_input_event(_key_event(KEY_Q)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"超出运行期预算的 cancel action 必须失败关闭。"
+	)
+	assert_true(canvas.has_active_placement())
+
+
+func test_manual_forwarding_distinguishes_handled_and_consumed() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas(Vector2(200.0, 100.0))
+	canvas.position = Vector2(30.0, 40.0)
+	canvas.scale = Vector2(1.5, 2.0)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.consume_wheel_events = false
+	assert_true(canvas.set_input_policy(policy))
+	var screen_focus: Vector2 = canvas.world_to_screen(Vector2.ZERO)
+	var wheel: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_WHEEL_UP,
+		screen_focus,
+		true
+	)
+	var original_position: Vector2 = wheel.position
+
+	assert_eq(
+		canvas.handle_screen_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.HANDLED,
+		"手工转发必须能观察到已处理但继续传播。"
+	)
+	assert_eq(wheel.position, original_position, "屏幕转发不得原地改写调用方事件。")
+	assert_gt(canvas.get_zoom(), 1.0)
+
+	policy.consume_wheel_events = true
+	assert_true(canvas.set_input_policy(policy))
+	assert_eq(
+		canvas.handle_screen_input_event(wheel),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+
+
+func test_system_gesture_policy_controls_pan_magnify_and_disposition() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.consume_handled_events = false
+	assert_true(canvas.set_input_policy(policy))
+
+	var pan_gesture: InputEventPanGesture = InputEventPanGesture.new()
+	pan_gesture.position = Vector2(400.0, 300.0)
+	pan_gesture.delta = Vector2(12.0, -8.0)
+	assert_eq(
+		canvas.handle_input_event(pan_gesture),
+		GFSpatialCanvas2D.InputDisposition.HANDLED
+	)
+	assert_eq(canvas.get_world_center(), Vector2(-12.0, 8.0))
+
+	policy.system_pan_gesture_enabled = false
+	assert_true(canvas.set_input_policy(policy))
+	var center_before_disabled_pan: Vector2 = canvas.get_world_center()
+	assert_eq(
+		canvas.handle_input_event(pan_gesture),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(canvas.get_world_center(), center_before_disabled_pan)
+
+	var magnify_gesture: InputEventMagnifyGesture = InputEventMagnifyGesture.new()
+	magnify_gesture.position = Vector2(400.0, 300.0)
+	magnify_gesture.factor = 2.0
+	assert_eq(
+		canvas.handle_input_event(magnify_gesture),
+		GFSpatialCanvas2D.InputDisposition.HANDLED
+	)
+	assert_almost_eq(canvas.get_zoom(), 2.0, 0.001)
+
+	policy.system_magnify_gesture_enabled = false
+	assert_true(canvas.set_input_policy(policy))
+	var zoom_before_disabled_magnify: float = canvas.get_zoom()
+	assert_eq(
+		canvas.handle_input_event(magnify_gesture),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(canvas.get_zoom(), zoom_before_disabled_magnify)
+
+
+func test_manual_screen_forwarding_localizes_system_gestures_without_mutation() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas(Vector2(240.0, 120.0))
+	canvas.position = Vector2(30.0, 40.0)
+	canvas.scale = Vector2(2.0, 2.0)
+	var world_focus: Vector2 = Vector2(20.0, 10.0)
+	var screen_focus: Vector2 = canvas.world_to_screen(world_focus)
+	var magnify_gesture: InputEventMagnifyGesture = InputEventMagnifyGesture.new()
+	magnify_gesture.position = screen_focus
+	magnify_gesture.factor = 2.0
+
+	assert_eq(
+		canvas.handle_screen_input_event(magnify_gesture),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(magnify_gesture.position, screen_focus, "屏幕转发不得改写调用方手势事件。")
+	assert_almost_eq(canvas.get_zoom(), 2.0, 0.001)
+	var restored_focus: Vector2 = canvas.screen_to_world(screen_focus)
+	assert_almost_eq(restored_focus.x, world_focus.x, 0.001)
+	assert_almost_eq(restored_focus.y, world_focus.y, 0.001)
+
+	var pan_gesture: InputEventPanGesture = InputEventPanGesture.new()
+	pan_gesture.position = screen_focus
+	pan_gesture.delta = Vector2(20.0, 0.0)
+	var center_before_pan: Vector2 = canvas.get_world_center()
+	assert_eq(
+		canvas.handle_screen_input_event(pan_gesture),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(pan_gesture.position, screen_focus, "屏幕转发不得原地局部化 pan gesture。")
+	assert_false(canvas.get_world_center().is_equal_approx(center_before_pan))
+
+
+func test_touch_policy_selects_pans_and_can_disable_raw_touch() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_true(
+		canvas.upsert_item(&"touch_target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var touch_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = (
+		GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	)
+	assert_true(canvas.set_input_policy(policy))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, true, touch_position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, false, touch_position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_selection(), PackedStringArray(["touch_target"]))
+	assert_eq(canvas.get_world_center(), Vector2.ZERO, "触摸选择不得同时平移视图。")
+
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.PAN
+	assert_true(canvas.set_input_policy(policy))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, true, touch_position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(1, touch_position + Vector2(20.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, false, touch_position + Vector2(20.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_world_center(), Vector2(-20.0, 0.0))
+
+	policy.touch_enabled = false
+	assert_true(canvas.set_input_policy(policy))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(2, true, touch_position)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+
+
+func test_touch_primary_none_ignores_single_touch_when_multitouch_is_disabled() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.NONE
+	policy.touch_multi_pan_enabled = false
+	policy.touch_multi_zoom_enabled = false
+	assert_true(canvas.set_input_policy(policy))
+	var start: Vector2 = Vector2(320.0, 240.0)
+	var center_before: Vector2 = canvas.get_world_center()
+	var zoom_before: float = canvas.get_zoom()
+
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, true, start)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(0, start + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, false, start + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(canvas.get_world_center(), center_before)
+	assert_eq(canvas.get_zoom(), zoom_before)
+	assert_true(canvas.get_selection().is_empty())
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+	policy.touch_multi_pan_enabled = true
+	assert_true(canvas.set_input_policy(policy))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, true, start)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"启用多指行为时首触点必须被捕获以等待第二触点。"
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(1, start + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_world_center(), center_before, "NONE 单指移动不得应用多指 pan。")
+	assert_eq(canvas.get_zoom(), zoom_before)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, false, start + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_touch_multi_pan_and_zoom_are_independently_configurable() -> void:
+	var first_point: Vector2 = Vector2(300.0, 300.0)
+	var second_point: Vector2 = Vector2(400.0, 300.0)
+	var moved_first_point: Vector2 = Vector2(280.0, 300.0)
+
+	var pan_canvas: GFSpatialCanvas2D = _make_canvas()
+	var pan_expected: GFSpatialCanvas2D = _make_canvas()
+	var pan_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	pan_policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.NONE
+	pan_policy.touch_multi_pan_enabled = true
+	pan_policy.touch_multi_zoom_enabled = false
+	assert_true(pan_canvas.set_input_policy(pan_policy))
+	assert_eq(
+		pan_canvas.handle_input_event(_touch_event(0, true, first_point)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		pan_canvas.handle_input_event(_touch_event(1, true, second_point)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		pan_canvas.handle_input_event(_touch_drag_event(0, moved_first_point)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(pan_expected.pan_by_canvas_delta(Vector2(-10.0, 0.0)))
+	assert_eq(pan_canvas.get_world_center(), pan_expected.get_world_center())
+	assert_eq(pan_canvas.get_zoom(), pan_expected.get_zoom(), "禁用多指缩放后距离变化不得修改 zoom。")
+	var _pan_release_first: GFSpatialCanvas2D.InputDisposition = pan_canvas.handle_input_event(
+		_touch_event(0, false, moved_first_point)
+	)
+	var _pan_release_second: GFSpatialCanvas2D.InputDisposition = pan_canvas.handle_input_event(
+		_touch_event(1, false, second_point)
+	)
+
+	var zoom_canvas: GFSpatialCanvas2D = _make_canvas()
+	var zoom_expected: GFSpatialCanvas2D = _make_canvas()
+	var zoom_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	zoom_policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.NONE
+	zoom_policy.touch_multi_pan_enabled = false
+	zoom_policy.touch_multi_zoom_enabled = true
+	assert_true(zoom_canvas.set_input_policy(zoom_policy))
+	assert_eq(
+		zoom_canvas.handle_input_event(_touch_event(0, true, first_point)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		zoom_canvas.handle_input_event(_touch_event(1, true, second_point)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		zoom_canvas.handle_input_event(_touch_drag_event(0, moved_first_point)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(zoom_expected.zoom_at(Vector2(340.0, 300.0), 1.2))
+	assert_almost_eq(zoom_canvas.get_zoom(), zoom_expected.get_zoom(), 0.001)
+	assert_almost_eq(
+		zoom_canvas.get_world_center().x,
+		zoom_expected.get_world_center().x,
+		0.001,
+		"禁用多指平移后只允许焦点缩放产生的中心修正。"
+	)
+	assert_almost_eq(
+		zoom_canvas.get_world_center().y,
+		zoom_expected.get_world_center().y,
+		0.001
+	)
+	var _zoom_release_first: GFSpatialCanvas2D.InputDisposition = zoom_canvas.handle_input_event(
+		_touch_event(0, false, moved_first_point)
+	)
+	var _zoom_release_second: GFSpatialCanvas2D.InputDisposition = zoom_canvas.handle_input_event(
+		_touch_event(1, false, second_point)
+	)
+
+
+func test_touch_select_multi_to_single_does_not_restart_selection() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_true(
+		canvas.upsert_item(&"target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	assert_true(canvas.set_input_policy(policy))
+	var center: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, true, center)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, true, center + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"第二触点应把未提交单指选择升级为多指手势。"
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(1, center + Vector2(60.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, false, center + Vector2(60.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	var center_after_downgrade: Vector2 = canvas.get_world_center()
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(0, center + Vector2(10.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"降级后的剩余触点仍归当前手势所有，直到物理 release。"
+	)
+	assert_eq(canvas.get_world_center(), center_after_downgrade, "降级不得隐式切换为单指 pan。")
+	assert_true(canvas.get_selection().is_empty(), "降级不得隐式重启选择捕获。")
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, false, center + Vector2(10.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_touch_multi_pan_and_zoom_disabled_leave_additional_pointer_unowned() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.PAN
+	policy.touch_multi_pan_enabled = false
+	policy.touch_multi_zoom_enabled = false
+	assert_true(canvas.set_input_policy(policy))
+	var start: Vector2 = Vector2(100.0, 100.0)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, true, start)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, true, start + Vector2(30.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(1, start + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(1, false, start + Vector2(40.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"未接管的额外触点 press/drag/release 都必须继续传播。"
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(0, start + Vector2(20.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_world_center(), Vector2(-20.0, 0.0))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, false, start + Vector2(20.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+
+
+func test_raw_touch_capture_excludes_mouse_without_polluting_selection_or_view() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_true(
+		canvas.upsert_item(&"target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	assert_true(canvas.set_input_policy(policy))
+	var target_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, true, target_position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	var center_before_mouse: Vector2 = canvas.get_world_center()
+	var zoom_before_mouse: float = canvas.get_zoom()
+	var mouse_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_LEFT,
+		target_position + Vector2(80.0, 0.0),
+		true
+	)
+	var mouse_drag: InputEventMouseMotion = InputEventMouseMotion.new()
+	mouse_drag.position = target_position + Vector2(120.0, 0.0)
+	mouse_drag.button_mask = MOUSE_BUTTON_MASK_LEFT
+	var mouse_release: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_LEFT,
+		mouse_drag.position,
+		false
+	)
+	var wheel: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_WHEEL_UP,
+		target_position,
+		true
+	)
+
+	for conflicting_event: InputEvent in [mouse_press, mouse_drag, wheel, mouse_release]:
+		assert_eq(
+			canvas.handle_input_event(conflicting_event),
+			GFSpatialCanvas2D.InputDisposition.IGNORED,
+			"raw touch 捕获期间全部鼠标事件（含 wheel）都必须继续传播。"
+		)
+	assert_eq(canvas.get_world_center(), center_before_mouse)
+	assert_eq(canvas.get_zoom(), zoom_before_mouse)
+	assert_true(canvas.get_selection().is_empty(), "冲突鼠标不得提交或改写触摸选择几何。")
+	assert_eq(
+		canvas.handle_input_event(_touch_event(0, false, target_position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_selection(), PackedStringArray(["target"]))
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_mouse_capture_excludes_raw_touch_until_matching_mouse_release() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_true(
+		canvas.upsert_item(&"target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	assert_true(canvas.set_input_policy(policy))
+	var target_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	assert_eq(
+		canvas.handle_input_event(
+			_mouse_button(MOUSE_BUTTON_LEFT, target_position, true)
+		),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	var touch_position: Vector2 = target_position + Vector2(100.0, 0.0)
+	var center_before_touch: Vector2 = canvas.get_world_center()
+	for conflicting_event: InputEvent in [
+		_touch_event(7, true, touch_position),
+		_touch_drag_event(7, touch_position + Vector2(30.0, 0.0)),
+		_touch_event(7, false, touch_position + Vector2(30.0, 0.0)),
+	]:
+		assert_eq(
+			canvas.handle_input_event(conflicting_event),
+			GFSpatialCanvas2D.InputDisposition.IGNORED,
+			"鼠标捕获期间 raw touch press/drag/release 都不得接管状态。"
+		)
+	assert_eq(canvas.get_world_center(), center_before_touch)
+	assert_true(canvas.get_selection().is_empty())
+	assert_eq(
+		canvas.handle_input_event(
+			_mouse_button(MOUSE_BUTTON_LEFT, target_position, false)
+		),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_selection(), PackedStringArray(["target"]))
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_active_physical_capture_excludes_system_gestures_until_release() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var focus: Vector2 = Vector2(400.0, 300.0)
+	var pan_gesture: InputEventPanGesture = InputEventPanGesture.new()
+	pan_gesture.position = focus
+	pan_gesture.delta = Vector2(25.0, -10.0)
+	var magnify_gesture: InputEventMagnifyGesture = InputEventMagnifyGesture.new()
+	magnify_gesture.position = focus
+	magnify_gesture.factor = 2.0
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_MIDDLE, focus, true)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	for system_gesture: InputEvent in [pan_gesture, magnify_gesture]:
+		assert_eq(
+			canvas.handle_input_event(system_gesture),
+			GFSpatialCanvas2D.InputDisposition.IGNORED,
+			"鼠标捕获期间系统手势不得修改 Canvas。"
+		)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+	assert_eq(canvas.get_zoom(), 1.0)
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_MIDDLE, focus, false)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+	assert_eq(
+		canvas.handle_input_event(_touch_event(3, true, focus)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	for system_gesture: InputEvent in [pan_gesture, magnify_gesture]:
+		assert_eq(
+			canvas.handle_input_event(system_gesture),
+			GFSpatialCanvas2D.InputDisposition.IGNORED,
+			"raw touch 捕获期间系统手势不得修改 Canvas。"
+		)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+	assert_eq(canvas.get_zoom(), 1.0)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(3, false, focus)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	assert_eq(
+		canvas.handle_input_event(pan_gesture),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"物理捕获结束后系统手势应恢复正常处理。"
+	)
+	assert_eq(canvas.get_world_center(), Vector2(-25.0, 10.0))
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_cancel_and_policy_replacement_release_entire_physical_capture() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	_add_key_action(_CANCEL_ACTION, KEY_Q)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.placement_cancel_action = _CANCEL_ACTION
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	assert_true(canvas.set_input_policy(policy))
+	var position: Vector2 = Vector2(200.0, 150.0)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(4, true, position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_key_event(KEY_Q)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED,
+		"显式 cancel 应释放 raw-touch owner 和 pointer tracking。"
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	assert_eq(
+		canvas.handle_input_event(_touch_drag_event(4, position + Vector2(20.0, 0.0))),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(4, false, position)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"cancel 后的陈旧 release 不得复活已结束捕获。"
+	)
+
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_MIDDLE, position, true)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_key_event(KEY_Q)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_MIDDLE, position, false)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+	assert_eq(
+		canvas.handle_input_event(_touch_event(5, true, position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(canvas.set_input_policy(GFSpatialCanvasInputPolicy.new()))
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(5, false, position)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"成功替换策略必须原子释放旧 raw-touch 捕获。"
+	)
+
+
+func test_canceled_pointer_release_discards_capture_without_committing() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_true(
+		canvas.upsert_item(&"target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	assert_true(canvas.set_input_policy(policy))
+	var target_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(6, true, target_position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	var canceled_touch: InputEventScreenTouch = _touch_event(6, false, target_position)
+	canceled_touch.canceled = true
+	assert_eq(
+		canvas.handle_input_event(canceled_touch),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(canvas.get_selection().is_empty(), "系统取消的 touch 不得提交选择。")
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	assert_eq(
+		canvas.handle_input_event(_touch_event(6, false, target_position)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"取消后的陈旧 release 不得恢复 capture。"
+	)
+
+	var history_commit_count: Array[int] = [0]
+	canvas.set_history_hook(
+		func(_operation: Dictionary) -> bool:
+			history_commit_count[0] += 1
+			return true
+	)
+	assert_gt(canvas.begin_placement(&"marker", Rect2(Vector2.ZERO, Vector2.ONE)), 0)
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_LEFT, target_position, true)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	var canceled_mouse: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_LEFT,
+		target_position,
+		false
+	)
+	canceled_mouse.canceled = true
+	assert_eq(
+		canvas.handle_input_event(canceled_mouse),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(canvas.has_active_placement(), "系统取消的鼠标 release 不得提交 placement。")
+	assert_eq(history_commit_count[0], 0)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_input_disable_releases_capture_without_clearing_placement() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_gt(canvas.begin_placement(&"marker", Rect2(Vector2.ZERO, Vector2.ONE)), 0)
+	var pan_press: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_MIDDLE,
+		Vector2(100.0, 100.0),
+		true
+	)
+	assert_eq(
+		canvas.handle_input_event(pan_press),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	canvas.set_input_enabled(false)
+	canvas.set_input_enabled(true)
+	var stale_release: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_MIDDLE,
+		Vector2(120.0, 100.0),
+		false
+	)
+	assert_eq(
+		canvas.handle_input_event(stale_release),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"禁用输入必须释放已捕获的 pan。"
+	)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+	assert_true(canvas.has_active_placement(), "输入生命周期清理不得取消 placement。")
+
+
+func test_application_focus_loss_releases_mouse_capture_and_ignores_stale_release() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var position: Vector2 = Vector2(100.0, 100.0)
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_MIDDLE, position, true)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+	canvas.notification(NOTIFICATION_APPLICATION_FOCUS_OUT)
+
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	assert_eq(
+		canvas.handle_input_event(_mouse_button(MOUSE_BUTTON_MIDDLE, position, false)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"应用失焦后的陈旧 release 不得恢复已释放的 mouse owner。"
+	)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+
+
+func test_hiding_canvas_releases_raw_touch_capture_and_ignores_stale_release() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var position: Vector2 = Vector2(100.0, 100.0)
+	assert_eq(
+		canvas.handle_input_event(_touch_event(7, true, position)),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_true(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+	canvas.hide()
+
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	canvas.show()
+	assert_eq(
+		canvas.handle_input_event(_touch_event(7, false, position)),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"Canvas 隐藏后的陈旧 release 不得恢复已释放的 touch owner。"
+	)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+
+
+func test_modifier_gated_wheel_bubbles_to_parent_scroll_container() -> void:
+	var scroll: ScrollProbe = ScrollProbe.new()
+	add_child_autofree(scroll)
+	scroll.position = Vector2(40.0, 40.0)
+	scroll.size = Vector2(200.0, 120.0)
+	var content: Control = Control.new()
+	content.custom_minimum_size = Vector2(200.0, 600.0)
+	content.mouse_filter = Control.MOUSE_FILTER_PASS
+	scroll.add_child(content)
+	var canvas: GFSpatialCanvas2D = GFSpatialCanvas2D.new()
+	canvas.size = content.custom_minimum_size
+	content.add_child(canvas)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.wheel_routing = GFSpatialCanvasInputPolicy.WheelRouting.MODIFIER_GATED
+	policy.wheel_modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+	assert_true(canvas.set_input_policy(policy))
+	await wait_process_frames(2)
+
+	var wheel_position: Vector2 = scroll.position + Vector2(80.0, 60.0)
+	var plain_wheel: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_WHEEL_DOWN,
+		wheel_position,
+		true
+	)
+	Input.parse_input_event(plain_wheel)
+	await wait_process_frames(2)
+	assert_gt(scroll.wheel_event_count, 0, "未修饰 wheel 应冒泡到父 ScrollContainer。")
+	assert_eq(canvas.get_zoom(), 1.0)
+
+	var parent_count_before_ctrl: int = scroll.wheel_event_count
+	var ctrl_wheel: InputEventMouseButton = _mouse_button(
+		MOUSE_BUTTON_WHEEL_UP,
+		wheel_position,
+		true
+	)
+	ctrl_wheel.ctrl_pressed = true
+	Input.parse_input_event(ctrl_wheel)
+	await wait_process_frames(2)
+	assert_eq(
+		scroll.wheel_event_count,
+		parent_count_before_ctrl,
+		"Canvas 消费的 Ctrl+wheel 不得继续到父 ScrollContainer。"
+	)
+	assert_gt(canvas.get_zoom(), 1.0)
 
 
 func test_debug_snapshot_is_json_safe_and_excludes_callbacks_and_project_payloads() -> void:
@@ -849,3 +2249,113 @@ func _mouse_button(button_index: MouseButton, position: Vector2, pressed: bool) 
 	event.position = position
 	event.pressed = pressed
 	return event
+
+
+func _key_event(keycode: Key) -> InputEventKey:
+	var event: InputEventKey = InputEventKey.new()
+	event.keycode = keycode
+	event.pressed = true
+	return event
+
+
+func _touch_event(index: int, pressed: bool, position: Vector2) -> InputEventScreenTouch:
+	var event: InputEventScreenTouch = InputEventScreenTouch.new()
+	event.index = index
+	event.pressed = pressed
+	event.position = position
+	return event
+
+
+func _touch_drag_event(index: int, position: Vector2) -> InputEventScreenDrag:
+	var event: InputEventScreenDrag = InputEventScreenDrag.new()
+	event.index = index
+	event.position = position
+	return event
+
+
+func _add_mouse_action(
+	action_id: StringName,
+	button_index: MouseButton,
+	modifier_mask: int = GFSpatialCanvasInputPolicy.ModifierMask.NONE
+) -> void:
+	if InputMap.has_action(action_id):
+		InputMap.erase_action(action_id)
+	InputMap.add_action(action_id)
+	var input_event: InputEventMouseButton = InputEventMouseButton.new()
+	input_event.button_index = button_index
+	_apply_modifier_mask(input_event, modifier_mask)
+	InputMap.action_add_event(action_id, input_event)
+
+
+func _add_key_action(action_id: StringName, keycode: Key) -> void:
+	if InputMap.has_action(action_id):
+		InputMap.erase_action(action_id)
+	InputMap.add_action(action_id)
+	var input_event: InputEventKey = InputEventKey.new()
+	input_event.keycode = keycode
+	InputMap.action_add_event(action_id, input_event)
+
+
+func _apply_modifier_mask(event: InputEventMouseButton, modifier_mask: int) -> void:
+	event.shift_pressed = (
+		modifier_mask & GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	) != 0
+	event.ctrl_pressed = (
+		modifier_mask & GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+	) != 0
+	event.alt_pressed = (
+		modifier_mask & GFSpatialCanvasInputPolicy.ModifierMask.ALT
+	) != 0
+	event.meta_pressed = (
+		modifier_mask & GFSpatialCanvasInputPolicy.ModifierMask.META
+	) != 0
+
+
+func _report_has_issue_kind(report: Dictionary, expected_kind: String) -> bool:
+	for issue_value: Variant in GFVariantData.get_option_array(report, "issues"):
+		var issue: Dictionary = GFVariantData.as_dictionary(issue_value)
+		if GFVariantData.get_option_string(issue, "kind") == expected_kind:
+			return true
+	return false
+
+
+# --- 内部类 ---
+
+class MaliciousInputPolicy extends GFSpatialCanvasInputPolicy:
+	var validate_call_count: int = 0
+	var duplicate_call_count: int = 0
+
+
+	func validate_policy() -> Dictionary:
+		validate_call_count += 1
+		return { "ok": true, "issues": [] }
+
+
+	func duplicate_policy() -> GFSpatialCanvasInputPolicy:
+		duplicate_call_count += 1
+		return self
+
+
+class MaliciousSelectionBinding extends GFSpatialCanvasSelectionModeBinding:
+	var duplicate_call_count: int = 0
+
+
+	func duplicate_binding() -> GFSpatialCanvasSelectionModeBinding:
+		duplicate_call_count += 1
+		return self
+
+
+class ScrollProbe extends ScrollContainer:
+	var wheel_event_count: int = 0
+
+
+	func _gui_input(event: InputEvent) -> void:
+		if event is InputEventMouseButton:
+			var mouse_event: InputEventMouseButton = event
+			if mouse_event.button_index in [
+				MOUSE_BUTTON_WHEEL_UP,
+				MOUSE_BUTTON_WHEEL_DOWN,
+				MOUSE_BUTTON_WHEEL_LEFT,
+				MOUSE_BUTTON_WHEEL_RIGHT,
+			]:
+				wheel_event_count += 1

--- a/tests/gf_core/standard/utilities/spatial_canvas/test_gf_spatial_canvas_2d.gd
+++ b/tests/gf_core/standard/utilities/spatial_canvas/test_gf_spatial_canvas_2d.gd
@@ -1076,6 +1076,35 @@ func test_canvas_isolates_policy_without_calling_overridable_candidate_methods()
 	assert_eq(malicious_binding.duplicate_call_count, 0)
 
 
+func test_input_policy_duplicate_isolates_nested_subclass_without_virtual_dispatch() -> void:
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.selection_modifier_bindings.clear()
+	var malicious_binding: MaliciousSelectionBinding = MaliciousSelectionBinding.new()
+	malicious_binding.modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.SHIFT
+	malicious_binding.selection_mode = GFSpatialCanvas2D.SelectionMode.ADD
+	policy.selection_modifier_bindings.append(malicious_binding)
+
+	var copied_policy: GFSpatialCanvasInputPolicy = policy.duplicate_policy()
+	var copied_binding: GFSpatialCanvasSelectionModeBinding = (
+		copied_policy.selection_modifier_bindings[0]
+	)
+
+	assert_eq(malicious_binding.duplicate_call_count, 0, "策略复制不得调用嵌套候选 override。")
+	assert_false(copied_binding is MaliciousSelectionBinding, "副本必须收敛到 GF 基类绑定。")
+	assert_false(is_same(copied_binding, malicious_binding), "嵌套绑定不得与源对象共享引用。")
+	assert_eq(copied_binding.modifier_mask, GFSpatialCanvasInputPolicy.ModifierMask.SHIFT)
+	assert_eq(copied_binding.selection_mode, GFSpatialCanvas2D.SelectionMode.ADD)
+
+	malicious_binding.selection_mode = GFSpatialCanvas2D.SelectionMode.SUBTRACT
+	assert_eq(copied_binding.selection_mode, GFSpatialCanvas2D.SelectionMode.ADD)
+	copied_binding.modifier_mask = GFSpatialCanvasInputPolicy.ModifierMask.CTRL
+	assert_eq(
+		malicious_binding.modifier_mask,
+		GFSpatialCanvasInputPolicy.ModifierMask.SHIFT,
+		"源绑定与副本必须双向隔离。"
+	)
+
+
 func test_pan_modifier_is_exact_and_action_owns_its_modifier_chord() -> void:
 	var canvas: GFSpatialCanvas2D = _make_canvas()
 	var direct_policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
@@ -1936,6 +1965,167 @@ func test_mouse_capture_excludes_raw_touch_until_matching_mouse_release() -> voi
 	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
 
 
+func test_mouse_capture_requires_matching_device_for_motion_release_and_cancel() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	var capture_device: int = 3
+	var foreign_device: int = 4
+	_add_mouse_action_for_device(
+		_PAN_ACTION,
+		MOUSE_BUTTON_MIDDLE,
+		GFSpatialCanvasInputPolicy.ModifierMask.NONE,
+		capture_device
+	)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.pan_mouse_button = MOUSE_BUTTON_NONE
+	policy.pan_action = _PAN_ACTION
+	assert_true(canvas.set_input_policy(policy))
+	var start_position: Vector2 = Vector2(200.0, 150.0)
+	assert_eq(
+		canvas.handle_input_event(
+			_mouse_button_for_device(
+				MOUSE_BUTTON_MIDDLE,
+				start_position,
+				true,
+				capture_device
+			)
+		),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+
+	var foreign_motion: InputEventMouseMotion = InputEventMouseMotion.new()
+	foreign_motion.device = foreign_device
+	foreign_motion.position = start_position + Vector2(100.0, 0.0)
+	foreign_motion.button_mask = MOUSE_BUTTON_MASK_MIDDLE
+	assert_eq(
+		canvas.handle_input_event(foreign_motion),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO, "其他鼠标设备不得推动当前捕获。")
+
+	var foreign_release: InputEventMouseButton = _mouse_button_for_device(
+		MOUSE_BUTTON_MIDDLE,
+		foreign_motion.position,
+		false,
+		foreign_device
+	)
+	assert_eq(
+		canvas.handle_input_event(foreign_release),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_true(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	var foreign_cancel: InputEventMouseButton = _mouse_button_for_device(
+		MOUSE_BUTTON_MIDDLE,
+		foreign_motion.position,
+		false,
+		foreign_device
+	)
+	foreign_cancel.canceled = true
+	assert_eq(
+		canvas.handle_input_event(foreign_cancel),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_true(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+	var matching_motion: InputEventMouseMotion = InputEventMouseMotion.new()
+	matching_motion.device = capture_device
+	matching_motion.position = start_position + Vector2(20.0, 0.0)
+	matching_motion.button_mask = MOUSE_BUTTON_MASK_MIDDLE
+	assert_eq(
+		canvas.handle_input_event(matching_motion),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_world_center(), Vector2(-20.0, 0.0))
+	assert_eq(
+		canvas.handle_input_event(
+			_mouse_button_for_device(
+				MOUSE_BUTTON_MIDDLE,
+				matching_motion.position,
+				false,
+				capture_device
+			)
+		),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
+func test_raw_touch_capture_requires_matching_device_for_drag_release_and_cancel() -> void:
+	var canvas: GFSpatialCanvas2D = _make_canvas()
+	assert_true(
+		canvas.upsert_item(&"target", Rect2(Vector2(-5.0, -5.0), Vector2(10.0, 10.0)))
+	)
+	var policy: GFSpatialCanvasInputPolicy = GFSpatialCanvasInputPolicy.new()
+	policy.touch_primary_behavior = GFSpatialCanvasInputPolicy.TouchPrimaryBehavior.SELECT
+	assert_true(canvas.set_input_policy(policy))
+	var capture_device: int = 7
+	var foreign_device: int = 8
+	var touch_index: int = 2
+	var target_position: Vector2 = canvas.world_to_canvas(Vector2.ZERO)
+	assert_eq(
+		canvas.handle_input_event(
+			_touch_event_for_device(touch_index, true, target_position, capture_device)
+		),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+
+	assert_eq(
+		canvas.handle_input_event(
+			_touch_drag_event_for_device(
+				touch_index,
+				target_position + Vector2(100.0, 0.0),
+				foreign_device
+			)
+		),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_eq(canvas.get_world_center(), Vector2.ZERO)
+	assert_true(canvas.get_selection().is_empty())
+	var foreign_release: InputEventScreenTouch = _touch_event_for_device(
+		touch_index,
+		false,
+		target_position + Vector2(100.0, 0.0),
+		foreign_device
+	)
+	assert_eq(
+		canvas.handle_input_event(foreign_release),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_true(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	var foreign_cancel: InputEventScreenTouch = _touch_event_for_device(
+		touch_index,
+		false,
+		target_position,
+		foreign_device
+	)
+	foreign_cancel.canceled = true
+	assert_eq(
+		canvas.handle_input_event(foreign_cancel),
+		GFSpatialCanvas2D.InputDisposition.IGNORED
+	)
+	assert_true(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+	assert_eq(
+		canvas.handle_input_event(
+			_touch_event_for_device(
+				touch_index + 1,
+				true,
+				target_position,
+				foreign_device
+			)
+		),
+		GFSpatialCanvas2D.InputDisposition.IGNORED,
+		"其他触摸设备不得并入当前多指手势。"
+	)
+
+	assert_eq(
+		canvas.handle_input_event(
+			_touch_event_for_device(touch_index, false, target_position, capture_device)
+		),
+		GFSpatialCanvas2D.InputDisposition.CONSUMED
+	)
+	assert_eq(canvas.get_selection(), PackedStringArray(["target"]))
+	assert_false(GFVariantData.get_option_bool(canvas.get_debug_snapshot(), "input_active"))
+
+
 func test_active_physical_capture_excludes_system_gestures_until_release() -> void:
 	var canvas: GFSpatialCanvas2D = _make_canvas()
 	var focus: Vector2 = Vector2(400.0, 300.0)
@@ -2251,6 +2441,17 @@ func _mouse_button(button_index: MouseButton, position: Vector2, pressed: bool) 
 	return event
 
 
+func _mouse_button_for_device(
+	button_index: MouseButton,
+	position: Vector2,
+	pressed: bool,
+	device: int
+) -> InputEventMouseButton:
+	var event: InputEventMouseButton = _mouse_button(button_index, position, pressed)
+	event.device = device
+	return event
+
+
 func _key_event(keycode: Key) -> InputEventKey:
 	var event: InputEventKey = InputEventKey.new()
 	event.keycode = keycode
@@ -2266,10 +2467,31 @@ func _touch_event(index: int, pressed: bool, position: Vector2) -> InputEventScr
 	return event
 
 
+func _touch_event_for_device(
+	index: int,
+	pressed: bool,
+	position: Vector2,
+	device: int
+) -> InputEventScreenTouch:
+	var event: InputEventScreenTouch = _touch_event(index, pressed, position)
+	event.device = device
+	return event
+
+
 func _touch_drag_event(index: int, position: Vector2) -> InputEventScreenDrag:
 	var event: InputEventScreenDrag = InputEventScreenDrag.new()
 	event.index = index
 	event.position = position
+	return event
+
+
+func _touch_drag_event_for_device(
+	index: int,
+	position: Vector2,
+	device: int
+) -> InputEventScreenDrag:
+	var event: InputEventScreenDrag = _touch_drag_event(index, position)
+	event.device = device
 	return event
 
 
@@ -2282,6 +2504,22 @@ func _add_mouse_action(
 		InputMap.erase_action(action_id)
 	InputMap.add_action(action_id)
 	var input_event: InputEventMouseButton = InputEventMouseButton.new()
+	input_event.button_index = button_index
+	_apply_modifier_mask(input_event, modifier_mask)
+	InputMap.action_add_event(action_id, input_event)
+
+
+func _add_mouse_action_for_device(
+	action_id: StringName,
+	button_index: MouseButton,
+	modifier_mask: int,
+	device: int
+) -> void:
+	if InputMap.has_action(action_id):
+		InputMap.erase_action(action_id)
+	InputMap.add_action(action_id)
+	var input_event: InputEventMouseButton = InputEventMouseButton.new()
+	input_event.device = device
 	input_event.button_index = button_index
 	_apply_modifier_mask(input_event, modifier_mask)
 	InputMap.action_add_event(action_id, input_event)

--- a/tests/gf_core/standard/utilities/ui/test_gf_table_data_view.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_table_data_view.gd
@@ -4,21 +4,21 @@ extends GutTest
 
 func test_sort_and_filter_preserve_selection_by_row_id() -> void:
 	var view: GFTableDataView = _make_people_view()
-	var _select_result: bool = view.selection_model.set_selected("row-a", true)
+	var _select_result: bool = view.get_selection_model().set_selected("row-a", true)
 
 	assert_true(view.sort_by_column(&"score", false), "可排序列应接受排序设置。")
 	assert_eq(view.get_visible_row_ids(), ["row-b", "row-a", "row-c"], "分数降序应只改变可见顺序。")
-	assert_true(view.selection_model.is_selected("row-a"), "排序后选择应由稳定 row_id 保留。")
+	assert_true(view.get_selection_model().is_selected("row-a"), "排序后选择应由稳定 row_id 保留。")
 
-	view.set_filter_query("ali")
+	var _filter_ali_result: GFTableViewRebuildResult = view.set_filter_query("ali")
 
 	assert_eq(view.get_visible_row_ids(), ["row-a"], "过滤应只保留匹配行。")
-	assert_true(view.selection_model.is_selected("row-a"), "过滤后选择仍应保留。")
+	assert_true(view.get_selection_model().is_selected("row-a"), "过滤后选择仍应保留。")
 
-	view.set_filter_query("")
+	var _clear_filter_result: GFTableViewRebuildResult = view.set_filter_query("")
 
 	assert_eq(view.get_visible_row_ids(), ["row-b", "row-a", "row-c"], "清空过滤后应恢复排序视图。")
-	assert_true(view.selection_model.is_selected("row-a"), "清空过滤后选择仍应保留。")
+	assert_true(view.get_selection_model().is_selected("row-a"), "清空过滤后选择仍应保留。")
 
 
 func test_commit_cell_value_updates_row_and_resorts_view() -> void:
@@ -37,7 +37,7 @@ func test_commit_cell_value_updates_row_and_resorts_view() -> void:
 	assert_eq(first_visible_row_id, "row-c", "提交排序列后视图应重新排序。")
 
 
-func test_commit_cell_values_reports_partial_failures_and_refreshes_once() -> void:
+func test_commit_cell_values_rejects_the_entire_batch_before_publication() -> void:
 	var view: GFTableDataView = _make_people_view()
 	watch_signals(view)
 
@@ -48,14 +48,14 @@ func test_commit_cell_values_reports_partial_failures_and_refreshes_once() -> vo
 		{ "row_index": 2, "column_id": &"name", "new_value": "C" },
 	])
 
-	assert_false(GFVariantData.get_option_bool(report, "ok"), "部分失败时批量报告应标记为失败。")
+	assert_false(GFVariantData.get_option_bool(report, "ok"), "任一校验失败都应中止整个批次。")
 	assert_eq(GFVariantData.get_option_int(report, "requested_count"), 4, "报告应记录请求数量。")
-	assert_eq(GFVariantData.get_option_int(report, "applied_count"), 1, "只应计入实际改值的单元格。")
-	assert_eq(GFVariantData.get_option_int(report, "unchanged_count"), 1, "相同值应计为未变化。")
+	assert_eq(GFVariantData.get_option_int(report, "applied_count"), 0, "失败批次不得提交有效子集。")
+	assert_eq(GFVariantData.get_option_int(report, "unchanged_count"), 0, "失败批次不产生提交报告。")
 	assert_eq(GFVariantData.get_option_int(report, "failed_count"), 2, "无效行和不可编辑列应计为失败。")
-	assert_eq(_get_row_score(view, 0), 12, "有效变更应写回源行。")
-	assert_signal_emit_count(view, "view_changed", 1)
-	assert_signal_emit_count(view, "cell_value_committed", 1)
+	assert_eq(_get_row_score(view, 0), 10, "批次失败时有效候选也不得写回源行。")
+	assert_signal_emit_count(view, "view_changed", 0)
+	assert_signal_emit_count(view, "cell_value_committed", 0)
 
 
 func test_commit_visible_cell_values_resolves_indices_before_refresh() -> void:
@@ -96,14 +96,14 @@ func test_selection_model_range_and_prune_use_stable_ids() -> void:
 
 func test_set_rows_prunes_selection_to_existing_row_ids() -> void:
 	var view: GFTableDataView = _make_people_view()
-	var _select_result: bool = view.selection_model.set_selected("row-c", true)
+	var _select_result: bool = view.get_selection_model().set_selected("row-c", true)
 
-	view.set_rows([
+	var _set_rows_result: GFTableViewRebuildResult = view.set_rows([
 		{ "id": "row-a", "name": "Alice", "score": 10 },
 	])
 
-	assert_false(view.selection_model.is_selected("row-c"), "set_rows 后不存在的 row_id 选择应被修剪。")
-	assert_true(view.selection_model.is_empty(), "只剩不存在选择时 selection 应为空。")
+	assert_false(view.get_selection_model().is_selected("row-c"), "set_rows 后不存在的 row_id 选择应被修剪。")
+	assert_true(view.get_selection_model().is_empty(), "只剩不存在选择时 selection 应为空。")
 
 
 func test_custom_column_formatter_participates_in_filtering() -> void:
@@ -111,7 +111,7 @@ func test_custom_column_formatter_participates_in_filtering() -> void:
 	var score_column: GFTableColumnDefinition = view.get_column(&"score")
 	score_column.value_formatter = Callable(self, &"_format_score")
 
-	view.set_filter_query("score:10")
+	var _filter_score_result: GFTableViewRebuildResult = view.set_filter_query("score:10")
 
 	assert_eq(view.get_visible_row_ids(), ["row-a"], "自定义 formatter 应参与过滤文本。")
 
@@ -120,10 +120,10 @@ func test_describe_view_exports_current_visible_snapshot() -> void:
 	var view: GFTableDataView = _make_people_view()
 	var id_column: GFTableColumnDefinition = view.get_column(&"id")
 	id_column.visible = false
-	var _select_result: bool = view.selection_model.set_selected("row-c", true)
+	var _select_result: bool = view.get_selection_model().set_selected("row-c", true)
 	var _sort_result: bool = view.sort_by_column(&"score", false)
 
-	view.set_filter_query("a")
+	var _filter_a_result: GFTableViewRebuildResult = view.set_filter_query("a")
 
 	var snapshot: Dictionary = view.describe_view()
 	assert_eq(GFVariantData.get_option_int(snapshot, "row_count"), 3, "快照应记录源行数量。")
@@ -151,7 +151,7 @@ func test_describe_view_can_include_source_rows_and_copied_row_data() -> void:
 	var view: GFTableDataView = _make_people_view()
 	var id_column: GFTableColumnDefinition = view.get_column(&"id")
 	id_column.visible = false
-	view.set_filter_query("ali")
+	var _filter_ali_result: GFTableViewRebuildResult = view.set_filter_query("ali")
 
 	var snapshot: Dictionary = view.describe_view({
 		"visible_only": false,
@@ -196,8 +196,8 @@ func _make_people_view() -> GFTableDataView:
 	score_column.editable = true
 	score_column.sort_mode = GFTableColumnDefinition.SortMode.NUMBER
 	var columns: Array[GFTableColumnDefinition] = [id_column, name_column, score_column]
-	view.set_columns(columns)
-	view.set_rows([
+	var _columns_result: GFTableViewRebuildResult = view.set_columns(columns)
+	var _rows_result: GFTableViewRebuildResult = view.set_rows([
 		{ "id": "row-a", "name": "Alice", "score": 10 },
 		{ "id": "row-b", "name": "Bob", "score": 18 },
 		{ "id": "row-c", "name": "Cara", "score": 7 },

--- a/tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd
@@ -488,6 +488,7 @@ func test_framework_evaluation_bypasses_overridden_public_evaluate() -> void:
 	assert_eq(view.get_view_revision(), previous_revision + 1)
 	assert_signal_emit_count(view, "view_changed", 1)
 	assert_signal_emit_count(view, "filter_changed", 0)
+	predicate.view = null
 
 
 func test_framework_normalizes_result_without_calling_overridden_getters() -> void:
@@ -516,6 +517,7 @@ func test_framework_normalizes_result_without_calling_overridden_getters() -> vo
 	assert_eq(view.get_view_revision(), previous_revision + 1)
 	assert_signal_emit_count(view, "view_changed", 1)
 	assert_signal_emit_count(view, "filter_changed", 0)
+	hostile_result.view = null
 
 
 func test_each_predicate_receives_an_independent_row_view_snapshot() -> void:
@@ -1246,13 +1248,21 @@ func test_cell_commit_isolates_mutable_input_report_and_signal_payloads() -> voi
 		view.cell_value_committed.connect(observer.on_cell_value_committed)
 		as Error
 	)
-	var requested_tags: Array = ["new"]
+	var requested_tags: Array[String] = ["new"]
 
 	var report: Dictionary = view.commit_cell_values([
 		{ "row_index": 0, "column_id": &"tags", "new_value": requested_tags },
 	])
 
 	assert_true(GFVariantData.get_option_bool(report, "ok"))
+	var committed_cell_value: Variant = view.get_cell_value(0, &"tags")
+	assert_true(committed_cell_value is Array)
+	if committed_cell_value is Array:
+		var committed_tags: Array = committed_cell_value
+		assert_true(
+			committed_tags.is_same_typed(requested_tags),
+			"权威候选值必须保留 Array[String] 约束。"
+		)
 	requested_tags.append("caller-mutation")
 	var committed_reports_value: Variant = GFVariantData.get_option_value(report, "committed")
 	var committed_reports: Array = []
@@ -1269,6 +1279,10 @@ func test_cell_commit_isolates_mutable_input_report_and_signal_payloads() -> voi
 			)
 			if report_tags_value is Array:
 				var report_tags: Array = report_tags_value
+				assert_true(
+					report_tags.is_same_typed(requested_tags),
+					"提交报告必须保留 typed Array 元数据。"
+				)
 				report_tags.append("report-mutation")
 	assert_eq(
 		GFVariantData.get_option_array(GFVariantData.as_dictionary(view.get_row(0)), "tags"),
@@ -1511,6 +1525,44 @@ func test_row_view_returns_an_isolated_copy_of_builtin_resources() -> void:
 		assert_eq(copied_resource.min_value, -10.0)
 		copied_resource.min_value = -20.0
 		assert_eq(source_resource.min_value, -10.0)
+
+
+func test_row_view_preserves_nested_typed_container_metadata() -> void:
+	var source_numbers: Array[int] = [1, 2]
+	var source_weights: Dictionary[StringName, float] = { &"alpha": 1.5 }
+	var source_values: Dictionary[StringName, Variant] = {
+		&"numbers": source_numbers,
+		&"weights": source_weights,
+	}
+	var row_view: GFTableRowView = GFTableRowView.new()
+
+	assert_true(row_view.configure_for_framework(0, &"typed-row", source_values))
+	var copied_values: Dictionary = row_view.get_values()
+
+	assert_true(copied_values.is_same_typed(source_values), "根 Dictionary 类型约束必须保留。")
+	assert_false(is_same(copied_values, source_values))
+	var copied_numbers_value: Variant = copied_values.get(&"numbers")
+	assert_true(copied_numbers_value is Array)
+	if copied_numbers_value is Array:
+		var copied_numbers: Array = copied_numbers_value
+		assert_true(copied_numbers.is_same_typed(source_numbers))
+		assert_false(is_same(copied_numbers, source_numbers))
+		copied_numbers.append(3)
+		assert_eq(source_numbers, [1, 2])
+	var copied_weights_value: Variant = copied_values.get(&"weights")
+	assert_true(copied_weights_value is Dictionary)
+	if copied_weights_value is Dictionary:
+		var copied_weights: Dictionary = copied_weights_value
+		assert_true(copied_weights.is_same_typed(source_weights))
+		assert_false(is_same(copied_weights, source_weights))
+		copied_weights[&"beta"] = 2.5
+		assert_false(source_weights.has(&"beta"))
+	source_numbers.append(4)
+	var second_numbers_value: Variant = row_view.get_value(&"numbers")
+	assert_true(second_numbers_value is Array)
+	if second_numbers_value is Array:
+		var second_numbers: Array = second_numbers_value
+		assert_eq(second_numbers, [1, 2], "配置后的 RowView 不得与源 typed Array 共享引用。")
 
 
 func test_set_columns_rolls_back_when_candidate_predicate_fails() -> void:

--- a/tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd
@@ -1,0 +1,1718 @@
+## 测试 GFTableDataView 的命名行谓词与事务式投影重建。
+extends GutTest
+
+
+class RecordingPredicate extends GFTableRowPredicate:
+	var label: String = ""
+	var minimum_score: int = -1
+	var invocation_log: Array[String] = []
+
+
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		invocation_log.append("%s:%s" % [label, GFVariantData.to_text(row_view.get_row_id())])
+		if minimum_score >= 0 and GFVariantData.to_int(row_view.get_value(&"score")) < minimum_score:
+			return GFTableRowPredicateResult.excluded()
+		return GFTableRowPredicateResult.included()
+
+
+class FailingPredicate extends GFTableRowPredicate:
+	var failed_row_id: Variant = null
+	var error_message: String = ""
+
+
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		if failed_row_id == null or row_view.get_row_id() == failed_row_id:
+			return GFTableRowPredicateResult.failed(&"predicate_fixture_failed", error_message)
+		return GFTableRowPredicateResult.included()
+
+
+class SnapshotMutationPredicate extends GFTableRowPredicate:
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		var values: Dictionary = row_view.get_values()
+		var tags_value: Variant = GFVariantData.get_option_value(values, &"tags")
+		if tags_value is Array:
+			var tags: Array = tags_value
+			tags.append("mutated")
+		values[&"score"] = 999
+		return GFTableRowPredicateResult.included()
+
+
+class ReentrantPredicate extends GFTableRowPredicate:
+	var view: GFTableDataView = null
+	var inner_result: GFTableViewRebuildResult = null
+
+
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		inner_result = view.refresh_view()
+		return GFTableRowPredicateResult.included()
+
+
+class PublicEvaluateOverridePredicate extends GFTableRowPredicate:
+	var view: GFTableDataView = null
+	var public_evaluate_call_count: int = 0
+	var hook_call_count: int = 0
+	var inner_result: GFTableViewRebuildResult = null
+
+
+	func evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		public_evaluate_call_count += 1
+		inner_result = view.set_filter_query("public-evaluate-reentry")
+		return GFTableRowPredicateResult.excluded()
+
+
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		hook_call_count += 1
+		return GFTableRowPredicateResult.included()
+
+
+class ReentrantResult extends GFTableRowPredicateResult:
+	var view: GFTableDataView = null
+	var getter_call_count: int = 0
+	var inner_result: GFTableViewRebuildResult = null
+
+
+	func is_successful() -> bool:
+		_attempt_reentry()
+		return true
+
+
+	func should_include() -> bool:
+		_attempt_reentry()
+		return true
+
+
+	func get_error_code() -> StringName:
+		_attempt_reentry()
+		return &"override_error"
+
+
+	func get_error_message() -> String:
+		_attempt_reentry()
+		return "override error"
+
+
+	func _attempt_reentry() -> void:
+		getter_call_count += 1
+		if inner_result == null:
+			inner_result = view.set_filter_query("result-getter-reentry")
+
+
+class ReentrantResultPredicate extends GFTableRowPredicate:
+	var result: ReentrantResult = null
+
+
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		return result
+
+
+class BackingMutationPredicate extends GFTableRowPredicate:
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		row_view.set("_row_id", "forged-row")
+		row_view.set("_source_row_index", 999)
+		var backing_value: Variant = row_view.get("_values")
+		if backing_value is Dictionary:
+			var backing_values: Dictionary = backing_value
+			backing_values[&"score"] = 999
+		row_view.set("_values", { &"score": 777 })
+		return GFTableRowPredicateResult.included()
+
+
+class ObservingRowViewPredicate extends GFTableRowPredicate:
+	var observed_row_ids: Array = []
+	var observed_source_indices: Array[int] = []
+	var observed_scores: Array[int] = []
+
+
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		observed_row_ids.append(row_view.get_row_id())
+		observed_source_indices.append(row_view.get_source_row_index())
+		observed_scores.append(GFVariantData.to_int(row_view.get_value(&"score")))
+		return GFTableRowPredicateResult.failed(
+			&"observer_failure",
+			"Observer stopped the candidate projection."
+		)
+
+
+class ReconfiguringRowViewPredicate extends GFTableRowPredicate:
+	var configure_results: Array[bool] = []
+	var observed_row_ids: Array = []
+	var observed_scores: Array[int] = []
+
+
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		configure_results.append(row_view.configure_for_framework(
+			999,
+			&"hijacked",
+			{ &"score": 999 }
+		))
+		observed_row_ids.append(row_view.get_row_id())
+		observed_scores.append(GFVariantData.to_int(row_view.get_value(&"score")))
+		return GFTableRowPredicateResult.included()
+
+
+class UninitializedResultPredicate extends GFTableRowPredicate:
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		return GFTableRowPredicateResult.new()
+
+
+class RebuildResultMutationObserver extends RefCounted:
+	var configure_result: bool = true
+
+
+	func on_view_rebuild_failed(result: GFTableViewRebuildResult) -> void:
+		configure_result = result.configure_success_for_framework(true, 999, 999, 999, 999)
+		result.set("_error_code", &"observer_tampered")
+		result.set("_error_message", "observer tampered")
+
+
+class CountingRegistration extends GFTableRowPredicateRegistration:
+	var getter_call_count: int = 0
+
+
+	func get_predicate_id() -> StringName:
+		getter_call_count += 1
+		return &"counted"
+
+
+	func get_predicate() -> GFTableRowPredicate:
+		getter_call_count += 1
+		return null
+
+
+	func get_order() -> int:
+		getter_call_count += 1
+		return 0
+
+
+	func is_enabled() -> bool:
+		getter_call_count += 1
+		return true
+
+
+class ReentrantRegistration extends GFTableRowPredicateRegistration:
+	var view: GFTableDataView = null
+	var getter_call_count: int = 0
+	var inner_result: GFTableViewRebuildResult = null
+
+
+	func get_predicate_id() -> StringName:
+		_attempt_reentry()
+		return &"override_id"
+
+
+	func get_predicate() -> GFTableRowPredicate:
+		_attempt_reentry()
+		return null
+
+
+	func get_order() -> int:
+		_attempt_reentry()
+		return -999
+
+
+	func is_enabled() -> bool:
+		_attempt_reentry()
+		return false
+
+
+	func _attempt_reentry() -> void:
+		getter_call_count += 1
+		if inner_result == null and view != null:
+			inner_result = view.set_filter_query("hostile-reentry")
+
+
+class ScoreFailurePredicate extends GFTableRowPredicate:
+	var failed_score: int = 0
+
+
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		if GFVariantData.to_int(row_view.get_value(&"score")) == failed_score:
+			return GFTableRowPredicateResult.failed(
+				&"score_rejected",
+				"The staged score is rejected."
+			)
+		return GFTableRowPredicateResult.included()
+
+
+class ColumnPresenceFailurePredicate extends GFTableRowPredicate:
+	var rejected_column_id: StringName = &""
+
+
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		if row_view.has_value(rejected_column_id):
+			return GFTableRowPredicateResult.failed(
+				&"column_rejected",
+				"The candidate column set is rejected."
+			)
+		return GFTableRowPredicateResult.included()
+
+
+class SelectionRebuildObserver extends RefCounted:
+	var view: GFTableDataView = null
+	var inner_result: GFTableViewRebuildResult = null
+
+
+	func on_selection_changed(_selected_ids: Array) -> void:
+		inner_result = view.set_filter_query("observer-filter")
+
+
+class ConfigurationMutationPredicate extends GFTableRowPredicate:
+	var view: GFTableDataView = null
+	var replacement_model: GFTableSelectionModel = null
+	var row_id_result: GFTableViewRebuildResult = null
+	var case_result: GFTableViewRebuildResult = null
+	var selection_model_result: GFTableViewRebuildResult = null
+
+
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		row_id_result = view.set_row_id_column(&"account")
+		case_result = view.set_filter_case_sensitive(true)
+		selection_model_result = view.set_selection_model(replacement_model)
+		return GFTableRowPredicateResult.included()
+
+
+class SelectionStateObserver extends RefCounted:
+	var model: GFTableSelectionModel = null
+	var emission_count: int = 0
+	var observed_ids: Array = []
+	var observed_anchor: Variant = null
+
+
+	func on_selection_changed(selected_ids: Array) -> void:
+		emission_count += 1
+		observed_ids = selected_ids.duplicate()
+		observed_anchor = model.anchor_row_id
+
+
+class ReentrantFormatter extends RefCounted:
+	var view: GFTableDataView = null
+	var inner_result: GFTableViewRebuildResult = null
+
+
+	func format_value(
+		_value: Variant,
+		_row_data: Variant,
+		_column: GFTableColumnDefinition
+	) -> String:
+		inner_result = view.refresh_view()
+		return "matching text"
+
+
+class CommittingPredicate extends GFTableRowPredicate:
+	var view: GFTableDataView = null
+	var commit_succeeded: bool = true
+
+
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		commit_succeeded = view.commit_cell_value(0, &"score", 777)
+		return GFTableRowPredicateResult.included()
+
+
+class MutablePayload extends RefCounted:
+	var amount: int = 1
+
+
+class PayloadMutationPredicate extends GFTableRowPredicate:
+	func _evaluate(row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		var payload_value: Variant = row_view.get_value(&"payload")
+		if payload_value is MutablePayload:
+			var payload: MutablePayload = payload_value
+			payload.amount = 999
+		return GFTableRowPredicateResult.included()
+
+
+class ClearingPredicate extends GFTableRowPredicate:
+	var view: GFTableDataView = null
+	var observed_row_count: int = -1
+
+
+	func _evaluate(_row_view: GFTableRowView) -> GFTableRowPredicateResult:
+		view.clear_rows()
+		observed_row_count = view.get_row_count()
+		return GFTableRowPredicateResult.included()
+
+
+class CountingSetter extends RefCounted:
+	var invocation_count: int = 0
+
+
+	func write_value(
+		_row_data: Variant,
+		_new_value: Variant,
+		_column: GFTableColumnDefinition
+	) -> bool:
+		invocation_count += 1
+		return true
+
+
+class CellPayloadMutationObserver extends RefCounted:
+	func on_cell_value_committed(
+		_row_index: int,
+		_row_id: Variant,
+		_column_id: StringName,
+		_old_value: Variant,
+		new_value: Variant
+	) -> void:
+		if new_value is Array:
+			var new_values: Array = new_value
+			new_values.append("observer-mutation")
+
+
+class RecordingComparator extends RefCounted:
+	var invocation_log: Array[String] = []
+
+
+	func compare_values(
+		left_value: Variant,
+		right_value: Variant,
+		_left_row: Variant,
+		_right_row: Variant,
+		_column: GFTableColumnDefinition
+	) -> int:
+		invocation_log.append("sort")
+		var left_score: int = GFVariantData.to_int(left_value)
+		var right_score: int = GFVariantData.to_int(right_value)
+		if left_score == right_score:
+			return 0
+		return -1 if left_score < right_score else 1
+
+
+class ScriptedTableRow extends Resource:
+	@export var id: String = "scripted-row"
+	@export var score: int = 10
+
+
+func test_predicates_run_after_text_filter_in_deterministic_order_before_sort() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var trace: Array[String] = []
+	var comparator: RecordingComparator = RecordingComparator.new()
+	comparator.invocation_log = trace
+	view.get_column(&"score").value_comparator = comparator.compare_values
+	var predicate_b: RecordingPredicate = RecordingPredicate.new()
+	predicate_b.label = "b"
+	predicate_b.invocation_log = trace
+	var predicate_a: RecordingPredicate = RecordingPredicate.new()
+	predicate_a.label = "a"
+	predicate_a.invocation_log = trace
+	var _filter_result: GFTableViewRebuildResult = view.set_filter_query("a")
+	var _sort_result: bool = view.sort_by_column(&"score", true)
+	trace.clear()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"b", predicate_b, 10),
+		GFTableRowPredicateRegistration.create(&"a", predicate_a, 10),
+	])
+
+	assert_true(result.is_successful(), "有效谓词集合应成功提交。")
+	assert_eq(
+		trace.slice(0, 4),
+		["a:row-a", "b:row-a", "a:row-c", "b:row-c"],
+		"文本过滤后应按 order 与稳定 ID 顺序执行谓词。"
+	)
+	assert_gt(trace.size(), 4, "两个候选行必须实际进入自定义排序比较器。")
+	for trace_index: int in range(4, trace.size()):
+		assert_eq(trace[trace_index], "sort", "所有排序回调都必须发生在谓词阶段之后。")
+	assert_eq(view.get_visible_row_ids(), ["row-c", "row-a"], "谓词完成后才应排序候选投影。")
+
+
+func test_set_row_predicates_commits_one_rebuild_and_one_revision() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate_a: RecordingPredicate = RecordingPredicate.new()
+	predicate_a.label = "a"
+	var predicate_b: RecordingPredicate = RecordingPredicate.new()
+	predicate_b.label = "b"
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"a", predicate_a, 0),
+		GFTableRowPredicateRegistration.create(&"b", predicate_b, 1),
+	])
+
+	assert_true(result.is_successful())
+	assert_true(result.was_committed())
+	assert_eq(view.get_view_revision(), previous_revision + 1, "批量注册只能提交一个 revision。")
+	assert_signal_emit_count(view, "view_changed", 1)
+	assert_signal_emit_count(view, "view_rebuild_failed", 0)
+
+
+func test_predicate_failure_preserves_registry_projection_revision_and_selection() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "row-a"
+	failing.error_message = "x".repeat(2_000)
+	var setup_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"failing", failing, 0, false),
+	])
+	assert_true(setup_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicate_enabled(&"failing", true)
+
+	assert_false(result.is_successful(), "谓词显式失败应中止重建。")
+	assert_eq(result.get_error_code(), &"predicate_fixture_failed")
+	assert_eq(result.get_failed_predicate_id(), &"failing")
+	assert_true(GFVariantData.values_equal(result.get_failed_row_id(), "row-a"))
+	assert_eq(result.get_error_message().length(), 1_024, "诊断说明必须有界。")
+	assert_eq(view.get_visible_row_ids(), previous_ids, "失败必须保留 prior projection。")
+	assert_eq(view.get_view_revision(), previous_revision, "失败不得推进 revision。")
+	assert_false(view.get_row_predicate(&"failing").is_enabled(), "失败必须回滚候选 enablement。")
+	assert_true(view.get_selection_model().is_selected("row-a"), "失败不得改变稳定 ID 选择。")
+	assert_true(
+		GFVariantData.values_equal(view.get_selection_model().anchor_row_id, "row-a"),
+		"失败不得改变选择 anchor。"
+	)
+	assert_signal_emit_count(view, "view_changed", 0)
+	assert_signal_emit_count(view, "view_rebuild_failed", 1)
+
+
+func test_framework_evaluation_bypasses_overridden_public_evaluate() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: PublicEvaluateOverridePredicate = PublicEvaluateOverridePredicate.new()
+	predicate.view = view
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"template_method", predicate),
+	])
+
+	assert_true(result.is_successful())
+	assert_eq(predicate.public_evaluate_call_count, 0)
+	assert_eq(predicate.hook_call_count, view.get_row_count())
+	assert_null(predicate.inner_result)
+	assert_eq(view.get_filter_query(), "")
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+	assert_signal_emit_count(view, "view_changed", 1)
+	assert_signal_emit_count(view, "filter_changed", 0)
+
+
+func test_framework_normalizes_result_without_calling_overridden_getters() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var _single_row_result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "row-a", "name": "Alice", "score": 10, "account": "p1", "tags": [] },
+	])
+	var hostile_result: ReentrantResult = ReentrantResult.new()
+	hostile_result.view = view
+	hostile_result.set("_configured", true)
+	hostile_result.set("_successful", true)
+	hostile_result.set("_should_include", true)
+	var predicate: ReentrantResultPredicate = ReentrantResultPredicate.new()
+	predicate.result = hostile_result
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"normalized_result", predicate),
+	])
+
+	assert_true(result.is_successful())
+	assert_eq(hostile_result.getter_call_count, 0)
+	assert_null(hostile_result.inner_result)
+	assert_eq(view.get_filter_query(), "")
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+	assert_signal_emit_count(view, "view_changed", 1)
+	assert_signal_emit_count(view, "filter_changed", 0)
+
+
+func test_each_predicate_receives_an_independent_row_view_snapshot() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var observer: ObservingRowViewPredicate = ObservingRowViewPredicate.new()
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(
+			&"mutator",
+			BackingMutationPredicate.new(),
+			0
+		),
+		GFTableRowPredicateRegistration.create(&"observer", observer, 1),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"observer_failure")
+	assert_true(GFVariantData.values_equal(result.get_failed_row_id(), "row-a"))
+	assert_eq(observer.observed_row_ids, ["row-a"])
+	assert_eq(observer.observed_source_indices, [0])
+	assert_eq(observer.observed_scores, [10])
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_invalid_duplicate_and_over_limit_registrations_preserve_prior_state() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: RecordingPredicate = RecordingPredicate.new()
+	var initial_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"initial", predicate),
+	])
+	assert_true(initial_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+	var previous_selection: Array = view.get_selection_model().get_selected_ids()
+	var previous_anchor: Variant = view.get_selection_model().anchor_row_id
+
+	var duplicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"duplicate", predicate),
+		GFTableRowPredicateRegistration.create(&"duplicate", predicate),
+	])
+	assert_false(duplicate_result.is_successful())
+	assert_eq(duplicate_result.get_error_code(), &"duplicate_predicate_id")
+
+	var registrations: Array[GFTableRowPredicateRegistration] = []
+	var counting_registration: CountingRegistration = CountingRegistration.new()
+	for index: int in range(GFTableDataView.MAX_ROW_PREDICATE_COUNT + 1):
+		registrations.append(counting_registration)
+	var limit_result: GFTableViewRebuildResult = view.set_row_predicates(registrations)
+	assert_false(limit_result.is_successful())
+	assert_eq(limit_result.get_error_code(), &"predicate_limit_exceeded")
+	assert_eq(
+		counting_registration.getter_call_count,
+		0,
+		"超限 registry 必须在 snapshot 或调用任一候选 getter 前失败关闭。"
+	)
+	assert_eq(view.get_row_predicate_ids(), [&"initial"])
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_eq(view.get_selection_model().get_selected_ids(), previous_selection)
+	assert_true(
+		GFVariantData.values_equal(view.get_selection_model().anchor_row_id, previous_anchor)
+	)
+
+
+func test_registration_subclass_getters_cannot_reenter_bulk_commit() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: RecordingPredicate = RecordingPredicate.new()
+	var registration: ReentrantRegistration = ReentrantRegistration.new()
+	registration.view = view
+	registration.set("_predicate_id", &"bulk_safe")
+	registration.set("_predicate", predicate)
+	registration.set("_order", 7)
+	registration.set("_enabled", true)
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([registration])
+
+	assert_true(result.is_successful())
+	assert_eq(registration.getter_call_count, 0, "候选 override getter 不得进入事务边界。")
+	assert_null(registration.inner_result)
+	assert_eq(view.get_filter_query(), "", "候选 getter 不得重入提交过滤状态。")
+	assert_eq(view.get_row_predicate_ids(), [&"bulk_safe"])
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+	assert_signal_emit_count(view, "view_changed", 1)
+	assert_signal_emit_count(view, "filter_changed", 0)
+
+	var invalid_registration: ReentrantRegistration = ReentrantRegistration.new()
+	invalid_registration.view = view
+	var committed_revision: int = view.get_view_revision()
+	var invalid_result: GFTableViewRebuildResult = view.set_row_predicates([
+		invalid_registration,
+	])
+	assert_false(invalid_result.is_successful())
+	assert_eq(invalid_registration.getter_call_count, 0)
+	assert_null(invalid_registration.inner_result)
+	assert_eq(view.get_filter_query(), "")
+	assert_eq(view.get_row_predicate_ids(), [&"bulk_safe"])
+	assert_eq(view.get_view_revision(), committed_revision)
+	assert_signal_emit_count(view, "view_changed", 1)
+
+
+func test_register_row_predicate_delegates_to_base_field_snapshot() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: RecordingPredicate = RecordingPredicate.new()
+	var registration: ReentrantRegistration = ReentrantRegistration.new()
+	registration.view = view
+	registration.set("_predicate_id", &"register_safe")
+	registration.set("_predicate", predicate)
+	registration.set("_order", 3)
+	registration.set("_enabled", true)
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.register_row_predicate(registration)
+
+	assert_true(result.is_successful())
+	assert_eq(registration.getter_call_count, 0)
+	assert_null(registration.inner_result)
+	assert_eq(view.get_filter_query(), "")
+	assert_eq(view.get_row_predicate_ids(), [&"register_safe"])
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+	assert_signal_emit_count(view, "view_changed", 1)
+	assert_signal_emit_count(view, "filter_changed", 0)
+
+
+func test_predicate_receives_isolated_row_view() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var mutation_predicate: SnapshotMutationPredicate = SnapshotMutationPredicate.new()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"mutation", mutation_predicate),
+	])
+
+	assert_true(result.is_successful())
+	var row_value: Variant = view.get_row(0)
+	assert_true(row_value is Dictionary)
+	if row_value is Dictionary:
+		var row: Dictionary = row_value
+		assert_eq(GFVariantData.get_option_int(row, &"score"), 10, "RowView 值修改不得写回源 row。")
+		assert_eq(GFVariantData.get_option_array(row, &"tags"), ["alpha"], "嵌套集合也必须隔离。")
+
+
+func test_set_rows_prunes_selection_only_after_successful_projection() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "row-new"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"conditional_failure", failing),
+	])
+	assert_true(predicate_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_revision: int = view.get_view_revision()
+
+	var failed_result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "row-new", "name": "New", "score": 1, "account": "p1", "tags": [] },
+	])
+
+	assert_false(failed_result.is_successful())
+	assert_eq(view.get_row_ids(), ["row-a", "row-b", "row-c"], "失败的 source transition 不得替换源行。")
+	assert_true(view.get_selection_model().is_selected("row-a"), "失败不得提前 prune selection。")
+	assert_eq(view.get_view_revision(), previous_revision)
+
+	var unregister_result: GFTableViewRebuildResult = view.unregister_row_predicate(&"conditional_failure")
+	assert_true(unregister_result.is_successful())
+	var success_result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "row-new", "name": "New", "score": 1, "account": "p1", "tags": [] },
+	])
+	assert_true(success_result.is_successful())
+	assert_false(view.get_selection_model().is_selected("row-a"), "成功提交后才应按新 source IDs prune。")
+
+
+func test_append_row_predicate_failure_preserves_all_committed_state() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "not-present"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"append_guard", failing),
+	])
+	assert_true(predicate_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_row_ids: Array = view.get_row_ids()
+	var previous_visible_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+	failing.failed_row_id = "row-new"
+
+	var appended_index: int = view.append_row({
+		"id": "row-new",
+		"name": "New",
+		"score": 1,
+		"account": "p3",
+		"tags": [],
+	})
+
+	assert_eq(appended_index, -1)
+	assert_eq(view.get_row_ids(), previous_row_ids)
+	assert_eq(view.get_visible_row_ids(), previous_visible_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_selection_model().is_selected("row-a"))
+	assert_true(GFVariantData.values_equal(view.get_selection_model().anchor_row_id, "row-a"))
+
+
+func test_remove_row_predicate_failure_preserves_all_committed_state() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "not-present"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"remove_guard", failing),
+	])
+	assert_true(predicate_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_row_ids: Array = view.get_row_ids()
+	var previous_visible_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+	failing.failed_row_id = "row-b"
+
+	var removed: bool = view.remove_row(0)
+
+	assert_false(removed)
+	assert_eq(view.get_row_ids(), previous_row_ids)
+	assert_eq(view.get_visible_row_ids(), previous_visible_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_selection_model().is_selected("row-a"))
+	assert_true(GFVariantData.values_equal(view.get_selection_model().anchor_row_id, "row-a"))
+
+
+func test_clear_rows_requested_from_predicate_fails_without_partial_state() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_row_ids: Array = view.get_row_ids()
+	var previous_visible_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+	var predicate: ClearingPredicate = ClearingPredicate.new()
+	predicate.view = view
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"clear_attempt", predicate),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"reentrant_rebuild")
+	assert_eq(predicate.observed_row_count, 3)
+	assert_eq(view.get_row_ids(), previous_row_ids)
+	assert_eq(view.get_visible_row_ids(), previous_visible_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_selection_model().is_selected("row-a"))
+	assert_true(view.get_row_predicate_ids().is_empty())
+
+
+func test_reentrant_rebuild_aborts_outer_transaction() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var reentrant: ReentrantPredicate = ReentrantPredicate.new()
+	reentrant.view = view
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+	watch_signals(view)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"reentrant", reentrant),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"reentrant_rebuild")
+	assert_not_null(reentrant.inner_result)
+	assert_false(reentrant.inner_result.is_successful())
+	assert_true(view.get_row_predicate_ids().is_empty(), "失败的候选 registry 不得泄漏。")
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_signal_emit_count(view, "view_changed", 0)
+	assert_signal_emit_count(view, "view_rebuild_failed", 1)
+
+
+func test_configuration_setters_fail_closed_during_predicate_evaluation() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var authoritative_model: GFTableSelectionModel = view.get_selection_model()
+	var _selection_result: bool = authoritative_model.set_selected("row-a", true)
+	var replacement_model: GFTableSelectionModel = GFTableSelectionModel.new()
+	var _replacement_selection_result: bool = replacement_model.set_selected("row-b", true)
+	var predicate: ConfigurationMutationPredicate = ConfigurationMutationPredicate.new()
+	predicate.view = view
+	predicate.replacement_model = replacement_model
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"configuration_mutation", predicate),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"reentrant_rebuild")
+	for inner_result: GFTableViewRebuildResult in [
+		predicate.row_id_result,
+		predicate.case_result,
+		predicate.selection_model_result,
+	]:
+		assert_not_null(inner_result)
+		assert_false(inner_result.is_successful())
+		assert_eq(inner_result.get_error_code(), &"reentrant_rebuild")
+	assert_eq(view.get_row_id_column(), &"id")
+	assert_false(view.is_filter_case_sensitive())
+	assert_true(is_same(view.get_selection_model(), authoritative_model))
+	assert_eq(authoritative_model.get_selected_ids(), ["row-a"])
+	assert_eq(replacement_model.get_selected_ids(), ["row-b"])
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_row_predicate_ids().is_empty())
+
+
+func test_row_id_configuration_failure_preserves_selection_anchor_and_revision() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "p1"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"account_guard", failing),
+	])
+	assert_true(predicate_result.is_successful())
+	var model: GFTableSelectionModel = view.get_selection_model()
+	var _select_a_result: bool = model.set_selected("row-a", true)
+	var _select_b_result: bool = model.set_selected("row-b", true)
+	var _move_anchor_result: bool = model.set_selected("row-a", true)
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_id_column(&"account")
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"predicate_fixture_failed")
+	assert_eq(view.get_row_id_column(), &"id")
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_eq(model.get_selected_ids(), ["row-a", "row-b"])
+	assert_true(GFVariantData.values_equal(model.anchor_row_id, "row-a"))
+
+
+func test_filter_case_configuration_failure_preserves_prior_projection() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var case_result: GFTableViewRebuildResult = view.set_filter_case_sensitive(true)
+	assert_true(case_result.is_successful())
+	var filter_result: GFTableViewRebuildResult = view.set_filter_query("ALICE")
+	assert_true(filter_result.is_successful())
+	assert_true(view.get_visible_row_ids().is_empty())
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "row-a"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"case_guard", failing),
+	])
+	assert_true(predicate_result.is_successful())
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_filter_case_sensitive(false)
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"predicate_fixture_failed")
+	assert_true(view.is_filter_case_sensitive())
+	assert_true(view.get_visible_row_ids().is_empty())
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_selection_model_configuration_failure_preserves_both_models() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "not-present"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"selection_model_guard", failing),
+	])
+	assert_true(predicate_result.is_successful())
+	var authoritative_model: GFTableSelectionModel = view.get_selection_model()
+	var _authoritative_selection_result: bool = authoritative_model.set_selected(
+		"row-a",
+		true
+	)
+	var replacement_model: GFTableSelectionModel = GFTableSelectionModel.new()
+	var _replacement_selection_result: bool = replacement_model.set_selected("row-b", true)
+	failing.failed_row_id = "row-a"
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_selection_model(replacement_model)
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"predicate_fixture_failed")
+	assert_true(is_same(view.get_selection_model(), authoritative_model))
+	assert_eq(authoritative_model.get_selected_ids(), ["row-a"])
+	assert_true(GFVariantData.values_equal(authoritative_model.anchor_row_id, "row-a"))
+	assert_eq(replacement_model.get_selected_ids(), ["row-b"])
+	assert_true(GFVariantData.values_equal(replacement_model.anchor_row_id, "row-b"))
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_row_id_configuration_migrates_selection_and_original_anchor_atomically() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var model: GFTableSelectionModel = view.get_selection_model()
+	var _select_a_result: bool = model.set_selected("row-a", true)
+	var _select_b_result: bool = model.set_selected("row-b", true)
+	var _move_anchor_result: bool = model.set_selected("row-a", true)
+	var observer: SelectionStateObserver = SelectionStateObserver.new()
+	observer.model = model
+	var _connection_result: Error = model.selection_changed.connect(
+		observer.on_selection_changed
+	) as Error
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_id_column(&"name")
+
+	assert_true(result.is_successful())
+	assert_eq(view.get_row_id_column(), &"name")
+	assert_eq(view.get_visible_row_ids(), ["Alice", "Bob", "Cara"])
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+	assert_eq(model.get_selected_ids(), ["Alice", "Bob"])
+	assert_true(GFVariantData.values_equal(model.anchor_row_id, "Alice"))
+	assert_eq(observer.emission_count, 1)
+	assert_eq(observer.observed_ids, ["Alice", "Bob"])
+	assert_true(GFVariantData.values_equal(observer.observed_anchor, "Alice"))
+
+
+func test_row_id_configuration_maps_each_selection_by_its_source_row() -> void:
+	var view: GFTableDataView = GFTableDataView.new()
+	var columns_result: GFTableViewRebuildResult = view.set_columns([
+		_make_column(&"id"),
+		_make_column(&"next_id"),
+	])
+	assert_true(columns_result.is_successful())
+	var rows_result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "row-a", "next_id": "row-b" },
+		{ "id": "row-b", "next_id": "row-c" },
+	])
+	assert_true(rows_result.is_successful())
+	var model: GFTableSelectionModel = view.get_selection_model()
+	var _selection_result: bool = model.set_selected("row-a", true)
+
+	var result: GFTableViewRebuildResult = view.set_row_id_column(&"next_id")
+
+	assert_true(result.is_successful())
+	assert_eq(model.get_selected_ids(), ["row-b"])
+	assert_true(GFVariantData.values_equal(model.anchor_row_id, "row-b"))
+
+
+func test_filter_case_and_selection_model_setters_commit_through_rebuild() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var filter_result: GFTableViewRebuildResult = view.set_filter_query("ALICE")
+	assert_true(filter_result.is_successful())
+	assert_eq(view.get_visible_row_ids(), ["row-a"])
+	var previous_revision: int = view.get_view_revision()
+
+	var case_result: GFTableViewRebuildResult = view.set_filter_case_sensitive(true)
+
+	assert_true(case_result.is_successful())
+	assert_true(view.is_filter_case_sensitive())
+	assert_true(view.get_visible_row_ids().is_empty())
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+
+	var replacement_model: GFTableSelectionModel = GFTableSelectionModel.new()
+	var _select_unknown_result: bool = replacement_model.set_selected("unknown", true)
+	var _select_row_result: bool = replacement_model.set_selected("row-b", true)
+	previous_revision = view.get_view_revision()
+	var model_result: GFTableViewRebuildResult = view.set_selection_model(replacement_model)
+
+	assert_true(model_result.is_successful())
+	assert_true(is_same(view.get_selection_model(), replacement_model))
+	assert_eq(replacement_model.get_selected_ids(), ["row-b"])
+	assert_true(GFVariantData.values_equal(replacement_model.anchor_row_id, "row-b"))
+	assert_eq(view.get_view_revision(), previous_revision + 1)
+
+
+func test_row_view_is_frozen_before_project_predicate_runs() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: ReconfiguringRowViewPredicate = ReconfiguringRowViewPredicate.new()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"reconfigure", predicate),
+	])
+
+	assert_true(result.is_successful())
+	assert_eq(predicate.configure_results, [false, false, false])
+	assert_eq(predicate.observed_row_ids, ["row-a", "row-b", "row-c"])
+	assert_eq(predicate.observed_scores, [10, 18, 7])
+
+
+func test_uninitialized_typed_predicate_result_fails_closed() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(
+			&"uninitialized",
+			UninitializedResultPredicate.new()
+		),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"invalid_predicate_result")
+	assert_eq(result.get_failed_predicate_id(), &"uninitialized")
+	assert_true(view.get_row_predicate_ids().is_empty())
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_rebuild_results_are_frozen_and_observers_cannot_pollute_last_result() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = "row-a"
+	failing.error_message = "original failure"
+	var observer: RebuildResultMutationObserver = RebuildResultMutationObserver.new()
+	var _connected: int = view.view_rebuild_failed.connect(observer.on_view_rebuild_failed)
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"failing", failing),
+	])
+
+	assert_false(result.is_successful())
+	assert_false(observer.configure_result, "信号观察者不得重配已冻结结果。")
+	assert_eq(result.get_error_code(), &"predicate_fixture_failed")
+	assert_eq(result.get_error_message(), "original failure")
+	assert_false(result.configure_success_for_framework(true, 999, 999, 999, 999))
+	assert_eq(result.get_error_code(), &"predicate_fixture_failed")
+	var last_result: GFTableViewRebuildResult = view.get_last_view_rebuild_result()
+	assert_eq(last_result.get_error_code(), &"predicate_fixture_failed")
+	last_result.set("_error_code", &"caller_tampered")
+	assert_eq(
+		view.get_last_view_rebuild_result().get_error_code(),
+		&"predicate_fixture_failed",
+		"last result getter 必须返回隔离副本。"
+	)
+	var result_copy: GFTableViewRebuildResult = result.duplicate_result()
+	assert_eq(result_copy.get_error_code(), &"predicate_fixture_failed")
+	assert_false(result_copy.configure_success_for_framework(true, 999, 999, 999, 999))
+
+
+func test_predicates_reject_unsafe_object_row_identity_without_leaking_alias() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var unsafe_row_id: RefCounted = RefCounted.new()
+	var rows_result: GFTableViewRebuildResult = view.set_rows([
+		{
+			"id": unsafe_row_id,
+			"name": "Unsafe",
+			"score": 1,
+			"account": "p1",
+			"tags": [],
+		},
+	])
+	assert_true(rows_result.is_successful())
+	var previous_revision: int = view.get_view_revision()
+	var predicate: RecordingPredicate = RecordingPredicate.new()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"safe_identity", predicate),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"invalid_row_id")
+	assert_eq(result.get_failed_source_row_index(), 0)
+	assert_true(
+		GFVariantData.values_equal(result.get_failed_row_id(), null),
+		"失败结果不得携带源 Object row_id alias。"
+	)
+	assert_true(view.get_row_predicate_ids().is_empty())
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_cell_commit_rolls_back_source_projection_revision_and_selection_on_predicate_failure() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: ScoreFailurePredicate = ScoreFailurePredicate.new()
+	predicate.failed_score = 99
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"score_guard", predicate),
+	])
+	assert_true(predicate_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+
+	var committed: bool = view.commit_cell_value(0, &"score", 99)
+
+	assert_false(committed)
+	assert_eq(GFVariantData.to_int(view.get_cell_value(0, &"score")), 10)
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_selection_model().is_selected("row-a"))
+	assert_eq(view.get_last_view_rebuild_result().get_error_code(), &"score_rejected")
+
+
+func test_batch_cell_commit_is_atomic_when_candidate_projection_fails() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: ScoreFailurePredicate = ScoreFailurePredicate.new()
+	predicate.failed_score = 99
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"score_guard", predicate),
+	])
+	assert_true(predicate_result.is_successful())
+	var previous_revision: int = view.get_view_revision()
+
+	var report: Dictionary = view.commit_cell_values([
+		{ "row_index": 0, "column_id": &"score", "new_value": 12 },
+		{ "row_index": 1, "column_id": &"score", "new_value": 99 },
+	])
+
+	assert_false(GFVariantData.get_option_bool(report, "ok"))
+	assert_eq(GFVariantData.to_int(view.get_cell_value(0, &"score")), 10)
+	assert_eq(GFVariantData.to_int(view.get_cell_value(1, &"score")), 18)
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_eq(view.get_last_view_rebuild_result().get_error_code(), &"score_rejected")
+
+
+func test_row_id_cell_commit_rolls_back_selection_and_source_on_predicate_failure() -> void:
+	var view: GFTableDataView = _make_people_view()
+	view.get_column(&"id").editable = true
+	var predicate: FailingPredicate = FailingPredicate.new()
+	predicate.failed_row_id = "row-z"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"row_id_guard", predicate),
+	])
+	assert_true(predicate_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_revision: int = view.get_view_revision()
+
+	var committed: bool = view.commit_cell_value(0, &"id", "row-z")
+
+	assert_false(committed)
+	assert_eq(view.get_row_ids(), ["row-a", "row-b", "row-c"])
+	assert_eq(view.get_visible_row_ids(), ["row-a", "row-b", "row-c"])
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_selection_model().is_selected("row-a"))
+	assert_true(GFVariantData.values_equal(view.get_selection_model().anchor_row_id, "row-a"))
+	assert_eq(view.get_last_view_rebuild_result().get_error_code(), &"predicate_fixture_failed")
+
+
+func test_row_id_cell_commit_migrates_selection_and_original_anchor_atomically() -> void:
+	var view: GFTableDataView = _make_people_view()
+	view.get_column(&"id").editable = true
+	var model: GFTableSelectionModel = view.get_selection_model()
+	var _select_a_result: bool = model.set_selected("row-a", true)
+	var _select_b_result: bool = model.set_selected("row-b", true)
+	var _move_anchor_result: bool = model.set_selected("row-a", true)
+	var observer: SelectionStateObserver = SelectionStateObserver.new()
+	observer.model = model
+	var _connection_result: Error = model.selection_changed.connect(
+		observer.on_selection_changed
+	) as Error
+
+	var committed: bool = view.commit_cell_value(0, &"id", "row-a-next")
+
+	assert_true(committed)
+	assert_eq(view.get_row_ids(), ["row-a-next", "row-b", "row-c"])
+	assert_eq(model.get_selected_ids(), ["row-a-next", "row-b"])
+	assert_true(GFVariantData.values_equal(model.anchor_row_id, "row-a-next"))
+	assert_eq(observer.emission_count, 1)
+	assert_eq(observer.observed_ids, ["row-a-next", "row-b"])
+	assert_true(GFVariantData.values_equal(observer.observed_anchor, "row-a-next"))
+
+
+func test_batch_row_id_commit_maps_swapped_ids_by_source_row() -> void:
+	var view: GFTableDataView = _make_people_view()
+	view.get_column(&"id").editable = true
+	var model: GFTableSelectionModel = view.get_selection_model()
+	var _selection_result: bool = model.set_selected("row-a", true)
+
+	var report: Dictionary = view.commit_cell_values([
+		{ "row_index": 0, "column_id": &"id", "new_value": "row-b" },
+		{ "row_index": 1, "column_id": &"id", "new_value": "row-a" },
+	])
+
+	assert_true(GFVariantData.get_option_bool(report, "ok"))
+	assert_eq(view.get_row_ids(), ["row-b", "row-a", "row-c"])
+	assert_eq(model.get_selected_ids(), ["row-b"])
+	assert_true(GFVariantData.values_equal(model.anchor_row_id, "row-b"))
+
+
+func test_batch_row_id_cell_commit_rolls_back_every_staged_change() -> void:
+	var view: GFTableDataView = _make_people_view()
+	view.get_column(&"id").editable = true
+	var predicate: FailingPredicate = FailingPredicate.new()
+	predicate.failed_row_id = "row-z"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"batch_row_id_guard", predicate),
+	])
+	assert_true(predicate_result.is_successful())
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var previous_revision: int = view.get_view_revision()
+
+	var report: Dictionary = view.commit_cell_values([
+		{ "row_index": 0, "column_id": &"score", "new_value": 12 },
+		{ "row_index": 0, "column_id": &"id", "new_value": "row-z" },
+	])
+
+	assert_false(GFVariantData.get_option_bool(report, "ok"))
+	assert_eq(GFVariantData.to_int(view.get_cell_value(0, &"score")), 10)
+	assert_eq(view.get_row_ids(), ["row-a", "row-b", "row-c"])
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_true(view.get_selection_model().is_selected("row-a"))
+	assert_true(GFVariantData.values_equal(view.get_selection_model().anchor_row_id, "row-a"))
+
+
+func test_custom_value_setter_is_rejected_before_it_can_run() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var setter: CountingSetter = CountingSetter.new()
+	view.get_column(&"score").value_setter = setter.write_value
+	var previous_revision: int = view.get_view_revision()
+
+	var report: Dictionary = view.commit_cell_values([
+		{ "row_index": 0, "column_id": &"score", "new_value": 12 },
+	])
+
+	assert_false(GFVariantData.get_option_bool(report, "ok"))
+	assert_eq(setter.invocation_count, 0, "事务入口必须在调用自定义 setter 前失败关闭。")
+	assert_eq(GFVariantData.to_int(view.get_cell_value(0, &"score")), 10)
+	assert_eq(view.get_view_revision(), previous_revision)
+	var errors: Array = GFVariantData.get_option_array(report, "errors")
+	assert_eq(errors.size(), 1)
+	if not errors.is_empty():
+		assert_eq(
+			GFVariantData.get_option_string_name(
+				GFVariantData.as_dictionary(errors[0]),
+				"reason"
+			),
+			&"non_transactional_value_setter"
+		)
+
+
+func test_cell_commit_isolates_mutable_input_report_and_signal_payloads() -> void:
+	var view: GFTableDataView = _make_people_view()
+	view.get_column(&"tags").editable = true
+	var observer: CellPayloadMutationObserver = CellPayloadMutationObserver.new()
+	var _connection_result: Error = (
+		view.cell_value_committed.connect(observer.on_cell_value_committed)
+		as Error
+	)
+	var requested_tags: Array = ["new"]
+
+	var report: Dictionary = view.commit_cell_values([
+		{ "row_index": 0, "column_id": &"tags", "new_value": requested_tags },
+	])
+
+	assert_true(GFVariantData.get_option_bool(report, "ok"))
+	requested_tags.append("caller-mutation")
+	var committed_reports_value: Variant = GFVariantData.get_option_value(report, "committed")
+	var committed_reports: Array = []
+	if committed_reports_value is Array:
+		committed_reports = committed_reports_value
+	assert_eq(committed_reports.size(), 1)
+	if not committed_reports.is_empty():
+		var committed_report_value: Variant = committed_reports[0]
+		if committed_report_value is Dictionary:
+			var committed_report: Dictionary = committed_report_value
+			var report_tags_value: Variant = GFVariantData.get_option_value(
+				committed_report,
+				"new_value"
+			)
+			if report_tags_value is Array:
+				var report_tags: Array = report_tags_value
+				report_tags.append("report-mutation")
+	assert_eq(
+		GFVariantData.get_option_array(GFVariantData.as_dictionary(view.get_row(0)), "tags"),
+		["new"],
+		"调用方、报告和信号观察者都不得持有权威候选值的别名。"
+	)
+
+
+func test_builtin_resource_row_is_copied_before_transactional_commit() -> void:
+	var view: GFTableDataView = GFTableDataView.new()
+	var row_id_result: GFTableViewRebuildResult = view.set_row_id_column(&"resource_name")
+	assert_true(row_id_result.is_successful())
+	var id_column: GFTableColumnDefinition = _make_column(&"resource_name")
+	var minimum_column: GFTableColumnDefinition = GFTableColumnDefinition.new()
+	var _minimum_configure_result: GFTableColumnDefinition = minimum_column.configure(
+		&"minimum",
+		"",
+		&"min_value"
+	)
+	minimum_column.editable = true
+	var _columns_result: GFTableViewRebuildResult = view.set_columns([
+		id_column,
+		minimum_column,
+	])
+	var source_row: Curve = Curve.new()
+	source_row.resource_name = "curve-row"
+	source_row.min_value = -10.0
+	var _rows_result: GFTableViewRebuildResult = view.set_rows([source_row])
+
+	var committed: bool = view.commit_cell_value(0, &"minimum", -20.0)
+
+	assert_true(committed, "无脚本且可验证深复制的内建 Resource 行应可事务提交。")
+	assert_eq(source_row.min_value, -10.0, "候选写入不得修改调用方持有的 Resource。")
+	var committed_row_value: Variant = view.get_row(0)
+	assert_true(committed_row_value is Curve)
+	if committed_row_value is Curve:
+		var committed_row: Curve = committed_row_value
+		assert_false(is_same(committed_row, source_row))
+		assert_eq(committed_row.resource_name, "curve-row")
+		assert_eq(committed_row.min_value, -20.0)
+
+
+func test_scripted_resource_row_fails_closed_before_transactional_commit() -> void:
+	var view: GFTableDataView = GFTableDataView.new()
+	var id_column: GFTableColumnDefinition = _make_column(&"id")
+	var score_column: GFTableColumnDefinition = _make_column(&"score")
+	score_column.editable = true
+	var _columns_result: GFTableViewRebuildResult = view.set_columns([
+		id_column,
+		score_column,
+	])
+	var source_row: ScriptedTableRow = ScriptedTableRow.new()
+	var _rows_result: GFTableViewRebuildResult = view.set_rows([source_row])
+	var previous_revision: int = view.get_view_revision()
+
+	var committed: bool = view.commit_cell_value(0, &"score", 12)
+
+	assert_false(committed)
+	assert_eq(source_row.score, 10)
+	assert_true(is_same(view.get_row(0), source_row))
+	assert_eq(view.get_view_revision(), previous_revision)
+	assert_eq(
+		view.get_last_view_rebuild_result().get_error_code(),
+		&"unisolatable_source_row"
+	)
+
+
+func test_set_rows_commits_coherent_state_before_selection_observers_run() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var _selection_result: bool = view.get_selection_model().set_selected("row-a", true)
+	var observer: SelectionRebuildObserver = SelectionRebuildObserver.new()
+	observer.view = view
+	var _connection_result: Error = (
+		view.get_selection_model().selection_changed.connect(observer.on_selection_changed)
+		as Error
+	)
+
+	var result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "row-new", "name": "New", "score": 1, "account": "p3", "tags": [] },
+	])
+
+	assert_true(result.is_successful())
+	assert_not_null(observer.inner_result)
+	assert_false(observer.inner_result.is_successful(), "提交期 selection listener 不得重入修改 view。")
+	assert_eq(observer.inner_result.get_error_code(), &"reentrant_rebuild")
+	assert_eq(view.get_filter_query(), "")
+	assert_eq(view.get_visible_row_ids(), ["row-new"])
+	assert_false(view.get_selection_model().is_selected("row-a"))
+
+
+func test_text_formatter_true_match_reentrancy_aborts_outer_projection() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var formatter: ReentrantFormatter = ReentrantFormatter.new()
+	formatter.view = view
+	var name_column: GFTableColumnDefinition = view.get_column(&"name")
+	name_column.value_formatter = formatter.format_value
+	var previous_ids: Array = view.get_visible_row_ids()
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_filter_query("matching")
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"reentrant_rebuild")
+	assert_not_null(formatter.inner_result)
+	assert_false(formatter.inner_result.is_successful())
+	assert_eq(view.get_filter_query(), "")
+	assert_eq(view.get_visible_row_ids(), previous_ids)
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_predicate_cannot_commit_source_during_candidate_rebuild() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: CommittingPredicate = CommittingPredicate.new()
+	predicate.view = view
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"committing", predicate),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"reentrant_rebuild")
+	assert_false(predicate.commit_succeeded)
+	assert_eq(GFVariantData.to_int(view.get_cell_value(0, &"score")), 10)
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_row_view_rejects_nested_non_resource_object_aliases() -> void:
+	var view: GFTableDataView = GFTableDataView.new()
+	var id_column: GFTableColumnDefinition = _make_column(&"id")
+	var payload_column: GFTableColumnDefinition = _make_column(&"payload")
+	var _columns_result: GFTableViewRebuildResult = view.set_columns([
+		id_column,
+		payload_column,
+	])
+	var payload: MutablePayload = MutablePayload.new()
+	var _rows_result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "unsafe", "payload": { "nested": [payload] } },
+	])
+	var previous_revision: int = view.get_view_revision()
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(
+			&"payload_mutation",
+			PayloadMutationPredicate.new()
+		),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_error_code(), &"invalid_row_view_snapshot")
+	assert_eq(payload.amount, 1)
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_row_view_rejects_circular_and_over_budget_values() -> void:
+	var row_view: GFTableRowView = GFTableRowView.new()
+	var circular_values: Array = []
+	circular_values.append(circular_values)
+	assert_false(row_view.configure_for_framework(
+		0,
+		&"circular",
+		{ &"value": circular_values }
+	))
+
+	var deep_value: Variant = 1
+	for _index: int in range(80):
+		deep_value = [deep_value]
+	var deep_row_view: GFTableRowView = GFTableRowView.new()
+	assert_false(deep_row_view.configure_for_framework(
+		0,
+		&"deep",
+		{ &"value": deep_value }
+	))
+
+	var node_heavy_values: Array = []
+	var _node_resize_result: int = node_heavy_values.resize(17_000)
+	var node_heavy_row_view: GFTableRowView = GFTableRowView.new()
+	assert_false(node_heavy_row_view.configure_for_framework(
+		0,
+		&"node-heavy",
+		{ &"value": node_heavy_values }
+	))
+
+	var collection_heavy_values: Array = []
+	var _collection_resize_result: int = collection_heavy_values.resize(65_537)
+	var collection_heavy_row_view: GFTableRowView = GFTableRowView.new()
+	assert_false(collection_heavy_row_view.configure_for_framework(
+		0,
+		&"collection-heavy",
+		{ &"value": collection_heavy_values }
+	))
+
+	var utf8_heavy_row_view: GFTableRowView = GFTableRowView.new()
+	assert_false(utf8_heavy_row_view.configure_for_framework(
+		0,
+		&"utf8-heavy",
+		{ &"value": "界".repeat(350_000) }
+	))
+
+	var packed_bytes: PackedByteArray = PackedByteArray()
+	var _resize_error: int = packed_bytes.resize(1_048_577)
+	var packed_heavy_row_view: GFTableRowView = GFTableRowView.new()
+	assert_false(packed_heavy_row_view.configure_for_framework(
+		0,
+		&"packed-heavy",
+		{ &"value": packed_bytes }
+	))
+
+	var packed_vector_boundary: PackedVector4Array = PackedVector4Array()
+	var _boundary_resize_error: int = packed_vector_boundary.resize(32_768)
+	var packed_vector_boundary_report: Dictionary = (
+		GFTableRowView.duplicate_isolated_variant_for_framework(packed_vector_boundary)
+	)
+	assert_true(GFVariantData.get_option_bool(packed_vector_boundary_report, "ok"))
+	var packed_vector_over_budget: PackedVector4Array = PackedVector4Array()
+	var _over_budget_resize_error: int = packed_vector_over_budget.resize(32_769)
+	var packed_vector_over_budget_report: Dictionary = (
+		GFTableRowView.duplicate_isolated_variant_for_framework(packed_vector_over_budget)
+	)
+	assert_false(GFVariantData.get_option_bool(packed_vector_over_budget_report, "ok"))
+
+
+func test_row_view_returns_an_isolated_copy_of_builtin_resources() -> void:
+	var source_resource: Curve = Curve.new()
+	source_resource.resource_name = "snapshot-curve"
+	source_resource.min_value = -10.0
+	var row_view: GFTableRowView = GFTableRowView.new()
+
+	assert_true(row_view.configure_for_framework(
+		0,
+		&"resource-row",
+		{ &"curve": source_resource }
+	))
+	var copied_value: Variant = row_view.get_value(&"curve")
+	assert_true(copied_value is Curve)
+	if copied_value is Curve:
+		var copied_resource: Curve = copied_value
+		assert_false(is_same(copied_resource, source_resource))
+		assert_eq(copied_resource.resource_name, "snapshot-curve")
+		assert_eq(copied_resource.min_value, -10.0)
+		copied_resource.min_value = -20.0
+		assert_eq(source_resource.min_value, -10.0)
+
+
+func test_set_columns_rolls_back_when_candidate_predicate_fails() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: ColumnPresenceFailurePredicate = ColumnPresenceFailurePredicate.new()
+	predicate.rejected_column_id = &"forbidden"
+	var predicate_result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"column_guard", predicate),
+	])
+	assert_true(predicate_result.is_successful())
+	var previous_revision: int = view.get_view_revision()
+	var next_columns: Array[GFTableColumnDefinition] = view.get_columns()
+	next_columns.append(_make_column(&"forbidden"))
+
+	var result: GFTableViewRebuildResult = view.set_columns(next_columns)
+
+	assert_false(result.is_successful())
+	assert_null(view.get_column(&"forbidden"))
+	assert_eq(view.get_view_revision(), previous_revision)
+
+
+func test_row_predicate_crud_is_transactional_and_deterministic() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate_a: RecordingPredicate = RecordingPredicate.new()
+	predicate_a.label = "a"
+	var predicate_b: RecordingPredicate = RecordingPredicate.new()
+	predicate_b.label = "b"
+
+	var register_b: GFTableViewRebuildResult = view.register_row_predicate(
+		GFTableRowPredicateRegistration.create(&"b", predicate_b, 10, false)
+	)
+	var register_a: GFTableViewRebuildResult = view.register_row_predicate(
+		GFTableRowPredicateRegistration.create(&"a", predicate_a, 20)
+	)
+	assert_true(register_b.is_successful())
+	assert_true(register_a.is_successful())
+	assert_eq(view.get_row_predicate_ids(), [&"b", &"a"])
+
+	var enable_b: GFTableViewRebuildResult = view.set_row_predicate_enabled(&"b", true)
+	var reorder_b: GFTableViewRebuildResult = view.set_row_predicate_order(&"b", 30)
+	assert_true(enable_b.is_successful())
+	assert_true(reorder_b.is_successful())
+	assert_eq(view.get_row_predicate_ids(), [&"a", &"b"])
+
+	var unregister_a: GFTableViewRebuildResult = view.unregister_row_predicate(&"a")
+	assert_true(unregister_a.is_successful())
+	assert_eq(view.get_row_predicate_ids(), [&"b"])
+
+
+func test_registration_metadata_is_owned_and_getters_return_snapshots() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var authoritative_predicate: RecordingPredicate = RecordingPredicate.new()
+	authoritative_predicate.label = "authoritative"
+	authoritative_predicate.minimum_score = 8
+	var replacement_predicate: RecordingPredicate = RecordingPredicate.new()
+	replacement_predicate.label = "replacement"
+	replacement_predicate.minimum_score = 999
+	var caller_registration: GFTableRowPredicateRegistration = (
+		GFTableRowPredicateRegistration.create(
+			&"owned",
+			authoritative_predicate,
+			10,
+			true
+		)
+	)
+	var registration_result: GFTableViewRebuildResult = view.set_row_predicates([
+		caller_registration,
+	])
+	assert_true(registration_result.is_successful())
+	assert_eq(view.get_visible_row_ids(), ["row-a", "row-b"])
+	var committed_revision: int = view.get_view_revision()
+
+	caller_registration.set("_predicate_id", &"caller-hijack")
+	caller_registration.set("_order", -100)
+	caller_registration.set("_enabled", false)
+	caller_registration.set("_predicate", replacement_predicate)
+
+	assert_eq(view.get_row_predicate_ids(), [&"owned"])
+	assert_null(view.get_row_predicate(&"caller-hijack"))
+	assert_eq(view.get_visible_row_ids(), ["row-a", "row-b"])
+	assert_eq(view.get_view_revision(), committed_revision)
+	var registration_snapshot: GFTableRowPredicateRegistration = (
+		view.get_row_predicate(&"owned")
+	)
+	assert_not_null(registration_snapshot)
+	registration_snapshot.set("_predicate_id", &"getter-hijack")
+	registration_snapshot.set("_order", -200)
+	registration_snapshot.set("_enabled", false)
+	registration_snapshot.set("_predicate", replacement_predicate)
+	var registration_snapshots: Array[GFTableRowPredicateRegistration] = (
+		view.get_row_predicates()
+	)
+	assert_eq(registration_snapshots.size(), 1)
+	registration_snapshots[0].set("_predicate_id", &"array-hijack")
+	registration_snapshots[0].set("_order", -300)
+	registration_snapshots[0].set("_enabled", false)
+	registration_snapshots[0].set("_predicate", replacement_predicate)
+
+	var authoritative_snapshot: GFTableRowPredicateRegistration = (
+		view.get_row_predicate(&"owned")
+	)
+	assert_not_null(authoritative_snapshot)
+	assert_eq(authoritative_snapshot.get_predicate_id(), &"owned")
+	assert_eq(authoritative_snapshot.get_order(), 10)
+	assert_true(authoritative_snapshot.is_enabled())
+	assert_true(is_same(authoritative_snapshot.get_predicate(), authoritative_predicate))
+	assert_eq(view.get_row_predicate_ids(), [&"owned"])
+	assert_eq(view.get_visible_row_ids(), ["row-a", "row-b"])
+	assert_eq(view.get_view_revision(), committed_revision)
+
+	authoritative_predicate.invocation_log.clear()
+	replacement_predicate.invocation_log.clear()
+	var refresh_result: GFTableViewRebuildResult = view.refresh_view()
+	assert_true(refresh_result.is_successful())
+	assert_false(authoritative_predicate.invocation_log.is_empty())
+	assert_true(replacement_predicate.invocation_log.is_empty())
+	assert_eq(view.get_visible_row_ids(), ["row-a", "row-b"])
+
+
+func test_failure_diagnostic_identity_payloads_have_utf8_byte_budgets() -> void:
+	var view: GFTableDataView = _make_people_view()
+	var predicate: RecordingPredicate = RecordingPredicate.new()
+	var oversized_id: StringName = StringName("界".repeat(64))
+
+	var result: GFTableViewRebuildResult = view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(oversized_id, predicate),
+	])
+
+	assert_false(result.is_successful())
+	assert_eq(result.get_failed_predicate_id(), &"", "超预算 predicate id 不得进入诊断载荷。")
+	assert_false(result.get_error_message().contains(String(oversized_id)))
+
+	var diagnostic_view: GFTableDataView = _make_people_view()
+	var oversized_row_id: String = "行".repeat(300)
+	var rows_result: GFTableViewRebuildResult = diagnostic_view.set_rows([
+		{
+			"id": oversized_row_id,
+			"name": "Diagnostic",
+			"score": 1,
+			"account": "p4",
+			"tags": [],
+		},
+	])
+	assert_true(rows_result.is_successful())
+	var failing: FailingPredicate = FailingPredicate.new()
+	failing.failed_row_id = oversized_row_id
+	var registration_result: GFTableViewRebuildResult = diagnostic_view.set_row_predicates([
+		GFTableRowPredicateRegistration.create(&"diagnostic_guard", failing, 0, false),
+	])
+	assert_true(registration_result.is_successful())
+
+	failing.error_message = "A".repeat(4_096) + "ASCII_SECRET_TAIL"
+	var ascii_result: GFTableViewRebuildResult = diagnostic_view.set_row_predicate_enabled(
+		&"diagnostic_guard",
+		true
+	)
+	assert_false(ascii_result.is_successful())
+	assert_true(ascii_result.get_error_message().to_utf8_buffer().size() <= 1_024)
+	assert_false(ascii_result.get_error_message().contains("ASCII_SECRET_TAIL"))
+	assert_true(
+		GFVariantData.values_equal(ascii_result.get_failed_row_id(), null),
+		"超预算 row id 必须整体省略，不能被诊断层回显。"
+	)
+
+	failing.error_message = "界".repeat(2_000) + "多字节秘密尾部"
+	var multibyte_result: GFTableViewRebuildResult = (
+		diagnostic_view.set_row_predicate_enabled(&"diagnostic_guard", true)
+	)
+	assert_false(multibyte_result.is_successful())
+	assert_true(multibyte_result.get_error_message().to_utf8_buffer().size() <= 1_024)
+	assert_false(multibyte_result.get_error_message().contains("多字节秘密尾部"))
+	assert_true(GFVariantData.values_equal(multibyte_result.get_failed_row_id(), null))
+
+
+func _make_people_view() -> GFTableDataView:
+	var view: GFTableDataView = GFTableDataView.new()
+	var id_column: GFTableColumnDefinition = _make_column(&"id")
+	var name_column: GFTableColumnDefinition = _make_column(&"name")
+	var score_column: GFTableColumnDefinition = _make_column(&"score")
+	score_column.editable = true
+	score_column.sort_mode = GFTableColumnDefinition.SortMode.NUMBER
+	var account_column: GFTableColumnDefinition = _make_column(&"account")
+	account_column.visible = false
+	var tags_column: GFTableColumnDefinition = _make_column(&"tags")
+	tags_column.visible = false
+	var columns: Array[GFTableColumnDefinition] = [
+		id_column,
+		name_column,
+		score_column,
+		account_column,
+		tags_column,
+	]
+	var _columns_result: GFTableViewRebuildResult = view.set_columns(columns)
+	var _rows_result: GFTableViewRebuildResult = view.set_rows([
+		{ "id": "row-a", "name": "Alice", "score": 10, "account": "p1", "tags": ["alpha"] },
+		{ "id": "row-b", "name": "Bob", "score": 18, "account": "p1", "tags": ["beta"] },
+		{ "id": "row-c", "name": "Cara", "score": 7, "account": "p2", "tags": ["gamma"] },
+	])
+	return view
+
+
+func _make_column(column_id: StringName) -> GFTableColumnDefinition:
+	var column: GFTableColumnDefinition = GFTableColumnDefinition.new()
+	var _configure_result: GFTableColumnDefinition = column.configure(column_id)
+	return column

--- a/tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd.uid
+++ b/tests/gf_core/standard/utilities/ui/test_gf_table_row_predicates.gd.uid
@@ -1,0 +1,1 @@
+uid://c05omw8nkg7pk

--- a/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd
@@ -1,0 +1,2902 @@
+## 测试 GFVirtualListBinder 的有界物化、回收、测量、焦点与生命周期。
+extends GutTest
+
+
+# --- 常量 ---
+
+const GF_VIRTUAL_LIST_BINDER_SCRIPT = preload("res://addons/gf/standard/utilities/ui/gf_virtual_list_binder.gd")
+const GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = preload("res://addons/gf/standard/utilities/ui/gf_virtual_list_sync_result.gd")
+const _JSON_SAFE_INTEGER_MAX: int = 9_007_199_254_740_991
+const _NONNEGATIVE_JSON_INTEGER_FIELDS: Array[String] = [
+	"layout_revision",
+	"data_revision",
+	"pooled_count",
+	"created_count",
+	"reused_count",
+	"released_count",
+	"measured_count",
+]
+
+
+# --- 私有变量 ---
+
+var _nodes: Array[Node] = []
+var _binders: Array[RefCounted] = []
+var _item_ids: Array = []
+var _factory_count: int = 0
+var _bind_events: Array[Dictionary] = []
+var _unbind_events: Array[Dictionary] = []
+var _fail_factory: bool = false
+var _factory_success_budget: int = -1
+var _last_factory_control: Control = null
+var _fail_bind_index: int = -1
+var _expanded_first_extent: bool = false
+var _measured_extents: Dictionary = {}
+var _reentrant_mode: StringName = &""
+var _invalidate_callback_budget: int = 0
+var _layout_callback_budget: int = 0
+var _measurement_requeue_budget: int = 0
+var _focus_callback_budget: int = 0
+var _layout_model_for_callback: GFVirtualListModel = null
+var _focus_model_for_callback: GFVirtualListFocusModel = null
+var _active_binder: RefCounted = null
+var _foreign_parent_for_callback: Control = null
+var _sync_completed_event_count: int = 0
+var _reentrant_sync_result: RefCounted = null
+var _captured_round_geometry: bool = false
+var _captured_round_offset: float = 0.0
+var _captured_round_extent: float = 0.0
+var _identity_callback_count: int = 0
+
+
+# --- Godot 生命周期方法 ---
+
+func before_each() -> void:
+	_reset_fixture_state()
+
+
+func after_each() -> void:
+	for binder: RefCounted in _binders:
+		if binder != null and binder.has_method("dispose"):
+			var _dispose_result: Variant = binder.call("dispose")
+	_binders.clear()
+	_active_binder = null
+	for node: Node in _nodes:
+		if is_instance_valid(node):
+			node.free()
+	_nodes.clear()
+	await get_tree().process_frame
+
+
+# --- 测试方法 ---
+
+func test_bind_materializes_only_viewport_plus_overscan() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful(), "首次同步应成功。")
+	assert_eq(result.get_viewport_range(), Vector2i(0, 5), "真实视口应命中前五项。")
+	assert_eq(result.get_requested_range(), Vector2i(0, 6), "overscan 应额外请求一个条目。")
+	assert_eq(result.get_materialized_count(), 6, "只应物化 visible + overscan 范围。")
+	assert_eq(_factory_count, 6, "factory 调用次数应与首次物化数量一致。")
+
+
+func test_scroll_reuses_rows_and_unbinds_each_previous_binding_once() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var initial_controls: Array[Control] = []
+	for item_index: int in range(6):
+		initial_controls.append(binder.get_materialized_control(item_index))
+
+	scroll_container.scroll_vertical = 100
+	var scrolled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(scrolled_result.is_successful(), "滚动后的同步应成功。")
+	assert_eq(scrolled_result.get_requested_range(), Vector2i(4, 11), "滚动范围应更新为新的 visible + overscan。")
+	assert_eq(scrolled_result.get_materialized_count(), 7, "新范围只保留七个物化行。")
+	assert_eq(_factory_count, 7, "离开范围的行应先回收复用，只为净增长创建一个行。")
+	assert_eq(_unbind_events.size(), 4, "离开范围的四项应各解绑一次。")
+	var reused_count: int = 0
+	for item_index: int in range(6, 11):
+		if binder.get_materialized_control(item_index) in initial_controls:
+			reused_count += 1
+	assert_true(reused_count >= 4, "新范围应复用已离开范围的 Control。")
+
+
+func test_stable_identity_follows_visible_reorder() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var alpha_id: StringName = _item_ids[1]
+	var beta_id: StringName = _item_ids[2]
+	var alpha_control: Control = binder.get_materialized_control_by_id(alpha_id)
+	var beta_control: Control = binder.get_materialized_control_by_id(beta_id)
+	_item_ids[1] = beta_id
+	_item_ids[2] = alpha_id
+
+	assert_true(binder.invalidate_items(), "数据 identity 变化应可显式失效。")
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful(), "可见范围内的稳定 identity 重排应成功。")
+	assert_same(binder.get_materialized_control(2), alpha_control, "同一稳定 identity 应沿用原 Control。")
+	assert_same(binder.get_materialized_control(1), beta_control, "交换后的另一 identity 也应沿用原 Control。")
+	assert_eq(_unbind_events.size(), 6, "invalidate 应对每个旧活动绑定执行一次对称 unbind。")
+
+
+func test_invalid_identity_preserves_previous_materialization() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var previous_control: Control = binder.get_materialized_control(2)
+	var previous_unbind_count: int = _unbind_events.size()
+	_item_ids[2] = { "unstable": true }
+	var _invalidated: bool = binder.invalidate_items()
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_INVALID_IDENTITY)
+	assert_same(binder.get_materialized_control(2), previous_control, "identity 预检失败不得破坏旧提交。")
+	assert_eq(_unbind_events.size(), previous_unbind_count, "失败预检不得调用旧行 unbind。")
+
+
+func test_duplicate_identity_preserves_previous_materialization() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var previous_control: Control = binder.get_materialized_control(1)
+	_item_ids[2] = _item_ids[1]
+	var _invalidated: bool = binder.invalidate_items()
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DUPLICATE_IDENTITY)
+	assert_same(binder.get_materialized_control(1), previous_control, "重复 identity 不得替换旧 materialization。")
+	assert_eq(_unbind_events.size(), 0, "重复 identity 预检失败不得解绑旧行。")
+
+
+func test_factory_failure_rolls_back_staged_rows() -> void:
+	var fixture: Dictionary = _create_fixture(50, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var previous_controls: Array[Control] = []
+	for item_index: int in range(6):
+		previous_controls.append(binder.get_materialized_control(item_index))
+	_factory_success_budget = 1
+	scroll_container.size.y = 200.0
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var staged_control: Control = _last_factory_control
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_FACTORY_FAILED)
+	assert_eq(result.get_materialized_count(), 6, "factory 失败后应保留完整旧范围。")
+	assert_eq(result.get_created_count(), 1, "失败前必须真实创建至少一个 staged Control。")
+	assert_eq(_factory_count, 7, "失败 factory 之前只允许一个新增 Control 成功交付。")
+	for item_index: int in range(6):
+		assert_same(binder.get_materialized_control(item_index), previous_controls[item_index])
+	assert_eq(_unbind_events.size(), 0, "staging 失败不得解绑旧行。")
+	assert_eq(_bind_events.size(), 6, "staged Control 在提交前不得调用 bind callback。")
+	assert_not_null(staged_control, "测试必须捕获失败前成功交付的 staged Control。")
+	if staged_control == null:
+		return
+	assert_true(is_instance_valid(staged_control))
+	assert_false(staged_control.is_queued_for_deletion())
+	assert_null(staged_control.get_parent(), "失败 staging 应把新增 Control 回收到 parentless pool。")
+	assert_eq(result.get_pooled_count(), 1, "失败结果应反映已回收的 staged Control。")
+
+	_factory_success_budget = -1
+	var retry_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(retry_result.is_successful(), "factory 恢复后同一计划应可直接重试。")
+	assert_eq(retry_result.get_materialized_count(), 11, "失败 staging 不得在 active 记录中遗留暂存状态。")
+	assert_eq(retry_result.get_created_count(), 4, "重试应复用已回收的 staged Control。")
+	assert_eq(retry_result.get_reused_count(), 7, "六个旧 active 与一个 staged Control 应被复用。")
+	assert_eq(retry_result.get_pooled_count(), 0)
+	assert_eq(_factory_count, 11, "重试不应因污染而额外创建 Control。")
+	var reused_staged_control: bool = false
+	for item_index: int in retry_result.get_materialized_indices():
+		if binder.get_materialized_control(item_index) == staged_control:
+			reused_staged_control = true
+			break
+	assert_true(reused_staged_control, "重试必须重新接纳失败轮次回收的 staged Control。")
+	assert_eq(_unbind_events.size(), 0, "成功重试前旧 active 不得被错误解绑。")
+	assert_eq(_bind_events.size(), retry_result.get_materialized_count())
+
+	binder.dispose()
+	assert_eq(_unbind_events.size(), _bind_events.size(), "最终 teardown 必须保持 bind/unbind 对称。")
+	assert_true(staged_control.is_queued_for_deletion(), "Binder-owned staged Control 最终必须被释放。")
+
+
+func test_bind_rejection_reports_first_index_without_item_payload() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var sensitive_identity: StringName = &"private_account_row"
+	_item_ids[2] = sensitive_identity
+	_fail_bind_index = 2
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_BIND_FAILED)
+	assert_eq(result.get_error_index(), 2, "typed result 应报告首个拒绝索引。")
+	assert_eq(result.get_error(), "bind_callback rejected an item", "错误说明应固定且有界。")
+	assert_false(result.get_error().contains(String(sensitive_identity)), "错误说明不得回显项目 identity。")
+	assert_eq(
+		_bind_events.size(),
+		_unbind_events.size() + result.get_materialized_count(),
+		"被拒绝的 bind 也必须保持 callback 与 active 行守恒。"
+	)
+
+
+func test_materialization_cap_prioritizes_raw_viewport() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 3, 5)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_TRUNCATED)
+	assert_true(result.was_truncated(), "超出物化硬上限时结果应显式报告截断。")
+	assert_eq(result.get_viewport_range(), Vector2i(0, 5))
+	assert_eq(result.get_materialized_indices(), PackedInt32Array([0, 1, 2, 3, 4]), "节点预算应优先完整覆盖 raw viewport。")
+	assert_eq(_factory_count, 5, "factory 调用不得突破硬上限。")
+
+
+func test_public_budgets_are_absolutely_bounded_and_pool_shrink_converges() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	binder.max_materialized_items = GF_VIRTUAL_LIST_BINDER_SCRIPT.ABSOLUTE_MAX_MATERIALIZED_ITEMS + 1
+	binder.max_pooled_items = GF_VIRTUAL_LIST_BINDER_SCRIPT.ABSOLUTE_MAX_POOLED_ITEMS + 1
+	assert_eq(
+		binder.max_materialized_items,
+		GF_VIRTUAL_LIST_BINDER_SCRIPT.ABSOLUTE_MAX_MATERIALIZED_ITEMS,
+		"活动节点预算不得突破框架绝对上限。"
+	)
+	assert_eq(
+		binder.max_pooled_items,
+		GF_VIRTUAL_LIST_BINDER_SCRIPT.ABSOLUTE_MAX_POOLED_ITEMS,
+		"pool 预算不得突破框架绝对上限。"
+	)
+
+	binder.max_pooled_items = 2
+	binder.max_materialized_items = 1
+	var _reduced_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_eq(
+		GFVariantData.get_option_int(binder.get_debug_snapshot(), "pooled_count"),
+		2,
+		"缩小活动范围后 pool 应遵循当前预算。"
+	)
+	binder.max_pooled_items = 0
+	assert_eq(
+		GFVariantData.get_option_int(binder.get_debug_snapshot(), "pooled_count"),
+		0,
+		"运行时缩小 pool 预算应立即回收超额 Control。"
+	)
+
+
+func test_oversized_identity_token_fails_closed_without_echoing_identity() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var previous_control: Control = binder.get_materialized_control(0)
+	var oversized_identity: String = "s".repeat(
+		GF_VIRTUAL_LIST_BINDER_SCRIPT.ABSOLUTE_MAX_IDENTITY_TOKEN_LENGTH + 1
+	)
+	_item_ids[0] = oversized_identity
+	var _invalidated: bool = binder.invalidate_items()
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(initial_result.is_successful())
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_INVALID_IDENTITY)
+	assert_same(binder.get_materialized_control(0), previous_control, "超长 identity 不得破坏已提交 materialization。")
+	assert_false(result.get_error().contains(oversized_identity.left(32)), "诊断不得回显 identity 内容。")
+
+
+func test_measurement_updates_extent_and_applies_one_anchor_correction() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 5, 20)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	scroll_container.scroll_vertical = 80
+	_expanded_first_extent = true
+	assert_true(binder.request_measurement(), "活动行应可请求重新测量。")
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful(), "重新测量应成功。")
+	assert_eq(model.get_item_extent(0), 40.0, "实测尺寸应回写布局模型。")
+	assert_eq(result.get_anchor_adjustment(), 20.0, "位于视口上方的尺寸差应累计为一次 anchor correction。")
+	assert_eq(scroll_container.scroll_vertical, 100, "滚动位置应只应用一次累计修正。")
+
+
+func test_anchor_scroll_invalidation_reports_applied_adjustment_as_deferred() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 5, 20)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	scroll_container.scroll_vertical = 80
+	_expanded_first_extent = true
+	var callback_budget: Array[int] = [1]
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(_value: float) -> void:
+			if not _binder_sync_is_in_progress(binder) or callback_budget[0] <= 0:
+				return
+			callback_budget[0] -= 1
+			var _invalidated_from_anchor: bool = binder.invalidate_items()
+	) as Error
+	assert_true(binder.request_measurement())
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(deferred_result.get_anchor_adjustment(), 20.0, "已执行的 anchor 写入不得在诊断中降为零。")
+	assert_eq(scroll_container.scroll_vertical, 100)
+	assert_eq(deferred_result.get_materialized_count(), 0)
+
+
+func test_measurement_anchor_uses_pre_measurement_snapshot_for_multiple_rows() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 6, 32)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	scroll_container.scroll_vertical = 120
+	_measured_extents = {
+		0: 35.0,
+		1: 45.0,
+		2: 55.0,
+		3: 65.0,
+	}
+	assert_true(binder.request_measurement())
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful())
+	assert_eq(result.get_anchor_adjustment(), 120.0, "所有测量前位于锚点上方的 delta 都应累计。")
+	assert_eq(scroll_container.scroll_vertical, 240, "多行 delta 应在该轮末尾一次性应用。")
+
+
+func test_explicit_measurement_ignores_auto_measure_toggle() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	binder.auto_measure = false
+	_measured_extents[0] = 48.0
+	assert_true(binder.request_measurement())
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful())
+	assert_eq(model.get_item_extent(0), 48.0, "显式测量请求不得被 auto_measure 禁用。")
+	assert_true(result.get_measured_count() > 0)
+
+
+func test_focus_change_reveals_item_and_hands_focus_to_row() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_true(focus_model.set_focused_index(20), "应能更新虚拟焦点。")
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	var focused_control: Control = binder.get_materialized_control(20)
+	assert_true(result.is_successful(), "焦点目标滚入视口后的同步应成功。")
+	assert_not_null(focused_control, "虚拟焦点对应行应被物化。")
+	assert_true(scroll_container.scroll_vertical > 0, "远端焦点应按 nearest 滚入视口。")
+	assert_same(get_viewport().gui_get_focus_owner(), focused_control, "Godot 焦点应交接到对应项目行。")
+
+
+func test_pending_focus_reveal_quantizes_range_before_materialization() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(
+		2,
+		20.0,
+		0,
+		512,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _first_extent: Dictionary = model.set_item_extent(0, 20.25, true)
+	var _second_extent: Dictionary = model.set_item_extent(1, 20.10, true)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_true(focus_model.set_focused_index(1))
+	assert_eq(scroll_container.scroll_vertical, 20, "实际 ScrollContainer 偏移应按整数规则量化。")
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful())
+	assert_eq(result.get_viewport_range(), Vector2i(0, 2))
+	assert_eq(result.get_requested_range(), Vector2i(0, 2))
+	assert_not_null(
+		binder.get_materialized_control(0),
+		"range 必须使用与实际滚动相同的量化偏移，保留仍露出 0.25px 的首行。"
+	)
+
+
+func test_pending_focus_reveal_measurement_anchors_to_planned_scroll() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(
+		100,
+		100.0,
+		1,
+		512,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	scroll_container.scroll_vertical = 200
+	var _scrolled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	_focus_model_for_callback = focus_model
+	_focus_callback_budget = 1
+	_reentrant_mode = &"focus_zero_on_bind"
+	assert_true(binder.invalidate_items())
+
+	var queued_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(queued_result.is_successful(), str(queued_result.to_dict()))
+	assert_eq(focus_model.focused_index, 0)
+	assert_eq(scroll_container.scroll_vertical, 200, "同步 callback 的 reveal 必须留给下一轮。")
+	_measured_extents[0] = 40.0
+	assert_true(binder.request_measurement(), str(binder.get_debug_snapshot()))
+
+	var reveal_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(reveal_result.is_successful(), str(reveal_result.to_dict()))
+	assert_eq(reveal_result.get_anchor_adjustment(), 0.0)
+	assert_eq(scroll_container.scroll_vertical, 0, "测量锚点必须基于本轮 reveal 后的量化偏移。")
+	assert_not_null(binder.get_materialized_control(0))
+
+
+func test_bind_callback_focus_intent_hands_off_only_in_next_sync_round() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	_focus_model_for_callback = focus_model
+	_focus_callback_budget = 1
+	_reentrant_mode = &"focus_zero_on_bind"
+	assert_true(binder.invalidate_items())
+
+	var intent_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(intent_result.is_successful())
+	assert_eq(focus_model.focused_index, 0)
+	assert_null(
+		get_viewport().gui_get_focus_owner(),
+		"bind callback 产生的新焦点意图不得在同一事务尾部执行物理 handoff。"
+	)
+
+	var handoff_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_true(handoff_result.is_successful())
+	assert_same(get_viewport().gui_get_focus_owner(), binder.get_materialized_control(0))
+
+
+func test_bind_adopts_preconfigured_virtual_focus() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var _count_changed: bool = focus_model.set_item_count(100)
+	assert_true(focus_model.set_focused_index(20))
+
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	await get_tree().process_frame
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var focused_control: Control = binder.get_materialized_control(20)
+
+	assert_true(result.is_successful())
+	assert_gt(scroll_container.scroll_vertical, 0, "bind 应 reveal 已存在的远端虚拟焦点。")
+	assert_not_null(focused_control)
+	assert_same(get_viewport().gui_get_focus_owner(), focused_control)
+
+
+func test_bind_reveals_preconfigured_focus_without_stealing_external_focus() -> void:
+	var external_button: Button = Button.new()
+	external_button.focus_mode = Control.FOCUS_ALL
+	add_child(external_button)
+	_nodes.append(external_button)
+	external_button.grab_focus()
+	await get_tree().process_frame
+	assert_same(get_viewport().gui_get_focus_owner(), external_button)
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var _count_changed: bool = focus_model.set_item_count(100)
+	assert_true(focus_model.set_focused_index(20))
+
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	await get_tree().process_frame
+	var _first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var _second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_gt(scroll_container.scroll_vertical, 0, "bind 仍应 reveal 已存在的虚拟焦点。")
+	assert_not_null(binder.get_materialized_control(20))
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		external_button,
+		"attach 不得把 bind 前已有的项目物理焦点抢给虚拟列表。"
+	)
+
+
+func test_existing_external_focus_wins_while_new_virtual_focus_is_revealed() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var external_button: Button = Button.new()
+	external_button.focus_mode = Control.FOCUS_ALL
+	add_child(external_button)
+	_nodes.append(external_button)
+	external_button.grab_focus()
+	await get_tree().process_frame
+	assert_same(get_viewport().gui_get_focus_owner(), external_button)
+
+	assert_true(focus_model.set_focused_index(80))
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_true(first_result.is_successful())
+	assert_true(second_result.is_successful())
+	assert_gt(scroll_container.scroll_vertical, 0, "外部焦点不得阻断虚拟焦点 reveal。")
+	assert_not_null(binder.get_materialized_control(80))
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		external_button,
+		"虚拟焦点变化不得抢走已经存在的项目物理焦点。"
+	)
+
+
+func test_focus_target_immediate_release_cancels_future_handoff_retries() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var focus_state: Dictionary = {
+		"connected": false,
+		"focus_entered_count": 0,
+	}
+	var focus_target_callback: Callable = func(
+		control: Control,
+		_item_index: int,
+		_item_id: Variant
+	) -> Control:
+		if not GFVariantData.get_option_bool(focus_state, "connected"):
+			focus_state["connected"] = true
+			var release_callback: Callable = func() -> void:
+				focus_state["focus_entered_count"] = (
+					GFVariantData.get_option_int(focus_state, "focus_entered_count") + 1
+				)
+				control.release_focus()
+			var _connected: Error = control.focus_entered.connect(release_callback) as Error
+		return control
+	var fixture: Dictionary = _create_fixture(
+		100, 100.0, 1, 32, focus_model, null, Vector2.ZERO, false, focus_target_callback
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_null(get_viewport().gui_get_focus_owner())
+	assert_eq(GFVariantData.get_option_int(focus_state, "focus_entered_count"), 1)
+
+	var _retry_one: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var _retry_two: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_eq(
+		GFVariantData.get_option_int(focus_state, "focus_entered_count"),
+		1,
+		"项目在 focus_entered 中显式 release 后不得被 Binder 连续重抢。"
+	)
+
+
+func test_recycled_focused_row_restores_focus_without_stealing_external_focus() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var first_focused_control: Control = binder.get_materialized_control(20)
+	assert_same(get_viewport().gui_get_focus_owner(), first_focused_control)
+
+	binder.auto_reveal_focus = false
+	scroll_container.scroll_vertical = 1_000
+	var recycled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(recycled_result.is_successful())
+	assert_null(binder.get_materialized_control(20), "离开 overscan 的聚焦行应进入回收路径。")
+	assert_null(get_viewport().gui_get_focus_owner(), "回收行不得把物理焦点留在复用 Control 上。")
+	assert_eq(focus_model.focused_index, 20, "物理行回收不得清除虚拟焦点。")
+
+	scroll_container.scroll_vertical = 400
+	var restored_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var restored_control: Control = binder.get_materialized_control(20)
+	assert_true(restored_result.is_successful())
+	assert_not_null(restored_control)
+	assert_same(get_viewport().gui_get_focus_owner(), restored_control, "焦点行重新物化后应恢复交接。")
+
+	scroll_container.scroll_vertical = 1_000
+	var _recycled_again_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var external_button: Button = Button.new()
+	external_button.focus_mode = Control.FOCUS_ALL
+	add_child(external_button)
+	_nodes.append(external_button)
+	external_button.grab_focus()
+	assert_same(get_viewport().gui_get_focus_owner(), external_button)
+	scroll_container.scroll_vertical = 400
+	var _returned_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		external_button,
+		"项目显式取得外部焦点后，Binder 不得在行返回时抢回焦点。"
+	)
+
+
+func test_focus_target_callback_cannot_overwrite_newer_virtual_focus_handoff() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var focus_callback_indices: Array[int] = []
+	var focus_target_callback: Callable = func(
+		control: Control,
+		item_index: int,
+		_item_id: Variant
+	) -> Control:
+		focus_callback_indices.append(item_index)
+		if item_index == 20:
+			var _focused_next: bool = focus_model.set_focused_index(21)
+		return control
+	var fixture: Dictionary = _create_fixture(
+		100,
+		100.0,
+		1,
+		32,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		focus_target_callback
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var old_focus_control: Control = binder.get_materialized_control(20)
+	assert_true(first_result.is_successful())
+	assert_eq(focus_model.focused_index, 21)
+	assert_ne(
+		get_viewport().gui_get_focus_owner(),
+		old_focus_control,
+		"callback 提出的新虚拟焦点必须使旧 handoff 失效。"
+	)
+
+	var second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var new_focus_control: Control = binder.get_materialized_control(21)
+	assert_true(second_result.is_successful())
+	assert_not_null(new_focus_control)
+	assert_same(get_viewport().gui_get_focus_owner(), new_focus_control)
+	assert_eq(focus_callback_indices, [20, 21], "新 handoff 应在下一轮执行且不得递归。")
+
+
+func test_hidden_focus_target_keeps_handoff_pending_until_focus_is_observed() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var focus_state: Dictionary = { "hidden": true }
+	var focus_target_callback: Callable = func(
+		control: Control,
+		item_index: int,
+		_item_id: Variant
+	) -> Control:
+		if item_index == 20:
+			control.visible = not GFVariantData.get_option_bool(focus_state, "hidden")
+		return control
+	var fixture: Dictionary = _create_fixture(
+		100,
+		100.0,
+		1,
+		32,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		focus_target_callback
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	get_viewport().gui_release_focus()
+	assert_true(focus_model.set_focused_index(20))
+
+	var hidden_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var hidden_control: Control = binder.get_materialized_control(20)
+
+	assert_true(hidden_result.is_successful())
+	assert_not_null(hidden_control)
+	assert_false(hidden_control.visible)
+	assert_null(get_viewport().gui_get_focus_owner(), "隐藏行不能被误报为已完成焦点交接。")
+
+	focus_state["hidden"] = false
+	assert_true(binder.request_sync())
+	var visible_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_true(visible_result.is_successful())
+	assert_true(hidden_control.visible)
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		hidden_control,
+		"失败的 handoff 必须保留到目标可见并实际取得焦点。"
+	)
+
+
+func test_virtual_focus_change_releases_stale_physical_focus() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_same(get_viewport().gui_get_focus_owner(), binder.get_materialized_control(20))
+
+	var _focus_cleared: bool = focus_model.clear_focus()
+	await get_tree().process_frame
+	assert_null(get_viewport().gui_get_focus_owner(), "清除虚拟焦点必须同步释放旧行物理焦点。")
+
+	assert_true(focus_model.set_focused_index(20))
+	var _restored_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_same(get_viewport().gui_get_focus_owner(), binder.get_materialized_control(20))
+	binder.auto_reveal_focus = false
+	assert_true(focus_model.set_focused_index(80))
+	await get_tree().process_frame
+	assert_null(get_viewport().gui_get_focus_owner(), "未物化的新虚拟焦点不得让旧行继续接收输入。")
+	assert_null(binder.get_materialized_control(80))
+
+	scroll_container.scroll_vertical = 1_600
+	var _remote_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		binder.get_materialized_control(80),
+		"新虚拟焦点物化后应完成延迟交接。"
+	)
+
+
+func test_project_focus_on_another_active_row_cancels_pending_handoff() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	binder.auto_reveal_focus = false
+	assert_true(focus_model.set_focused_index(20))
+	var project_focus_row: Control = binder.get_materialized_control(5)
+	assert_not_null(project_focus_row)
+	project_focus_row.grab_focus()
+	await get_tree().process_frame
+	assert_same(get_viewport().gui_get_focus_owner(), project_focus_row)
+
+	scroll_container.scroll_vertical = 400
+	var _target_visible_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_ne(
+		get_viewport().gui_get_focus_owner(),
+		binder.get_materialized_control(20),
+		"项目聚焦其他活动行后，旧 pending handoff 不得再次抢焦点。"
+	)
+
+
+func test_project_focus_release_cancels_pending_handoff() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	binder.auto_reveal_focus = false
+	var project_focus_row: Control = binder.get_materialized_control(5)
+	assert_not_null(project_focus_row)
+	project_focus_row.grab_focus()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	assert_same(get_viewport().gui_get_focus_owner(), project_focus_row)
+
+	project_focus_row.release_focus()
+	await get_tree().process_frame
+	assert_null(get_viewport().gui_get_focus_owner())
+	scroll_container.scroll_vertical = 400
+	var _target_visible_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_ne(
+		get_viewport().gui_get_focus_owner(),
+		binder.get_materialized_control(20),
+		"项目显式释放焦点后，旧 pending handoff 不得再次抢焦点。"
+	)
+
+
+func test_focus_exit_callback_to_external_control_wins_during_row_recycle() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var focused_row: Control = binder.get_materialized_control(20)
+	assert_same(get_viewport().gui_get_focus_owner(), focused_row)
+	var external_button: Button = Button.new()
+	external_button.focus_mode = Control.FOCUS_ALL
+	add_child(external_button)
+	_nodes.append(external_button)
+	var _focus_exit_connected: Error = focused_row.focus_exited.connect(
+		func() -> void: external_button.grab_focus()
+	) as Error
+	binder.auto_reveal_focus = false
+
+	scroll_container.scroll_vertical = 1_000
+	var _recycled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_same(get_viewport().gui_get_focus_owner(), external_button)
+	scroll_container.scroll_vertical = 400
+	var _returned_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_not_null(binder.get_materialized_control(20))
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		external_button,
+		"focus_exited 中产生的更新项目焦点不得被 recycle handoff 覆盖。"
+	)
+
+
+func test_focus_exit_callback_to_external_control_wins_over_new_virtual_focus() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var focused_row: Control = binder.get_materialized_control(20)
+	var external_button: Button = Button.new()
+	external_button.focus_mode = Control.FOCUS_ALL
+	add_child(external_button)
+	_nodes.append(external_button)
+	var _focus_exit_connected: Error = focused_row.focus_exited.connect(
+		func() -> void: external_button.grab_focus()
+	) as Error
+
+	assert_true(focus_model.set_focused_index(21))
+	var _next_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_eq(focus_model.focused_index, 21)
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		external_button,
+		"旧行 focus_exited 中的较新项目焦点必须取消新虚拟焦点的物理 handoff。"
+	)
+
+
+func test_focus_exit_nested_virtual_focus_change_preserves_newest_handoff() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var focused_row: Control = binder.get_materialized_control(20)
+	assert_not_null(focused_row)
+	var _focus_exit_connected: Error = focused_row.focus_exited.connect(
+		func() -> void:
+			var _newer_focus: bool = focus_model.set_focused_index(22),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	assert_true(focus_model.set_focused_index(21))
+	var _next_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_eq(focus_model.focused_index, 22)
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		binder.get_materialized_control(22),
+		"外层 focused_index_changed 回调不得覆盖 focus_exited 中产生的更新虚拟焦点。"
+	)
+
+
+func test_clear_focus_preserves_scroll_when_focus_exit_moves_to_external_control() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(100, 100.0, 1, 32, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(20))
+	var _focused_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var focused_row: Control = binder.get_materialized_control(20)
+	var external_button: Button = Button.new()
+	external_button.focus_mode = Control.FOCUS_ALL
+	add_child(external_button)
+	_nodes.append(external_button)
+	var _focus_exit_connected: Error = focused_row.focus_exited.connect(
+		func() -> void: external_button.grab_focus(),
+		CONNECT_ONE_SHOT
+	) as Error
+	var previous_scroll: int = scroll_container.scroll_vertical
+
+	assert_true(focus_model.clear_focus())
+	await get_tree().process_frame
+
+	assert_same(get_viewport().gui_get_focus_owner(), external_button)
+	assert_eq(
+		scroll_container.scroll_vertical,
+		previous_scroll,
+		"clear_focus 的 NO_FOCUS 不得被当作 index -1 滚回列表顶部。"
+	)
+
+
+func test_owner_exit_disposes_binding_and_releases_rows_once() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var active_count: int = result.get_materialized_count()
+
+	remove_child(scroll_container)
+	await get_tree().process_frame
+
+	assert_true(binder.is_disposed(), "owner 离开树后 binder 应进入不可复用终态。")
+	assert_eq(_unbind_events.size(), active_count, "每个成功绑定的活动行应恰好解绑一次。")
+	assert_eq(binder.get_last_sync_result().get_materialized_count(), 0, "dispose 后诊断不得保留活动行。")
+
+
+func test_content_exit_disposes_while_owner_remains_alive() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var active_count: int = initial_result.get_materialized_count()
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 1, "owner 与 scroll 同一节点时只能连接一次。")
+	assert_eq(content_root.tree_exited.get_connections().size(), 1)
+	scroll_container.remove_child(content_root)
+
+	assert_eq(binder.get_last_sync_result().get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed(), "content 退出树必须确定性 teardown，不能恢复 idle。")
+	assert_true(scroll_container.is_inside_tree(), "生命周期 owner 应仍保持存活。")
+	assert_eq(_unbind_events.size(), active_count)
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 0, "其余生命周期连接必须对称断开。")
+	assert_eq(content_root.tree_exited.get_connections().size(), 0)
+
+
+func test_scroll_exit_disposes_while_separate_owner_remains_alive() -> void:
+	var lifecycle_owner: Node = Node.new()
+	add_child(lifecycle_owner)
+	_nodes.append(lifecycle_owner)
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1, 512, null, lifecycle_owner)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var active_count: int = initial_result.get_materialized_count()
+	assert_eq(lifecycle_owner.tree_exited.get_connections().size(), 1)
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 1)
+	assert_eq(content_root.tree_exited.get_connections().size(), 1)
+	remove_child(scroll_container)
+
+	assert_eq(binder.get_last_sync_result().get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed(), "scroll 退出树必须确定性 teardown。")
+	assert_true(lifecycle_owner.is_inside_tree(), "独立 owner 应仍保持存活。")
+	assert_eq(_unbind_events.size(), active_count)
+	assert_eq(lifecycle_owner.tree_exited.get_connections().size(), 0)
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 0)
+	assert_eq(content_root.tree_exited.get_connections().size(), 0)
+
+
+func test_separate_owner_exit_disposes_while_scroll_and_content_remain_alive() -> void:
+	var lifecycle_owner: Node = Node.new()
+	add_child(lifecycle_owner)
+	_nodes.append(lifecycle_owner)
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1, 512, null, lifecycle_owner)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var active_count: int = initial_result.get_materialized_count()
+	assert_eq(lifecycle_owner.tree_exited.get_connections().size(), 1)
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 1)
+	assert_eq(content_root.tree_exited.get_connections().size(), 1)
+
+	remove_child(lifecycle_owner)
+
+	assert_true(binder.is_disposed(), "独立 owner 退出树必须立即 dispose。")
+	assert_true(scroll_container.is_inside_tree(), "owner 退出不得移除仍存活的 scroll。")
+	assert_true(content_root.is_inside_tree(), "owner 退出不得移除仍存活的 content。")
+	assert_eq(_unbind_events.size(), active_count, "owner 退出必须立即解绑全部活动行。")
+	assert_eq(lifecycle_owner.tree_exited.get_connections().size(), 0)
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 0)
+	assert_eq(content_root.tree_exited.get_connections().size(), 0)
+	assert_eq(
+		binder.get_last_sync_result().get_status(),
+		GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED
+	)
+
+
+func test_manual_unbind_disconnects_all_unique_tree_exit_signals() -> void:
+	var lifecycle_owner: Node = Node.new()
+	add_child(lifecycle_owner)
+	_nodes.append(lifecycle_owner)
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1, 512, null, lifecycle_owner)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	binder.unbind()
+
+	assert_eq(lifecycle_owner.tree_exited.get_connections().size(), 0)
+	assert_eq(scroll_container.tree_exited.get_connections().size(), 0)
+	assert_eq(content_root.tree_exited.get_connections().size(), 0)
+
+
+func test_externally_freed_owned_control_fails_closed() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var row: Control = binder.get_materialized_control(0)
+	row.free()
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed(), "外部破坏 Binder-owned Control 后应 fail-closed。")
+
+
+func test_externally_reparented_owned_control_fails_closed() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var row: Control = binder.get_materialized_control(0)
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	row.reparent(foreign_root)
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed(), "外部重挂载 Binder-owned Control 后应 fail-closed。")
+
+
+func test_externally_freed_pooled_control_fails_closed() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var owned_rows: Array[Control] = []
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	for item_index: int in range(6):
+		owned_rows.append(binder.get_materialized_control(item_index))
+	binder.max_pooled_items = 16
+	binder.max_materialized_items = 1
+	var _reduced_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var pooled_row: Control = _find_parentless_owned_control(owned_rows)
+	assert_not_null(pooled_row)
+	if pooled_row == null:
+		return
+	pooled_row.free()
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed(), "parentless pool 也属于 Binder 所有权边界。")
+
+
+func test_externally_reparented_pooled_control_fails_closed_without_reclaiming_it() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var owned_rows: Array[Control] = []
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	for item_index: int in range(6):
+		owned_rows.append(binder.get_materialized_control(item_index))
+	binder.max_pooled_items = 16
+	binder.max_materialized_items = 1
+	var _reduced_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var pooled_row: Control = _find_parentless_owned_control(owned_rows)
+	assert_not_null(pooled_row)
+	if pooled_row == null:
+		return
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	foreign_root.add_child(pooled_row)
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed())
+	assert_null(
+		binder.get_materialized_control(1),
+		"Binder 不得把被外部挂载的 pooled Control 静默抢回活动列表。"
+	)
+
+
+func test_zero_pool_budget_retires_rejected_row_after_transaction_commit() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	binder.max_pooled_items = 0
+	_fail_bind_index = 0
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_BIND_FAILED)
+	assert_true(binder.is_bound(), "单行 bind 拒绝不得被事务暂态误判为 ownership breach。")
+	assert_null(binder.get_materialized_control(0))
+	assert_not_null(binder.get_materialized_control(1), "后续行仍应完成同一事务提交。")
+	assert_eq(result.get_materialized_count(), 5)
+	assert_eq(GFVariantData.get_option_int(binder.get_debug_snapshot(), "pooled_count"), 0)
+	assert_eq(_bind_events.size(), 6)
+	assert_eq(_unbind_events.size(), 1)
+
+
+func test_pool_budget_change_inside_bind_is_applied_after_transaction_commit() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_fail_bind_index = 0
+	_reentrant_mode = &"shrink_pool_on_bind"
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_BIND_FAILED)
+	assert_true(binder.is_bound(), "callback 内收紧 pool 不得释放事务仍在引用的 Control。")
+	assert_eq(result.get_pooled_count(), 0, "结果必须报告事务结束后执行的最终 pool 裁剪。")
+	assert_null(binder.get_materialized_control(0))
+	assert_not_null(binder.get_materialized_control(1))
+	assert_eq(_bind_events.size(), 6)
+	assert_eq(_unbind_events.size(), 1)
+
+
+func test_unbind_callback_reparenting_owned_row_aborts_transaction_fail_closed() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	_foreign_parent_for_callback = foreign_root
+	_reentrant_mode = &"reparent_on_unbind"
+
+	scroll_container.scroll_vertical = 100
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed())
+	assert_eq(
+		_unbind_events.size(),
+		_bind_events.size(),
+		"ownership breach teardown 仍须为每次成功 bind 提供一次对称 unbind。"
+	)
+
+
+func test_tree_entered_unbind_aborts_before_bind_and_allows_clean_rebind() -> void:
+	_reentrant_mode = &"unbind_on_tree_enter"
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+
+	var interrupted_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(interrupted_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_UNBOUND)
+	assert_false(binder.is_bound())
+	assert_false(binder.is_disposed(), "tree_entered 的显式 unbind 不得被暂态 parent 误升级为 dispose。")
+	assert_eq(_bind_events.size(), 0, "generation 失效后不得调用迟到 bind callback。")
+	assert_eq(_unbind_events.size(), 0)
+	_reentrant_mode = &""
+	assert_true(binder.bind(
+		scroll_container,
+		scroll_container,
+		content_root,
+		model,
+		Callable(self, "_make_row"),
+		Callable(self, "_bind_row"),
+		Callable(self, "_unbind_row"),
+		Callable(self, "_get_item_identity"),
+		null,
+		Callable(self, "_measure_row")
+	))
+	var rebound_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(rebound_result.is_successful(), "中断事务清理后同一 Binder 应保持可重绑。")
+
+
+func test_measure_callback_ownership_breach_prevents_authoritative_extent_write() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	_foreign_parent_for_callback = foreign_root
+	_measured_extents[0] = 40.0
+	_reentrant_mode = &"reparent_other_on_measure"
+	assert_true(binder.request_measurement())
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed())
+	assert_eq(
+		model.get_item_extent(0),
+		20.0,
+		"measure callback 破坏其他 owned row 后不得继续写权威布局。"
+	)
+
+
+func test_focus_target_ownership_breach_prevents_physical_focus_side_effect() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var callback_state: Dictionary = { "binder": null, "count": 0 }
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	var focus_target_callback: Callable = func(
+		control: Control,
+		_item_index: int,
+		_item_id: Variant
+	) -> Control:
+		callback_state["count"] = GFVariantData.get_option_int(callback_state, "count") + 1
+		var callback_binder: Variant = callback_state["binder"]
+		if callback_binder is GF_VIRTUAL_LIST_BINDER_SCRIPT:
+			var typed_binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = callback_binder
+			var other_value: Variant = typed_binder.call("get_materialized_control", 4)
+			if other_value is Control:
+				var other_control: Control = other_value
+				other_control.reparent(foreign_root)
+		return control
+	var fixture: Dictionary = _create_fixture(
+		20, 100.0, 1, 32, focus_model, null, Vector2.ZERO, false, focus_target_callback
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	callback_state["binder"] = binder
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	get_viewport().gui_release_focus()
+	var target_row: Control = binder.get_materialized_control(5)
+	var target_focus_count: Array[int] = [0]
+	var _focus_connected: Error = target_row.focus_entered.connect(
+		func() -> void: target_focus_count[0] += 1
+	) as Error
+
+	assert_true(focus_model.set_focused_index(5))
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+
+	assert_eq(GFVariantData.get_option_int(callback_state, "count"), 1)
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed())
+	assert_eq(target_focus_count[0], 0, "ownership barrier 必须位于 grab_focus 副作用之前。")
+
+
+func test_layout_resize_teardown_prevents_pending_focus_callback() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var focus_callback_count: Array[int] = [0]
+	var focus_target_callback: Callable = func(
+		control: Control,
+		_item_index: int,
+		_item_id: Variant
+	) -> Control:
+		focus_callback_count[0] += 1
+		return control
+	var fixture: Dictionary = _create_fixture(
+		20, 100.0, 1, 32, focus_model, null, Vector2.ZERO, false, focus_target_callback
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var target_row: Control = binder.get_materialized_control(5)
+	var _resize_connected: Error = target_row.resized.connect(
+		func() -> void: binder.dispose(),
+		CONNECT_ONE_SHOT
+	) as Error
+	var _extent_report: Dictionary = model.set_item_extent(5, 40.0, false)
+	assert_true(focus_model.set_focused_index(5))
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_eq(focus_callback_count[0], 0, "layout callback teardown 后不得再调用 focus target。")
+
+
+func test_scroll_to_item_returns_false_when_scroll_callback_disposes_binding() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(_value: float) -> void: binder.dispose(),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var scrolled: bool = binder.scroll_to_item(10)
+
+	assert_false(scrolled, "滚动内部回调结束生命周期时不得报告成功。")
+	assert_true(binder.is_disposed())
+
+
+func test_scroll_to_item_returns_false_when_scroll_callback_invalidates_data_generation() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(_value: float) -> void:
+			var _invalidated_from_scroll: bool = binder.invalidate_items(),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var scrolled: bool = binder.scroll_to_item(10)
+
+	assert_false(scrolled, "滚动信号改变 data generation 后不得报告旧索引操作成功。")
+	assert_true(binder.is_bound())
+	assert_eq(scroll_container.scroll_vertical, 120, "已接受的物理写入不伪装成事务提交。")
+	var converged_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(converged_result.is_successful())
+	assert_eq(converged_result.get_data_revision(), 1)
+
+
+func test_scroll_to_item_aborts_when_scroll_callback_changes_snapshot() -> void:
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	model.trailing_padding = 80.0
+	var callback_count: Array[int] = [0]
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(_value: float) -> void:
+			callback_count[0] += 1
+			binder.layout_axis = GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.HORIZONTAL
+			model.trailing_padding = 100.0
+			scroll_container.scroll_vertical = 0
+			var _requested: bool = binder.request_sync(),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var scrolled: bool = binder.scroll_to_item(
+		10,
+		GF_VIRTUAL_LIST_BINDER_SCRIPT.ScrollAlignment.START
+	)
+
+	assert_false(scrolled, "滚动回调改变 operation snapshot 后不得报告混合状态成功。")
+	assert_eq(callback_count[0], 1)
+	assert_eq(scroll_container.scroll_vertical, 0)
+	assert_eq(scroll_container.scroll_horizontal, 0)
+	assert_eq(content_root.custom_minimum_size.y, 480.0, "已发生的写入必须保持旧轮内部一致。")
+
+	var next_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(next_result.is_successful())
+	assert_eq(content_root.custom_minimum_size, Vector2(500.0, 0.0))
+	assert_true(binder.is_bound(), "operation 漂移只拒绝本次滚动，不破坏绑定生命周期。")
+
+
+func test_scroll_to_item_fails_closed_when_scroll_callback_reparents_owned_row() -> void:
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var owned_row: Control = binder.get_materialized_control(1)
+	assert_not_null(owned_row)
+	if owned_row == null:
+		return
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(_value: float) -> void: owned_row.reparent(foreign_root),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var scrolled: bool = binder.scroll_to_item(
+		10,
+		GF_VIRTUAL_LIST_BINDER_SCRIPT.ScrollAlignment.START
+	)
+
+	assert_false(scrolled)
+	assert_true(binder.is_disposed(), "public operation 的信号边界也必须验证完整 owned set。")
+
+
+func test_callback_reentrancy_is_coalesced_and_dispose_aborts_generation() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_reentrant_mode = &"request_sync"
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(first_result.is_successful(), "bind callback 的 refresh 请求不得递归破坏当前提交。")
+	assert_eq(first_result.get_materialized_count(), 6)
+	_reentrant_mode = &"dispose"
+	var _invalidated: bool = binder.invalidate_items()
+	var disposed_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(binder.is_disposed(), "callback 中 dispose 应使当前 generation 失效并完成清理。")
+	assert_eq(disposed_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_eq(_unbind_events.size(), _bind_events.size(), "每次已调用的 bind 都必须有且仅有一次对称 unbind。")
+
+
+func test_bind_callback_invalidation_defers_and_rebuilds_the_next_generation() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_reentrant_mode = &"invalidate_items"
+	_invalidate_callback_budget = 1
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(first_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(first_result.is_successful(), "失效快照不得伪装成成功提交。")
+	assert_eq(first_result.get_data_revision(), 0, "结果只报告本轮开始时冻结的 data revision。")
+	assert_eq(first_result.get_materialized_count(), 0, "带项目副作用的漂移必须清空不可信 materialization。")
+	assert_eq(_bind_events.size(), 1, "首个 bind 漂移后不得继续读取后续数据世代。")
+	assert_eq(_unbind_events.size(), 1, "每次已调用 bind 必须在回滚时精确对称 unbind。")
+	assert_eq(_get_last_committed_data_revision(binder), -1, "deferred 不得推进提交 revision。")
+	assert_true(GFVariantData.get_option_bool(binder.get_debug_snapshot(), "pending_sync"))
+
+	var second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(second_result.is_successful())
+	assert_eq(second_result.get_data_revision(), 1)
+	assert_eq(_unbind_events.size(), 1)
+	assert_eq(_bind_events.size(), 7, "下一轮必须从清空状态按新 generation 完整重建。")
+	assert_eq(second_result.get_materialized_count(), 6)
+	assert_gt(second_result.get_measured_count(), 0, "invalidate 的测量请求也不得被上一轮清除。")
+
+
+func test_identity_callback_invalidation_stops_before_factory_and_commits_next_generation() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_reentrant_mode = &"invalidate_identity"
+	_invalidate_callback_budget = 1
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(_identity_callback_count, 1, "identity 漂移后不得读取下一条目。")
+	assert_eq(_factory_count, 0, "失效 identity 计划不得进入 staging。")
+	assert_eq(_bind_events.size(), 0)
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(_get_last_committed_data_revision(binder), -1)
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(rebuilt_result.is_successful())
+	assert_eq(rebuilt_result.get_data_revision(), 1)
+	assert_eq(_identity_callback_count, 7)
+	assert_eq(_factory_count, 6)
+	assert_not_null(binder.get_materialized_control_by_id(&"replacement_0"))
+
+
+func test_deferred_identity_plan_preserves_truncation_diagnostic() -> void:
+	var fixture: Dictionary = _create_fixture(100, 100.0, 5, 3)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_reentrant_mode = &"invalidate_identity"
+	_invalidate_callback_budget = 1
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_true(deferred_result.was_truncated(), "deferred 不得丢失本轮已确定的节点预算截断。")
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(_factory_count, 0)
+
+
+func test_factory_invalidation_rolls_back_parentless_stage_before_binding() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_reentrant_mode = &"invalidate_in_factory"
+	_invalidate_callback_budget = 1
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(_factory_count, 1, "factory 漂移后不得继续创建候选。")
+	assert_eq(_bind_events.size(), 0)
+	assert_eq(_unbind_events.size(), 0)
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(deferred_result.get_created_count(), 1)
+	assert_eq(deferred_result.get_reused_count(), 0)
+	assert_eq(deferred_result.get_pooled_count(), 1, "回滚后的 pool 诊断必须反映真实候选归还。")
+	assert_not_null(_last_factory_control)
+	if _last_factory_control != null:
+		assert_null(_last_factory_control.get_parent(), "staged Control 必须回滚为 parentless pool。")
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(rebuilt_result.is_successful())
+	assert_eq(rebuilt_result.get_data_revision(), 1)
+	assert_eq(rebuilt_result.get_materialized_count(), 6)
+
+
+func test_unbind_callback_invalidation_clears_unknown_materialization_and_rebuilds() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(initial_result.is_successful())
+	_reentrant_mode = &"invalidate_on_unbind"
+	_invalidate_callback_budget = 1
+	assert_true(binder.invalidate_items())
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(deferred_result.get_released_count(), 6, "回滚诊断必须计入全部实际旧 binding 释放。")
+	assert_eq(_unbind_events.size(), 6, "旧 active binding 必须各自精确 unbind 一次。")
+	assert_eq(_bind_events.size(), 6, "漂移后不得调用新 generation bind。")
+	assert_true(binder.is_bound())
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(rebuilt_result.is_successful())
+	assert_eq(rebuilt_result.get_data_revision(), 2)
+	assert_eq(rebuilt_result.get_materialized_count(), 6)
+	assert_eq(_bind_events.size(), 12)
+	assert_eq(_unbind_events.size(), 6)
+
+
+func test_measurement_invalidation_stops_before_authoritative_extent_write() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	_reentrant_mode = &"invalidate_on_measure"
+	_invalidate_callback_budget = 1
+	_measured_extents[0] = 37.0
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(model.get_item_extent(0), 20.0, "漂移 measurement 不得写入权威布局模型。")
+	assert_eq(deferred_result.get_measured_count(), 0)
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(_bind_events.size(), 6)
+	assert_eq(_unbind_events.size(), 6)
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(rebuilt_result.is_successful())
+	assert_eq(model.get_item_extent(0), 37.0)
+	assert_gt(rebuilt_result.get_measured_count(), 0)
+
+
+func test_layout_signal_invalidation_reports_completed_authoritative_measurement() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	_measured_extents[0] = 37.0
+	var callback_budget: Array[int] = [1]
+	var _layout_connected: Error = model.layout_changed.connect(
+		func(_revision: int) -> void:
+			if not _binder_sync_is_in_progress(binder) or callback_budget[0] <= 0:
+				return
+			callback_budget[0] -= 1
+			var _invalidated_from_layout: bool = binder.invalidate_items()
+	) as Error
+	assert_true(binder.request_measurement())
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(model.get_item_extent(0), 37.0, "信号返回前已完成的权威写入必须保留。")
+	assert_eq(deferred_result.get_measured_count(), 1, "诊断必须计入已成功完成的测量写入。")
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(_unbind_events.size(), 6)
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(rebuilt_result.is_successful())
+	assert_eq(rebuilt_result.get_data_revision(), 1)
+
+
+func test_focus_target_invalidation_stops_before_grab_focus_and_rebuilds() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(self, "_resolve_focus_target")
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(initial_result.is_successful())
+	_reentrant_mode = &"invalidate_on_focus_target"
+	_invalidate_callback_budget = 1
+	assert_true(focus_model.set_focused_index(1))
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_null(get_viewport().gui_get_focus_owner(), "漂移 focus callback 后不得继续 grab_focus。")
+	assert_eq(_unbind_events.size(), 6)
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var rebuilt_row: Control = binder.get_materialized_control(1)
+
+	assert_true(rebuilt_result.is_successful())
+	assert_not_null(rebuilt_row)
+	assert_same(get_viewport().gui_get_focus_owner(), rebuilt_row)
+
+
+func test_layout_resize_invalidation_stops_remaining_control_writes() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(initial_result.is_successful())
+	binder.auto_measure = false
+	var first_row: Control = binder.get_materialized_control(0)
+	assert_not_null(first_row)
+	if first_row == null:
+		return
+	var _resize_connected: Error = first_row.resized.connect(
+		func() -> void:
+			var _invalidated_from_resize: bool = binder.invalidate_items(),
+		CONNECT_ONE_SHOT
+	) as Error
+	var _extent_report: Dictionary = model.set_item_extent(0, 40.0, false)
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful())
+	assert_eq(deferred_result.get_materialized_count(), 0)
+	assert_eq(_unbind_events.size(), 6, "Control signal 漂移后必须清空全部旧 active binding。")
+
+	var rebuilt_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(rebuilt_result.is_successful())
+	assert_eq(rebuilt_result.get_materialized_count(), 5)
+	assert_eq(model.get_item_extent(0), 40.0)
+
+
+func test_scroll_listener_layout_drift_returns_non_successful_deferred_snapshot() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1, 512, focus_model)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(initial_result.is_successful())
+	binder.auto_measure = false
+	await get_tree().process_frame
+	var callback_budget: Array[int] = [1]
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(_value: float) -> void:
+			if not _binder_sync_is_in_progress(binder) or callback_budget[0] <= 0:
+				return
+			callback_budget[0] -= 1
+			model.trailing_padding = 80.0
+			scroll_container.scroll_vertical = 0
+	) as Error
+	assert_true(focus_model.set_focused_index(10))
+	scroll_container.scroll_vertical = 0
+	var frozen_layout_revision: int = model.get_revision()
+
+	var deferred_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(deferred_result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(deferred_result.is_successful(), "未提交滚动快照不得使用 UNCHANGED 成功语义。")
+	assert_eq(deferred_result.get_layout_revision(), frozen_layout_revision)
+	assert_eq(deferred_result.get_requested_range(), Vector2i(5, 12))
+	assert_eq(deferred_result.get_materialized_count(), 6, "pre-commit 漂移应保留最近可信 materialization。")
+	assert_eq(_bind_events.size(), 6)
+	assert_eq(_unbind_events.size(), 0)
+
+	var converged_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(converged_result.is_successful())
+	assert_eq(converged_result.get_layout_revision(), model.get_revision())
+	assert_gt(scroll_container.scroll_vertical, 0)
+
+
+func test_bind_callback_layout_change_is_reported_by_the_next_sync() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var initial_layout_revision: int = model.get_revision()
+	_layout_model_for_callback = model
+	_layout_callback_budget = 1
+	_reentrant_mode = &"change_layout"
+
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(first_result.is_successful())
+	assert_eq(first_result.get_layout_revision(), initial_layout_revision)
+	assert_eq(first_result.get_requested_range(), Vector2i(0, 6), "首轮范围必须对应冻结 revision。")
+	assert_eq(first_result.get_measured_count(), 0, "外部布局 revision 漂移后不得写入旧轮测量。")
+	assert_gt(model.get_revision(), initial_layout_revision, "callback 与测量可以排队后续 layout revision。")
+	var second_layout_revision: int = model.get_revision()
+
+	var second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(second_result.is_successful())
+	assert_eq(second_result.get_layout_revision(), second_layout_revision)
+	assert_eq(second_result.get_requested_range(), Vector2i(0, 8))
+	assert_eq(second_result.get_materialized_count(), 8)
+	assert_gt(second_result.get_measured_count(), 0, "被跳过的测量请求必须保留到下一轮。")
+
+
+func test_layout_geometry_change_inside_bind_is_isolated_to_next_sync_round() -> void:
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	binder.auto_measure = false
+	_layout_model_for_callback = model
+	_layout_callback_budget = 1
+	_reentrant_mode = &"change_layout_geometry"
+	var initial_layout_revision: int = model.get_revision()
+	assert_true(binder.invalidate_items())
+
+	var frozen_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var frozen_second_row: Control = binder.get_materialized_control(1)
+
+	assert_true(frozen_result.is_successful())
+	assert_eq(frozen_result.get_layout_revision(), initial_layout_revision)
+	assert_eq(frozen_result.get_requested_range(), Vector2i(0, 6))
+	assert_eq(content_root.custom_minimum_size.y, 400.0, "当前轮 content extent 必须来自冻结布局。")
+	assert_not_null(frozen_second_row)
+	if frozen_second_row != null:
+		assert_eq(frozen_second_row.position.y, 20.0)
+	assert_eq(model.get_content_extent(), 800.0, "callback 的模型写入应立即进入模型但不污染当前轮。")
+
+	var next_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var next_second_row: Control = binder.get_materialized_control(1)
+
+	assert_true(next_result.is_successful())
+	assert_eq(next_result.get_layout_revision(), model.get_revision())
+	assert_eq(next_result.get_requested_range(), Vector2i(0, 4))
+	assert_eq(content_root.custom_minimum_size.y, 800.0)
+	assert_not_null(next_second_row)
+	if next_second_row != null:
+		assert_eq(next_second_row.position.y, 40.0)
+
+
+func test_round_geometry_snapshot_preserves_float64_layout_math() -> void:
+	var fixture: Dictionary = _create_fixture(
+		3,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var large_extent: float = 100_000_003.25
+	var _extent_report: Dictionary = model.set_item_extent(0, large_extent, true)
+	_reentrant_mode = &"capture_round_geometry"
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful())
+	assert_true(_captured_round_geometry)
+	assert_eq(_captured_round_extent, 20.0)
+	assert_eq(_captured_round_offset, model.get_item_offset(1))
+	assert_eq(_captured_round_offset, large_extent, "轮次布局数学不得提前降为 Vector2/Float32。")
+
+
+func test_explicit_measurement_survives_invalidation_when_auto_measure_is_disabled() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	binder.auto_measure = false
+	_measured_extents[0] = 37.0
+	assert_true(binder.request_measurement())
+	assert_true(binder.invalidate_items())
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(result.is_successful())
+	assert_gt(result.get_measured_count(), 0)
+	assert_eq(model.get_item_extent(0), 37.0, "invalidate 不得清除显式测量请求。")
+
+
+func test_measurement_callback_requeue_runs_in_the_next_sync() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	_reentrant_mode = &"request_measurement"
+	_measurement_requeue_budget = 1
+
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(first_result.is_successful())
+	assert_gt(first_result.get_measured_count(), 0)
+	var second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(second_result.is_successful())
+	assert_gt(second_result.get_measured_count(), 0, "测量 callback 的重测请求必须留给下一轮。")
+
+
+func test_unbind_callback_can_escalate_teardown_to_dispose_without_recursion() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	_reentrant_mode = &"dispose_on_unbind"
+
+	binder.unbind()
+
+	assert_true(binder.is_disposed(), "unbind callback 中请求 dispose 应升级为单次终态 teardown。")
+	assert_eq(_unbind_events.size(), _bind_events.size(), "teardown 升级不得递归或重复 unbind。")
+
+
+func test_sync_completed_recursive_sync_is_coalesced_into_next_generation() -> void:
+	var fixture: Dictionary = _create_fixture(20, 100.0, 1)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var connected: Error = binder.sync_completed.connect(
+		Callable(self, "_on_sync_completed_reentrant")
+	) as Error
+	assert_eq(connected, OK)
+
+	var first_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(first_result.is_successful())
+	assert_eq(_sync_completed_event_count, 1, "监听器内 sync_now 不得同步递归发出第二个事件。")
+	assert_not_null(_reentrant_sync_result)
+	var second_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_true(second_result.is_successful())
+	assert_eq(_sync_completed_event_count, 2, "递归请求应合并到下一轮。")
+	assert_true(binder.is_bound())
+
+
+func test_axis_switch_restores_only_previous_owned_axis() -> void:
+	var original_minimum: Vector2 = Vector2(13.0, 17.0)
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		original_minimum
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_eq(content_root.custom_minimum_size.x, original_minimum.x)
+	assert_eq(content_root.custom_minimum_size.y, model.get_content_extent())
+
+	binder.layout_axis = GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.HORIZONTAL
+	var _horizontal_requested: bool = binder.request_sync()
+	var _horizontal_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_eq(content_root.custom_minimum_size.x, model.get_content_extent())
+	assert_eq(content_root.custom_minimum_size.y, original_minimum.y, "切轴必须先恢复旧 owned 轴。")
+
+	binder.layout_axis = GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.VERTICAL
+	var _vertical_requested: bool = binder.request_sync()
+	var _vertical_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	assert_eq(content_root.custom_minimum_size.x, original_minimum.x)
+	assert_eq(content_root.custom_minimum_size.y, model.get_content_extent())
+
+
+func test_axis_change_inside_bind_is_isolated_to_next_sync_round() -> void:
+	var original_minimum: Vector2 = Vector2(13.0, 17.0)
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		original_minimum,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	binder.auto_measure = false
+	_reentrant_mode = &"change_axis_on_bind"
+	assert_true(binder.invalidate_items())
+
+	var vertical_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var vertical_second_row: Control = binder.get_materialized_control(1)
+
+	assert_true(vertical_result.is_successful())
+	assert_eq(content_root.custom_minimum_size, Vector2(original_minimum.x, model.get_content_extent()))
+	assert_not_null(vertical_second_row)
+	if vertical_second_row != null:
+		assert_eq(vertical_second_row.position, Vector2(0.0, 20.0))
+
+	var horizontal_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var horizontal_second_row: Control = binder.get_materialized_control(1)
+
+	assert_true(horizontal_result.is_successful())
+	assert_eq(content_root.custom_minimum_size, Vector2(model.get_content_extent(), original_minimum.y))
+	assert_not_null(horizontal_second_row)
+	if horizontal_second_row != null:
+		assert_eq(horizontal_second_row.position, Vector2(20.0, 0.0))
+
+
+func test_fill_cross_axis_change_during_layout_is_isolated_to_next_sync_round() -> void:
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	binder.auto_measure = false
+	binder.fill_cross_axis = false
+	var first_row: Control = binder.get_materialized_control(0)
+	assert_not_null(first_row)
+	if first_row == null:
+		return
+	for item_index: int in initial_result.get_materialized_indices():
+		var row: Control = binder.get_materialized_control(item_index)
+		if row != null:
+			row.size.x = 120.0 + float(item_index)
+	first_row.size.y = 40.0
+	var _resized_connected: Error = first_row.resized.connect(
+		func() -> void:
+			binder.fill_cross_axis = true
+			var _requested: bool = binder.request_sync(),
+		CONNECT_ONE_SHOT
+	) as Error
+	assert_true(binder.request_sync())
+
+	var unfilled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var second_row: Control = binder.get_materialized_control(1)
+
+	assert_true(unfilled_result.is_successful())
+	assert_true(binder.fill_cross_axis)
+	assert_not_null(second_row)
+	if second_row != null:
+		assert_eq(second_row.size.x, 121.0, "当前轮所有行必须继续使用冻结的非填充策略。")
+
+	var filled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	second_row = binder.get_materialized_control(1)
+
+	assert_true(filled_result.is_successful())
+	assert_not_null(second_row)
+	if second_row != null:
+		assert_eq(second_row.position.x, 0.0)
+		assert_eq(second_row.size.x, scroll_container.size.x, "下一轮才应用新的交叉轴填充策略。")
+
+
+func test_cross_extent_change_during_row_resize_is_isolated_to_next_sync_round() -> void:
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var first_row: Control = binder.get_materialized_control(0)
+	var second_row: Control = binder.get_materialized_control(1)
+	assert_not_null(first_row)
+	assert_not_null(second_row)
+	if first_row == null or second_row == null:
+		return
+	scroll_container.size.x = 300.0
+	var _resized_connected: Error = first_row.resized.connect(
+		func() -> void: scroll_container.size.x = 360.0,
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var frozen_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(frozen_result.is_successful())
+	assert_eq(first_row.size.x, 300.0)
+	assert_eq(second_row.size.x, 300.0, "同一轮全部行必须使用入口冻结的 cross extent。")
+
+	var next_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(next_result.is_successful())
+	assert_eq(first_row.size.x, 360.0)
+	assert_eq(second_row.size.x, 360.0)
+
+
+func test_layout_ownership_breach_stops_before_writing_later_rows() -> void:
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var first_row: Control = binder.get_materialized_control(0)
+	var second_row: Control = binder.get_materialized_control(1)
+	assert_not_null(first_row)
+	assert_not_null(second_row)
+	if first_row == null or second_row == null:
+		return
+	var foreign_root: Control = Control.new()
+	add_child(foreign_root)
+	_nodes.append(foreign_root)
+	var external_position: Vector2 = Vector2(777.0, 888.0)
+	first_row.size.y = 40.0
+	var _resized_connected: Error = first_row.resized.connect(
+		func() -> void:
+			second_row.reparent(foreign_root)
+			second_row.position = external_position,
+		CONNECT_ONE_SHOT
+	) as Error
+	assert_true(binder.request_sync())
+
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DISPOSED)
+	assert_true(binder.is_disposed())
+	assert_true(is_instance_valid(second_row))
+	if is_instance_valid(second_row):
+		assert_eq(
+			second_row.position,
+			external_position,
+			"ownership breach 后 Binder 不得继续写入已转交到外部 parent 的后续行。"
+		)
+
+
+func test_teardown_preserves_project_change_on_unowned_cross_axis() -> void:
+	var original_minimum: Vector2 = Vector2(13.0, 17.0)
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		original_minimum
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var project_minimum: Vector2 = content_root.custom_minimum_size
+	project_minimum.x = 91.0
+	content_root.custom_minimum_size = project_minimum
+
+	binder.dispose()
+
+	assert_eq(content_root.custom_minimum_size.x, 91.0, "teardown 不得覆盖项目对未拥有轴的修改。")
+	assert_eq(content_root.custom_minimum_size.y, original_minimum.y, "实际 owned 轴应恢复绑定前分量。")
+
+
+func test_horizontal_acquisition_captures_latest_unowned_x_baseline() -> void:
+	var original_minimum: Vector2 = Vector2(13.0, 17.0)
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		original_minimum
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var project_minimum: Vector2 = content_root.custom_minimum_size
+	project_minimum.x = 91.0
+	content_root.custom_minimum_size = project_minimum
+	binder.layout_axis = GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.HORIZONTAL
+	var _requested: bool = binder.request_sync()
+	var _horizontal_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	binder.dispose()
+
+	assert_eq(content_root.custom_minimum_size.x, 91.0, "horizontal 接管应捕获项目最新的 unowned x。")
+	assert_eq(content_root.custom_minimum_size.y, original_minimum.y)
+
+
+func test_vertical_acquisition_captures_latest_unowned_y_baseline() -> void:
+	var original_minimum: Vector2 = Vector2(13.0, 17.0)
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		original_minimum,
+		true
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var project_minimum: Vector2 = content_root.custom_minimum_size
+	project_minimum.y = 93.0
+	content_root.custom_minimum_size = project_minimum
+	binder.layout_axis = GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.VERTICAL
+	var _requested: bool = binder.request_sync()
+	var _vertical_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	binder.dispose()
+
+	assert_eq(content_root.custom_minimum_size.x, original_minimum.x)
+	assert_eq(content_root.custom_minimum_size.y, 93.0, "vertical 接管应捕获项目最新的 unowned y。")
+
+
+func test_invalid_dynamic_layout_axis_write_preserves_owned_axis_and_baseline() -> void:
+	var original_minimum: Vector2 = Vector2(13.0, 17.0)
+	var fixture: Dictionary = _create_fixture(
+		20,
+		100.0,
+		1,
+		512,
+		null,
+		null,
+		original_minimum
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var content_root: Control = _get_fixture_content(fixture)
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var _settled_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	var project_minimum: Vector2 = content_root.custom_minimum_size
+	project_minimum.x = 91.0
+	content_root.custom_minimum_size = project_minimum
+	var pending_before: bool = GFVariantData.get_option_bool(
+		binder.get_debug_snapshot(),
+		"pending_sync"
+	)
+
+	binder.set(&"layout_axis", 999)
+
+	assert_eq(binder.layout_axis, GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.VERTICAL)
+	assert_eq(
+		GFVariantData.get_option_bool(binder.get_debug_snapshot(), "pending_sync"),
+		pending_before,
+		"非法轴写入不得隐式请求同步。"
+	)
+	binder.dispose()
+	assert_eq(content_root.custom_minimum_size.x, 91.0, "非法轴写入不得改变 unowned 轴。")
+	assert_eq(content_root.custom_minimum_size.y, original_minimum.y, "teardown 应继续恢复原 owned 轴 baseline。")
+
+
+func test_sync_result_to_dict_is_json_safe_and_round_trips() -> void:
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = _make_configured_sync_result()
+	var report: Dictionary = result.to_dict()
+	var viewport_range: Dictionary = GFVariantData.get_option_dictionary(
+		report,
+		"viewport_range"
+	)
+	var requested_range: Dictionary = GFVariantData.get_option_dictionary(
+		report,
+		"requested_range"
+	)
+
+	assert_eq(typeof(GFVariantData.get_option_value(report, "status")), TYPE_STRING)
+	assert_eq(typeof(GFVariantData.get_option_value(report, "viewport_range")), TYPE_DICTIONARY)
+	assert_eq(typeof(GFVariantData.get_option_value(report, "requested_range")), TYPE_DICTIONARY)
+	assert_eq(typeof(GFVariantData.get_option_value(report, "materialized_indices")), TYPE_ARRAY)
+	assert_eq(viewport_range, { "start": 3, "end_exclusive": 8 })
+	assert_eq(requested_range, { "start": 2, "end_exclusive": 10 })
+	assert_eq(
+		GFVariantData.get_option_array(report, "materialized_indices"),
+		[3, 4, 7]
+	)
+
+	var encoded: String = JSON.stringify(report)
+	assert_false(encoded.is_empty(), "JSON-safe 同步摘要必须可直接编码。")
+	assert_false(encoded.contains(":null"), "同步摘要不得依赖 JSON.stringify 降级非法值。")
+	var parsed_value: Variant = JSON.parse_string(encoded)
+	assert_eq(typeof(parsed_value), TYPE_DICTIONARY, "编码后的同步摘要必须能解析为 Dictionary。")
+	var parsed: Dictionary = GFVariantData.as_dictionary(parsed_value)
+	var restored: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	assert_true(restored.configure_for_framework(parsed), "configure 应接受 JSON 往返后的纯数据形状。")
+	assert_eq(restored.to_dict(), report, "JSON 往返不得丢失同步诊断字段。")
+
+
+func test_sync_result_duplicate_preserves_every_field() -> void:
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = _make_configured_sync_result()
+	var result_copy: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = result.duplicate_result()
+
+	assert_ne(result_copy, result, "duplicate_result 必须返回独立对象。")
+	assert_eq(result_copy.to_dict(), result.to_dict(), "duplicate_result 不得丢失任何诊断字段。")
+	assert_eq(result_copy.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_BIND_FAILED)
+	assert_eq(result_copy.get_viewport_range(), Vector2i(3, 8))
+	assert_eq(result_copy.get_requested_range(), Vector2i(2, 10))
+	assert_eq(result_copy.get_materialized_indices(), PackedInt32Array([3, 4, 7]))
+	assert_eq(result_copy.get_anchor_adjustment(), -12.5)
+	assert_eq(result_copy.get_error_index(), 7)
+	assert_eq(result_copy.get_error(), "row binding rejected")
+
+
+func test_sync_result_deferred_is_known_non_successful_and_round_trips() -> void:
+	var data: Dictionary = _make_sync_result_data()
+	data["status"] = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED
+	data["error_index"] = -1
+	data["error"] = ""
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+
+	assert_true(result.configure_for_framework(data))
+	assert_eq(result.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(result.is_successful())
+	var report: Dictionary = result.to_dict()
+	assert_eq(GFVariantData.get_option_string(report, "status"), "deferred")
+	var parsed_value: Variant = JSON.parse_string(JSON.stringify(report))
+	assert_eq(typeof(parsed_value), TYPE_DICTIONARY)
+	var restored: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	assert_true(restored.configure_for_framework(GFVariantData.as_dictionary(parsed_value)))
+	assert_eq(restored.get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+	assert_false(restored.is_successful())
+	assert_eq(result.duplicate_result().get_status(), GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_DEFERRED)
+
+
+func test_sync_result_accepts_json_safe_integer_boundaries_and_round_trips_exactly() -> void:
+	var minimum_data: Dictionary = _make_sync_result_data()
+	for field: String in _NONNEGATIVE_JSON_INTEGER_FIELDS:
+		minimum_data[field] = 0
+	minimum_data["error_index"] = -1
+	var minimum_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = (
+		GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	)
+	assert_true(minimum_result.configure_for_framework(minimum_data))
+
+	var maximum_data: Dictionary = _make_sync_result_data()
+	for field: String in _NONNEGATIVE_JSON_INTEGER_FIELDS:
+		maximum_data[field] = _JSON_SAFE_INTEGER_MAX
+	maximum_data["error_index"] = _JSON_SAFE_INTEGER_MAX
+	var maximum_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = (
+		GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	)
+	assert_true(maximum_result.configure_for_framework(maximum_data))
+	var encoded: String = JSON.stringify(maximum_result.to_dict())
+	var parsed_value: Variant = JSON.parse_string(encoded)
+	assert_eq(typeof(parsed_value), TYPE_DICTIONARY)
+	var restored: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	assert_true(restored.configure_for_framework(GFVariantData.as_dictionary(parsed_value)))
+	var restored_report: Dictionary = restored.to_dict()
+	for field: String in _NONNEGATIVE_JSON_INTEGER_FIELDS:
+		assert_eq(
+			GFVariantData.get_option_int(restored_report, field),
+			_JSON_SAFE_INTEGER_MAX,
+			"JSON safe integer 上界必须精确往返：%s。" % field
+		)
+	assert_eq(restored.get_error_index(), _JSON_SAFE_INTEGER_MAX)
+	assert_eq(restored_report, maximum_result.to_dict())
+
+
+func test_sync_result_rejects_out_of_range_integers_before_freezing() -> void:
+	for field: String in _NONNEGATIVE_JSON_INTEGER_FIELDS:
+		var too_large_data: Dictionary = _make_sync_result_data()
+		too_large_data[field] = _JSON_SAFE_INTEGER_MAX + 1
+		var too_large_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = (
+			GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+		)
+		assert_false(
+			too_large_result.configure_for_framework(too_large_data),
+			"MAX + 1 必须拒绝：%s。" % field
+		)
+		assert_true(
+			too_large_result.configure_for_framework(_make_sync_result_data()),
+			"越界失败不得提前冻结结果：%s。" % field
+		)
+
+		var negative_data: Dictionary = _make_sync_result_data()
+		negative_data[field] = -1
+		var negative_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = (
+			GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+		)
+		assert_false(
+			negative_result.configure_for_framework(negative_data),
+			"revision/count 不得为负数：%s。" % field
+		)
+
+	for invalid_error_index: int in [-2, _JSON_SAFE_INTEGER_MAX + 1]:
+		var invalid_error_data: Dictionary = _make_sync_result_data()
+		invalid_error_data["error_index"] = invalid_error_index
+		var invalid_error_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = (
+			GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+		)
+		assert_false(
+			invalid_error_result.configure_for_framework(invalid_error_data),
+			"error_index 必须位于 -1..MAX。"
+		)
+
+
+func test_sync_result_json_inputs_and_reports_are_alias_isolated() -> void:
+	var typed_indices: PackedInt32Array = PackedInt32Array([3, 4, 7])
+	var typed_data: Dictionary = _make_sync_result_data()
+	typed_data["materialized_indices"] = typed_indices
+	var typed_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	assert_true(typed_result.configure_for_framework(typed_data))
+	typed_indices[0] = 99
+	var _typed_append_result: bool = typed_indices.append(100)
+	assert_eq(
+		typed_result.get_materialized_indices(),
+		PackedInt32Array([3, 4, 7]),
+		"configure 必须复制 typed PackedInt32Array 输入。"
+	)
+
+	var source: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = _make_configured_sync_result()
+	var input_report: Dictionary = source.to_dict()
+	var restored: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	assert_true(restored.configure_for_framework(input_report))
+
+	var input_viewport_value: Variant = input_report.get("viewport_range")
+	assert_true(input_viewport_value is Dictionary)
+	if not input_viewport_value is Dictionary:
+		return
+	var input_viewport: Dictionary = input_viewport_value
+	input_viewport["start"] = 99
+	var input_indices_value: Variant = input_report.get("materialized_indices")
+	assert_true(input_indices_value is Array)
+	if not input_indices_value is Array:
+		return
+	var input_indices: Array = input_indices_value
+	input_indices[0] = 99
+	input_indices.append(100)
+	assert_eq(restored.get_viewport_range(), Vector2i(3, 8), "configure 必须复制 JSON range。")
+	assert_eq(
+		restored.get_materialized_indices(),
+		PackedInt32Array([3, 4, 7]),
+		"configure 必须复制 JSON index array。"
+	)
+
+	var exported: Dictionary = restored.to_dict()
+	var exported_requested_value: Variant = exported.get("requested_range")
+	assert_true(exported_requested_value is Dictionary)
+	if not exported_requested_value is Dictionary:
+		return
+	var exported_requested: Dictionary = exported_requested_value
+	exported_requested["end_exclusive"] = 999
+	var exported_indices_value: Variant = exported.get("materialized_indices")
+	assert_true(exported_indices_value is Array)
+	if not exported_indices_value is Array:
+		return
+	var exported_indices: Array = exported_indices_value
+	exported_indices.clear()
+	assert_eq(restored.get_requested_range(), Vector2i(2, 10), "to_dict range 不得引用内部状态。")
+	assert_eq(
+		restored.get_materialized_indices(),
+		PackedInt32Array([3, 4, 7]),
+		"to_dict index array 不得引用内部状态。"
+	)
+	var result_copy: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = restored.duplicate_result()
+	var copy_report: Dictionary = result_copy.to_dict()
+	var copy_viewport_value: Variant = copy_report.get("viewport_range")
+	assert_true(copy_viewport_value is Dictionary)
+	if not copy_viewport_value is Dictionary:
+		return
+	var copy_viewport: Dictionary = copy_viewport_value
+	copy_viewport["start"] = 777
+	var copy_indices_value: Variant = copy_report.get("materialized_indices")
+	assert_true(copy_indices_value is Array)
+	if not copy_indices_value is Array:
+		return
+	var copy_indices: Array = copy_indices_value
+	copy_indices[0] = 777
+	assert_eq(result_copy.get_viewport_range(), Vector2i(3, 8))
+	assert_eq(result_copy.get_materialized_indices(), PackedInt32Array([3, 4, 7]))
+	assert_eq(restored.get_viewport_range(), Vector2i(3, 8))
+	assert_eq(restored.get_materialized_indices(), PackedInt32Array([3, 4, 7]))
+
+
+# --- 私有/辅助方法 ---
+
+func _binder_sync_is_in_progress(binder: GF_VIRTUAL_LIST_BINDER_SCRIPT) -> bool:
+	var value: Variant = binder.get("_sync_in_progress")
+	if value is bool:
+		var in_progress: bool = value
+		return in_progress
+	return false
+
+
+func _get_last_committed_data_revision(binder: GF_VIRTUAL_LIST_BINDER_SCRIPT) -> int:
+	var value: Variant = binder.get("_last_committed_data_revision")
+	if value is int:
+		var revision: int = value
+		return revision
+	return -2
+
+
+func _make_configured_sync_result() -> GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT:
+	var result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.new()
+	var configured: bool = result.configure_for_framework(_make_sync_result_data())
+	assert_true(configured, "同步结果 fixture 必须成功配置。")
+	return result
+
+
+func _make_sync_result_data() -> Dictionary:
+	return {
+		"status": GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT.STATUS_BIND_FAILED,
+		"layout_revision": 17,
+		"data_revision": 19,
+		"viewport_range": Vector2i(3, 8),
+		"requested_range": Vector2i(2, 10),
+		"materialized_indices": PackedInt32Array([3, 4, 7]),
+		"pooled_count": 2,
+		"created_count": 3,
+		"reused_count": 4,
+		"released_count": 5,
+		"measured_count": 6,
+		"anchor_adjustment": -12.5,
+		"truncated": false,
+		"error_index": 7,
+		"error": "row binding rejected",
+	}
+
+
+func _create_fixture(
+	item_count: int,
+	viewport_extent: float,
+	overscan_items: int,
+	max_materialized_items: int = 512,
+	focus_model: GFVirtualListFocusModel = null,
+	lifecycle_owner: Node = null,
+	content_minimum_size: Vector2 = Vector2.ZERO,
+	start_horizontal: bool = false,
+	focus_target_callback: Callable = Callable(),
+	auto_measure_items: bool = true
+) -> Dictionary:
+	_item_ids.clear()
+	for item_index: int in range(item_count):
+		_item_ids.append(StringName("item_%d" % item_index))
+
+	var scroll_container: ScrollContainer = ScrollContainer.new()
+	scroll_container.size = Vector2(240.0, viewport_extent)
+	var content_root: Control = Control.new()
+	content_root.custom_minimum_size = content_minimum_size
+	scroll_container.add_child(content_root)
+	add_child(scroll_container)
+	_nodes.append(scroll_container)
+	_nodes.append(content_root)
+
+	var model: GFVirtualListModel = GFVirtualListModel.new()
+	model.estimated_item_extent = 20.0
+	model.overscan_items = overscan_items
+	model.set_item_count(item_count)
+	if focus_model != null:
+		var _focus_count_changed: bool = focus_model.set_item_count(item_count)
+
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = GF_VIRTUAL_LIST_BINDER_SCRIPT.new()
+	binder.auto_measure = auto_measure_items
+	if start_horizontal:
+		binder.layout_axis = GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.HORIZONTAL
+	binder.max_materialized_items = max_materialized_items
+	binder.max_pooled_items = 2
+	_active_binder = binder
+	_binders.append(binder)
+	var binding_owner: Node = lifecycle_owner if lifecycle_owner != null else scroll_container
+	var bound: bool = binder.bind(
+		binding_owner,
+		scroll_container,
+		content_root,
+		model,
+		Callable(self, "_make_row"),
+		Callable(self, "_bind_row"),
+		Callable(self, "_unbind_row"),
+		Callable(self, "_get_item_identity"),
+		focus_model,
+		Callable(self, "_measure_row"),
+		focus_target_callback
+	)
+	assert_true(bound, "测试 fixture 应成功绑定。")
+	return {
+		"binder": binder,
+		"scroll": scroll_container,
+		"content": content_root,
+		"model": model,
+	}
+
+
+func _make_row() -> Control:
+	if _fail_factory:
+		return null
+	if _factory_success_budget == 0:
+		return null
+	if _factory_success_budget > 0:
+		_factory_success_budget -= 1
+	_factory_count += 1
+	var row: Button = Button.new()
+	row.custom_minimum_size = Vector2(0.0, 20.0)
+	row.focus_mode = Control.FOCUS_ALL
+	if _reentrant_mode == &"unbind_on_tree_enter" and _active_binder != null:
+		var _tree_entered_connected: Error = row.tree_entered.connect(
+			func() -> void:
+				if _active_binder != null:
+					var _unbound: Variant = _active_binder.call("unbind"),
+			CONNECT_ONE_SHOT
+		) as Error
+	_last_factory_control = row
+	if (
+		_reentrant_mode == &"invalidate_in_factory"
+		and _invalidate_callback_budget > 0
+		and _active_binder != null
+	):
+		_invalidate_callback_budget -= 1
+		var _invalidated_in_factory: Variant = _active_binder.call("invalidate_items")
+	return row
+
+
+func _bind_row(row: Control, item_index: int, item_id: Variant) -> bool:
+	_bind_events.append({
+		"row_id": row.get_instance_id(),
+		"index": item_index,
+		"item_id": item_id,
+	})
+	if row is Button:
+		var button: Button = row
+		button.text = str(item_id)
+	if _reentrant_mode == &"request_sync" and item_index == 0 and _active_binder != null:
+		var _requested: Variant = _active_binder.call("request_sync")
+	elif _reentrant_mode == &"dispose" and item_index == 0 and _active_binder != null:
+		var _disposed: Variant = _active_binder.call("dispose")
+	elif (
+		_reentrant_mode == &"invalidate_items"
+		and item_index == 0
+		and _invalidate_callback_budget > 0
+		and _active_binder != null
+	):
+		_invalidate_callback_budget -= 1
+		var _invalidated: Variant = _active_binder.call("invalidate_items")
+	elif (
+		_reentrant_mode == &"change_layout"
+		and item_index == 0
+		and _layout_callback_budget > 0
+		and _layout_model_for_callback != null
+	):
+		_layout_callback_budget -= 1
+		_layout_model_for_callback.overscan_items = 3
+	elif (
+		_reentrant_mode == &"change_layout_geometry"
+		and item_index == 0
+		and _layout_callback_budget > 0
+		and _layout_model_for_callback != null
+	):
+		_layout_callback_budget -= 1
+		_layout_model_for_callback.estimated_item_extent = 40.0
+	elif _reentrant_mode == &"change_axis_on_bind" and item_index == 0 and _active_binder != null:
+		_reentrant_mode = &""
+		_active_binder.set(
+			"layout_axis",
+			GF_VIRTUAL_LIST_BINDER_SCRIPT.LayoutAxis.HORIZONTAL
+		)
+		var _requested_axis_sync: Variant = _active_binder.call("request_sync")
+	elif _reentrant_mode == &"shrink_pool_on_bind" and item_index == 1 and _active_binder != null:
+		_reentrant_mode = &""
+		_active_binder.set("max_pooled_items", 0)
+	elif (
+		_reentrant_mode == &"focus_zero_on_bind"
+		and _focus_callback_budget > 0
+		and _focus_model_for_callback != null
+	):
+		_focus_callback_budget -= 1
+		var _focused: bool = _focus_model_for_callback.set_focused_index(0)
+	return item_index != _fail_bind_index
+
+
+func _unbind_row(row: Control, item_index: int, item_id: Variant) -> void:
+	_unbind_events.append({
+		"row_id": row.get_instance_id(),
+		"index": item_index,
+		"item_id": item_id,
+	})
+	if _reentrant_mode == &"dispose_on_unbind" and item_index == 0 and _active_binder != null:
+		var _disposed: Variant = _active_binder.call("dispose")
+	elif (
+		_reentrant_mode == &"invalidate_on_unbind"
+		and _invalidate_callback_budget > 0
+		and _active_binder != null
+	):
+		_invalidate_callback_budget -= 1
+		var _invalidated_on_unbind: Variant = _active_binder.call("invalidate_items")
+	elif (
+		_reentrant_mode == &"reparent_on_unbind"
+		and item_index == 0
+		and _foreign_parent_for_callback != null
+		and is_instance_valid(_foreign_parent_for_callback)
+	):
+		_reentrant_mode = &""
+		row.reparent(_foreign_parent_for_callback)
+
+
+func _get_item_identity(item_index: int) -> Variant:
+	_identity_callback_count += 1
+	if item_index < 0 or item_index >= _item_ids.size():
+		return null
+	if (
+		_reentrant_mode == &"invalidate_identity"
+		and item_index == 0
+		and _invalidate_callback_budget > 0
+		and _active_binder != null
+	):
+		_invalidate_callback_budget -= 1
+		_item_ids[0] = &"replacement_0"
+		var _invalidated_identity: Variant = _active_binder.call("invalidate_items")
+	if (
+		_reentrant_mode == &"capture_round_geometry"
+		and item_index == 0
+		and _active_binder != null
+	):
+		_reentrant_mode = &""
+		var geometries_value: Variant = _active_binder.get("_sync_item_geometries")
+		if geometries_value is Dictionary:
+			var geometries: Dictionary = geometries_value
+			var geometry_value: Variant = geometries.get(1)
+			if geometry_value is Dictionary:
+				var geometry: Dictionary = geometry_value
+				_captured_round_geometry = true
+				_captured_round_offset = GFVariantData.get_option_float(geometry, "offset")
+				_captured_round_extent = GFVariantData.get_option_float(geometry, "extent")
+	return _item_ids[item_index]
+
+
+func _resolve_focus_target(
+	row: Control,
+	_item_index: int,
+	_item_id: Variant
+) -> Control:
+	if (
+		_reentrant_mode == &"invalidate_on_focus_target"
+		and _invalidate_callback_budget > 0
+		and _active_binder != null
+	):
+		_invalidate_callback_budget -= 1
+		var _invalidated_on_focus: Variant = _active_binder.call("invalidate_items")
+	return row
+
+
+func _measure_row(_row: Control, item_index: int, _item_id: Variant) -> float:
+	if (
+		_reentrant_mode == &"invalidate_on_measure"
+		and item_index == 0
+		and _invalidate_callback_budget > 0
+		and _active_binder != null
+	):
+		_invalidate_callback_budget -= 1
+		var _invalidated_on_measure: Variant = _active_binder.call("invalidate_items")
+	if (
+		_reentrant_mode == &"reparent_other_on_measure"
+		and item_index == 0
+		and _active_binder != null
+		and _foreign_parent_for_callback != null
+	):
+		_reentrant_mode = &""
+		var other_value: Variant = _active_binder.call("get_materialized_control", 1)
+		if other_value is Control:
+			var other_control: Control = other_value
+			other_control.reparent(_foreign_parent_for_callback)
+	if (
+		_reentrant_mode == &"request_measurement"
+		and item_index == 0
+		and _measurement_requeue_budget > 0
+		and _active_binder != null
+	):
+		_measurement_requeue_budget -= 1
+		var _requested: Variant = _active_binder.call("request_measurement")
+	if _measured_extents.has(item_index):
+		var measured_value: Variant = _measured_extents.get(item_index)
+		if measured_value is float:
+			var measured_extent: float = measured_value
+			return measured_extent
+	if _expanded_first_extent and item_index == 0:
+		return 40.0
+	return 20.0
+
+
+func _find_parentless_owned_control(controls: Array[Control]) -> Control:
+	for control: Control in controls:
+		if (
+			control != null
+			and is_instance_valid(control)
+			and not control.is_queued_for_deletion()
+			and control.get_parent() == null
+		):
+			return control
+	return null
+
+
+func _get_fixture_binder(fixture: Dictionary) -> GF_VIRTUAL_LIST_BINDER_SCRIPT:
+	var value: Variant = fixture.get("binder")
+	if value is GF_VIRTUAL_LIST_BINDER_SCRIPT:
+		var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = value
+		return binder
+	return null
+
+
+func _get_fixture_scroll(fixture: Dictionary) -> ScrollContainer:
+	var value: Variant = fixture.get("scroll")
+	if value is ScrollContainer:
+		var scroll_container: ScrollContainer = value
+		return scroll_container
+	return null
+
+
+func _get_fixture_model(fixture: Dictionary) -> GFVirtualListModel:
+	var value: Variant = fixture.get("model")
+	if value is GFVirtualListModel:
+		var model: GFVirtualListModel = value
+		return model
+	return null
+
+
+func _get_fixture_content(fixture: Dictionary) -> Control:
+	var value: Variant = fixture.get("content")
+	if value is Control:
+		var content_root: Control = value
+		return content_root
+	return null
+
+
+func _on_sync_completed_reentrant(_result: RefCounted) -> void:
+	_sync_completed_event_count += 1
+	if _sync_completed_event_count != 1 or _active_binder == null:
+		return
+	var value: Variant = _active_binder.call("sync_now")
+	if value is RefCounted:
+		_reentrant_sync_result = value
+
+
+func _reset_fixture_state() -> void:
+	_item_ids.clear()
+	_factory_count = 0
+	_bind_events.clear()
+	_unbind_events.clear()
+	_fail_factory = false
+	_factory_success_budget = -1
+	_last_factory_control = null
+	_fail_bind_index = -1
+	_expanded_first_extent = false
+	_measured_extents.clear()
+	_reentrant_mode = &""
+	_invalidate_callback_budget = 0
+	_layout_callback_budget = 0
+	_measurement_requeue_budget = 0
+	_focus_callback_budget = 0
+	_layout_model_for_callback = null
+	_focus_model_for_callback = null
+	_active_binder = null
+	_foreign_parent_for_callback = null
+	_sync_completed_event_count = 0
+	_reentrant_sync_result = null
+	_captured_round_geometry = false
+	_captured_round_offset = 0.0
+	_captured_round_extent = 0.0
+	_identity_callback_count = 0

--- a/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd
@@ -434,6 +434,63 @@ func test_pending_focus_reveal_quantizes_range_before_materialization() -> void:
 	)
 
 
+func test_pending_focus_reveal_recomputes_one_pixel_drift_at_large_offset() -> void:
+	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
+	var fixture: Dictionary = _create_fixture(
+		2,
+		20.0,
+		0,
+		512,
+		focus_model,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var extent_report: Dictionary = model.set_item_extent(0, 1_000_000_000.0, true)
+	assert_true(GFVariantData.get_option_bool(extent_report, "changed"))
+	model.trailing_padding = 100.0
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	assert_true(focus_model.set_focused_index(1))
+	assert_eq(scroll_container.scroll_vertical, 1_000_000_000)
+	scroll_container.scroll_vertical = 0
+	var callback_count: Array[int] = [0]
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(value: float) -> void:
+			if callback_count[0] == 0:
+				callback_count[0] += 1
+				scroll_container.scroll_vertical = maxi(int(value) - 1, 0),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var drifted_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(drifted_result.is_successful())
+	assert_eq(callback_count[0], 1)
+	assert_eq(scroll_container.scroll_vertical, 999_999_999)
+	assert_eq(
+		drifted_result.get_viewport_range(),
+		Vector2i(0, 2),
+		"当前轮必须按真实整数偏移重算，而不是保留计划范围。"
+	)
+	assert_true(
+		GFVariantData.get_option_bool(binder.get_debug_snapshot(), "pending_sync"),
+		"一像素漂移必须保留下一轮收敛请求。"
+	)
+
+	var converged_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+
+	assert_true(converged_result.is_successful())
+	assert_eq(scroll_container.scroll_vertical, 1_000_000_000)
+	assert_eq(converged_result.get_viewport_range(), Vector2i(1, 2))
+	assert_false(GFVariantData.get_option_bool(binder.get_debug_snapshot(), "pending_sync"))
+
+
 func test_pending_focus_reveal_measurement_anchors_to_planned_scroll() -> void:
 	var focus_model: GFVirtualListFocusModel = GFVirtualListFocusModel.new()
 	var fixture: Dictionary = _create_fixture(
@@ -1413,6 +1470,47 @@ func test_scroll_to_item_returns_false_when_scroll_callback_invalidates_data_gen
 	var converged_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
 	assert_true(converged_result.is_successful())
 	assert_eq(converged_result.get_data_revision(), 1)
+
+
+func test_scroll_to_item_rejects_one_pixel_drift_at_large_quantized_offset() -> void:
+	var fixture: Dictionary = _create_fixture(
+		2,
+		20.0,
+		0,
+		512,
+		null,
+		null,
+		Vector2.ZERO,
+		false,
+		Callable(),
+		false
+	)
+	var binder: GF_VIRTUAL_LIST_BINDER_SCRIPT = _get_fixture_binder(fixture)
+	var scroll_container: ScrollContainer = _get_fixture_scroll(fixture)
+	var model: GFVirtualListModel = _get_fixture_model(fixture)
+	var extent_report: Dictionary = model.set_item_extent(0, 1_000_000_000.0, true)
+	assert_true(GFVariantData.get_option_bool(extent_report, "changed"))
+	model.trailing_padding = 100.0
+	var _initial_result: GF_VIRTUAL_LIST_SYNC_RESULT_SCRIPT = binder.sync_now()
+	await get_tree().process_frame
+	var callback_count: Array[int] = [0]
+	var _scroll_connected: Error = scroll_container.get_v_scroll_bar().value_changed.connect(
+		func(value: float) -> void:
+			if callback_count[0] == 0:
+				callback_count[0] += 1
+				scroll_container.scroll_vertical = maxi(int(value) - 1, 0),
+		CONNECT_ONE_SHOT
+	) as Error
+
+	var scrolled: bool = binder.scroll_to_item(
+		1,
+		GF_VIRTUAL_LIST_BINDER_SCRIPT.ScrollAlignment.START
+	)
+
+	assert_false(scrolled, "整数滚动写入漂移一像素时不得报告成功。")
+	assert_eq(callback_count[0], 1)
+	assert_eq(scroll_container.scroll_vertical, 999_999_999)
+	assert_true(GFVariantData.get_option_bool(binder.get_debug_snapshot(), "pending_sync"))
 
 
 func test_scroll_to_item_aborts_when_scroll_callback_changes_snapshot() -> void:

--- a/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd.uid
+++ b/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_binder.gd.uid
@@ -1,0 +1,1 @@
+uid://qm7sfy3t5ese

--- a/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_model.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_model.gd
@@ -67,6 +67,25 @@ func test_remove_item_and_trailing_padding_keep_content_extent_consistent() -> v
 	assert_eq(model.get_content_extent(), 132.0, "默认内容尺寸应包含 trailing padding。")
 
 
+func test_large_trailing_padding_preserves_one_pixel_updates() -> void:
+	var model: GFVirtualListModel = GFVirtualListModel.new()
+	model.set_item_count(1)
+	model.trailing_padding = 1_000_000_000.0
+	watch_signals(model)
+	var previous_revision: int = model.get_revision()
+
+	model.trailing_padding = 1_000_000_001.0
+
+	assert_eq(model.trailing_padding, 1_000_000_001.0)
+	assert_eq(
+		model.get_content_extent(),
+		model.estimated_item_extent + 1_000_000_001.0,
+		"大数值下的整像素 padding 变化不得被相对容差吞掉。"
+	)
+	assert_eq(model.get_revision(), previous_revision + 1)
+	assert_signal_emit_count(model, "layout_changed", 1)
+
+
 func test_reset_item_extent_returns_item_to_estimate() -> void:
 	var model: GFVirtualListModel = GFVirtualListModel.new()
 	model.estimated_item_extent = 40.0
@@ -77,6 +96,40 @@ func test_reset_item_extent_returns_item_to_estimate() -> void:
 	assert_true(reset, "合法索引应可重置。")
 	assert_eq(model.get_item_extent(0), 40.0, "重置后应回到估算尺寸。")
 	assert_false(model.is_item_measured(0), "重置后条目不应仍标记为实测。")
+
+
+func test_reset_item_extent_restores_large_unmeasured_one_pixel_difference() -> void:
+	var model: GFVirtualListModel = GFVirtualListModel.new()
+	model.estimated_item_extent = 1_000_000_000.0
+	model.set_item_count(1)
+	var report: Dictionary = model.set_item_extent(0, 1_000_000_001.0, false)
+	assert_true(GFVariantData.get_option_bool(report, "changed"))
+	assert_false(model.is_item_measured(0))
+	watch_signals(model)
+	var previous_revision: int = model.get_revision()
+
+	var reset: bool = model.reset_item_extent(0)
+
+	assert_true(reset)
+	assert_eq(model.get_item_extent(0), 1_000_000_000.0)
+	assert_false(model.is_item_measured(0))
+	assert_eq(model.get_revision(), previous_revision + 1)
+	assert_signal_emit_count(model, "layout_changed", 1)
+
+
+func test_large_estimated_extent_preserves_one_pixel_updates() -> void:
+	var model: GFVirtualListModel = GFVirtualListModel.new()
+	model.estimated_item_extent = 1_000_000_000.0
+	model.set_item_count(1)
+	watch_signals(model)
+	var previous_revision: int = model.get_revision()
+
+	model.estimated_item_extent = 1_000_000_001.0
+
+	assert_eq(model.estimated_item_extent, 1_000_000_001.0)
+	assert_eq(model.get_item_extent(0), 1_000_000_001.0)
+	assert_eq(model.get_revision(), previous_revision + 1)
+	assert_signal_emit_count(model, "layout_changed", 1)
 
 
 func test_non_finite_layout_inputs_cannot_poison_offsets() -> void:

--- a/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_model.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_virtual_list_model.gd
@@ -96,3 +96,36 @@ func test_non_finite_layout_inputs_cannot_poison_offsets() -> void:
 	assert_true(is_finite(model.get_content_extent()), "累计内容尺寸必须保持有限。")
 	var visible_range: Vector2i = model.get_visible_range(INF, NAN)
 	assert_true(visible_range.x >= 0 and visible_range.y <= model.get_item_count(), "异常滚动输入不得产生越界范围。")
+
+
+func test_viewport_range_excludes_overscan_while_visible_range_includes_it() -> void:
+	var model: GFVirtualListModel = GFVirtualListModel.new()
+	model.estimated_item_extent = 50.0
+	model.overscan_items = 2
+	model.set_item_count(10)
+
+	assert_eq(model.get_viewport_range(100.0, 100.0), Vector2i(2, 4), "原始视口范围不应包含 overscan。")
+	assert_eq(model.get_visible_range(100.0, 100.0), Vector2i(0, 6), "可见范围应在原始视口两端加入 overscan。")
+
+
+func test_layout_revision_changes_once_per_effective_public_mutation() -> void:
+	var model: GFVirtualListModel = GFVirtualListModel.new()
+	watch_signals(model)
+
+	assert_eq(model.get_revision(), 0, "新模型 revision 应从 0 开始。")
+	model.set_item_count(3)
+	assert_eq(model.get_revision(), 1, "条目数量变化应推进一次 revision。")
+	assert_signal_emit_count(model, "layout_changed", 1)
+	assert_signal_emitted_with_parameters(model, "layout_changed", [1])
+
+	model.set_item_count(3)
+	model.overscan_items = GFVirtualListModel.DEFAULT_OVERSCAN_ITEMS
+	var invalid_report: Dictionary = model.set_item_extent(0, INF)
+	assert_false(GFVariantData.get_option_bool(invalid_report, "ok"), "无效尺寸应被拒绝。")
+	assert_eq(model.get_revision(), 1, "无变化和无效写入不得推进 revision。")
+	assert_signal_emit_count(model, "layout_changed", 1)
+
+	model.estimated_item_extent = 72.0
+	assert_eq(model.get_revision(), 2, "一次 estimate 更新无论影响多少条目都只推进一次 revision。")
+	assert_signal_emit_count(model, "layout_changed", 2)
+	assert_signal_emitted_with_parameters(model, "layout_changed", [2], 1)

--- a/tests/gf_core/tools/ai_developer/fixtures/evaluation_cases.json
+++ b/tests/gf_core/tools/ai_developer/fixtures/evaluation_cases.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_version": "1.8.0",
+  "catalog_version": "1.9.0",
   "catalog_api_requirements": [
     {
       "catalog": "capability",
@@ -136,6 +136,34 @@
         "has_metric",
         "get_metric"
       ]
+    },
+    {
+      "catalog": "capability",
+      "record_id": "ui-scalability",
+      "class_name": "GFVirtualListBinder",
+      "members": [
+        "bind",
+        "sync_now",
+        "invalidate_items"
+      ]
+    },
+    {
+      "catalog": "recipe",
+      "record_id": "scalable-ui-collection",
+      "class_name": "GFTableDataView",
+      "members": [
+        "set_row_predicates",
+        "get_view_revision"
+      ]
+    },
+    {
+      "catalog": "capability",
+      "record_id": "spatial-physics",
+      "class_name": "GFSpatialCanvasInputPolicy",
+      "members": [
+        "validate_policy",
+        "duplicate_policy"
+      ]
     }
   ],
   "feedback_cases": [
@@ -267,6 +295,14 @@
       "expected_id": "ui-scalability"
     },
     {
+      "query": "bounded Control recycler for a virtual list",
+      "expected_id": "ui-scalability"
+    },
+    {
+      "query": "transactional structured table row predicates",
+      "expected_id": "ui-scalability"
+    },
+    {
       "query": "shader parameter controls for visual feedback",
       "expected_id": "render-feedback"
     },
@@ -347,6 +383,10 @@
       "expected_id": "spatial-physics"
     },
     {
+      "query": "canvas wheel parent scroll input policy",
+      "expected_id": "spatial-physics"
+    },
+    {
       "query": "GFObjectPoolUtility",
       "expected_id": "runtime-performance"
     },
@@ -401,7 +441,8 @@
     },
     {
       "recipe_id": "scalable-ui-collection",
-      "expected_class": "GFVirtualListModel"
+      "expected_class": "GFVirtualListBinder",
+      "expected_step_fragment": "committed view changes"
     },
     {
       "recipe_id": "render-feedback-orchestration",
@@ -439,6 +480,18 @@
     {
       "query": "GFSpatialQueryIndex2D",
       "expected_class": "GFSpatialQueryIndex2D"
+    },
+    {
+      "query": "GFVirtualListBinder",
+      "expected_class": "GFVirtualListBinder"
+    },
+    {
+      "query": "GFSpatialCanvasInputPolicy",
+      "expected_class": "GFSpatialCanvasInputPolicy"
+    },
+    {
+      "query": "GFTableRowPredicate",
+      "expected_class": "GFTableRowPredicate"
     }
   ],
   "module_queries": [

--- a/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
+++ b/tests/gf_core/tools/ai_developer/test_gf_ai_project_tool.py
@@ -666,7 +666,6 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 		self.assertEqual(readiness["unsatisfied_recipe_any_of_package_groups"], [])
 
 	def test_new_recipe_package_readiness_matches_declared_requirements(self) -> None:
-		scalable_group = [["gf.standard.ui", "gf.standard.ui.state"]]
 		render_group = [["gf.extension.feedback", "gf.standard.assets", "gf.standard.display"]]
 		artifact_packages = [
 			"gf.extension.content_package",
@@ -714,28 +713,28 @@ class GFAIDeveloperKitTest(unittest.TestCase):
 				"recipe_id": "scalable-ui-collection",
 				"available": ["gf.standard.ui"],
 				"satisfied": True,
-				"all_of": [],
+				"all_of": ["gf.standard.ui"],
 				"missing_all_of": [],
-				"any_of": scalable_group,
+				"any_of": [],
 				"unsatisfied_any_of": [],
 			},
 			{
 				"recipe_id": "scalable-ui-collection",
 				"available": ["gf.standard.ui.state"],
 				"satisfied": True,
-				"all_of": [],
+				"all_of": ["gf.standard.ui"],
 				"missing_all_of": [],
-				"any_of": scalable_group,
+				"any_of": [],
 				"unsatisfied_any_of": [],
 			},
 			{
 				"recipe_id": "scalable-ui-collection",
 				"available": ["gf.kernel"],
 				"satisfied": False,
-				"all_of": [],
-				"missing_all_of": [],
-				"any_of": scalable_group,
-				"unsatisfied_any_of": scalable_group,
+				"all_of": ["gf.standard.ui"],
+				"missing_all_of": ["gf.standard.ui"],
+				"any_of": [],
+				"unsatisfied_any_of": [],
 			},
 			*[
 				{


### PR DESCRIPTION
## Summary

- add a lifecycle-safe `GFVirtualListBinder` and typed sync result for bounded viewport materialization, pooling, focus handoff, measurement, and generation-aware reentrancy
- add a fail-closed `GFSpatialCanvasInputPolicy` plus explicit selection-mode binding for owned input disposition and canvas gesture coordination
- add typed table row views, predicates, registrations, and rebuild results so filtering composes transactionally without exposing authoritative rows
- update package manifests, focused-test mapping, AI Developer knowledge, generated API references, Chinese guides, and changelog entries

## Design and impact

These are framework-level composition contracts rather than business-specific widgets. Project callbacks are isolated behind typed snapshots, mutation is generation-checked, and invalid or reentrant work fails closed. The implementation intentionally does not add compatibility shims for unreleased APIs.

Closes #68
Closes #69
Closes #73

## Validation

- focused GUT: virtual-list binder 85/85 (675 assertions), spatial canvas 57/57 (458 assertions), table predicates 46/46 (362 assertions)
- full GUT: 5805/5805 tests, 48807 assertions, lifecycle orphan/warning counts 0/0, Godot exit-leak count 0
- framework static: 22/22 checks; quick: 27/27 checks
- package contract: 10/10 checks; editor wizard: 11/11 scenarios
- package CLI: local 12/12 scenarios, network 13/13 scenarios
- package Godot smoke: 5/5 scenarios with zero exit leaks
- credential gate: tracked mode, 5095 files, 0 issues; 59/59 gate self-tests
- API reference, AI API, and AI Developer kit current checks
- `git diff --check` and path hygiene
