### PR TITLE
Require patched pymdown-extensions for documentation builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs>=1.6,<2.0
 mkdocs-material>=9.5,<10.0
-pymdown-extensions>=10.0,<11.0
+pymdown-extensions>=11.0.1,<12.0


### PR DESCRIPTION
## Summary

Require `pymdown-extensions>=11.0.1,<12.0` for documentation builds so the resolver cannot select versions affected by GHSA-gm37-52c6-37mw / CVE-2026-67422.

The dependency is used only by MkDocs and is not part of the GF runtime or package artifacts.

## Contract and Risk

- Change type: build
- Consumer-visible behavior: documentation builds resolve a patched pymdown-extensions release.
- API or extension contract: unaffected.
- Persisted data, package, protocol, or ProjectSettings impact: none.
- Failure, cancellation, rollback, concurrency, and ownership impact: none in the runtime; this removes a ReDoS exposure from the documentation parser.
- Compatibility and migration: no runtime migration. Repository documentation builds use Python 3.12 and the configured MkDocs extensions build successfully with 11.0.1.

## Verification

- [x] Isolated requirements installation resolved pymdown-extensions 11.0.1.
- [x] `pip check`
- [x] `mkdocs build --strict`
- [x] `python tools/gf_maintenance.py check --suite docs --json`
- [x] `git diff --check`
- [ ] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

## Documentation and Release

- [x] No guide or changelog update is needed because this changes only the documentation build dependency.
- [x] Development version and public API are unaffected.
- [x] This PR does not create a tag or publish a release.
