### PR TITLE
Capture panel focus before tree entry

### DIFF
--- a/addons/gf/standard/utilities/ui/gf_ui_utility.gd
+++ b/addons/gf/standard/utilities/ui/gf_ui_utility.gd
@@ -1462,6 +1462,7 @@ func _add_panel_instance(
 			push_warning("[GFUIUtility] config_callback 销毁了面板实例，本次入栈已取消。")
 			return false
 
+	_capture_previous_focus(panel, normalized_options, canvas.get_viewport())
 	if panel.get_parent() != null and panel.get_parent() != canvas:
 		panel.get_parent().remove_child(panel)
 	if panel.get_parent() != canvas:
@@ -1473,7 +1474,6 @@ func _add_panel_instance(
 		_on_panel_tree_exited.bind(panel, layer),
 		CONNECT_ONE_SHOT as Object.ConnectFlags
 	) as Error
-	_capture_previous_focus(panel, normalized_options)
 	_apply_open_focus_policy(panel, normalized_options)
 	_sync_layer_visibility(layer)
 	panel_opened.emit(panel, layer)
@@ -1586,10 +1586,13 @@ func _normalize_panel_options(options: Dictionary, layer: int) -> Dictionary:
 	}
 
 
-func _capture_previous_focus(panel: Node, options: Dictionary) -> void:
+func _capture_previous_focus(
+	panel: Node,
+	options: Dictionary,
+	viewport: Viewport
+) -> void:
 	if not GFVariantData.get_option_bool(options, "restore_focus_on_close", false):
 		return
-	var viewport: Viewport = panel.get_viewport()
 	if viewport == null:
 		return
 	var focused: Control = viewport.gui_get_focus_owner()

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -106,6 +106,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFUIUtility` 在 panel 入树并执行 `_ready()` 后才捕获 previous focus，导致 modal 在 `_ready()` 主动取得焦点时无法恢复外部焦点的问题；现在会从目标 `CanvasLayer` 的 `Viewport` 在入树前捕获。
 - 修复共享资源与存储的取消、替换、恢复和释放边界：Broker 会在 queued Lease 离开后按剩余消费者重算类型与 admission 约束；Asset、Scene 与 BackgroundWork 私有 Broker 在 drain 完成前拒绝替换；Scene 自动邻居可加入外部消费者已活动且 type hint 兼容的同路径请求；BackgroundWork 不会把新任务并入已取消 Lease；Storage 异步单文件入口会按完整多文件事务恢复，并在 dispose 终态回调重入期间持续关闭新 admission。
 - 修复 AI Developer 依赖分析只编译 Module roots、导致合法 Module → Adapter 资源引用被误报为未归属的问题；Adapter root 与其中声明的 `class_name` 现在作为目标所有权进入同一有界索引，但 Adapter 仍不作为依赖源或模块循环节点，缺失、不安全、不可读、歧义及预算耗尽继续失败关闭。
 - 修复依赖所有权计划允许 Module/Adapter ID 占用 `gf`、`godot` 保留 token，以及目录枚举错误被 `os.walk()` 静默跳过的问题；共享命名空间现在统一拒绝保留与重复 ID，任一后代枚举失败都会使分析不完整。Module 与 Adapter 扫描只允许经路径安全校验的普通 `.gdignore` 文件剪除根或后代子树；链接、损坏或不可验证的同名条目不会再静默隐藏源码，而会计入不安全路径并使分析不完整。

--- a/tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd
+++ b/tests/gf_core/standard/utilities/ui/test_gf_ui_utility.gd
@@ -88,6 +88,17 @@ class SampleModalPanel extends Control:
 		return true
 
 
+class ReadyFocusPanel extends Control:
+	var focus_button: Button = Button.new()
+
+	func _init() -> void:
+		focus_button.focus_mode = Control.FOCUS_ALL
+		add_child(focus_button)
+
+	func _ready() -> void:
+		focus_button.grab_focus()
+
+
 class ModalCallbackState:
 	var result: GFModalResult = null
 	var status: StringName = &""
@@ -472,6 +483,35 @@ func test_keep_focus_inside_top_modal() -> void:
 	assert_true(corrected, "焦点落在 modal 外部时应能被拉回 modal 内部。")
 	assert_eq(get_viewport().gui_get_focus_owner(), inside, "焦点应移动到 modal 内第一个可聚焦控件。")
 
+	outside.queue_free()
+
+
+func test_modal_restores_focus_captured_before_panel_ready() -> void:
+	var outside: Button = Button.new()
+	outside.focus_mode = Control.FOCUS_ALL
+	add_child(outside)
+	outside.grab_focus()
+	assert_same(get_viewport().gui_get_focus_owner(), outside)
+
+	var panel: ReadyFocusPanel = ReadyFocusPanel.new()
+	_ui_utility.push_panel_instance_with_options(panel, GFUIUtility.Layer.POPUP, {
+		"modal": true,
+		"focus_on_open": false,
+		"restore_focus_on_close": true,
+	})
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		panel.focus_button,
+		"面板 _ready() 应能同步取得焦点。"
+	)
+
+	_ui_utility.pop_panel(GFUIUtility.Layer.POPUP, false)
+	assert_same(
+		get_viewport().gui_get_focus_owner(),
+		outside,
+		"关闭面板时应恢复其入树前的外部焦点。"
+	)
+	panel.queue_free()
 	outside.queue_free()
 
 


### PR DESCRIPTION
## Summary

- capture the previous GUI focus from the target CanvasLayer viewport before a panel enters the tree
- preserve the focus that existed before a panel's synchronous `_ready()` callback can grab focus
- add a regression panel whose `_ready()` focuses an internal button, then verify closing restores the external button

Fixes #91

## Contract and risk

This changes only the internal capture timing. Public API signatures, panel option schema, modal ordering, and close behavior remain unchanged. The config callback still runs before capture, so a callback that rejects or destroys the panel leaves no stale focus entry.

## Verification

- focused UI GUT: 43/43 tests, 231 assertions
- red/green regression: old implementation restored null; fixed implementation restores the external focus owner
- targeted maintenance gates: 8/8
- full maintenance suite: 41/41
- GDScript LSP: 1,279 files, 0 diagnostics
- `git diff --check`

## Documentation and release

- updated the unreleased changelog
- no generated API reference or version bump required