### PR TITLE
Make scene preload cancellation idempotent

### DIFF
--- a/addons/gf/standard/utilities/scene/gf_scene_utility.gd
+++ b/addons/gf/standard/utilities/scene/gf_scene_utility.gd
@@ -756,6 +756,8 @@ func cancel_scene_preload(path: String) -> void:
 		return
 
 	var request: Dictionary = _get_preload_request(scene_path)
+	if _is_preload_request_cancelled(request):
+		return
 	request["cancelled"] = true
 	_cancel_secondary_auto_neighbor_leases(
 		request,

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -109,6 +109,7 @@
 - 修复 `GFObjectPoolUtility` 的同步、分批与时间预算预热在并发、回调重入或运行中缩小上限时可共同写穿 `max_available_per_scene` 的问题；同一场景现在共享当前生命周期的在途容量预留，变更上限、归还节点或 dispose/init 会在提交前重新验收并丢弃过期候选。
 - 修复项目 Installer 主动取消并返回后仍保持 running、并发 `Gf.init()` 永久等待且半注册模块未回滚的问题；取消与 timeout 等失败入口现在统一在 Architecture 失败结算中先回滚再恰好一次唤醒等待方，terminal 回调不能重开或提交 Installer，detached 旧 continuation 收尾前继续阻止重试和迟到写入。
 - 修复 `GFUIUtility` 在 panel 入树并执行 `_ready()` 后才捕获 previous focus，导致 modal 在 `_ready()` 主动取得焦点时无法恢复外部焦点的问题；现在会从目标 `CanvasLayer` 的 `Viewport` 在入树前捕获。
+- 修复同一路径的场景预加载在底层请求 drain 前重复调用 `cancel_scene_preload()`、导致 Lease 取消副作用和 `scene_preload_cancelled` 信号重复发生的问题；首次调用后，同一规范化路径的后续调用会保持幂等，不改变既有的迟到完成清理和共享 path-level 取消边界。
 - 修复共享资源与存储的取消、替换、恢复和释放边界：Broker 会在 queued Lease 离开后按剩余消费者重算类型与 admission 约束；Asset、Scene 与 BackgroundWork 私有 Broker 在 drain 完成前拒绝替换；Scene 自动邻居可加入外部消费者已活动且 type hint 兼容的同路径请求；BackgroundWork 不会把新任务并入已取消 Lease；Storage 异步单文件入口会按完整多文件事务恢复，并在 dispose 终态回调重入期间持续关闭新 admission。
 - 修复 AI Developer 模块依赖分析只排除小写 `res://addons/gf/` 后代、导致框架保留根本身及大小写等价路径被误报为未归属项目资源的问题；路径引用现在统一复用框架保留资源边界判定，其他资源形状字符串的现行分类策略保持不变。
 - 修复 AI Developer 依赖分析只编译 Module roots、导致合法 Module → Adapter 资源引用被误报为未归属的问题；Adapter root 与其中声明的 `class_name` 现在作为目标所有权进入同一有界索引，但 Adapter 仍不作为依赖源或模块循环节点，缺失、不安全、不可读、歧义及预算耗尽继续失败关闭。

--- a/docs/zh/standard/utilities/runtime/settings-ui-scene/scene-flow/preload-cache-map.md
+++ b/docs/zh/standard/utilities/runtime/settings-ui-scene/scene-flow/preload-cache-map.md
@@ -19,7 +19,7 @@ var snapshot := scene_util.get_scene_cache_debug_snapshot()
 print(snapshot["preload_cache"]["paths"])
 ```
 
-`get_scene_resource_state()` 可区分未加载、预加载中、已缓存和当前加载。`get_scene_resource_info()` 会额外返回固定缓存、预加载进度和文件大小信息。预加载请求可用 `cancel_scene_preload()` 或 `cancel_all_scene_preloads()` 标记取消；它只取消当前消费者 Lease、完成信号和缓存写入，不保证中止 Godot 已发起的资源线程。最后一个消费者取消后，底层请求会进入 Broker drain，迟到结果不会重新写入场景缓存。`get_scene_cache_debug_snapshot()` 的 `resource_broker` 可用于观察 active、pending、draining 与独占 admission。已缓存的场景可用 `remove_preloaded_scene()` 或 `clear_preloaded_scenes()` 手动释放；固定缓存可通过 `move_preloaded_scene_to_fixed()` / `move_preloaded_scene_to_temporary()` 在长期保留和 LRU 管理之间切换。
+`get_scene_resource_state()` 可区分未加载、预加载中、已缓存和当前加载。`get_scene_resource_info()` 会额外返回固定缓存、预加载进度和文件大小信息。预加载请求可用 `cancel_scene_preload()` 或 `cancel_all_scene_preloads()` 标记取消；它只取消当前消费者 Lease、完成信号和缓存写入，不保证中止 Godot 已发起的资源线程。同一规范化路径在请求完成清理前重复调用 `cancel_scene_preload()` 是幂等空操作，只有第一次调用会释放 Lease 并发出 `scene_preload_cancelled`。该入口仍按共享路径取消，不区分同一路径上的项目消费者身份。最后一个消费者取消后，底层请求会进入 Broker drain，迟到结果不会重新写入场景缓存。`get_scene_cache_debug_snapshot()` 的 `resource_broker` 可用于观察 active、pending、draining 与独占 admission。已缓存的场景可用 `remove_preloaded_scene()` 或 `clear_preloaded_scenes()` 手动释放；固定缓存可通过 `move_preloaded_scene_to_fixed()` / `move_preloaded_scene_to_temporary()` 在长期保留和 LRU 管理之间切换。
 
 场景路径会在缓存、后台加载参数、历史和图谱查询中规范化：去掉首尾空白，统一反斜杠为 `/`，并折叠 `res://` 下的 `.` / `..` 片段。图谱查找、相邻遍历、固定/临时列表去重和重复校验会使用 `GFResourceIdentity.cache_key`，因此 `uid://` 与 canonical `res://` 指向同一资源时不会生成重复计划；对外报告仍保留 canonical 路径，便于项目层阅读和调试。
 

--- a/tests/gf_core/standard/utilities/scene/test_gf_scene_utility.gd
+++ b/tests/gf_core/standard/utilities/scene/test_gf_scene_utility.gd
@@ -292,6 +292,90 @@ func test_cancelled_scene_preload_drains_late_completion_without_cache() -> void
 	_scene_util.threaded_resource = null
 
 
+func test_repeated_scene_preload_cancel_emits_once_before_drain() -> void:
+	var scene_path: String = "res://addons/gut/gui/NormalGui.tscn"
+	_scene_util.use_fake_threaded_resource = true
+	_scene_util.threaded_resource = _make_empty_scene()
+	watch_signals(_scene_util)
+
+	var error: Error = _scene_util.preload_scene(scene_path)
+	_scene_util.cancel_scene_preload(scene_path)
+	_scene_util.cancel_scene_preload(scene_path)
+
+	assert_eq(error, OK, "模拟预加载应成功发起。")
+	assert_signal_emit_count(
+		_scene_util,
+		"scene_preload_cancelled",
+		1,
+		"同一路径在 drain 前重复取消只应发出一次取消信号。"
+	)
+	assert_false(_scene_util.is_scene_preloading(scene_path), "首次取消后请求不应再对外显示为进行中。")
+
+	_scene_util.threaded_complete = true
+	_scene_util.tick(0.0)
+
+	assert_signal_emit_count(
+		_scene_util,
+		"scene_preload_cancelled",
+		1,
+		"迟到完成 drain 不应补发取消信号。"
+	)
+	assert_false(_scene_util.is_scene_preloaded(scene_path), "重复取消后的迟到完成不应写入缓存。")
+	_scene_util.threaded_resource = null
+
+
+func test_cancel_all_reentry_does_not_repeat_first_path_cancel_signal() -> void:
+	var first_path: String = "res://addons/gut/gui/NormalGui.tscn"
+	var second_path: String = "res://addons/gut/gui/GutRunner.tscn"
+	_scene_util.use_fake_threaded_resource = true
+	_scene_util.threaded_resource = _make_empty_scene()
+	watch_signals(_scene_util)
+
+	var first_error: Error = _scene_util.preload_scene(first_path)
+	var second_error: Error = _scene_util.preload_scene(second_path)
+	var cancel_all_on_first: Callable = func(_cancelled_path: String) -> void:
+		_scene_util.cancel_all_scene_preloads()
+	var connect_error: Error = _scene_util.scene_preload_cancelled.connect(
+		cancel_all_on_first,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+
+	_scene_util.cancel_scene_preload(first_path)
+
+	assert_eq(first_error, OK, "第一个模拟预加载应成功发起。")
+	assert_eq(second_error, OK, "第二个模拟预加载应成功发起。")
+	assert_eq(connect_error, OK, "一次性取消回调应成功连接。")
+	assert_signal_emit_count(
+		_scene_util,
+		"scene_preload_cancelled",
+		2,
+		"取消信号中的 cancel_all 重入应让两个路径各终止一次。"
+	)
+	assert_signal_emitted_with_parameters(
+		_scene_util,
+		"scene_preload_cancelled",
+		[first_path],
+		0
+	)
+	assert_signal_emitted_with_parameters(
+		_scene_util,
+		"scene_preload_cancelled",
+		[second_path],
+		1
+	)
+
+	_scene_util.threaded_complete = true
+	_scene_util.tick(0.0)
+
+	assert_signal_emit_count(
+		_scene_util,
+		"scene_preload_cancelled",
+		2,
+		"两个已取消请求 drain 后不应补发取消信号。"
+	)
+	_scene_util.threaded_resource = null
+
+
 func test_scene_load_completed_is_not_emitted_when_scene_change_fails() -> void:
 	var scene_path: String = "res://addons/gut/gui/NormalGui.tscn"
 	_scene_util.put_preloaded_scene(scene_path, _make_empty_scene())


### PR DESCRIPTION
## Summary

- make repeated public path-level scene preload cancellation return before lease and signal side effects once the request is already cancelled
- add regressions for direct repeated cancellation, synchronous `cancel_all_scene_preloads()` reentry, and late completion drain
- document the idempotent public cancellation boundary without changing shared-path ownership semantics

## Scope

This is the directly repairable repeated-cancellation subproblem from #95. It does not add request-scoped typed operations, stable request IDs, independent same-path consumer leases, owner/cancellation-token binding, or a global exactly-once guarantee across internal auto-neighbor cancellation sources.

Refs #95

## Validation

- red regression on the old implementation: focused test 0/1; `scene_preload_cancelled` emitted 2 times instead of 1
- final `test_gf_scene_utility.gd`: 26/26 passed, 104 assertions, lifecycle gate passed with 0 warnings/orphans
- signal reentry regression: two pending paths each emit cancellation exactly once
- Full maintenance suite: 41/41 passed on the immediately preceding `fd1fe458` base with the exact #95 patch
- after unrelated Object Pool PR #104 advanced `main`: rebased to `a3d142f8`, then Scene tests 26/26, focused LSP 2 files/0 diagnostics, Docs 4/4, resource/asset/API/warnings gates all passed
- project-settings drift, diff check, and log hygiene: passed
