### PR TITLE
refactor(storage): confine runtime paths to storage root

### DIFF
--- a/addons/gf/standard/utilities/storage/gf_storage_async_operation.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_async_operation.gd
@@ -83,7 +83,7 @@ func get_operation() -> StringName:
 ## [br]
 ## @since 10.0.0
 ## [br]
-## @return 请求实际使用的文件名。
+## @return 已通过路径校验的请求返回规范相对文件名；校验前被拒绝时返回空字符串。
 func get_file_name() -> String:
 	return _file_name
 
@@ -172,7 +172,7 @@ func reclaim_failed_payload() -> GFStoragePayloadTransfer:
 ## [br]
 ## @param operation: 请求类型。
 ## [br]
-## @param file_name: 规范化文件名。
+## @param file_name: 当前 Storage root 内的规范相对文件名；校验前初始化请求身份时允许为空。
 ## [br]
 ## @return 首次配置成功返回 true。
 func configure_for_framework(request_id: int, operation: StringName, file_name: String) -> bool:
@@ -192,7 +192,7 @@ func configure_for_framework(request_id: int, operation: StringName, file_name: 
 ## [br]
 ## @since 10.0.0
 ## [br]
-## @param file_name: 规范化文件名。
+## @param file_name: 当前 Storage root 内的规范相对文件名。
 ## [br]
 ## @return 请求仍在等待且文件名非空时返回 true。
 func set_file_name_for_framework(file_name: String) -> bool:

--- a/addons/gf/standard/utilities/storage/gf_storage_async_result.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_async_result.gd
@@ -79,7 +79,7 @@ func get_operation() -> StringName:
 ## [br]
 ## @since 10.0.0
 ## [br]
-## @return 请求实际使用的存储相对文件名或绝对文件名。
+## @return 已通过路径校验的请求返回规范相对文件名；校验前被拒绝时返回空字符串。
 func get_file_name() -> String:
 	return _file_name
 
@@ -197,7 +197,7 @@ func to_dict() -> Dictionary:
 ## [br]
 ## @param operation: 请求类型。
 ## [br]
-## @param file_name: 规范化文件名。
+## @param file_name: 当前 Storage root 内的规范相对文件名；请求在路径校验前失败时为空。
 ## [br]
 ## @param ok: 请求是否成功。
 ## [br]

--- a/addons/gf/standard/utilities/storage/gf_storage_utility.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_utility.gd
@@ -2,6 +2,9 @@
 ##
 ## 支持槽位存档、元数据分离读取、`Resource` 存取，
 ## 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。
+## 所有公开文件与目录入口只接受当前 Storage root 内的规范相对路径；运行时不提供
+## 任意绝对路径能力，需要访问外部路径的可信编辑器工具应直接使用其自有 FileAccess 边界。
+## 这是 GF API 的词法路径与所有权边界，不是抵御同进程 FileAccess、宿主链接或挂载点的文件系统沙箱。
 ## 该混淆不提供安全加密能力，请勿用于保护敏感数据。
 ## `Resource` 存取只面向项目生成或项目已确认来源与格式的本地文件；它不是未确认来源资源的沙盒化导入器。
 ## [br]
@@ -86,9 +89,11 @@ const DEFAULT_MAX_LISTED_FILES: int = 10000
 ## @api public
 var encrypt_key: int = 42
 
-## 保存子目录名；为空时直接写入 `user://`。
+## 保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 var save_dir_name: String = "saves"
 
 ## 存档 codec。为 null 时会自动创建默认 GFStorageCodec。
@@ -133,13 +138,6 @@ var require_integrity_checksum: bool = true
 ## [br]
 ## @since 9.0.0
 var include_storage_metadata: bool = false
-
-## 是否允许传入绝对路径。关闭后绝对路径会被拒绝。
-## [br]
-## @api public
-## [br]
-## @since 2.0.0
-var allow_absolute_paths: bool = false
 
 ## 是否允许通过 `load_resource()` 调用 Godot `ResourceLoader`。默认关闭，避免未确认来源文件进入资源加载链路。
 ## [br]
@@ -243,6 +241,8 @@ func init() -> void:
 	_ensure_storage_helpers()
 	ignore_pause = true
 	var dir_path: String = _get_save_base_path()
+	if dir_path.is_empty():
+		return
 	var dir_error: Error = _ensure_directory_absolute(dir_path)
 	if dir_error != OK:
 		push_error("[GFStorageUtility] 无法初始化存储目录：%s，错误码：%s" % [dir_path, dir_error])
@@ -432,9 +432,11 @@ func ensure_directory(directory_name: String = "") -> Error:
 		return ERR_UNAVAILABLE
 	if not _validate_public_directory_name(directory_name, "ensure_directory"):
 		return ERR_INVALID_PARAMETER
-	init()
 	var normalized_directory: String = _normalize_storage_directory_name(directory_name)
 	var path: String = _get_full_directory_path_from_normalized(normalized_directory)
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	init()
 	var error: Error = _ensure_directory_absolute(path)
 	if error != OK:
 		push_error("[GFStorageUtility] 无法创建目录：%s，错误码：%s" % [path, error])
@@ -461,6 +463,8 @@ func get_storage_directory_path(directory_name: String = "") -> String:
 ## [br]
 ## @api public
 ## [br]
+## @since 2.3.0
+## [br]
 ## @param directory_name: 相对存储目录；为空时枚举根存储目录。
 ## [br]
 ## @param extension_filter: 可选扩展名过滤，允许传入 `"json"` 或 `".json"`。
@@ -471,7 +475,7 @@ func get_storage_directory_path(directory_name: String = "") -> String:
 ## [br]
 ## @schema options: Dictionary，包含 max_scan_depth: int 和 max_file_count: int。
 ## [br]
-## @return 存储相对文件路径数组；若传入允许的绝对目录，则返回绝对文件路径。
+## @return 当前 Storage root 内的规范相对文件路径数组。
 func list_files(
 	directory_name: String = "",
 	extension_filter: String = "",
@@ -482,10 +486,12 @@ func list_files(
 		return PackedStringArray()
 	if not _validate_public_directory_name(directory_name, "list_files"):
 		return PackedStringArray()
-	init()
 	var result: PackedStringArray = PackedStringArray()
 	var normalized_directory: String = _normalize_storage_directory_name(directory_name)
 	var directory_path: String = _get_full_directory_path_from_normalized(normalized_directory)
+	if directory_path.is_empty():
+		return result
+	init()
 	var normalized_extension: String = _normalize_extension_filter(extension_filter)
 	var max_scan_depth: int = maxi(GFVariantData.get_option_int(options, "max_scan_depth", DEFAULT_MAX_LIST_DEPTH), 0)
 	var max_file_count: int = maxi(GFVariantData.get_option_int(options, "max_file_count", DEFAULT_MAX_LISTED_FILES), 0)
@@ -673,7 +679,7 @@ func load_data(file_name: String) -> GFStorageReadResult:
 ## [br]
 ## @param file_name: 待校验文件名。
 ## [br]
-## @return 合法时返回规范化文件名；非法时返回空字符串。
+## @return 合法时返回当前 Storage root 内的规范相对文件名；非法时返回空字符串。
 func canonicalize_data_file_name(file_name: String) -> String:
 	if not _validate_public_file_name(file_name, "canonicalize_data_file_name"):
 		return ""
@@ -712,8 +718,7 @@ func save_data_async(file_name: String, data: Dictionary) -> Error:
 ## @return 已配置的请求句柄；输入无效或启动失败时句柄立即进入失败终态。
 func save_data_request_async(file_name: String, data: Dictionary) -> GFStorageAsyncOperation:
 	var operation: GFStorageAsyncOperation = _make_async_operation(
-		GFStorageAsyncOperation.OPERATION_SAVE,
-		file_name
+		GFStorageAsyncOperation.OPERATION_SAVE
 	)
 	var _error: Error = _enqueue_async_save(file_name, data, operation, "save_data_request_async")
 	return operation
@@ -740,8 +745,7 @@ func save_payload_request_async(
 	transfer: GFStoragePayloadTransfer
 ) -> GFStorageAsyncOperation:
 	var operation: GFStorageAsyncOperation = _make_async_operation(
-		GFStorageAsyncOperation.OPERATION_SAVE,
-		file_name
+		GFStorageAsyncOperation.OPERATION_SAVE
 	)
 	var _error: Error = _enqueue_async_payload_save(
 		file_name,
@@ -776,8 +780,7 @@ func load_data_async(file_name: String) -> Error:
 ## @return 已配置的请求句柄；输入无效或启动失败时句柄立即进入失败终态。
 func load_data_request_async(file_name: String) -> GFStorageAsyncOperation:
 	var operation: GFStorageAsyncOperation = _make_async_operation(
-		GFStorageAsyncOperation.OPERATION_LOAD,
-		file_name
+		GFStorageAsyncOperation.OPERATION_LOAD
 	)
 	var _error: Error = _enqueue_async_load(file_name, operation, "load_data_request_async")
 	return operation
@@ -915,20 +918,19 @@ func get_registered_migrations() -> Array[Dictionary]:
 
 # --- 私有/辅助方法 ---
 
-func _make_async_operation(operation_kind: StringName, file_name: String) -> GFStorageAsyncOperation:
+func _make_async_operation(operation_kind: StringName) -> GFStorageAsyncOperation:
 	var operation: GFStorageAsyncOperation = GFStorageAsyncOperation.new()
 	var request_id: int = _next_async_request_id
 	_next_async_request_id += 1
 	if _next_async_request_id <= 0:
 		_next_async_request_id = 1
-	var _configured: bool = operation.configure_for_framework(request_id, operation_kind, file_name)
+	var _configured: bool = operation.configure_for_framework(request_id, operation_kind, "")
 	return operation
 
 
 func _make_async_target_family(canonical_file_name: String) -> Dictionary:
 	var final_path: String = _get_full_path(canonical_file_name)
 	return {
-		"allow_absolute_paths": allow_absolute_paths,
 		"storage_root_path": _get_save_base_path(),
 		"file_key": final_path,
 		"final_path": final_path,
@@ -985,7 +987,6 @@ func _enqueue_async_save(
 		"type": &"save",
 		"file_name": file_name,
 		"storage_file_name": canonical_file_name,
-		"allow_absolute_paths": GFVariantData.get_option_bool(target_family, "allow_absolute_paths"),
 		"storage_root_path": GFVariantData.get_option_string(target_family, "storage_root_path"),
 		"file_key": GFVariantData.get_option_string(target_family, "file_key"),
 		"final_path": GFVariantData.get_option_string(target_family, "final_path"),
@@ -1084,7 +1085,6 @@ func _enqueue_async_payload_save(
 		"type": &"save",
 		"file_name": file_name,
 		"storage_file_name": canonical_file_name,
-		"allow_absolute_paths": GFVariantData.get_option_bool(target_family, "allow_absolute_paths"),
 		"storage_root_path": GFVariantData.get_option_string(target_family, "storage_root_path"),
 		"file_key": target_file_key,
 		"final_path": GFVariantData.get_option_string(target_family, "final_path"),
@@ -1140,7 +1140,6 @@ func _enqueue_async_load(
 		"type": &"load",
 		"file_name": file_name,
 		"storage_file_name": canonical_file_name,
-		"allow_absolute_paths": GFVariantData.get_option_bool(target_family, "allow_absolute_paths"),
 		"storage_root_path": GFVariantData.get_option_string(target_family, "storage_root_path"),
 		"file_key": GFVariantData.get_option_string(target_family, "file_key"),
 		"final_path": GFVariantData.get_option_string(target_family, "final_path"),
@@ -1227,7 +1226,9 @@ func _release_storage_helpers() -> void:
 
 
 func _ensure_directory_absolute(path: String) -> Error:
-	if path.is_empty() or DirAccess.dir_exists_absolute(path):
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	if DirAccess.dir_exists_absolute(path):
 		return OK
 	return DirAccess.make_dir_recursive_absolute(path)
 
@@ -1275,10 +1276,6 @@ func _get_task_file_name(task: Dictionary) -> String:
 
 func _get_task_storage_file_name(task: Dictionary) -> String:
 	return GFVariantData.get_option_string(task, "storage_file_name", _get_task_file_name(task))
-
-
-func _get_task_allow_absolute_paths(task: Dictionary) -> bool:
-	return GFVariantData.get_option_bool(task, "allow_absolute_paths")
 
 
 func _get_task_storage_root_path(task: Dictionary) -> String:
@@ -1435,15 +1432,16 @@ func _start_async_task(task: Dictionary) -> void:
 
 func _recover_frozen_async_transaction(task: Dictionary) -> Error:
 	var storage_file_name: String = _get_task_storage_file_name(task)
-	var allow_frozen_absolute_paths: bool = _get_task_allow_absolute_paths(task)
 	var storage_root_path: String = _get_task_storage_root_path(task)
 	var final_path: String = _get_task_final_path(task)
 	var temp_path: String = _get_task_temp_path(task)
 	var backup_path: String = _get_task_backup_path(task)
 	var transaction_path: String = _get_task_transaction_path(task)
+	_ensure_storage_helpers()
 	if (
 		storage_file_name.is_empty()
 		or storage_root_path.is_empty()
+		or not _path_policy._is_valid_frozen_storage_root_path(storage_root_path)
 		or final_path.is_empty()
 		or temp_path.is_empty()
 		or backup_path.is_empty()
@@ -1451,10 +1449,8 @@ func _recover_frozen_async_transaction(task: Dictionary) -> Error:
 		or _get_task_file_key(task) != final_path
 	):
 		return ERR_INVALID_PARAMETER
-	_ensure_storage_helpers()
 	var frozen_path_policy: _FrozenStoragePathPolicy = _FrozenStoragePathPolicy.new(
-		storage_root_path,
-		allow_frozen_absolute_paths
+		storage_root_path
 	)
 	var frozen_transaction_manager: _StorageTransactionManager = _StorageTransactionManager.new(
 		self,
@@ -1466,8 +1462,7 @@ func _recover_frozen_async_transaction(task: Dictionary) -> Error:
 		final_path,
 		temp_path,
 		backup_path,
-		transaction_path,
-		allow_frozen_absolute_paths
+		transaction_path
 	)
 	frozen_transaction_manager._dispose()
 	frozen_path_policy._dispose()
@@ -2390,6 +2385,12 @@ func _set_payload_validation_failure(
 
 
 func _load_data_thread(_file_name: String, path: String, codec_options: Dictionary) -> Dictionary:
+	if path.is_empty():
+		return _make_thread_load_failure(
+			"Storage path is invalid",
+			ERR_INVALID_PARAMETER,
+			GFStorageReadResult.FailureKind.INVALID_REQUEST
+		)
 	if not FileAccess.file_exists(path):
 		return _make_thread_load_failure(
 			"File not found",
@@ -2444,6 +2445,8 @@ func _write_buffer_absolute(path: String, bytes: PackedByteArray) -> Error:
 
 
 func _copy_file_bytes(source_path: String, target_path: String) -> Error:
+	if source_path.is_empty() or target_path.is_empty():
+		return ERR_INVALID_PARAMETER
 	var source_file: FileAccess = FileAccess.open(source_path, FileAccess.READ)
 	if source_file == null:
 		return FileAccess.get_open_error()
@@ -2561,6 +2564,8 @@ func _append_listed_files(
 	max_file_count: int,
 	scan_state: Dictionary
 ) -> void:
+	if directory_path.is_empty():
+		return
 	if not _can_append_listed_file(result, max_file_count):
 		_warn_list_file_limit(max_file_count, scan_state)
 		return
@@ -2670,16 +2675,18 @@ func _validate_public_file_name(file_name: String, operation: String) -> bool:
 		return false
 	if not _is_safe_storage_path(file_name, "file_name"):
 		return false
-	return true
+	return not _get_save_base_path().is_empty()
 
 
 func _validate_public_directory_name(directory_name: String, operation: String) -> bool:
-	if directory_name.is_empty() or directory_name == ".":
-		return true
-	if not _is_safe_storage_path(directory_name, "directory_name"):
+	if (
+		not directory_name.is_empty()
+		and directory_name != "."
+		and not _is_safe_storage_path(directory_name, "directory_name")
+	):
 		push_error("[GFStorageUtility] %s 失败：directory_name 非法。" % operation)
 		return false
-	return true
+	return not _get_save_base_path().is_empty()
 
 
 func _is_parent_directory_path(path: String) -> bool:
@@ -3127,53 +3134,88 @@ class _StoragePathPolicy:
 			return fallback
 		return str(value)
 
-	func _get_bool_property(property_name: String, fallback: bool = false) -> bool:
-		var value: Variant = _get_owner_property(property_name)
-		if value is bool:
-			return value
-		if value is int:
-			var int_value: int = value
-			return int_value != 0
-		if value is float:
-			var float_value: float = value
-			return not is_zero_approx(float_value)
-		return fallback
-
 	func _get_save_base_path() -> String:
 		var save_dir_name: String = _get_string_property("save_dir_name")
 		if save_dir_name.is_empty():
 			return "user://"
-		return "user://" + _sanitize_storage_relative_path(save_dir_name, "save_dir_name")
+		if _is_absolute_storage_path(save_dir_name):
+			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % save_dir_name)
+			return ""
+		if _contains_parent_segment(save_dir_name):
+			push_error("[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：%s" % save_dir_name)
+			return ""
+		if _has_invalid_storage_root_character(save_dir_name):
+			push_error("[GFStorageUtility] save_dir_name 包含不支持的字符：%s" % save_dir_name)
+			return ""
+		var normalized_save_dir_name: String = save_dir_name.replace("\\", "/").simplify_path()
+		if (
+			normalized_save_dir_name.is_empty()
+			or normalized_save_dir_name == "."
+			or normalized_save_dir_name != save_dir_name
+		):
+			push_error("[GFStorageUtility] save_dir_name 必须是规范相对目录：%s" % save_dir_name)
+			return ""
+		return "user://" + normalized_save_dir_name
+
+	func _is_absolute_storage_path(path: String) -> bool:
+		return path.replace("\\", "/").is_absolute_path()
+
+	func _has_invalid_storage_root_character(path: String) -> bool:
+		const FORBIDDEN_CHARACTERS: String = "<>:\"|?*"
+		for index: int in range(path.length()):
+			var codepoint: int = path.unicode_at(index)
+			if codepoint < 32 or codepoint == 127:
+				return true
+			if FORBIDDEN_CHARACTERS.contains(String.chr(codepoint)):
+				return true
+		return false
+
+	func _is_valid_frozen_storage_root_path(storage_root_path: String) -> bool:
+		if storage_root_path == "user://":
+			return true
+		if not storage_root_path.begins_with("user://"):
+			return false
+		var relative_root: String = storage_root_path.trim_prefix("user://")
+		if (
+			relative_root.is_empty()
+			or relative_root.begins_with("/")
+			or relative_root.contains("\\")
+			or _contains_parent_segment(relative_root)
+			or _has_invalid_storage_root_character(relative_root)
+		):
+			return false
+		return relative_root == relative_root.simplify_path()
 
 	func _get_full_path(file_name: String) -> String:
-		if file_name.is_absolute_path():
-			if _get_bool_property("allow_absolute_paths"):
-				return file_name
+		if _is_absolute_storage_path(file_name):
 			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % file_name)
 			return ""
 
 		file_name = _sanitize_storage_relative_path(file_name, "file_name")
 		if file_name.is_empty():
 			return ""
-		if _get_string_property("save_dir_name").is_empty():
+		var storage_root_path: String = _get_save_base_path()
+		if storage_root_path.is_empty():
+			return ""
+		if storage_root_path == "user://":
 			return "user://" + file_name
-		return _get_save_base_path() + "/" + file_name
+		return storage_root_path + "/" + file_name
 
 	func _get_full_directory_path_from_normalized(directory_name: String) -> String:
-		if directory_name.is_empty():
-			return _get_save_base_path()
-		if directory_name.is_absolute_path():
-			return directory_name
-		if _get_string_property("save_dir_name").is_empty():
+		if _is_absolute_storage_path(directory_name):
+			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % directory_name)
+			return ""
+		var storage_root_path: String = _get_save_base_path()
+		if storage_root_path.is_empty() or directory_name.is_empty():
+			return storage_root_path
+		if storage_root_path == "user://":
 			return "user://" + directory_name
-		return _get_save_base_path().path_join(directory_name)
+		return storage_root_path.path_join(directory_name)
 
 	func _normalize_storage_directory_name(directory_name: String) -> String:
 		if directory_name.is_empty() or directory_name == ".":
 			return ""
-		if directory_name.is_absolute_path():
-			if _get_bool_property("allow_absolute_paths"):
-				return directory_name.replace("\\", "/").simplify_path()
+		if _is_absolute_storage_path(directory_name):
 			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % directory_name)
 			return "_invalid_storage_directory"
 
@@ -3221,17 +3263,13 @@ class _StoragePathPolicy:
 		return false
 
 	func _canonicalize_file_name(path: String, label: String) -> String:
-		if path.is_absolute_path():
-			if not _get_bool_property("allow_absolute_paths"):
-				push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
-				return ""
-			return path.replace("\\", "/").simplify_path()
+		if _is_absolute_storage_path(path):
+			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
+			return ""
 		return _sanitize_storage_relative_path(path, label)
 
 	func _is_safe_storage_path(path: String, label: String) -> bool:
-		if path.is_absolute_path():
-			if _get_bool_property("allow_absolute_paths"):
-				return true
+		if _is_absolute_storage_path(path):
 			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
 			return false
 
@@ -3252,21 +3290,17 @@ class _StoragePathPolicy:
 
 class _FrozenStoragePathPolicy extends _StoragePathPolicy:
 	var _storage_root_path: String
-	var _allow_absolute_paths: bool
 
-	func _init(storage_root_path: String, allow_absolute_paths: bool) -> void:
+	func _init(storage_root_path: String) -> void:
 		_storage_root_path = storage_root_path
-		_allow_absolute_paths = allow_absolute_paths
 
 	func _get_save_base_path() -> String:
 		return _storage_root_path
 
 	func _get_full_path(file_name: String) -> String:
-		if file_name.is_absolute_path():
-			if not _allow_absolute_paths:
-				push_error("[GFStorageUtility] 已禁用绝对路径：%s" % file_name)
-				return ""
-			return file_name
+		if _is_absolute_storage_path(file_name):
+			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % file_name)
+			return ""
 		file_name = _sanitize_storage_relative_path(file_name, "file_name")
 		if file_name.is_empty():
 			return ""
@@ -3275,11 +3309,9 @@ class _FrozenStoragePathPolicy extends _StoragePathPolicy:
 		return _storage_root_path + "/" + file_name
 
 	func _canonicalize_file_name(path: String, label: String) -> String:
-		if path.is_absolute_path():
-			if not _allow_absolute_paths:
-				push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
-				return ""
-			return path.replace("\\", "/").simplify_path()
+		if _is_absolute_storage_path(path):
+			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
+			return ""
 		return _sanitize_storage_relative_path(path, label)
 
 
@@ -3342,6 +3374,8 @@ class _StorageFileOps:
 			push_warning("[GFStorageUtility] 删除文件失败：%s，错误码：%s" % [path, remove_error])
 
 	func _ensure_absolute_parent_directory(path: String) -> Error:
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
 		var base_dir: String = path.get_base_dir()
 		if base_dir.is_empty() or base_dir == "user://":
 			return OK
@@ -3350,6 +3384,8 @@ class _StorageFileOps:
 		return DirAccess.make_dir_recursive_absolute(base_dir)
 
 	func _ensure_parent_directory(path: String) -> Error:
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
 		if not _get_bool_property("create_directories_for_nested_paths"):
 			return OK
 
@@ -3365,6 +3401,8 @@ class _StorageFileOps:
 		return error
 
 	func _write_buffer_absolute(path: String, bytes: PackedByteArray) -> Error:
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
 		var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
 		if file == null:
 			return FileAccess.get_open_error()
@@ -3374,6 +3412,8 @@ class _StorageFileOps:
 		return error
 
 	func _write_plain_json_absolute(path: String, data: Dictionary) -> Error:
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
 		var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
 		if file == null:
 			return FileAccess.get_open_error()
@@ -3389,12 +3429,16 @@ class _StorageFileOps:
 		_remove_absolute_if_exists(path)
 
 	func _move_file(from_path: String, to_path: String) -> Error:
+		if from_path.is_empty() or to_path.is_empty():
+			return ERR_INVALID_PARAMETER
 		if not FileAccess.file_exists(from_path):
 			return ERR_FILE_NOT_FOUND
 		return DirAccess.rename_absolute(from_path, to_path)
 
 	func _write_json(file_name: String, data: Dictionary) -> Error:
 		var path: String = _path_policy._get_full_path(file_name)
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
 		var dir_error: Error = _ensure_parent_directory(path)
 		if dir_error != OK:
 			return dir_error
@@ -3415,6 +3459,8 @@ class _StorageFileOps:
 
 	func _write_plain_json(file_name: String, data: Dictionary) -> Error:
 		var path: String = _path_policy._get_full_path(file_name)
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
 		var dir_error: Error = _ensure_parent_directory(path)
 		if dir_error != OK:
 			return dir_error
@@ -3489,8 +3535,7 @@ class _StorageTransactionManager:
 		final_path: String,
 		temp_path: String,
 		backup_path: String,
-		transaction_path: String,
-		allow_frozen_absolute_paths: bool
+		transaction_path: String
 	) -> Error:
 		if (
 			_path_policy._get_full_path(file_name) != final_path
@@ -3501,7 +3546,7 @@ class _StorageTransactionManager:
 			return ERR_INVALID_PARAMETER
 
 		var marker: Dictionary = _read_transaction_marker_absolute(transaction_path)
-		if _has_unauthorized_frozen_marker_member(marker, allow_frozen_absolute_paths):
+		if _has_absolute_marker_member(marker):
 			return ERR_UNAUTHORIZED
 		var transaction_files: Array[String] = _discover_transaction_marker_files(marker, file_name)
 		if transaction_files.size() > 1:
@@ -3883,12 +3928,7 @@ class _StorageTransactionManager:
 				result.append(file_name)
 		return result
 
-	func _has_unauthorized_frozen_marker_member(
-		marker: Dictionary,
-		allow_frozen_absolute_paths: bool
-	) -> bool:
-		if allow_frozen_absolute_paths:
-			return false
+	func _has_absolute_marker_member(marker: Dictionary) -> bool:
 		var raw_files: Variant = GFVariantData.get_option_value(marker, "files", [])
 		if not (raw_files is Array):
 			return false
@@ -3896,14 +3936,14 @@ class _StorageTransactionManager:
 			var file_name: String = _canonicalize_marker_file_name(
 				GFVariantData.to_text(raw_file)
 			)
-			if file_name.is_absolute_path():
+			if _path_policy._is_absolute_storage_path(file_name):
 				return true
 		return false
 
 	func _canonicalize_marker_file_name(file_name: String) -> String:
 		if file_name.is_empty():
 			return ""
-		if file_name.is_absolute_path():
+		if _path_policy._is_absolute_storage_path(file_name):
 			return file_name.replace("\\", "/").simplify_path()
 		if _path_policy._contains_parent_segment(file_name):
 			return ""

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "105c37647b4b6a41703d4ed3882ac6f14043d7b2e905084c96ede3fa6bb0c025",
+  "source_digest": "26a8cb0edc078dc6cc5b56f0f76b470e50bcf938dadc99734f917c08204a0d26",
   "class_count": 789,
   "package_count": 52,
   "packages": [
@@ -81167,7 +81167,7 @@
           "kind": "var",
           "name": "save_dir_name",
           "signature": "var save_dir_name: String = \"saves\"",
-          "summary": "保存子目录名；为空时直接写入 `user://`。",
+          "summary": "保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。",
           "visibility": "public"
         },
         {
@@ -81224,13 +81224,6 @@
           "name": "include_storage_metadata",
           "signature": "var include_storage_metadata: bool = false",
           "summary": "是否写入时间戳、编码格式和压缩方式等诊断元数据。",
-          "visibility": "public"
-        },
-        {
-          "kind": "var",
-          "name": "allow_absolute_paths",
-          "signature": "var allow_absolute_paths: bool = false",
-          "summary": "是否允许传入绝对路径。关闭后绝对路径会被拒绝。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFStorageAsyncOperation.xml
+++ b/docs/api_catalog/classes/GFStorageAsyncOperation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageAsyncOperation" path="addons/gf/standard/utilities/storage/gf_storage_async_operation.gd" module="standard" extends="RefCounted" classDigest="ef5af697d5600139f1dadc54792e4abe956dda1224b96f1825b4126873ed93e5">
+<class name="GFStorageAsyncOperation" path="addons/gf/standard/utilities/storage/gf_storage_async_operation.gd" module="standard" extends="RefCounted" classDigest="cbcc52e7f4693e4e1c4fd8aaf8ae5cba3e38feca504570921e31a39053527691">
 	<description>GFStorageAsyncOperation: 单次异步存储请求句柄。
 句柄由 `GFStorageUtility` 分配唯一请求 ID，并且只接受一个终态。调用方应先
 检查 `is_completed()`，再决定是否等待 `completed` 信号。</description>
@@ -63,7 +63,7 @@
 			<description>获取规范化存储文件名。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">请求实际使用的文件名。</tag>
+				<tag name="return">已通过路径校验的请求返回规范相对文件名；校验前被拒绝时返回空字符串。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFStorageAsyncResult.xml
+++ b/docs/api_catalog/classes/GFStorageAsyncResult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageAsyncResult" path="addons/gf/standard/utilities/storage/gf_storage_async_result.gd" module="standard" extends="RefCounted" classDigest="28f26129816065b93a4e3cfa6949a31affef4d142a59c4709211d3992911e6a6">
+<class name="GFStorageAsyncResult" path="addons/gf/standard/utilities/storage/gf_storage_async_result.gd" module="standard" extends="RefCounted" classDigest="fb993505d167d3b286658bc5163c66c7c429a2a256e186406c42041ff14c2568">
 	<description>GFStorageAsyncResult: 单次异步存储请求的不可变终态。
 结果通过请求 ID 与具体句柄绑定；读取结果保留 `GFStorageReadResult` 的类型化
 失败分类；写入结果额外暴露稳定写入失败分类与隔离的 payload 预检报告。</description>
@@ -60,7 +60,7 @@
 			<description>获取规范化存储文件名。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">请求实际使用的存储相对文件名或绝对文件名。</tag>
+				<tag name="return">已通过路径校验的请求返回规范相对文件名；校验前被拒绝时返回空字符串。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFStorageUtility.xml
+++ b/docs/api_catalog/classes/GFStorageUtility.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="5ec43970f594a2213d612fdb8a22bff66a7eb291823462a37ee3db86872b3686">
+<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="1362022a7a63c35105242627cddef6fa42ca7244f236a0494ca651b7f834a1e3">
 	<description>GFStorageUtility: 基于 `user://` 的轻量存档系统。
 支持槽位存档、元数据分离读取、`Resource` 存取，
 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。
+所有公开文件与目录入口只接受当前 Storage root 内的规范相对路径；运行时不提供
+任意绝对路径能力，需要访问外部路径的可信编辑器工具应直接使用其自有 FileAccess 边界。
+这是 GF API 的词法路径与所有权边界，不是抵御同进程 FileAccess、宿主链接或挂载点的文件系统沙箱。
 该混淆不提供安全加密能力，请勿用于保护敏感数据。
 `Resource` 存取只面向项目生成或项目已确认来源与格式的本地文件；它不是未确认来源资源的沙盒化导入器。</description>
 	<tags>
@@ -77,9 +80,10 @@
 		</member>
 		<member kind="property" name="save_dir_name">
 			<signature>var save_dir_name: String = "saves"</signature>
-			<description>保存子目录名；为空时直接写入 `user://`。</description>
+			<description>保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="codec">
@@ -138,14 +142,6 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">9.0.0</tag>
-			</tags>
-		</member>
-		<member kind="property" name="allow_absolute_paths">
-			<signature>var allow_absolute_paths: bool = false</signature>
-			<description>是否允许传入绝对路径。关闭后绝对路径会被拒绝。</description>
-			<tags>
-				<tag name="api">public</tag>
-				<tag name="since">2.0.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="allow_resource_loads">
@@ -320,8 +316,9 @@
 				<tag name="param">extension_filter: 可选扩展名过滤，允许传入 `"json"` 或 `".json"`。</tag>
 				<tag name="param">recursive: 是否递归枚举子目录。</tag>
 				<tag name="param">options: 可选参数，支持 `max_scan_depth` 与 `max_file_count`。</tag>
-				<tag name="return">存储相对文件路径数组；若传入允许的绝对目录，则返回绝对文件路径。</tag>
+				<tag name="return">当前 Storage root 内的规范相对文件路径数组。</tag>
 				<tag name="schema">options: Dictionary，包含 max_scan_depth: int 和 max_file_count: int。</tag>
+				<tag name="since">2.3.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="delete_file">
@@ -374,7 +371,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">file_name: 待校验文件名。</tag>
-				<tag name="return">合法时返回规范化文件名；非法时返回空字符串。</tag>
+				<tag name="return">合法时返回当前 Storage root 内的规范相对文件名；非法时返回空字符串。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="1b21a6e7d990ef41528ff8cfca4eda11b771676780d6cbd1e2141941b4b6e96d" classCount="813" methodCount="7405">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="ed3d23f7e398c81482c86ff30b102bfe90ff6cce850ef68a7495fbfcb159d9e0" classCount="813" methodCount="7405">
 	<module id="kernel" label="Kernel" classCount="74" methodCount="793">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -64,6 +64,7 @@
 
 ### 🔄 机制更改 (Changed)
 
+- `GFStorageUtility` 的所有运行时文件与目录入口统一使用规范相对身份，并在词法上解析到当前 Storage root；同步、异步、payload transfer、目录管理和事务恢复不再存在可动态扩大的绝对路径授权，非法非空 `save_dir_name` 也不再退化到 `user://` 根。需要任意本机路径的可信编辑器或离线迁移工具改由自身 `FileAccess` / `DirAccess` 边界负责；该约束不是宿主 symlink、junction 或挂载点沙箱。
 - 播放区间在请求开始时连同 `GFAudioClip` 一起复制；本地执行始终复制 `AudioStream`，只修改 session 私有副本。异步回调、crossfade 回退和环境音 session 都携带冻结后的规范化区间。
 - 本地音频只接受引擎能够精确表达的起点和循环点，不使用 Timer、每帧轮询或近似 seek 模拟非循环有限终点；有效但无法精确执行的组合明确返回 `UNSUPPORTED`。
 - WAV 终点按最后有效帧索引写入，原生无法保持初始位置语义的 backward 明确返回 `UNSUPPORTED`；Ogg Vorbis / MP3 私有循环副本清除会改变自然终点的 `beat_count`。后端评估与执行只接收由验证结果重建的规范化 clip/context 快照。
@@ -143,6 +144,7 @@
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
+- 移除 `GFStorageUtility.allow_absolute_paths`；运行时 Storage 不再提供重新启用任意绝对路径的开关，也不保留 deprecated alias。
 - 移除 `play_bgm_with_options()` 的 `loop` / `playback_region` 通用选项，并保留事件 metadata/options 中的同名键；继续传入会在资源加载和后端派发前失败关闭，类型化区间只能来自 `GFAudioClip.playback_region`。
 - 移除框架内部 `gf_threaded_resource_coordinator.gd` 与 `gf_threaded_resource_operation.gd`；不保留双轨协调实现，统一由公开 `GFResourceBroker` / `GFResourceLease` 承担跨 Utility 所有权与 admission。
 - 移除 `GFSaveProfileUtility.save_profile(profile_id, metadata, context)` 字典重载；保存调用统一改用一次性 `GFSaveProfileRequest`，不保留隐式复制兼容路径。
@@ -154,6 +156,7 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
+- `GFStorageUtility.allow_absolute_paths` 已移除；`list_files()` 只返回 Storage root 内的规范相对路径，`canonicalize_data_file_name()`、`GFStorageAsyncOperation.get_file_name()` 与 `GFStorageAsyncResult.get_file_name()` 不再产生绝对路径身份。
 - 本轮有意移除 10.x 已公开的通用 `loop` 输入与 `current_bgm_loop` 快照字段，开发身份进入 `11.0.0-dev.0` 主版本迁移线；不提供双轨兼容分支。
 - `GFAudioClip.playback_region: GFAudioPlaybackRegion` 为新的可选公开属性。
 - `GFAudioBackendCapability.supports_playback_region_contract`、`GFAudioBackend.evaluate_playback_region()`、`GFAudioUtility.playback_region_rejected` 与 `GFAudioUtility.get_last_playback_region_rejection()` 为新的公开 API。
@@ -233,6 +236,7 @@
 29. 大型列表把项目 `ScrollContainer` 的直接子内容根、行工厂、bind/unbind、稳定 identity 和 owner 交给 `GFVirtualListBinder`；内容根不能是接管子节点位置的 `Container`。排序、过滤或数据内容提交后显式调用 `invalidate_items()`，只使用稳定且有界的标量 identity；若在 Binder callback 内失效，当前结果会是非成功 `STATUS_DEFERRED`，副作用已开始时 active 可被安全清空，调用方应以结果索引为准等待下一轮重建。需要切换 `layout_axis`、`fill_cross_axis`、`auto_measure` 或 callback 内的预算时，先更新配置并调用 `request_sync()`，当前同步轮仍使用入口快照，下一轮才采用新值。`scroll_to_item()` 返回 `false` 表示操作快照或最终整数偏移未能完整提交，调用方不要把它当作部分成功。Binder 会按每段轴所有权恢复接管前的最小尺寸。owner 退出前让 Binder 自动或显式 `dispose()`，不得重挂载或释放 Binder-owned Control。
 30. 表格结构化过滤改为继承 `GFTableRowPredicate`，返回 `GFTableRowPredicateResult`，再用 `GFTableRowPredicateRegistration.create()` 批量事务注册。将 `row_id_column`、`case_sensitive_filter` 与 `selection_model` 直接赋值迁移到 `set_row_id_column()`、`set_filter_case_sensitive()` 与 `set_selection_model()`，并通过 getter 读取已提交配置。更新所有 `view_changed` 连接以接收 revision 与 visible count；只有 rebuild result 成功且 committed，或收到 `view_changed` 时，才更新 VirtualList count 与 Binder identity，失败时继续展示上一份已提交投影。谓词实例的项目参数改变后显式调用 `refresh_view()`，不要依赖框架观察任意成员写入。经 `GFTableDataView.commit_cell_value()` 或批量入口写入的行必须可安全隔离；把带任意副作用的 `value_setter` 移到项目事务层，提交完成后再用新的 source 行调用 `set_rows()`。
 31. Spatial Canvas 输入转发改为检查 `InputDisposition`：只有 `CONSUMED` 才停止项目路由。创建并校验 `GFSpatialCanvasInputPolicy` 来替代硬编码按键；嵌套滚动界面用 modifier-gated 或 parent-only wheel，让未匹配滚轮继续 GUI 冒泡。需要禁用单指时使用 `TouchPrimaryBehavior.NONE`，并分别决定 raw 多指 pan 与 pinch zoom；若二者也都关闭，首触点不会被 Canvas 捕获。取消行为使用只含非指针事件的项目 InputMap action，不得与鼠标、触摸或位置手势复用；项目运行时修改 InputMap 后，超出事件预算或变成指针映射的取消 action 会失败关闭。
+32. 删除对 `GFStorageUtility.allow_absolute_paths` 的赋值，并把传给 Storage 的文件名、目录名统一改为当前 Storage root 内的规范相对路径。可信编辑器或离线迁移工具若需要外部路径，直接在工具层使用 `FileAccess` / `DirAccess`，不要向运行时 Utility 重新注入绝对路径能力。
 
 ### 📁 核心受影响文件 (Affected Files)
 

--- a/docs/zh/reference/api/classes/GFStorageAsyncOperation.md
+++ b/docs/zh/reference/api/classes/GFStorageAsyncOperation.md
@@ -121,7 +121,7 @@ func get_file_name() -> String:
 
 获取规范化存储文件名。
 
-返回：请求实际使用的文件名。
+返回：已通过路径校验的请求返回规范相对文件名；校验前被拒绝时返回空字符串。
 
 <a id="member-gfstorageasyncoperation-methods-is_pending"></a>
 

--- a/docs/zh/reference/api/classes/GFStorageAsyncResult.md
+++ b/docs/zh/reference/api/classes/GFStorageAsyncResult.md
@@ -102,7 +102,7 @@ func get_file_name() -> String:
 
 获取规范化存储文件名。
 
-返回：请求实际使用的存储相对文件名或绝对文件名。
+返回：已通过路径校验的请求返回规范相对文件名；校验前被拒绝时返回空字符串。
 
 <a id="member-gfstorageasyncresult-methods-is_successful"></a>
 

--- a/docs/zh/reference/api/classes/GFStorageUtility.md
+++ b/docs/zh/reference/api/classes/GFStorageUtility.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`3.17.0`
 
-基于 `user://` 的轻量存档系统。 支持槽位存档、元数据分离读取、`Resource` 存取， 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。 该混淆不提供安全加密能力，请勿用于保护敏感数据。 `Resource` 存取只面向项目生成或项目已确认来源与格式的本地文件；它不是未确认来源资源的沙盒化导入器。
+基于 `user://` 的轻量存档系统。 支持槽位存档、元数据分离读取、`Resource` 存取， 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。 所有公开文件与目录入口只接受当前 Storage root 内的规范相对路径；运行时不提供 任意绝对路径能力，需要访问外部路径的可信编辑器工具应直接使用其自有 FileAccess 边界。 这是 GF API 的词法路径与所有权边界，不是抵御同进程 FileAccess、宿主链接或挂载点的文件系统沙箱。 该混淆不提供安全加密能力，请勿用于保护敏感数据。 `Resource` 存取只面向项目生成或项目已确认来源与格式的本地文件；它不是未确认来源资源的沙盒化导入器。
 
 ## 成员概览
 
@@ -31,7 +31,6 @@
 | 属性 | [`strict_integrity`](#member-gfstorageutility-properties-strict_integrity) | `var strict_integrity: bool = true` |
 | 属性 | [`require_integrity_checksum`](#member-gfstorageutility-properties-require_integrity_checksum) | `var require_integrity_checksum: bool = true` |
 | 属性 | [`include_storage_metadata`](#member-gfstorageutility-properties-include_storage_metadata) | `var include_storage_metadata: bool = false` |
-| 属性 | [`allow_absolute_paths`](#member-gfstorageutility-properties-allow_absolute_paths) | `var allow_absolute_paths: bool = false` |
 | 属性 | [`allow_resource_loads`](#member-gfstorageutility-properties-allow_resource_loads) | `var allow_resource_loads: bool = false` |
 | 属性 | [`allowed_resource_load_extensions`](#member-gfstorageutility-properties-allowed_resource_load_extensions) | `var allowed_resource_load_extensions: PackedStringArray = PackedStringArray(["tres", "res"])` |
 | 属性 | [`allowed_resource_load_type_hints`](#member-gfstorageutility-properties-allowed_resource_load_type_hints) | `var allowed_resource_load_type_hints: PackedStringArray = PackedStringArray()` |
@@ -194,12 +193,13 @@ var encrypt_key: int = 42
 ### `save_dir_name`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var save_dir_name: String = "saves"
 ```
 
-保存子目录名；为空时直接写入 `user://`。
+保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。
 
 <a id="member-gfstorageutility-properties-codec"></a>
 
@@ -297,19 +297,6 @@ var include_storage_metadata: bool = false
 ```
 
 是否写入时间戳、编码格式和压缩方式等诊断元数据。 数据版本始终写入独立文档 metadata，不受该选项影响。
-
-<a id="member-gfstorageutility-properties-allow_absolute_paths"></a>
-
-### `allow_absolute_paths`
-
-- API：`public`
-- 首次版本：`2.0.0`
-
-```gdscript
-var allow_absolute_paths: bool = false
-```
-
-是否允许传入绝对路径。关闭后绝对路径会被拒绝。
 
 <a id="member-gfstorageutility-properties-allow_resource_loads"></a>
 
@@ -616,6 +603,7 @@ func get_storage_directory_path(directory_name: String = "") -> String:
 ### `list_files`
 
 - API：`public`
+- 首次版本：`2.3.0`
 
 ```gdscript
 func list_files( directory_name: String = "", extension_filter: String = "", recursive: bool = false, options: Dictionary = {} ) -> PackedStringArray:
@@ -632,7 +620,7 @@ func list_files( directory_name: String = "", extension_filter: String = "", rec
 | `recursive` | 是否递归枚举子目录。 |
 | `options` | 可选参数，支持 `max_scan_depth` 与 `max_file_count`。 |
 
-返回：存储相对文件路径数组；若传入允许的绝对目录，则返回绝对文件路径。
+返回：当前 Storage root 内的规范相对文件路径数组。
 
 结构：
 
@@ -749,7 +737,7 @@ func canonicalize_data_file_name(file_name: String) -> String:
 |---|---|
 | `file_name` | 待校验文件名。 |
 
-返回：合法时返回规范化文件名；非法时返回空字符串。
+返回：合法时返回当前 Storage root 内的规范相对文件名；非法时返回空字符串。
 
 <a id="member-gfstorageutility-methods-save_data_async"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 74 | 1094 | [Kernel](#module-kernel) |
-| Standard | 454 | 7245 | [Standard](#module-standard) |
+| Standard | 454 | 7244 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -267,7 +267,7 @@
 | [`GFSteeringMath`](GFSteeringMath.md#gfsteeringmath) | 运行时服务 (`runtime_service`) | `RefCounted` | 16 | `addons/gf/standard/foundation/math/gf_steering_math.gd` |
 | [`GFStorageFailoverBackend`](GFStorageFailoverBackend.md#gfstoragefailoverbackend) | 运行时服务 (`runtime_service`) | `GFStorageBackend` | 16 | `addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd` |
 | [`GFStorageSyncUtility`](GFStorageSyncUtility.md#gfstoragesyncutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 11 | `addons/gf/standard/utilities/storage/gf_storage_sync_utility.gd` |
-| [`GFStorageUtility`](GFStorageUtility.md#gfstorageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 53 | `addons/gf/standard/utilities/storage/gf_storage_utility.gd` |
+| [`GFStorageUtility`](GFStorageUtility.md#gfstorageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 52 | `addons/gf/standard/utilities/storage/gf_storage_utility.gd` |
 | [`GFSupportReportUtility`](GFSupportReportUtility.md#gfsupportreportutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 32 | `addons/gf/standard/utilities/debug/gf_support_report_utility.gd` |
 | [`GFSupportReportWorkflow`](GFSupportReportWorkflow.md#gfsupportreportworkflow) | 运行时服务 (`runtime_service`) | `GFUtility` | 23 | `addons/gf/standard/utilities/debug/gf_support_report_workflow.gd` |
 | [`GFSurfaceScatterSampler3D`](GFSurfaceScatterSampler3D.md#gfsurfacescattersampler3d) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/foundation/math/gf_surface_scatter_sampler_3d.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -6,7 +6,7 @@
 
 - 源码根目录：`addons/gf`
 - 公开类：`813`
-- 公开成员：`11994`
+- 公开成员：`11993`
 - 公开方法：`7405`
 
 ## 模块
@@ -14,7 +14,7 @@
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 74 | 1094 | 793 | [kernel.md](kernel.md) |
-| Standard | 454 | 7245 | 4582 | [standard.md](standard.md) |
+| Standard | 454 | 7244 | 4582 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 188 | 3424 | 2313 |
+| [运行时服务](#category-runtime_service) | 188 | 3423 | 2313 |
 | [协议与扩展点](#category-protocol) | 25 | 340 | 269 |
 | [资源定义](#category-resource_definition) | 122 | 1570 | 795 |
 | [运行时句柄](#category-runtime_handle) | 50 | 881 | 560 |

--- a/docs/zh/standard/utilities/io/storage-snapshot/integrity-migrations/legacy-compatibility.md
+++ b/docs/zh/standard/utilities/io/storage-snapshot/integrity-migrations/legacy-compatibility.md
@@ -6,9 +6,9 @@
 
 JSON 读取默认保留解析出的数字类型。如果旧存档列表或元数据依赖把接近整数的 float 归一为 int，可临时开启 `GFStorageUtility.normalize_json_numbers` 或 `GFStorageCodec.normalize_json_numbers` 后读出并重写。
 
-`allow_absolute_paths` 默认关闭，绝对路径会被拒绝；包含 `..` 的跨目录相对路径同样会 fail closed，不再收敛到同名文件。
+11.0 移除了 `GFStorageUtility.allow_absolute_paths`。运行时 Storage 只接受规范相对路径并在词法上解析到当前 Storage root；绝对路径、包含 `..` 的跨目录路径和非法非空 `save_dir_name` 始终 fail closed，不再提供可重新开启的兼容开关。这是 GF API 边界，不替代宿主文件系统对 symlink、junction 或挂载点的隔离。
 
-只有可信编辑器工具或迁移脚本确实需要写入外部路径时，才应显式设为 `true`。
+可信编辑器工具或一次性迁移脚本确实需要访问外部路径时，应在独立工具边界直接使用 `FileAccess` / `DirAccess`，并自行承担来源授权、路径固定和生命周期清理；不要把该能力重新包装进运行时 Storage。
 
 内置整数槽位 facade 已移除。项目应由自己的 slot adapter 定义槽位身份、文件模板、metadata schema 和枚举策略，再通过 `save_data_group()` 完成 data/meta 事务写入，通过 `load_data_result()`、`list_files()` 和 `delete_file()` 组合读取与管理。标准存储层不认识读档 UI、自动存档、预览图或项目业务槽位。
 

--- a/docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md
+++ b/docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md
@@ -166,7 +166,9 @@ if not async_result.is_successful():
 
 除槽位和字典读写外，`get_storage_directory_path()`、`ensure_directory()`、`list_files()` 与 `delete_file()` 可用于管理同一存储根目录下的通用文件，例如列出本地缩略图、缓存 manifest 或项目自定义资源文件。
 
-`get_storage_directory_path()` 只解析路径，不创建目录；需要目录实际存在时再调用 `ensure_directory()`。这些 API 复用 `GFStorageUtility` 的路径安全策略：默认拒绝绝对路径并阻止 `..` 跨目录；纯字典读写和多文件事务 API 会直接拒绝空 `file_name` 或任意非法成员，而不是写入内部兜底文件名。
+`get_storage_directory_path()` 只解析路径，不创建目录；需要目录实际存在时再调用 `ensure_directory()`。这些 API 复用 `GFStorageUtility` 的路径安全策略：所有运行时入口只接受规范相对路径，并在词法上解析到当前 Storage root；绝对路径、`..` 跨目录路径和非法非空 `save_dir_name` 始终失败关闭，不会退化到 `user://` 根。纯字典读写和多文件事务 API 会直接拒绝空 `file_name` 或任意非法成员，而不是写入内部兜底文件名。需要读取任意本机路径的可信编辑器或离线迁移工具，应在自己的工具能力边界内直接使用 `FileAccess` / `DirAccess`，不能重新扩大运行时 Storage 的权限。
+
+这是一条 GF API 的词法身份与所有权边界，不是宿主文件系统安全沙箱：同进程代码仍可直接调用 `FileAccess` / `DirAccess`，宿主预先建立的 symlink、junction、挂载点或等价重定向也不在该保证内。涉及不可信宿主环境时，应由平台沙箱和文件系统权限提供实际隔离。
 
 递归枚举默认限制深度和返回数量，可通过 `list_files(..., { "max_scan_depth": 64, "max_file_count": 20000 })` 调整。枚举结果返回存储相对路径，适合交给 `load_data()`、显式启用后的 `load_resource()` 或项目自己的读取流程继续处理。
 

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd
@@ -104,6 +104,33 @@ func test_invalid_path_does_not_claim_transfer() -> void:
 	assert_push_error("[GFStorageUtility] save_payload_request_async 失败：file_name 为空。")
 
 
+func test_absolute_path_does_not_claim_transfer() -> void:
+	var transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({"value": 1})
+
+	var operation: GFStorageAsyncOperation = _storage.save_payload_request_async(
+		"C:/outside/transfer.json",
+		transfer
+	)
+
+	assert_true(operation.is_completed())
+	assert_false(operation.get_result().is_successful())
+	assert_eq(operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
+	assert_eq(operation.get_file_name(), "")
+	assert_eq(operation.get_result().get_file_name(), "")
+	assert_eq(
+		operation.get_result().get_write_failure_kind(),
+		GFStorageAsyncResult.WriteFailureKind.INVALID_REQUEST
+	)
+	assert_eq(transfer.get_state(), GFStoragePayloadTransfer.State.READY)
+	assert_eq(transfer.get_active_attempt_count(), 0)
+	assert_null(operation.get_payload_transfer())
+	assert_null(operation.reclaim_failed_payload())
+	assert_true(transfer.release())
+	assert_push_error(
+		"[GFStorageUtility] 已禁用绝对路径：C:/outside/transfer.json"
+	)
+
+
 func test_malformed_transfer_payload_fails_closed_before_queueing() -> void:
 	var transfer: GFStoragePayloadTransfer = MalformedPayloadTransfer.new()
 

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -291,18 +291,244 @@ func test_storage_paths_reject_parent_segments_before_simplification() -> void:
 	assert_push_error("[GFStorageUtility] 已拒绝跨目录路径（file_name）：group/../escape.json")
 
 
-func test_absolute_path_is_rejected_to_save_directory_by_default() -> void:
+func test_runtime_storage_has_no_absolute_path_escape_hatch() -> void:
 	var path: String = _storage._get_full_path("C:/outside/save.json")
 
-	assert_false(_storage.allow_absolute_paths, "2.0 默认应拒绝绝对路径。")
-	assert_eq(path, "", "绝对路径默认应 fail closed，不应收敛到存档目录。")
+	assert_false(_storage.get_property_list().any(func(property: Dictionary) -> bool:
+		return GFVariantData.get_option_string(property, "name") == "allow_absolute_paths"
+	), "运行时 Storage 不应保留可重新启用绝对路径的公共能力。")
+	assert_eq(path, "", "绝对路径必须始终 fail closed，不应收敛到存档目录。")
 	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
 
 
-func test_absolute_path_can_be_enabled_for_trusted_tools() -> void:
-	_storage.allow_absolute_paths = true
+func test_public_storage_file_and_directory_apis_reject_absolute_paths() -> void:
+	var absolute_file_name: String = "C:/outside/save.json"
+	var absolute_directory_name: String = "C:/outside"
 
-	assert_eq(_storage._get_full_path("C:/outside/save.json"), "C:/outside/save.json", "可信编辑器工具可显式启用绝对路径。")
+	assert_eq(
+		_storage.canonicalize_data_file_name(absolute_file_name),
+		"",
+		"规范化入口不得把绝对路径变成可用 file identity。"
+	)
+	assert_eq(
+		_storage.save_data(absolute_file_name, { "value": 1 }),
+		ERR_INVALID_PARAMETER,
+		"同步保存不得接受绝对路径。"
+	)
+	assert_eq(
+		_storage.ensure_directory(absolute_directory_name),
+		ERR_INVALID_PARAMETER,
+		"目录管理不得接受绝对路径。"
+	)
+	assert_eq(
+		_storage.get_storage_directory_path(absolute_directory_name),
+		"",
+		"目录解析不得泄漏 root 外的绝对路径。"
+	)
+	assert_true(
+		_storage.list_files(absolute_directory_name).is_empty(),
+		"枚举入口不得扫描 root 外的绝对目录。"
+	)
+	assert_eq(
+		_storage.delete_file(absolute_file_name),
+		ERR_INVALID_PARAMETER,
+		"删除入口不得接受绝对路径。"
+	)
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside")
+	assert_push_error("[GFStorageUtility] ensure_directory 失败：directory_name 非法。")
+	assert_push_error("[GFStorageUtility] get_storage_directory_path 失败：directory_name 非法。")
+	assert_push_error("[GFStorageUtility] list_files 失败：directory_name 非法。")
+
+
+func test_storage_rejects_cross_platform_absolute_path_forms() -> void:
+	var absolute_paths: Array[String] = [
+		"C:/outside/save.json",
+		"C:\\outside\\save.json",
+		"/tmp/outside/save.json",
+		"\\rooted\\save.json",
+		"//server/share/save.json",
+		"\\\\server\\share\\save.json",
+		"\\\\?\\C:\\outside\\save.json",
+		"\\\\?\\UNC\\server\\share\\save.json",
+		"\\\\.\\pipe\\gf_storage",
+		"\\??\\C:\\outside\\save.json",
+		"user://outside/save.json",
+		"res://outside/save.json",
+		"file://outside/save.json",
+		"pipe://gf_storage",
+	]
+
+	for absolute_path: String in absolute_paths:
+		assert_eq(
+			_storage.canonicalize_data_file_name(absolute_path),
+			"",
+			"Windows、POSIX、UNC 与 Godot scheme 绝对路径都必须失败关闭：%s" % absolute_path
+		)
+		assert_push_error("[GFStorageUtility] 已禁用绝对路径：%s" % absolute_path)
+
+
+func test_invalid_storage_root_configuration_fails_closed() -> void:
+	var invalid_roots: Array[Dictionary] = [
+		{
+			"value": "../escape",
+			"error": "[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：../escape",
+		},
+		{
+			"value": "nested/../escape",
+			"error": "[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：nested/../escape",
+		},
+		{
+			"value": "/outside",
+			"error": "[GFStorageUtility] 已禁用绝对路径：/outside",
+		},
+		{
+			"value": "\\outside",
+			"error": "[GFStorageUtility] 已禁用绝对路径：\\outside",
+		},
+		{
+			"value": "C:/outside",
+			"error": "[GFStorageUtility] 已禁用绝对路径：C:/outside",
+		},
+		{
+			"value": "user://outside",
+			"error": "[GFStorageUtility] 已禁用绝对路径：user://outside",
+		},
+		{
+			"value": ".",
+			"error": "[GFStorageUtility] save_dir_name 必须是规范相对目录：.",
+		},
+		{
+			"value": "nested//outside",
+			"error": "[GFStorageUtility] save_dir_name 必须是规范相对目录：nested//outside",
+		},
+		{
+			"value": "C:drive-relative",
+			"error": "[GFStorageUtility] save_dir_name 包含不支持的字符：C:drive-relative",
+		},
+	]
+
+	for invalid_root: Dictionary in invalid_roots:
+		var root_value: String = GFVariantData.get_option_string(invalid_root, "value")
+		var expected_error: String = GFVariantData.get_option_string(invalid_root, "error")
+		_storage.save_dir_name = root_value
+		assert_eq(_storage._get_save_base_path(), "", "非法配置不得退化为 user:// 根：%s" % root_value)
+		assert_push_error(expected_error)
+		assert_eq(_storage._get_full_path("probe.json"), "", "非法 root 不得拼出绝对文件路径。")
+		assert_push_error(expected_error)
+		assert_eq(_storage.get_storage_directory_path(), "", "公开目录解析必须失败关闭。")
+		assert_push_error(expected_error)
+		assert_true(_storage.list_files().is_empty(), "非法 root 不得退化为进程当前目录枚举。")
+		assert_push_error(expected_error)
+		assert_eq(
+			_storage.ensure_directory(),
+			ERR_INVALID_PARAMETER,
+			"非法 root 的目录创建不得伪装成成功。"
+		)
+		assert_push_error(expected_error)
+	_storage.save_dir_name = "test_saves"
+
+
+func test_invalid_storage_root_rejects_all_public_io_before_admission() -> void:
+	var root_error: String = "[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：../escape"
+	_storage.save_dir_name = "../escape"
+
+	assert_eq(_storage.canonicalize_data_file_name("probe.json"), "")
+	assert_push_error(root_error)
+	assert_eq(_storage.save_data("probe.json", {"value": 1}), ERR_INVALID_PARAMETER)
+	assert_push_error(root_error)
+	var load_result: GFStorageReadResult = _storage.load_data("probe.json")
+	assert_eq(load_result.error_code, ERR_INVALID_PARAMETER)
+	assert_eq(load_result.failure_kind, GFStorageReadResult.FailureKind.INVALID_REQUEST)
+	assert_push_error(root_error)
+	assert_eq(_storage.delete_file("probe.json"), ERR_INVALID_PARAMETER)
+	assert_push_error(root_error)
+	assert_eq(_storage.save_resource("probe.tres", Resource.new()), ERR_INVALID_PARAMETER)
+	assert_push_error(root_error)
+	assert_null(_storage.load_resource("probe.tres", "Resource"))
+	assert_push_error(root_error)
+	assert_eq(
+		_storage.save_data_group({"probe.json": {"value": 1}}),
+		ERR_INVALID_PARAMETER
+	)
+	assert_push_error(root_error)
+	assert_eq(_storage.save_data_async("probe.json", {"value": 1}), ERR_INVALID_PARAMETER)
+	assert_push_error(root_error)
+	assert_eq(_storage.load_data_async("probe.json"), ERR_INVALID_PARAMETER)
+	assert_push_error(root_error)
+
+	var save_operation: GFStorageAsyncOperation = _storage.save_data_request_async(
+		"probe.json",
+		{"value": 1}
+	)
+	assert_true(save_operation.is_completed())
+	assert_eq(save_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
+	assert_eq(save_operation.get_file_name(), "")
+	assert_push_error(root_error)
+	var load_operation: GFStorageAsyncOperation = _storage.load_data_request_async("probe.json")
+	assert_true(load_operation.is_completed())
+	assert_eq(load_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
+	assert_eq(load_operation.get_file_name(), "")
+	assert_push_error(root_error)
+
+	var transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({"value": 1})
+	var payload_operation: GFStorageAsyncOperation = _storage.save_payload_request_async(
+		"probe.json",
+		transfer
+	)
+	assert_true(payload_operation.is_completed())
+	assert_eq(payload_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
+	assert_eq(transfer.get_state(), GFStoragePayloadTransfer.State.READY)
+	assert_eq(transfer.get_active_attempt_count(), 0)
+	assert_push_error(root_error)
+	assert_true(transfer.release())
+
+	assert_true(_storage._async_queue.is_empty())
+	assert_true(_storage._async_tasks.is_empty())
+	assert_true(_storage._async_file_locks.is_empty())
+	_storage.save_dir_name = "test_saves"
+
+
+func test_group_resource_and_async_storage_entries_reject_absolute_paths() -> void:
+	var absolute_file_name: String = "C:/outside/save.json"
+	var group_files: Dictionary = {}
+	group_files[absolute_file_name] = { "value": 1 }
+
+	assert_eq(
+		_storage.save_resource(absolute_file_name, Resource.new()),
+		ERR_INVALID_PARAMETER,
+		"Resource 保存不得绕过相对路径边界。"
+	)
+	assert_eq(
+		_storage.save_data_group(group_files),
+		ERR_INVALID_PARAMETER,
+		"多文件事务不得接受任意绝对成员。"
+	)
+	var save_operation: GFStorageAsyncOperation = _storage.save_data_request_async(
+		absolute_file_name,
+		{ "value": 1 }
+	)
+	var load_operation: GFStorageAsyncOperation = _storage.load_data_request_async(
+		absolute_file_name
+	)
+	assert_true(save_operation.is_completed(), "非法异步保存必须同步进入失败终态。")
+	assert_eq(save_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
+	assert_eq(save_operation.get_file_name(), "", "拒绝前不得发布未规范化的 caller path。")
+	assert_eq(save_operation.get_result().get_file_name(), "")
+	assert_true(load_operation.is_completed(), "非法异步读取必须同步进入失败终态。")
+	assert_eq(load_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
+	assert_eq(load_operation.get_file_name(), "", "拒绝前不得发布未规范化的 caller path。")
+	assert_eq(load_operation.get_result().get_file_name(), "")
+	assert_true(_storage._async_queue.is_empty(), "非法绝对路径不得进入异步队列。")
+	assert_true(_storage._async_tasks.is_empty(), "非法绝对路径不得启动 worker。")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
 
 
 func test_parent_directory_path_is_rejected() -> void:
@@ -602,7 +828,6 @@ func test_transaction_marker_cannot_expand_recovery_beyond_requested_files() -> 
 
 func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> void:
 	_storage.encrypt_key = 0
-	_storage.allow_absolute_paths = false
 	var victim_file_name: String = "marker_victim.json"
 	var outsider_file_name: String = "marker_outsider.json"
 	var victim_path: String = _storage._get_full_path(victim_file_name)
@@ -659,7 +884,6 @@ func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> v
 	)
 	var operation: GFStorageAsyncOperation = _storage.load_data_request_async(victim_file_name)
 	assert_eq(_storage._async_queue.size(), 1, "目标读取应先保持排队，以验证冻结的路径授权。")
-	_storage.allow_absolute_paths = true
 	_storage.wait_for_async_tasks()
 
 	assert_true(blocker.get_result().is_successful(), "占位任务应正常完成。")
@@ -684,6 +908,33 @@ func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> v
 			ERR_UNAUTHORIZED,
 		]
 	)
+
+
+func test_frozen_async_task_rejects_absolute_storage_root() -> void:
+	var file_name: String = "probe.json"
+	var absolute_roots: Array[String] = [
+		ProjectSettings.globalize_path("user://gf_storage_absolute_root_probe").replace("\\", "/"),
+		"C:/gf_storage_absolute_root_probe",
+	]
+
+	for absolute_root: String in absolute_roots:
+		var final_path: String = absolute_root.path_join(file_name)
+		var task: Dictionary = {
+			"type": &"load",
+			"storage_file_name": file_name,
+			"storage_root_path": absolute_root,
+			"file_key": final_path,
+			"final_path": final_path,
+			"temp_path": final_path + ".tmp",
+			"backup_path": final_path + ".bak",
+			"transaction_path": final_path + ".txn",
+		}
+
+		assert_eq(
+			_storage._recover_frozen_async_transaction(task),
+			ERR_INVALID_PARAMETER,
+			"冻结 task 不得把 worker I/O root 扩大为任意绝对路径：%s" % absolute_root
+		)
 
 
 func test_save_data_group_removes_orphaned_files_when_member_write_fails() -> void:
@@ -1117,6 +1368,7 @@ func test_wait_for_async_tasks_drains_queued_tasks() -> void:
 
 	assert_true(_storage._async_tasks.is_empty(), "等待后不应残留运行中任务。")
 	assert_true(_storage._async_queue.is_empty(), "等待后不应残留排队任务。")
+	assert_true(_storage._async_file_locks.is_empty(), "等待后不应残留文件锁。")
 	assert_eq(GFVariantData.get_option_int(_load_payload("test_wait_async.json"), "value"), 2, "等待应处理完整队列并保留最后一次写入。")
 
 


### PR DESCRIPTION
## Summary

- remove the runtime `GFStorageUtility.allow_absolute_paths` capability
- require canonical relative file and directory identities under the configured Storage root across sync I/O, async requests, payload transfer, directory management, resource loading, and transaction recovery
- reject invalid non-empty `save_dir_name` values and empty resolved paths before initialization, recovery, queue admission, or filesystem access
- keep rejected async operation/result identities empty instead of reflecting unvalidated absolute caller input
- update focused regressions, handwritten migration guidance, generated API references, and the tracked AI API index

## Why

Runtime absolute-path opt-in dynamically expanded a gameplay-facing Storage service into an arbitrary filesystem capability. The previous root sanitization also had fail-open edge cases: an invalid configured root could collapse to an empty path, fall back to `user://`, reach `DirAccess.open("")`, or reach low-level write helpers. On affected hosts, that could enumerate or create temporary files in the process working directory.

This change makes the public boundary explicit and fail-closed: project runtime code supplies logical relative identities; trusted editor or offline migration tools that intentionally operate on arbitrary host paths own their own `FileAccess` / `DirAccess` boundary.

## Breaking changes

- `GFStorageUtility.allow_absolute_paths` is removed.
- Absolute, rooted, scheme-qualified, parent-traversing, or non-canonical public file/directory inputs are rejected.
- Invalid non-empty `save_dir_name` values no longer degrade to a broader root.
- Rejected async requests expose an empty canonical identity.

This is a lexical GF API ownership boundary. It is not advertised as a same-process security sandbox against direct Godot filesystem APIs, symlinks, junctions, or mount points.

## Validation

- `python tools/gf_maintenance.py check --suite full --jobs 3 --failed-only`: 41/41 checks passed
- focused Storage GUT: 65/65 tests, 547 assertions
- focused payload-transfer GUT: 22/22 tests, 192 assertions
- strict GDScript warnings and LSP diagnostics
- API reference and AI API generation checks
- Storage, Settings, and Save package Godot smoke checks
- independent API/standards, path-matrix, and security-boundary audits
- `git diff --check`

## Scope

Refs #87.

This PR is the prerequisite capability-boundary change only. The private family namespace/catalog layout and typed asynchronous family deletion remain separate follow-up PRs, so this PR intentionally does not close #87. Storage owner/cancellation and physical-work terminal semantics from #86 are also out of scope.