### PR TITLE
Allow unregistering inactive save profiles

### DIFF
--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
@@ -373,7 +373,7 @@ func unregister_profile(profile_id: StringName) -> bool:
 		or _notification_depth > 0
 		or profile == null
 		or domain == null
-		or domain.active_profile_id != &""
+		or domain.active_profile_id == profile_id
 		or domain.current_transaction != null
 		or domain.reconcile_lease != null
 	):

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -124,6 +124,7 @@
 - 修复共享 Provider 的 Profile 切换由项目拼接 flush/load 时缺少原子活动身份、目标失败后
   可能遗留部分应用状态的问题；新 Coordinator 在精确 domain 锁内完成源屏障、逆序恢复
   与单次身份提交。
+- 修复 `GFSaveProfileTransactionCoordinator.unregister_profile()` 因 domain 存在任意活动身份而拒绝注销空闲非活动 Profile 的问题；活动目标、进行中的事务和 reconcile fence 仍失败关闭。
 - 修复 section 修改与保存分离时，已知写入失败、未知提交和生命周期关闭之间没有统一
   所有权的问题；类型化 mutation 现在区分可逆确定失败与必须 fence 的未知结果。
 - 修复异步 UI 的全局完成遥测缺少请求身份，可能被同键重入或旧生命周期迟到回调误关联的问题；Router 现在在发出可重入信号前原子移除旧 pending，并以单调 request ID 与精确底层句柄双重校验终态。

--- a/docs/zh/extensions/save-graph/save-profile-transactions.md
+++ b/docs/zh/extensions/save-graph/save-profile-transactions.md
@@ -33,6 +33,8 @@ Profile 应通过 Coordinator 的 `register_profile()` / `unregister_profile()` 
 `flush_profile()`，供普通游戏状态与自动保存继续使用；直接 `load_profile()`、非活动
 Profile 的 save/flush，以及事务或 reconcile fence 期间的全部直接原语都会被拒绝。
 活动身份变更和原子 section 修改必须经 Coordinator，否则无法维持 domain 串行化。
+同一 domain 已有活动身份时，仍可注销空闲的非活动成员；活动成员、进行中的事务或
+reconcile fence 仍拒绝注销，成功注销会使该 domain 的 recovery lease 失效。
 
 ## 严格激活与切换
 

--- a/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
@@ -100,6 +100,85 @@ func test_registration_uses_exact_ordered_provider_topology_and_rejects_overlap(
 	assert_true(_profile_utility.get_profile_state_snapshot(partial_profile.profile_id).is_empty())
 
 
+func test_unregister_inactive_profile_after_shared_domain_transaction_settles() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 0)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var active_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.unregister.active",
+		providers
+	)
+	var inactive_profile: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.unregister.inactive",
+		providers
+	)
+	assert_true(_register(active_profile))
+	assert_true(_register(inactive_profile))
+
+	var activation: GFSaveProfileTransactionOperation = _coordinator.activate_profile(
+		active_profile.profile_id
+	)
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_count(), 1)
+	assert_false(
+		_coordinator.unregister_profile(inactive_profile.profile_id),
+		"共享 domain 的事务尚未结算时仍不得注销空闲成员。"
+	)
+	assert_false(
+		_coordinator.get_domain_state_snapshot(inactive_profile.profile_id).is_empty()
+	)
+	_storage.complete_next_load(GFSaveProfileTransactionTestSupport.read_success(
+		GFSaveProfileTransactionTestSupport.make_document(
+			active_profile,
+			{ &"state": { "value": 17 } }
+		)
+	))
+	assert_true(activation.is_completed())
+	assert_true(activation.get_result().is_successful())
+
+	var domain_before: Dictionary = _coordinator.get_domain_state_snapshot(
+		active_profile.profile_id
+	)
+	var domain_id: int = GFVariantData.get_option_int(domain_before, "domain_id")
+	assert_eq(
+		_coordinator.get_active_profile_id(inactive_profile.profile_id),
+		active_profile.profile_id
+	)
+	assert_true(
+		_coordinator.unregister_profile(inactive_profile.profile_id),
+		"活动 sibling 不应阻止注销已空闲的非活动 Profile。"
+	)
+	assert_true(
+		_coordinator.get_domain_state_snapshot(inactive_profile.profile_id).is_empty()
+	)
+	assert_true(
+		_profile_utility.get_profile_state_snapshot(inactive_profile.profile_id).is_empty()
+	)
+	var domain_after: Dictionary = _coordinator.get_domain_state_snapshot(
+		active_profile.profile_id
+	)
+	assert_eq(GFVariantData.get_option_int(domain_after, "domain_id"), domain_id)
+	assert_eq(
+		GFVariantData.get_option_string_name(domain_after, "active_profile_id"),
+		active_profile.profile_id
+	)
+	assert_eq(
+		GFVariantData.get_option_packed_string_array(domain_after, "profile_ids"),
+		PackedStringArray([String(active_profile.profile_id)])
+	)
+	assert_false(
+		_coordinator.unregister_profile(active_profile.profile_id),
+		"当前活动 Profile 自身仍必须拒绝注销。"
+	)
+	assert_false(
+		_coordinator.get_domain_state_snapshot(active_profile.profile_id).is_empty()
+	)
+	assert_false(
+		_profile_utility.get_profile_state_snapshot(active_profile.profile_id).is_empty()
+	)
+
+
 func test_disjoint_provider_domains_activate_concurrently() -> void:
 	var first_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
 		GFSaveProfileTransactionTestSupport.make_provider(&"first", 0)


### PR DESCRIPTION
## Summary

Allow `GFSaveProfileTransactionCoordinator.unregister_profile()` to remove an idle inactive profile when another profile in the same provider domain is active.

The previous guard rejected every unregister operation whenever the domain had any active identity. The guard now rejects only the active target profile itself while preserving the existing domain transaction, reconcile fence, admission, notification, and lower-level profile-state checks.

Fixes #90.

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: an idle inactive profile can be unregistered without deactivating its active sibling.
- API or extension contract: method signature and result contract are unchanged.
- Persisted data, package, protocol, or ProjectSettings impact: none.
- Failure, cancellation, rollback, concurrency, and ownership impact: the active target remains protected; an in-flight domain transaction and reconcile fence still reject unregister; lower-level pending operations and detached writes remain authoritative blockers.
- Compatibility and migration: no migration required.

## Verification

- [x] Regression demonstrated the old guard rejects an idle inactive sibling after activation settles.
- [x] Focused `test_gf_save_profile_session_transactions.gd`: 18/18 tests, 230 assertions.
- [x] The regression also covers transaction-time rejection, active-target rejection, coordinator cleanup, utility cleanup, and active-domain preservation.
- [x] GDScript warning gate.
- [x] GDScript LSP gate: 1279 files, zero diagnostics.
- [x] Changelog, public API, `@since`, dependency, docs-quality, and public-docs boundary checks.
- [x] `python tools/gf_maintenance.py check --suite full --jobs 3 --json`: 41/41 checks.
- [x] `git diff --check`.

## Documentation and Release

- [x] The Save Profile transaction guide documents inactive-member unregister behavior.
- [x] The `[未发布]` changelog records the fix.
- [x] Public API shape, extension version, and development version are unaffected.
- [x] This PR does not create a tag or publish a release.
