### PR TITLE
Refactor Storage into private logical families

### DIFF
--- a/addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd
+++ b/addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd
@@ -15,6 +15,7 @@ extends Resource
 # --- 常量 ---
 
 const _GF_SAVE_PERSISTED_VALUE_VALIDATOR = preload("res://addons/gf/extensions/save/core/gf_save_persisted_value_validator.gd")
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload("res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd")
 
 ## 默认槽位数据文件模板。
 ## [br]
@@ -140,7 +141,7 @@ func get_metadata_file_name(slot_index: int) -> String:
 
 ## 构建并校验一个槽位的文件计划。
 ##
-## 该方法不要求先配置 Storage，可供同步桥在访问任一后端前完成模板预检。
+## 该方法不要求先配置 Storage，可供同步桥在访问任一后端前完成 portable logical identity 模板预检。
 ## [br]
 ## @api public
 ## [br]
@@ -172,8 +173,16 @@ func build_slot_file_plan(slot_index: int) -> Dictionary:
 
 	var data_file_name: String = _format_slot_file_name(data_file_template, slot_index)
 	var metadata_file_name: String = _format_slot_file_name(metadata_file_template, slot_index)
-	var data_target: String = _get_canonical_relative_target(data_file_name)
-	var metadata_target: String = _get_canonical_relative_target(metadata_file_name)
+	var data_target: String = (
+		data_file_name
+		if _GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_logical_file_path_for_framework(data_file_name)
+		else ""
+	)
+	var metadata_target: String = (
+		metadata_file_name
+		if _GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_logical_file_path_for_framework(metadata_file_name)
+		else ""
+	)
 	result["data_file_name"] = data_file_name
 	result["metadata_file_name"] = metadata_file_name
 	result["data_target"] = data_target
@@ -181,7 +190,7 @@ func build_slot_file_plan(slot_index: int) -> Dictionary:
 	if data_target.is_empty() or metadata_target.is_empty():
 		result["error"] = "文件模板无法解析到有效存储目标。"
 		return result
-	if data_target.to_lower() == metadata_target.to_lower():
+	if data_target == metadata_target:
 		result["error"] = "数据与元数据模板解析到同一存储目标：%s。" % data_target
 		return result
 	result["ok"] = true
@@ -356,8 +365,8 @@ func has_slot(slot_index: int) -> bool:
 	if not _can_access_slot(slot_index, "has_slot"):
 		return false
 	return (
-		FileAccess.file_exists(_get_full_storage_path(get_data_file_name(slot_index)))
-		and FileAccess.file_exists(_get_full_storage_path(get_metadata_file_name(slot_index)))
+		_storage.has_file(get_data_file_name(slot_index))
+		and _storage.has_file(get_metadata_file_name(slot_index))
 	)
 
 
@@ -392,7 +401,7 @@ func delete_slot(slot_index: int) -> Error:
 ## [br]
 ## @return 槽位摘要数组。
 ## [br]
-## @schema return: Array[Dictionary]，每项包含 slot_index、slot_id、metadata 和 modified_time。
+## @schema return: Array[Dictionary]，每项包含 slot_index、slot_id、metadata，以及来自 metadata.updated_at_unix 的领域更新时间 modified_time: int；它不是文件系统 mtime。
 func list_slots() -> Array[Dictionary]:
 	if _storage == null:
 		return []
@@ -417,7 +426,7 @@ func list_slots() -> Array[Dictionary]:
 			"slot_index": slot_index,
 			"slot_id": GFVariantData.get_option_string_name(metadata, "slot_id", StringName(str(slot_index))),
 			"metadata": metadata,
-			"modified_time": FileAccess.get_modified_time(_get_full_storage_path(metadata_file_name)),
+			"modified_time": GFVariantData.get_option_int(metadata, "updated_at_unix"),
 		})
 	return result
 
@@ -561,26 +570,3 @@ func _parse_slot_index_from_file_name(file_name: String, template: String) -> in
 	if not index_text.is_valid_int():
 		return -1
 	return index_text.to_int()
-
-
-func _get_full_storage_path(file_name: String) -> String:
-	var directory_name: String = file_name.get_base_dir()
-	if directory_name == ".":
-		directory_name = ""
-	var directory_path: String = _storage.get_storage_directory_path(directory_name)
-	if directory_path.is_empty():
-		return ""
-	return directory_path.path_join(file_name.get_file())
-
-
-func _get_canonical_relative_target(file_name: String) -> String:
-	var normalized: String = file_name.replace("\\", "/").simplify_path()
-	if (
-		normalized.is_empty()
-		or normalized == "."
-		or normalized == ".."
-		or normalized.begins_with("../")
-		or normalized.is_absolute_path()
-	):
-		return ""
-	return normalized

--- a/addons/gf/standard/utilities/storage/gf_storage_family_store.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_family_store.gd
@@ -1,0 +1,1184 @@
+## GFStorageFamilyStore: Storage 私有 family 布局与逻辑 catalog 协作者。
+##
+## 该类型把 portable logical path 映射为私有、分片、可相互校验的 catalog 与 family。
+## descriptor 含有仅供 Storage 协作者使用的物理路径，因此整个类型标记为 framework_internal；
+## 该边界不是同进程安全沙箱。此类型不负责业务数据编码、事务提交或异步调度。
+## [br]
+## @api framework_internal
+## [br]
+## @category internal_helper
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @since unreleased
+class_name GFStorageFamilyStore
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _PRIVATE_ROOT_NAME: String = ".gf-storage"
+const _LAYOUT_VERSION: int = 1
+const _PATH_PROFILE: String = "portable-ascii-v1"
+const _IDENTITY_ALGORITHM: String = "sha256-domain-nul-uuidv8-v1"
+const _MAX_LOGICAL_PATH_BYTES: int = 255
+const _MAX_LOGICAL_SEGMENT_BYTES: int = 64
+const _MAX_LOGICAL_SEGMENTS: int = 16
+const _MAX_EXTENSION_BYTES: int = 16
+const _MAX_MANIFEST_BYTES: int = 16 * 1024
+
+const _IDENTITY_DOMAIN: String = "gf.storage.family/v1"
+const _LAYOUT_SCHEMA: String = "gf.storage.layout"
+const _CATALOG_SCHEMA: String = "gf.storage.catalog-entry"
+const _OWNER_SCHEMA: String = "gf.storage.family-owner"
+const _PUBLISH_PENDING_SEPARATOR: String = ".pending-"
+const _CLAIM_STAGING_SEPARATOR: String = ".claim-"
+const _HEX_CHARS: String = "0123456789abcdef"
+const _ALLOWED_SEGMENT_CHARS: String = "abcdefghijklmnopqrstuvwxyz0123456789._-"
+const _ALNUM_CHARS: String = "abcdefghijklmnopqrstuvwxyz0123456789"
+const _RESERVED_DEVICE_STEMS: Array[String] = [
+	"con", "prn", "aux", "nul",
+	"com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+	"lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+]
+
+
+# --- 私有变量 ---
+
+var _storage_root_path: String = ""
+
+
+# --- 框架内部方法 ---
+
+## 判断文件 logical identity 是否满足 portable-ascii-v1。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param logical_path: 未经改写的调用方输入。
+## [br]
+## @return 仅在输入本身已经是 canonical logical identity 时返回 true。
+static func is_valid_logical_file_path_for_framework(logical_path: String) -> bool:
+	return _is_valid_logical_path(logical_path, false)
+
+
+## 判断逻辑目录 selector 是否满足 portable-ascii-v1；空字符串表示逻辑根。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param logical_path: 未经改写的目录 selector。
+## [br]
+## @return selector 合法时返回 true。
+static func is_valid_logical_directory_path_for_framework(logical_path: String) -> bool:
+	return _is_valid_logical_path(logical_path, true)
+
+
+## 判断 list 扩展名过滤器是否已经是 canonical lowercase token。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param extension_filter: 空字符串或不带点号的 lowercase ASCII token。
+## [br]
+## @return 过滤器合法时返回 true。
+static func is_valid_extension_filter_for_framework(extension_filter: String) -> bool:
+	if extension_filter.is_empty():
+		return true
+	if extension_filter.length() > _MAX_EXTENSION_BYTES:
+		return false
+	if not _is_ascii_alnum(extension_filter.substr(0, 1)):
+		return false
+	for index: int in range(extension_filter.length()):
+		var character: String = extension_filter.substr(index, 1)
+		if not _ALNUM_CHARS.contains(character) and character != "_" and character != "-":
+			return false
+	return true
+
+
+## 判断一个框架生成的 private relative path 是否保持在固定 namespace 内。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param relative_path: 未经改写的 private relative path。
+## [br]
+## @return 仅接受 `.gf-storage/v1/...` 下无别名、无父段的 ASCII 路径。
+static func is_valid_private_relative_path_for_framework(relative_path: String) -> bool:
+	if (
+		relative_path.length() <= _PRIVATE_ROOT_NAME.length() + 4
+		or relative_path.length() > 1024
+		or not relative_path.begins_with("%s/v%d/" % [_PRIVATE_ROOT_NAME, _LAYOUT_VERSION])
+		or relative_path.contains("\\")
+	):
+		return false
+	var segments: PackedStringArray = relative_path.split("/", true)
+	if segments.size() < 3:
+		return false
+	for segment: String in segments:
+		if segment.is_empty() or segment == "." or segment == "..":
+			return false
+		for index: int in range(segment.length()):
+			var character: String = segment.substr(index, 1)
+			if not _ALLOWED_SEGMENT_CHARS.contains(character):
+				return false
+	return true
+
+
+## 由公开 save_dir_name 构造 canonical `user://` Storage root。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param save_dir_name: 空字符串或 portable logical directory。
+## [br]
+## @return 合法 root；非法时返回空字符串。
+static func make_storage_root_path_for_framework(save_dir_name: String) -> String:
+	if save_dir_name.is_empty():
+		return "user://"
+	if not is_valid_logical_directory_path_for_framework(save_dir_name):
+		return ""
+	return "user://" + save_dir_name
+
+
+## 从 logical identity 确定性派生 opaque UUID v8 family ID。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param logical_path: portable logical file path。
+## [br]
+## @return canonical UUID v8；输入非法时返回空字符串。
+static func make_family_id_for_framework(logical_path: String) -> String:
+	if not is_valid_logical_file_path_for_framework(logical_path):
+		return ""
+	var digest: String = _make_logical_digest(logical_path)
+	if digest.length() != 64:
+		return ""
+	var raw: String = digest.substr(0, 32)
+	var variant_source: int = _HEX_CHARS.find(raw.substr(16, 1))
+	var variant_nibble: String = _HEX_CHARS.substr(8 | (variant_source & 3), 1)
+	return "%s-%s-8%s-%s-%s" % [
+		raw.substr(0, 8),
+		raw.substr(8, 4),
+		raw.substr(13, 3),
+		variant_nibble + raw.substr(17, 3),
+		raw.substr(20, 12),
+	]
+
+
+## 纯计算一个 family descriptor；该方法不读取或创建文件。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param storage_root_path: canonical `user://` Storage root。
+## [br]
+## @param logical_path: portable logical file path。
+## [br]
+## @return 固定物理布局 descriptor；输入非法时为空字典。
+## [br]
+## @schema return: Dictionary，包含 logical_path、logical_sha256、family_id、file_key、catalog/family/owner、payload/candidate/backup/resource-stage、prepare/commit record 与 pending record 的物理及相对路径。
+static func make_family_descriptor_for_framework(
+	storage_root_path: String,
+	logical_path: String
+) -> Dictionary:
+	if not _is_valid_storage_root(storage_root_path):
+		return {}
+	if not is_valid_logical_file_path_for_framework(logical_path):
+		return {}
+	var logical_sha256: String = _make_logical_digest(logical_path)
+	var family_id: String = make_family_id_for_framework(logical_path)
+	if logical_sha256.length() != 64 or family_id.is_empty():
+		return {}
+	var compact_family_id: String = family_id.replace("-", "")
+	var physical_extension: String = _derive_physical_extension(logical_path)
+	var catalog_relative_path: String = "%s/v%d/catalog/%s/%s/%s.json" % [
+		_PRIVATE_ROOT_NAME,
+		_LAYOUT_VERSION,
+		logical_sha256.substr(0, 2),
+		logical_sha256.substr(2, 2),
+		logical_sha256,
+	]
+	var family_relative_path: String = "%s/v%d/families/%s/%s/%s" % [
+		_PRIVATE_ROOT_NAME,
+		_LAYOUT_VERSION,
+		compact_family_id.substr(0, 2),
+		compact_family_id.substr(2, 2),
+		family_id,
+	]
+	var payload_leaf: String = "payload.%s" % physical_extension
+	var candidate_leaf: String = "candidate.%s" % physical_extension
+	var backup_leaf: String = "backup.%s" % physical_extension
+	var resource_stage_leaf: String = "resource-stage.%s" % physical_extension
+	return {
+		"logical_path": logical_path,
+		"logical_sha256": logical_sha256,
+		"family_id": family_id,
+		"file_key": storage_root_path + "|gf-family|" + family_id,
+		"physical_extension": physical_extension,
+		"catalog_relative_path": catalog_relative_path,
+		"family_relative_path": family_relative_path,
+		"owner_relative_path": family_relative_path + "/owner.json",
+		"payload_relative_path": family_relative_path + "/" + payload_leaf,
+		"candidate_relative_path": family_relative_path + "/" + candidate_leaf,
+		"backup_relative_path": family_relative_path + "/" + backup_leaf,
+		"transaction_relative_path": family_relative_path + "/transaction.prepare.json",
+		"transaction_pending_relative_path": family_relative_path + "/transaction.prepare.pending.json",
+		"transaction_commit_relative_path": family_relative_path + "/transaction.commit.json",
+		"transaction_commit_pending_relative_path": family_relative_path + "/transaction.commit.pending.json",
+		"resource_stage_relative_path": family_relative_path + "/" + resource_stage_leaf,
+		"catalog_path": _join_storage_root(storage_root_path, catalog_relative_path),
+		"family_path": _join_storage_root(storage_root_path, family_relative_path),
+		"owner_path": _join_storage_root(storage_root_path, family_relative_path + "/owner.json"),
+		"payload_path": _join_storage_root(storage_root_path, family_relative_path + "/" + payload_leaf),
+		"candidate_path": _join_storage_root(storage_root_path, family_relative_path + "/" + candidate_leaf),
+		"backup_path": _join_storage_root(storage_root_path, family_relative_path + "/" + backup_leaf),
+		"transaction_path": _join_storage_root(storage_root_path, family_relative_path + "/transaction.prepare.json"),
+		"transaction_pending_path": _join_storage_root(storage_root_path, family_relative_path + "/transaction.prepare.pending.json"),
+		"transaction_commit_path": _join_storage_root(storage_root_path, family_relative_path + "/transaction.commit.json"),
+		"transaction_commit_pending_path": _join_storage_root(storage_root_path, family_relative_path + "/transaction.commit.pending.json"),
+		"resource_stage_path": _join_storage_root(storage_root_path, family_relative_path + "/" + resource_stage_leaf),
+	}
+
+
+## 绑定一个 canonical Storage root。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param storage_root_path: `user://` 或其 portable 子目录。
+## [br]
+## @return 配置成功时返回 true。
+func configure_for_framework(storage_root_path: String) -> bool:
+	if not _is_valid_storage_root(storage_root_path):
+		return false
+	_storage_root_path = storage_root_path
+	return true
+
+
+## 获取当前绑定的 canonical Storage root。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @return 未配置时为空字符串。
+func get_storage_root_path_for_framework() -> String:
+	return _storage_root_path
+
+
+## 确保 private v1 layout manifest 与分片目录存在并严格匹配。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @return Godot Error；未知或损坏布局返回 ERR_FILE_CORRUPT。
+func ensure_layout_for_framework() -> Error:
+	if _storage_root_path.is_empty():
+		return ERR_INVALID_PARAMETER
+	var root_error: Error = _ensure_directory(_storage_root_path)
+	if root_error != OK:
+		return root_error
+	var private_root: String = _join_storage_root(_storage_root_path, _PRIVATE_ROOT_NAME)
+	var version_root: String = private_root.path_join("v%d" % _LAYOUT_VERSION)
+	var layout_path: String = version_root.path_join("layout.json")
+	if DirAccess.dir_exists_absolute(private_root):
+		var private_entries: Dictionary = _read_directory_entries(private_root)
+		if GFVariantData.get_option_int(private_entries, "error", OK) != OK:
+			return GFVariantData.get_option_int(private_entries, "error", ERR_FILE_CANT_READ) as Error
+		for entry: String in GFVariantData.get_option_array(private_entries, "names"):
+			if entry != "v%d" % _LAYOUT_VERSION:
+				return ERR_FILE_CORRUPT
+	else:
+		var private_error: Error = _ensure_directory(private_root)
+		if private_error != OK:
+			return private_error
+	var version_error: Error = _ensure_directory(version_root)
+	if version_error != OK:
+		return version_error
+	var version_entries: Dictionary = _read_directory_entries(version_root)
+	if GFVariantData.get_option_int(version_entries, "error", OK) != OK:
+		return GFVariantData.get_option_int(version_entries, "error", ERR_FILE_CANT_READ) as Error
+	for entry: String in GFVariantData.get_option_array(version_entries, "names"):
+		if entry == "layout.json" or entry == "catalog" or entry == "families":
+			continue
+		if not _is_publish_pending_leaf(entry, "layout.json"):
+			return ERR_FILE_CORRUPT
+		if DirAccess.dir_exists_absolute(version_root.path_join(entry)):
+			return ERR_FILE_CORRUPT
+	var publish_error: Error = _publish_json_if_absent(layout_path, _make_layout_manifest())
+	if publish_error != OK:
+		return publish_error
+	var layout_entries: Dictionary = _read_directory_entries(version_root)
+	if GFVariantData.get_option_int(layout_entries, "error", OK) != OK:
+		return GFVariantData.get_option_int(layout_entries, "error", ERR_FILE_CANT_READ) as Error
+	for entry: String in GFVariantData.get_option_array(layout_entries, "names"):
+		if (
+			entry != "layout.json"
+			and entry != "catalog"
+			and entry != "families"
+		):
+			return ERR_FILE_CORRUPT
+	var catalog_error: Error = _ensure_directory(version_root.path_join("catalog"))
+	if catalog_error != OK:
+		return catalog_error
+	return _ensure_directory(version_root.path_join("families"))
+
+
+## 原子、幂等地 claim 一个 descriptor 的 owner 与 catalog。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param descriptor: make_family_descriptor_for_framework() 的结果。
+## [br]
+## @schema descriptor: Dictionary，必须精确匹配 make_family_descriptor_for_framework() 的固定字段与派生路径。
+## [br]
+## @return 已有同一 claim 也返回 OK；任何漂移或冲突失败关闭。
+func claim_family_for_framework(descriptor: Dictionary) -> Error:
+	var descriptor_error: Error = _validate_descriptor(descriptor)
+	if descriptor_error != OK:
+		return descriptor_error
+	var layout_error: Error = ensure_layout_for_framework()
+	if layout_error != OK:
+		return layout_error
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	var family_path: String = GFVariantData.get_option_string(descriptor, "family_path")
+	var family_parent_error: Error = _ensure_directory(family_path.get_base_dir())
+	if family_parent_error != OK:
+		return family_parent_error
+	var staging_recovery_error: Error = _reconcile_claim_staging(descriptor)
+	if staging_recovery_error != OK:
+		return staging_recovery_error
+	var catalog_exists: bool = FileAccess.file_exists(catalog_path)
+	var family_exists: bool = DirAccess.dir_exists_absolute(family_path)
+	if catalog_exists and family_exists:
+		return validate_family_for_framework(descriptor)
+	if catalog_exists and not family_exists:
+		return ERR_FILE_CORRUPT
+	if family_exists:
+		var owner_recovery_error: Error = _validate_owner_only_claim(descriptor)
+		if owner_recovery_error != OK:
+			return owner_recovery_error
+		var catalog_recovery_error: Error = _publish_json_if_absent(
+			catalog_path,
+			_make_identity_record(_CATALOG_SCHEMA, descriptor)
+		)
+		if catalog_recovery_error != OK:
+			return catalog_recovery_error
+		return validate_family_for_framework(descriptor)
+
+	var staging_path: String = family_path + _CLAIM_STAGING_SEPARATOR + GFUuid.generate_v4()
+	var staging_error: Error = _ensure_directory(staging_path)
+	if staging_error != OK:
+		return staging_error
+	var staging_owner_path: String = staging_path.path_join("owner.json")
+	var owner_write_error: Error = _write_json_direct(
+		staging_owner_path,
+		_make_identity_record(_OWNER_SCHEMA, descriptor)
+	)
+	if owner_write_error != OK:
+		var _staging_cleanup_error: Error = _remove_claim_staging(staging_path)
+		return owner_write_error
+	var install_error: Error = DirAccess.rename_absolute(staging_path, family_path)
+	if install_error != OK:
+		var _staging_cleanup_error_after_race: Error = _remove_claim_staging(staging_path)
+		if not DirAccess.dir_exists_absolute(family_path):
+			return install_error
+		var raced_owner_error: Error = _validate_owner_only_claim(descriptor)
+		if raced_owner_error != OK:
+			return raced_owner_error
+	var catalog_publish_error: Error = _publish_json_if_absent(
+		catalog_path,
+		_make_identity_record(_CATALOG_SCHEMA, descriptor)
+	)
+	if catalog_publish_error != OK:
+		return catalog_publish_error
+	return validate_family_for_framework(descriptor)
+
+
+## 严格校验 descriptor、catalog、owner 与 family 固定条目。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param descriptor: 待验证 descriptor。
+## [br]
+## @schema descriptor: Dictionary，必须精确匹配 make_family_descriptor_for_framework() 的固定字段与派生路径。
+## [br]
+## @return family 不存在返回 ERR_FILE_NOT_FOUND；漂移或损坏返回 ERR_FILE_CORRUPT。
+func validate_family_for_framework(descriptor: Dictionary) -> Error:
+	var descriptor_error: Error = _validate_descriptor(descriptor)
+	if descriptor_error != OK:
+		return descriptor_error
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	var family_path: String = GFVariantData.get_option_string(descriptor, "family_path")
+	var owner_path: String = GFVariantData.get_option_string(descriptor, "owner_path")
+	if not FileAccess.file_exists(catalog_path) and not DirAccess.dir_exists_absolute(family_path):
+		return ERR_FILE_NOT_FOUND
+	if not FileAccess.file_exists(catalog_path) or not DirAccess.dir_exists_absolute(family_path):
+		return ERR_FILE_CORRUPT
+	if not FileAccess.file_exists(owner_path):
+		return ERR_FILE_CORRUPT
+	var catalog_result: Dictionary = _read_json_dictionary(catalog_path)
+	var owner_result: Dictionary = _read_json_dictionary(owner_path)
+	if (
+		not GFVariantData.get_option_bool(catalog_result, "ok")
+		or not GFVariantData.get_option_bool(owner_result, "ok")
+	):
+		return ERR_FILE_CORRUPT
+	if not _matches_identity_record(
+		GFVariantData.get_option_dictionary(catalog_result, "data"),
+		_CATALOG_SCHEMA,
+		descriptor
+	):
+		return ERR_FILE_CORRUPT
+	if not _matches_identity_record(
+		GFVariantData.get_option_dictionary(owner_result, "data"),
+		_OWNER_SCHEMA,
+		descriptor
+	):
+		return ERR_FILE_CORRUPT
+	return _validate_family_entries(descriptor)
+
+
+## 从分片 catalog 投影 logical files。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param directory_name: 空或 portable logical directory。
+## [br]
+## @param extension_filter: 空或 canonical extension token。
+## [br]
+## @param recursive: 是否包含逻辑后代目录。
+## [br]
+## @param max_scan_depth: 相对 selector 的最大逻辑目录深度；0 表示不限制。
+## [br]
+## @param max_file_count: 最大结果数；0 表示不限制。
+## [br]
+## @return Dictionary，包含 error 与排序后的 PackedStringArray files。
+## [br]
+## @schema return: Dictionary，包含 error: Error 和 files: PackedStringArray。
+func list_files_for_framework(
+	directory_name: String,
+	extension_filter: String,
+	recursive: bool,
+	max_scan_depth: int,
+	max_file_count: int
+) -> Dictionary:
+	var empty_result: Dictionary = {"error": OK, "files": PackedStringArray()}
+	if (
+		not is_valid_logical_directory_path_for_framework(directory_name)
+		or not is_valid_extension_filter_for_framework(extension_filter)
+	):
+		empty_result["error"] = ERR_INVALID_PARAMETER
+		return empty_result
+	var layout_error: Error = ensure_layout_for_framework()
+	if layout_error != OK:
+		empty_result["error"] = layout_error
+		return empty_result
+	var descriptors_result: Dictionary = list_claimed_family_descriptors_for_framework()
+	var descriptors_error: Error = GFVariantData.get_option_int(
+		descriptors_result,
+		"error",
+		OK
+	) as Error
+	if descriptors_error != OK:
+		empty_result["error"] = descriptors_error
+		return empty_result
+	var result: PackedStringArray = PackedStringArray()
+	for descriptor_value: Variant in GFVariantData.get_option_array(
+		descriptors_result,
+		"descriptors"
+	):
+		var descriptor: Dictionary = GFVariantData.as_dictionary(descriptor_value)
+		var logical_path: String = GFVariantData.get_option_string(descriptor, "logical_path")
+		if not FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "payload_path")):
+			continue
+		if not _matches_list_selector(logical_path, directory_name, recursive, max_scan_depth):
+			continue
+		if not extension_filter.is_empty() and logical_path.get_extension() != extension_filter:
+			continue
+		var _appended: bool = result.append(logical_path)
+	result.sort()
+	if max_file_count > 0 and result.size() > max_file_count:
+		var _resized: bool = result.resize(max_file_count)
+	return {"error": OK, "files": result}
+
+
+## 枚举并严格校验 catalog-authoritative family descriptor。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @return Dictionary，包含 error 与按 logical_path 排序的 descriptors。
+## [br]
+## @schema return: Dictionary，包含 error: Error 和 descriptors: Array[Dictionary]。
+func list_claimed_family_descriptors_for_framework() -> Dictionary:
+	var empty_result: Dictionary = {"error": OK, "descriptors": []}
+	var layout_error: Error = ensure_layout_for_framework()
+	if layout_error != OK:
+		empty_result["error"] = layout_error
+		return empty_result
+	var catalog_root: String = _join_storage_root(
+		_storage_root_path,
+		"%s/v%d/catalog" % [_PRIVATE_ROOT_NAME, _LAYOUT_VERSION]
+	)
+	var pending_recovery_error: Error = _reconcile_catalog_publish_residue(catalog_root)
+	if pending_recovery_error != OK:
+		empty_result["error"] = pending_recovery_error
+		return empty_result
+	var catalog_paths_result: Dictionary = _collect_catalog_paths(catalog_root)
+	var collect_error: Error = GFVariantData.get_option_int(
+		catalog_paths_result,
+		"error",
+		OK
+	) as Error
+	if collect_error != OK:
+		empty_result["error"] = collect_error
+		return empty_result
+	var descriptors: Array[Dictionary] = []
+	for catalog_path: String in GFVariantData.get_option_array(catalog_paths_result, "paths"):
+		var catalog_result: Dictionary = _read_json_dictionary(catalog_path)
+		if not GFVariantData.get_option_bool(catalog_result, "ok"):
+			return {"error": ERR_FILE_CORRUPT, "descriptors": []}
+		var catalog: Dictionary = GFVariantData.get_option_dictionary(catalog_result, "data")
+		var logical_path: String = GFVariantData.get_option_string(catalog, "logical_path")
+		var descriptor: Dictionary = make_family_descriptor_for_framework(
+			_storage_root_path,
+			logical_path
+		)
+		if (
+			descriptor.is_empty()
+			or GFVariantData.get_option_string(descriptor, "catalog_path") != catalog_path
+			or validate_family_for_framework(descriptor) != OK
+		):
+			return {"error": ERR_FILE_CORRUPT, "descriptors": []}
+		descriptors.append(descriptor)
+	descriptors.sort_custom(func(left: Dictionary, right: Dictionary) -> bool:
+		return (
+			GFVariantData.get_option_string(left, "logical_path")
+			< GFVariantData.get_option_string(right, "logical_path")
+		)
+	)
+	return {"error": OK, "descriptors": descriptors}
+
+
+## 判断一个已 claim family 是否有 committed payload。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @param descriptor: family descriptor。
+## [br]
+## @schema descriptor: Dictionary，必须精确匹配 make_family_descriptor_for_framework() 的固定字段与派生路径。
+## [br]
+## @return catalog/owner 有效且 payload 存在时返回 true。
+func has_file_for_framework(descriptor: Dictionary) -> bool:
+	return (
+		validate_family_for_framework(descriptor) == OK
+		and FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "payload_path"))
+	)
+
+
+# --- 私有/辅助方法 ---
+
+static func _is_valid_logical_path(logical_path: String, allow_empty: bool) -> bool:
+	if logical_path.is_empty():
+		return allow_empty
+	if logical_path.length() > _MAX_LOGICAL_PATH_BYTES:
+		return false
+	var segments: PackedStringArray = logical_path.split("/", true)
+	if segments.is_empty() or segments.size() > _MAX_LOGICAL_SEGMENTS:
+		return false
+	for segment: String in segments:
+		if not _is_valid_logical_segment(segment):
+			return false
+	return true
+
+
+static func _is_valid_logical_segment(segment: String) -> bool:
+	if segment.is_empty() or segment.length() > _MAX_LOGICAL_SEGMENT_BYTES:
+		return false
+	if not _is_ascii_alnum(segment.substr(0, 1)):
+		return false
+	if not _is_ascii_alnum(segment.substr(segment.length() - 1, 1)):
+		return false
+	for index: int in range(segment.length()):
+		if not _ALLOWED_SEGMENT_CHARS.contains(segment.substr(index, 1)):
+			return false
+	var stem: String = segment.get_slice(".", 0)
+	return not _RESERVED_DEVICE_STEMS.has(stem)
+
+
+static func _is_ascii_alnum(character: String) -> bool:
+	return character.length() == 1 and _ALNUM_CHARS.contains(character)
+
+
+static func _is_valid_storage_root(storage_root_path: String) -> bool:
+	if storage_root_path == "user://":
+		return true
+	if not storage_root_path.begins_with("user://"):
+		return false
+	var relative_root: String = storage_root_path.trim_prefix("user://")
+	return is_valid_logical_directory_path_for_framework(relative_root)
+
+
+static func _make_logical_digest(logical_path: String) -> String:
+	var hashing: HashingContext = HashingContext.new()
+	var start_error: Error = hashing.start(HashingContext.HASH_SHA256)
+	if start_error != OK:
+		return ""
+	var domain_error: Error = hashing.update(_IDENTITY_DOMAIN.to_utf8_buffer())
+	if domain_error != OK:
+		return ""
+	var separator_error: Error = hashing.update(PackedByteArray([0]))
+	if separator_error != OK:
+		return ""
+	var logical_error: Error = hashing.update(logical_path.to_utf8_buffer())
+	if logical_error != OK:
+		return ""
+	return hashing.finish().hex_encode()
+
+
+static func _derive_physical_extension(logical_path: String) -> String:
+	var extension: String = logical_path.get_extension()
+	if not is_valid_extension_filter_for_framework(extension):
+		return "bin"
+	return extension if not extension.is_empty() else "bin"
+
+
+static func _join_storage_root(storage_root_path: String, relative_path: String) -> String:
+	if storage_root_path == "user://":
+		return "user://" + relative_path
+	return storage_root_path + "/" + relative_path
+
+
+static func _make_layout_manifest() -> Dictionary:
+	return {
+		"schema": _LAYOUT_SCHEMA,
+		"schema_version": _LAYOUT_VERSION,
+		"path_profile": _PATH_PROFILE,
+		"identity_algorithm": _IDENTITY_ALGORITHM,
+		"private_namespace": _PRIVATE_ROOT_NAME,
+	}
+
+
+static func _is_valid_layout_manifest(manifest: Dictionary) -> bool:
+	return _records_match_expected(manifest, _make_layout_manifest())
+
+
+static func _make_identity_record(schema: String, descriptor: Dictionary) -> Dictionary:
+	return {
+		"schema": schema,
+		"schema_version": _LAYOUT_VERSION,
+		"path_profile": _PATH_PROFILE,
+		"identity_algorithm": _IDENTITY_ALGORITHM,
+		"logical_path": GFVariantData.get_option_string(descriptor, "logical_path"),
+		"logical_sha256": GFVariantData.get_option_string(descriptor, "logical_sha256"),
+		"family_id": GFVariantData.get_option_string(descriptor, "family_id"),
+		"payload_leaf": GFVariantData.get_option_string(descriptor, "payload_path").get_file(),
+	}
+
+
+static func _matches_identity_record(record: Dictionary, schema: String, descriptor: Dictionary) -> bool:
+	return _records_match_expected(record, _make_identity_record(schema, descriptor))
+
+
+static func _records_match_expected(record: Dictionary, expected: Dictionary) -> bool:
+	if record.size() != expected.size():
+		return false
+	for key: Variant in expected.keys():
+		if not record.has(key):
+			return false
+		var expected_value: Variant = expected[key]
+		var actual_value: Variant = record[key]
+		if expected_value is int:
+			if GFVariantData.to_exact_int(actual_value, -1) != expected_value:
+				return false
+		elif typeof(actual_value) != typeof(expected_value) or actual_value != expected_value:
+			return false
+	return true
+
+
+func _validate_descriptor(descriptor: Dictionary) -> Error:
+	if _storage_root_path.is_empty():
+		return ERR_INVALID_PARAMETER
+	var logical_path: String = GFVariantData.get_option_string(descriptor, "logical_path")
+	var expected: Dictionary = make_family_descriptor_for_framework(_storage_root_path, logical_path)
+	if expected.is_empty() or descriptor != expected:
+		return ERR_INVALID_PARAMETER
+	return OK
+
+
+func _validate_owner_only_claim(descriptor: Dictionary) -> Error:
+	var family_path: String = GFVariantData.get_option_string(descriptor, "family_path")
+	var owner_path: String = GFVariantData.get_option_string(descriptor, "owner_path")
+	if not FileAccess.file_exists(owner_path):
+		return ERR_FILE_CORRUPT
+	var entries: Dictionary = _read_directory_entries(family_path)
+	if GFVariantData.get_option_int(entries, "error", OK) != OK:
+		return GFVariantData.get_option_int(entries, "error", ERR_FILE_CANT_READ) as Error
+	var names: Array = GFVariantData.get_option_array(entries, "names")
+	if names != ["owner.json"]:
+		return ERR_FILE_CORRUPT
+	var owner_result: Dictionary = _read_json_dictionary(owner_path)
+	if not GFVariantData.get_option_bool(owner_result, "ok"):
+		return ERR_FILE_CORRUPT
+	if not _matches_identity_record(
+		GFVariantData.get_option_dictionary(owner_result, "data"),
+		_OWNER_SCHEMA,
+		descriptor
+	):
+		return ERR_FILE_CORRUPT
+	return OK
+
+
+func _reconcile_claim_staging(descriptor: Dictionary) -> Error:
+	var family_path: String = GFVariantData.get_option_string(descriptor, "family_path")
+	var family_parent: String = family_path.get_base_dir()
+	var entries: Dictionary = _read_directory_entries(family_parent)
+	var entries_error: Error = GFVariantData.get_option_int(entries, "error", OK) as Error
+	if entries_error != OK:
+		return entries_error
+	var prefix: String = family_path.get_file() + _CLAIM_STAGING_SEPARATOR
+	var staging_paths: Array[String] = []
+	for entry: String in GFVariantData.get_option_array(entries, "names"):
+		if not entry.begins_with(prefix):
+			continue
+		var claim_id: String = entry.trim_prefix(prefix)
+		if not GFUuid.is_valid(claim_id, 4):
+			return ERR_FILE_CORRUPT
+		var staging_path: String = family_parent.path_join(entry)
+		if not DirAccess.dir_exists_absolute(staging_path):
+			return ERR_FILE_CORRUPT
+		var staging_error: Error = _validate_claim_staging(descriptor, staging_path)
+		if staging_error != OK:
+			return staging_error
+		staging_paths.append(staging_path)
+	staging_paths.sort()
+	if not DirAccess.dir_exists_absolute(family_path) and not staging_paths.is_empty():
+		var promoted_path: String = staging_paths[0]
+		var promote_error: Error = DirAccess.rename_absolute(promoted_path, family_path)
+		if promote_error != OK and not DirAccess.dir_exists_absolute(family_path):
+			return promote_error
+	for staging_path: String in staging_paths:
+		if DirAccess.dir_exists_absolute(staging_path):
+			var cleanup_error: Error = _remove_claim_staging(staging_path)
+			if cleanup_error != OK:
+				return cleanup_error
+	return OK
+
+
+func _validate_claim_staging(descriptor: Dictionary, staging_path: String) -> Error:
+	var entries: Dictionary = _read_directory_entries(staging_path)
+	var entries_error: Error = GFVariantData.get_option_int(entries, "error", OK) as Error
+	if entries_error != OK:
+		return entries_error
+	if GFVariantData.get_option_array(entries, "names") != ["owner.json"]:
+		return ERR_FILE_CORRUPT
+	var owner_result: Dictionary = _read_json_dictionary(staging_path.path_join("owner.json"))
+	if not GFVariantData.get_option_bool(owner_result, "ok"):
+		return ERR_FILE_CORRUPT
+	return OK if _matches_identity_record(
+		GFVariantData.get_option_dictionary(owner_result, "data"),
+		_OWNER_SCHEMA,
+		descriptor
+	) else ERR_FILE_CORRUPT
+
+
+func _validate_family_entries(descriptor: Dictionary) -> Error:
+	var family_path: String = GFVariantData.get_option_string(descriptor, "family_path")
+	var entries: Dictionary = _read_directory_entries(family_path)
+	var entries_error: Error = GFVariantData.get_option_int(entries, "error", OK) as Error
+	if entries_error != OK:
+		return entries_error
+	var allowed: Dictionary = {
+		"owner.json": true,
+		GFVariantData.get_option_string(descriptor, "payload_path").get_file(): true,
+		GFVariantData.get_option_string(descriptor, "candidate_path").get_file(): true,
+		GFVariantData.get_option_string(descriptor, "backup_path").get_file(): true,
+		"transaction.prepare.json": true,
+		"transaction.prepare.pending.json": true,
+		"transaction.commit.json": true,
+		"transaction.commit.pending.json": true,
+		GFVariantData.get_option_string(descriptor, "resource_stage_path").get_file(): true,
+	}
+	for entry: String in GFVariantData.get_option_array(entries, "names"):
+		if not allowed.has(entry):
+			return ERR_FILE_CORRUPT
+		if DirAccess.dir_exists_absolute(family_path.path_join(entry)):
+			return ERR_FILE_CORRUPT
+	return OK
+
+
+func _collect_catalog_paths(catalog_root: String) -> Dictionary:
+	var result: Array[String] = []
+	var first_level: Dictionary = _read_directory_entries(catalog_root)
+	var first_error: Error = GFVariantData.get_option_int(first_level, "error", OK) as Error
+	if first_error != OK:
+		return {"error": first_error, "paths": result}
+	for first_shard: String in GFVariantData.get_option_array(first_level, "names"):
+		if not _is_hex_shard(first_shard):
+			return {"error": ERR_FILE_CORRUPT, "paths": []}
+		var first_path: String = catalog_root.path_join(first_shard)
+		if not DirAccess.dir_exists_absolute(first_path):
+			return {"error": ERR_FILE_CORRUPT, "paths": []}
+		var second_level: Dictionary = _read_directory_entries(first_path)
+		var second_error: Error = GFVariantData.get_option_int(second_level, "error", OK) as Error
+		if second_error != OK:
+			return {"error": second_error, "paths": []}
+		for second_shard: String in GFVariantData.get_option_array(second_level, "names"):
+			if not _is_hex_shard(second_shard):
+				return {"error": ERR_FILE_CORRUPT, "paths": []}
+			var second_path: String = first_path.path_join(second_shard)
+			if not DirAccess.dir_exists_absolute(second_path):
+				return {"error": ERR_FILE_CORRUPT, "paths": []}
+			var leaf_entries: Dictionary = _read_directory_entries(second_path)
+			var leaf_error: Error = GFVariantData.get_option_int(leaf_entries, "error", OK) as Error
+			if leaf_error != OK:
+				return {"error": leaf_error, "paths": []}
+			for leaf_name: String in GFVariantData.get_option_array(leaf_entries, "names"):
+				if not _is_catalog_leaf(leaf_name, first_shard, second_shard):
+					return {"error": ERR_FILE_CORRUPT, "paths": []}
+				if DirAccess.dir_exists_absolute(second_path.path_join(leaf_name)):
+					return {"error": ERR_FILE_CORRUPT, "paths": []}
+				result.append(second_path.path_join(leaf_name))
+	result.sort()
+	return {"error": OK, "paths": result}
+
+
+func _reconcile_catalog_publish_residue(catalog_root: String) -> Error:
+	var pending_targets: Dictionary = {}
+	var first_level: Dictionary = _read_directory_entries(catalog_root)
+	var first_error: Error = GFVariantData.get_option_int(first_level, "error", OK) as Error
+	if first_error != OK:
+		return first_error
+	for first_shard: String in GFVariantData.get_option_array(first_level, "names"):
+		if not _is_hex_shard(first_shard):
+			return ERR_FILE_CORRUPT
+		var first_path: String = catalog_root.path_join(first_shard)
+		if not DirAccess.dir_exists_absolute(first_path):
+			return ERR_FILE_CORRUPT
+		var second_level: Dictionary = _read_directory_entries(first_path)
+		var second_error: Error = GFVariantData.get_option_int(
+			second_level,
+			"error",
+			OK
+		) as Error
+		if second_error != OK:
+			return second_error
+		for second_shard: String in GFVariantData.get_option_array(second_level, "names"):
+			if not _is_hex_shard(second_shard):
+				return ERR_FILE_CORRUPT
+			var second_path: String = first_path.path_join(second_shard)
+			if not DirAccess.dir_exists_absolute(second_path):
+				return ERR_FILE_CORRUPT
+			var leaf_entries: Dictionary = _read_directory_entries(second_path)
+			var leaf_error: Error = GFVariantData.get_option_int(
+				leaf_entries,
+				"error",
+				OK
+			) as Error
+			if leaf_error != OK:
+				return leaf_error
+			for leaf_name: String in GFVariantData.get_option_array(leaf_entries, "names"):
+				if _is_catalog_leaf(leaf_name, first_shard, second_shard):
+					continue
+				var separator_index: int = leaf_name.find(_PUBLISH_PENDING_SEPARATOR)
+				if separator_index <= 0:
+					return ERR_FILE_CORRUPT
+				var target_leaf: String = leaf_name.substr(0, separator_index)
+				if (
+					not _is_catalog_leaf(target_leaf, first_shard, second_shard)
+					or not _is_publish_pending_leaf(leaf_name, target_leaf)
+				):
+					return ERR_FILE_CORRUPT
+				var pending_path: String = second_path.path_join(leaf_name)
+				if DirAccess.dir_exists_absolute(pending_path):
+					return ERR_FILE_CORRUPT
+				var pending_result: Dictionary = _read_json_dictionary(pending_path)
+				if not GFVariantData.get_option_bool(pending_result, "ok"):
+					return ERR_FILE_CORRUPT
+				var pending_record: Dictionary = GFVariantData.get_option_dictionary(
+					pending_result,
+					"data"
+				)
+				var logical_path: String = GFVariantData.get_option_string(
+					pending_record,
+					"logical_path"
+				)
+				var descriptor: Dictionary = make_family_descriptor_for_framework(
+					_storage_root_path,
+					logical_path
+				)
+				var target_path: String = second_path.path_join(target_leaf)
+				var expected: Dictionary = _make_identity_record(_CATALOG_SCHEMA, descriptor)
+				if (
+					descriptor.is_empty()
+					or GFVariantData.get_option_string(descriptor, "catalog_path") != target_path
+					or not _records_match_expected(pending_record, expected)
+				):
+					return ERR_FILE_CORRUPT
+				pending_targets[target_path] = expected
+	var target_paths: Array[String] = []
+	for target_path_value: Variant in pending_targets.keys():
+		target_paths.append(GFVariantData.to_text(target_path_value))
+	target_paths.sort()
+	for target_path: String in target_paths:
+		var publish_error: Error = _publish_json_if_absent(
+			target_path,
+			GFVariantData.get_option_dictionary(pending_targets, target_path)
+		)
+		if publish_error != OK:
+			return publish_error
+	return OK
+
+
+static func _is_hex_shard(value: String) -> bool:
+	if value.length() != 2:
+		return false
+	return _HEX_CHARS.contains(value.substr(0, 1)) and _HEX_CHARS.contains(value.substr(1, 1))
+
+
+static func _is_catalog_leaf(leaf_name: String, first_shard: String, second_shard: String) -> bool:
+	if not leaf_name.ends_with(".json"):
+		return false
+	var digest: String = leaf_name.trim_suffix(".json")
+	if digest.length() != 64 or not digest.begins_with(first_shard + second_shard):
+		return false
+	for index: int in range(digest.length()):
+		if not _HEX_CHARS.contains(digest.substr(index, 1)):
+			return false
+	return true
+
+
+static func _is_publish_pending_leaf(leaf_name: String, target_leaf: String) -> bool:
+	var prefix: String = target_leaf + _PUBLISH_PENDING_SEPARATOR
+	if not leaf_name.begins_with(prefix):
+		return false
+	return GFUuid.is_valid(leaf_name.trim_prefix(prefix), 4)
+
+
+static func _matches_list_selector(
+	logical_path: String,
+	directory_name: String,
+	recursive: bool,
+	max_scan_depth: int
+) -> bool:
+	var remainder: String = logical_path
+	if not directory_name.is_empty():
+		var prefix: String = directory_name + "/"
+		if not logical_path.begins_with(prefix):
+			return false
+		remainder = logical_path.trim_prefix(prefix)
+	var directory_depth: int = maxi(remainder.get_slice_count("/") - 1, 0)
+	if not recursive and directory_depth > 0:
+		return false
+	return max_scan_depth <= 0 or directory_depth <= max_scan_depth
+
+
+func _publish_json_if_absent(path: String, data: Dictionary) -> Error:
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	var parent_error: Error = _ensure_directory(path.get_base_dir())
+	if parent_error != OK:
+		return parent_error
+	var pending_recovery_error: Error = _reconcile_publish_pending_files(path, data)
+	if pending_recovery_error != OK:
+		return pending_recovery_error
+	if FileAccess.file_exists(path):
+		var existing: Dictionary = _read_json_dictionary(path)
+		if not GFVariantData.get_option_bool(existing, "ok"):
+			return ERR_FILE_CORRUPT
+		return OK if _records_match_expected(
+			GFVariantData.get_option_dictionary(existing, "data"),
+			data
+		) else ERR_FILE_CORRUPT
+	var pending_path: String = path + _PUBLISH_PENDING_SEPARATOR + GFUuid.generate_v4()
+	var write_error: Error = _write_json_direct(pending_path, data)
+	if write_error != OK:
+		return write_error
+	var pending_result: Dictionary = _read_json_dictionary(pending_path)
+	if (
+		not GFVariantData.get_option_bool(pending_result, "ok")
+		or not _records_match_expected(
+			GFVariantData.get_option_dictionary(pending_result, "data"),
+			data
+		)
+	):
+		var _invalid_pending_cleanup: Error = _remove_file_if_exists(pending_path)
+		return ERR_FILE_CORRUPT
+	var publish_error: Error = DirAccess.rename_absolute(pending_path, path)
+	if publish_error != OK:
+		var _pending_cleanup_after_race: Error = _remove_file_if_exists(pending_path)
+		if not FileAccess.file_exists(path):
+			return publish_error
+		var raced: Dictionary = _read_json_dictionary(path)
+		if (
+			not GFVariantData.get_option_bool(raced, "ok")
+			or not _records_match_expected(
+				GFVariantData.get_option_dictionary(raced, "data"),
+				data
+			)
+		):
+			return ERR_FILE_CORRUPT
+	return OK
+
+
+func _reconcile_publish_pending_files(path: String, expected: Dictionary) -> Error:
+	var parent_path: String = path.get_base_dir()
+	var entries: Dictionary = _read_directory_entries(parent_path)
+	var entries_error: Error = GFVariantData.get_option_int(entries, "error", OK) as Error
+	if entries_error != OK:
+		return entries_error
+	var target_leaf: String = path.get_file()
+	var prefix: String = target_leaf + _PUBLISH_PENDING_SEPARATOR
+	var pending_paths: Array[String] = []
+	for entry: String in GFVariantData.get_option_array(entries, "names"):
+		if not entry.begins_with(prefix):
+			continue
+		if not _is_publish_pending_leaf(entry, target_leaf):
+			return ERR_FILE_CORRUPT
+		var pending_path: String = parent_path.path_join(entry)
+		if DirAccess.dir_exists_absolute(pending_path):
+			return ERR_FILE_CORRUPT
+		var pending_result: Dictionary = _read_json_dictionary(pending_path)
+		if (
+			not GFVariantData.get_option_bool(pending_result, "ok")
+			or not _records_match_expected(
+				GFVariantData.get_option_dictionary(pending_result, "data"),
+				expected
+			)
+		):
+			return ERR_FILE_CORRUPT
+		pending_paths.append(pending_path)
+	pending_paths.sort()
+	if FileAccess.file_exists(path):
+		var existing: Dictionary = _read_json_dictionary(path)
+		if (
+			not GFVariantData.get_option_bool(existing, "ok")
+			or not _records_match_expected(
+				GFVariantData.get_option_dictionary(existing, "data"),
+				expected
+			)
+		):
+			return ERR_FILE_CORRUPT
+		for pending_path: String in pending_paths:
+			var cleanup_error: Error = _remove_file_if_exists(pending_path)
+			if cleanup_error != OK:
+				return cleanup_error
+		return OK
+	if pending_paths.is_empty():
+		return OK
+	var promoted_path: String = pending_paths[0]
+	var promote_error: Error = DirAccess.rename_absolute(promoted_path, path)
+	if promote_error != OK and not FileAccess.file_exists(path):
+		return promote_error
+	var published: Dictionary = _read_json_dictionary(path)
+	if (
+		not GFVariantData.get_option_bool(published, "ok")
+		or not _records_match_expected(
+			GFVariantData.get_option_dictionary(published, "data"),
+			expected
+		)
+	):
+		return ERR_FILE_CORRUPT
+	for pending_path: String in pending_paths:
+		if pending_path == promoted_path:
+			continue
+		var cleanup_error: Error = _remove_file_if_exists(pending_path)
+		if cleanup_error != OK:
+			return cleanup_error
+	return OK
+
+
+static func _write_json_direct(path: String, data: Dictionary) -> Error:
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		return FileAccess.get_open_error()
+	var _stored: bool = file.store_string(JSON.stringify(data, "\t")) != null
+	file.flush()
+	var write_error: Error = file.get_error()
+	file.close()
+	return write_error
+
+
+static func _read_json_dictionary(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {"ok": false, "error": ERR_FILE_NOT_FOUND, "data": {}}
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {"ok": false, "error": FileAccess.get_open_error(), "data": {}}
+	var length: int = file.get_length()
+	if length <= 0 or length > _MAX_MANIFEST_BYTES:
+		file.close()
+		return {"ok": false, "error": ERR_FILE_CORRUPT, "data": {}}
+	var text: String = file.get_as_text()
+	var read_error: Error = file.get_error()
+	file.close()
+	if read_error != OK:
+		return {"ok": false, "error": read_error, "data": {}}
+	var parsed: Variant = JSON.parse_string(text)
+	if not parsed is Dictionary:
+		return {"ok": false, "error": ERR_FILE_CORRUPT, "data": {}}
+	var data: Dictionary = parsed
+	return {"ok": true, "error": OK, "data": data}
+
+
+static func _ensure_directory(path: String) -> Error:
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	if DirAccess.dir_exists_absolute(path):
+		return OK
+	return DirAccess.make_dir_recursive_absolute(path)
+
+
+static func _remove_file_if_exists(path: String) -> Error:
+	if not FileAccess.file_exists(path):
+		return OK
+	return DirAccess.remove_absolute(path)
+
+
+static func _remove_claim_staging(staging_path: String) -> Error:
+	var owner_error: Error = _remove_file_if_exists(staging_path.path_join("owner.json"))
+	if owner_error != OK:
+		return owner_error
+	if not DirAccess.dir_exists_absolute(staging_path):
+		return OK
+	return DirAccess.remove_absolute(staging_path)
+
+
+static func _read_directory_entries(path: String) -> Dictionary:
+	var dir: DirAccess = DirAccess.open(path)
+	if dir == null:
+		return {"error": ERR_FILE_CANT_OPEN, "names": []}
+	var begin_error: Error = dir.list_dir_begin()
+	if begin_error != OK:
+		return {"error": begin_error, "names": []}
+	var names: Array[String] = []
+	var entry: String = dir.get_next()
+	while not entry.is_empty():
+		names.append(entry)
+		entry = dir.get_next()
+	dir.list_dir_end()
+	names.sort()
+	return {"error": OK, "names": names}

--- a/addons/gf/standard/utilities/storage/gf_storage_family_store.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_family_store.gd
@@ -769,6 +769,12 @@ func _reconcile_claim_staging(descriptor: Dictionary) -> Error:
 		if not DirAccess.dir_exists_absolute(staging_path):
 			return ERR_FILE_CORRUPT
 		var staging_error: Error = _validate_claim_staging(descriptor, staging_path)
+		if staging_error == ERR_FILE_NOT_FOUND:
+			# staging 尚未发布；在单写者 root 契约下，空目录或截断的 owner 写入可安全丢弃。
+			var incomplete_cleanup_error: Error = _remove_claim_staging(staging_path)
+			if incomplete_cleanup_error != OK:
+				return incomplete_cleanup_error
+			continue
 		if staging_error != OK:
 			return staging_error
 		staging_paths.append(staging_path)
@@ -791,11 +797,19 @@ func _validate_claim_staging(descriptor: Dictionary, staging_path: String) -> Er
 	var entries_error: Error = GFVariantData.get_option_int(entries, "error", OK) as Error
 	if entries_error != OK:
 		return entries_error
-	if GFVariantData.get_option_array(entries, "names") != ["owner.json"]:
+	var names: Array = GFVariantData.get_option_array(entries, "names")
+	if names.is_empty():
+		return ERR_FILE_NOT_FOUND
+	if names != ["owner.json"]:
 		return ERR_FILE_CORRUPT
 	var owner_result: Dictionary = _read_json_dictionary(staging_path.path_join("owner.json"))
 	if not GFVariantData.get_option_bool(owner_result, "ok"):
-		return ERR_FILE_CORRUPT
+		var owner_error: Error = GFVariantData.get_option_int(
+			owner_result,
+			"error",
+			ERR_FILE_CORRUPT
+		) as Error
+		return ERR_FILE_NOT_FOUND if owner_error in [ERR_FILE_NOT_FOUND, ERR_FILE_CORRUPT] else owner_error
 	return OK if _matches_identity_record(
 		GFVariantData.get_option_dictionary(owner_result, "data"),
 		_OWNER_SCHEMA,
@@ -1137,7 +1151,10 @@ static func _read_json_dictionary(path: String) -> Dictionary:
 	file.close()
 	if read_error != OK:
 		return {"ok": false, "error": read_error, "data": {}}
-	var parsed: Variant = JSON.parse_string(text)
+	var parser: JSON = JSON.new()
+	if parser.parse(text) != OK:
+		return {"ok": false, "error": ERR_FILE_CORRUPT, "data": {}}
+	var parsed: Variant = parser.data
 	if not parsed is Dictionary:
 		return {"ok": false, "error": ERR_FILE_CORRUPT, "data": {}}
 	var data: Dictionary = parsed

--- a/addons/gf/standard/utilities/storage/gf_storage_family_store.gd.uid
+++ b/addons/gf/standard/utilities/storage/gf_storage_family_store.gd.uid
@@ -1,0 +1,1 @@
+uid://c6cphj1w10nw1

--- a/addons/gf/standard/utilities/storage/gf_storage_utility.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_utility.gd
@@ -686,6 +686,12 @@ func save_data_group(files: Dictionary) -> Error:
 	if files.is_empty():
 		push_error("[GFStorageUtility] save_data_group 失败：files 为空。")
 		return ERR_INVALID_PARAMETER
+	if files.size() > _MAX_TRANSACTION_FILES:
+		push_error(
+			"[GFStorageUtility] save_data_group 失败：成员数超过上限 %d。"
+			% _MAX_TRANSACTION_FILES
+		)
+		return ERR_INVALID_PARAMETER
 
 	var file_names: Array[String] = []
 	var payloads_by_file: Dictionary = {}

--- a/addons/gf/standard/utilities/storage/gf_storage_utility.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_utility.gd
@@ -62,10 +62,12 @@ signal load_completed(file_name: String, result: GFStorageReadResult)
 
 # --- 常量 ---
 
-const _TEMP_SUFFIX: String = ".tmp"
-const _BACKUP_SUFFIX: String = ".bak"
-const _TRANSACTION_SUFFIX: String = ".txn"
-const _TRANSACTION_MARKER_SCHEMA_VERSION: int = 1
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload(
+	"res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd"
+)
+const _TRANSACTION_PREPARE_SCHEMA: String = "gf.storage.transaction-prepare"
+const _TRANSACTION_COMMIT_SCHEMA: String = "gf.storage.transaction-commit"
+const _TRANSACTION_MARKER_SCHEMA_VERSION: int = 2
 const _MAX_TRANSACTION_FILES: int = 64
 const _PAYLOAD_VALIDATION_MAX_DEPTH: int = 128
 const _PAYLOAD_VALIDATION_MAX_VALUES: int = 1_000_000
@@ -89,12 +91,27 @@ const DEFAULT_MAX_LISTED_FILES: int = 10000
 ## @api public
 var encrypt_key: int = 42
 
-## 保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。
+## Storage root 的 portable logical 目录名；为空时使用 `user://`。
+## 首次 activation、显式 `init()` 或合法 I/O 尝试后冻结；非法配置失败关闭。
 ## [br]
 ## @api public
 ## [br]
 ## @since 3.17.0
-var save_dir_name: String = "saves"
+var save_dir_name: String = "saves":
+	set(value):
+		var _root_changed: bool = value != save_dir_name
+		if _storage_root_frozen and _root_changed:
+			push_error("[GFStorageUtility] save_dir_name 已在 Storage 初始化后冻结；请为另一个 root 创建新的 Utility。")
+			return
+		save_dir_name = value
+		if _family_store != null:
+			var _storage_root_path: String = GFStorageFamilyStore.make_storage_root_path_for_framework(
+				value
+			)
+			if not _storage_root_path.is_empty():
+				var _configured: bool = _family_store.configure_for_framework(_storage_root_path)
+				if _root_changed:
+					_storage_reconciled = false
 
 ## 存档 codec。为 null 时会自动创建默认 GFStorageCodec。
 ## [br]
@@ -167,11 +184,6 @@ var allowed_resource_load_type_hints: PackedStringArray = PackedStringArray()
 ## @since 6.0.0
 var require_resource_load_type_hint: bool = true
 
-## 写入嵌套相对路径时是否自动创建目录。
-## [br]
-## @api public
-var create_directories_for_nested_paths: bool = true
-
 ## 同时运行的异步存取线程数量。小于 1 时会被钳制为 1。
 ## [br]
 ## @api public
@@ -221,7 +233,10 @@ var _quiesce_completion: GFAsyncCompletion = null
 var _migration_steps: Dictionary = {}
 var _path_policy: _StoragePathPolicy
 var _file_ops: _StorageFileOps
+var _family_store: GFStorageFamilyStore
 var _transaction_manager: _StorageTransactionManager
+var _storage_root_frozen: bool = false
+var _storage_reconciled: bool = false
 
 
 # --- Godot 生命周期方法 ---
@@ -238,14 +253,10 @@ func _init() -> void:
 func init() -> void:
 	if not _io_admission_open:
 		return
-	_ensure_storage_helpers()
 	ignore_pause = true
-	var dir_path: String = _get_save_base_path()
-	if dir_path.is_empty():
-		return
-	var dir_error: Error = _ensure_directory_absolute(dir_path)
-	if dir_error != OK:
-		push_error("[GFStorageUtility] 无法初始化存储目录：%s，错误码：%s" % [dir_path, dir_error])
+	var layout_error: Error = _ensure_storage_ready()
+	if layout_error != OK:
+		push_error("[GFStorageUtility] 无法初始化私有 Storage layout，错误码：%s" % layout_error)
 
 
 ## 等待并清理异步存取任务。
@@ -261,6 +272,7 @@ func dispose() -> void:
 	_async_queue.clear()
 	_async_file_locks.clear()
 	_migration_steps.clear()
+	_storage_reconciled = false
 	last_load_result = null
 	_release_storage_helpers()
 	_is_disposing = false
@@ -298,7 +310,16 @@ func begin_activation(_scope: GFAsyncScope) -> GFAsyncCompletion:
 		return completion
 	_quiesce_completion = null
 	_io_admission_open = true
-	init()
+	ignore_pause = true
+	_storage_reconciled = false
+	var readiness_error: Error = _ensure_storage_ready()
+	if readiness_error != OK:
+		_io_admission_open = false
+		var _failed_readiness: bool = completion.fail(
+			"Storage private layout could not be activated.",
+			{"error_code": readiness_error}
+		)
+		return completion
 	var _succeeded: bool = completion.succeed()
 	return completion
 
@@ -339,7 +360,7 @@ func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:
 func save_resource(file_name: String, resource: Resource) -> Error:
 	if not _io_admission_open:
 		return ERR_UNAVAILABLE
-	if not _validate_public_file_name(file_name, "save_resource"):
+	if not _validate_public_resource_file_name(file_name, "save_resource"):
 		return ERR_INVALID_PARAMETER
 	if resource == null:
 		push_error("[GFStorageUtility] save_resource 失败：resource 为空。")
@@ -347,25 +368,38 @@ func save_resource(file_name: String, resource: Resource) -> Error:
 
 	init()
 	_wait_for_async_tasks_for_file(file_name)
-	_recover_transaction_files([file_name])
+	var prepare_error: Error = _prepare_family_for_write(file_name)
+	if prepare_error != OK:
+		return prepare_error
+	var marker_error: Error = _write_transaction_markers([file_name], false)
+	if marker_error != OK:
+		return marker_error
 
-	var temp_path: String = _get_full_path(_get_temp_filename(file_name))
-	var resource_temp_path: String = _get_full_path(_get_resource_temp_filename(file_name))
-	_remove_file_if_exists(resource_temp_path)
+	var descriptor: Dictionary = _make_family_descriptor(file_name)
+	var temp_path: String = GFVariantData.get_option_string(descriptor, "candidate_path")
+	var resource_temp_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"resource_stage_path"
+	)
+	var remove_stage_error: Error = _remove_absolute_file(resource_temp_path)
+	if remove_stage_error != OK:
+		var cleanup_error: Error = _cleanup_transaction_files([file_name])
+		return remove_stage_error if cleanup_error == OK else cleanup_error
 	var dir_error: Error = _ensure_parent_directory(temp_path)
 	if dir_error != OK:
-		return dir_error
+		var cleanup_error: Error = _cleanup_transaction_files([file_name])
+		return dir_error if cleanup_error == OK else cleanup_error
 	var save_error: Error = ResourceSaver.save(resource, resource_temp_path)
 	if save_error != OK:
 		_remove_file_if_exists(resource_temp_path)
-		_cleanup_transaction_files([file_name])
-		return save_error
+		var cleanup_error: Error = _cleanup_transaction_files([file_name])
+		return save_error if cleanup_error == OK else cleanup_error
 	var copy_error: Error = _copy_file_bytes(resource_temp_path, temp_path)
 	_remove_file_if_exists(resource_temp_path)
 	if copy_error != OK:
-		_cleanup_transaction_files([file_name])
-		return copy_error
-	return _commit_transaction([file_name])
+		var cleanup_error: Error = _cleanup_transaction_files([file_name])
+		return copy_error if cleanup_error == OK else cleanup_error
+	return _commit_transaction([file_name], true)
 
 
 ## 读取一个 `Resource` 文件。
@@ -384,7 +418,7 @@ func save_resource(file_name: String, resource: Resource) -> Error:
 func load_resource(file_name: String, type_hint: String = "") -> Resource:
 	if not _io_admission_open:
 		return null
-	if not _validate_public_file_name(file_name, "load_resource"):
+	if not _validate_public_resource_file_name(file_name, "load_resource"):
 		return null
 	if not allow_resource_loads:
 		push_error("[GFStorageUtility] load_resource 已被默认安全策略拒绝：请先显式启用 allow_resource_loads。")
@@ -392,9 +426,14 @@ func load_resource(file_name: String, type_hint: String = "") -> Resource:
 
 	init()
 	_wait_for_async_tasks_for_file(file_name)
-	_recover_transaction_files([file_name])
+	var prepare_error: Error = _prepare_family_for_read(file_name)
+	if prepare_error != OK:
+		return null
 
-	var path: String = _get_full_path(file_name)
+	var path: String = GFVariantData.get_option_string(
+		_make_family_descriptor(file_name),
+		"payload_path"
+	)
 	if not FileAccess.file_exists(path):
 		return null
 	if not _is_resource_load_extension_allowed(path):
@@ -420,45 +459,6 @@ func load_resource(file_name: String, type_hint: String = "") -> Resource:
 
 # --- 公共方法（文件管理） ---
 
-## 确保存储相对目录存在。
-## [br]
-## @api public
-## [br]
-## @param directory_name: 相对存储目录；为空时只确保根存储目录存在。
-## [br]
-## @return Godot 的 `Error` 结果码。
-func ensure_directory(directory_name: String = "") -> Error:
-	if not _io_admission_open:
-		return ERR_UNAVAILABLE
-	if not _validate_public_directory_name(directory_name, "ensure_directory"):
-		return ERR_INVALID_PARAMETER
-	var normalized_directory: String = _normalize_storage_directory_name(directory_name)
-	var path: String = _get_full_directory_path_from_normalized(normalized_directory)
-	if path.is_empty():
-		return ERR_INVALID_PARAMETER
-	init()
-	var error: Error = _ensure_directory_absolute(path)
-	if error != OK:
-		push_error("[GFStorageUtility] 无法创建目录：%s，错误码：%s" % [path, error])
-	return error
-
-
-## 获取存储目录路径，不创建目录。
-## [br]
-## @api public
-## [br]
-## @since 4.4.0
-## [br]
-## @param directory_name: 相对存储目录；为空时返回根存储目录。
-## [br]
-## @return 按当前路径策略解析后的目录路径。
-func get_storage_directory_path(directory_name: String = "") -> String:
-	if not _validate_public_directory_name(directory_name, "get_storage_directory_path"):
-		return ""
-	var normalized_directory: String = _normalize_storage_directory_name(directory_name)
-	return _get_full_directory_path_from_normalized(normalized_directory)
-
-
 ## 枚举指定存储目录下的文件。
 ## [br]
 ## @api public
@@ -467,7 +467,7 @@ func get_storage_directory_path(directory_name: String = "") -> String:
 ## [br]
 ## @param directory_name: 相对存储目录；为空时枚举根存储目录。
 ## [br]
-## @param extension_filter: 可选扩展名过滤，允许传入 `"json"` 或 `".json"`。
+## @param extension_filter: 可选 canonical lowercase 扩展名过滤，不包含点号。
 ## [br]
 ## @param recursive: 是否递归枚举子目录。
 ## [br]
@@ -475,7 +475,7 @@ func get_storage_directory_path(directory_name: String = "") -> String:
 ## [br]
 ## @schema options: Dictionary，包含 max_scan_depth: int 和 max_file_count: int。
 ## [br]
-## @return 当前 Storage root 内的规范相对文件路径数组。
+## @return 从已校验 catalog 投影的 committed portable logical file identity 数组。
 func list_files(
 	directory_name: String = "",
 	extension_filter: String = "",
@@ -486,39 +486,78 @@ func list_files(
 		return PackedStringArray()
 	if not _validate_public_directory_name(directory_name, "list_files"):
 		return PackedStringArray()
-	var result: PackedStringArray = PackedStringArray()
-	var normalized_directory: String = _normalize_storage_directory_name(directory_name)
-	var directory_path: String = _get_full_directory_path_from_normalized(normalized_directory)
-	if directory_path.is_empty():
-		return result
-	init()
-	var normalized_extension: String = _normalize_extension_filter(extension_filter)
+	if not GFStorageFamilyStore.is_valid_extension_filter_for_framework(extension_filter):
+		push_error("[GFStorageUtility] list_files 失败：extension_filter 非法。")
+		return PackedStringArray()
+	var readiness_error: Error = _ensure_storage_ready()
+	if readiness_error != OK:
+		push_error("[GFStorageUtility] list_files 无法加载 Storage layout，错误码：%s" % readiness_error)
+		return PackedStringArray()
+	var transaction_manager_at_entry: _StorageTransactionManager = _transaction_manager
+	var family_store_at_entry: GFStorageFamilyStore = _family_store
+	wait_for_async_tasks()
+	if (
+		not _io_admission_open
+		or _transaction_manager != transaction_manager_at_entry
+		or _family_store != family_store_at_entry
+	):
+		return PackedStringArray()
+	var recovery_error: Error = _transaction_manager._recover_all_catalog_transactions()
+	if recovery_error != OK:
+		_storage_reconciled = false
+		push_error("[GFStorageUtility] list_files 无法收敛 Storage 事务，错误码：%s" % recovery_error)
+		return PackedStringArray()
+	_storage_reconciled = true
 	var max_scan_depth: int = maxi(GFVariantData.get_option_int(options, "max_scan_depth", DEFAULT_MAX_LIST_DEPTH), 0)
 	var max_file_count: int = maxi(GFVariantData.get_option_int(options, "max_file_count", DEFAULT_MAX_LISTED_FILES), 0)
-	var scan_state: Dictionary = _make_list_scan_state()
-	_append_listed_files(
-		directory_path,
-		normalized_directory,
-		normalized_extension,
+	var list_result: Dictionary = _family_store.list_files_for_framework(
+		directory_name,
+		extension_filter,
 		recursive,
-		result,
-		0,
 		max_scan_depth,
-		max_file_count,
-		scan_state
+		max_file_count
 	)
-	result.sort()
-	return result
+	var list_error: Error = GFVariantData.get_option_int(list_result, "error", OK) as Error
+	if list_error != OK:
+		push_error("[GFStorageUtility] list_files 无法读取 logical catalog，错误码：%s" % list_error)
+		return PackedStringArray()
+	var files_value: Variant = list_result.get("files")
+	if files_value is PackedStringArray:
+		var files: PackedStringArray = files_value
+		return files
+	return PackedStringArray()
 
 
-## 删除一个存储文件。
-## 同时清理同名事务临时文件、备份文件和事务标记，避免删除后被遗留事务恢复。
+## 判断一个 logical file 是否存在 committed payload。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param file_name: portable logical file identity。
+## [br]
+## @return catalog、owner 与 payload 均有效时返回 true。
+func has_file(file_name: String) -> bool:
+	if not _io_admission_open:
+		return false
+	if not _validate_public_file_name(file_name, "has_file"):
+		return false
+	init()
+	_wait_for_async_tasks_for_file(file_name)
+	if _prepare_family_for_read(file_name) != OK:
+		return false
+	return _family_store.has_file_for_framework(_make_family_descriptor(file_name))
+
+
+## 删除一个精确 logical family 的 committed payload 与私有事务证据。
+##
+## 该方法不会扫描或收养 Storage root 下的旧版可见文件；immutable catalog/owner claim 会保留。
 ## [br]
 ## @api public
 ## [br]
 ## @since 3.17.0
 ## [br]
-## @param file_name: 存储相对文件路径。
+## @param file_name: portable logical file identity。
 ## [br]
 ## @return Godot 的 `Error` 结果码；文件不存在时返回 `ERR_FILE_NOT_FOUND`。
 func delete_file(file_name: String) -> Error:
@@ -529,25 +568,67 @@ func delete_file(file_name: String) -> Error:
 
 	init()
 	_wait_for_async_tasks_for_file(file_name)
+	var readiness_error: Error = _ensure_storage_ready()
+	if readiness_error != OK:
+		return readiness_error
+	var validate_error: Error = _family_store.validate_family_for_framework(
+		_make_family_descriptor(file_name)
+	)
+	if validate_error == ERR_FILE_NOT_FOUND:
+		return ERR_FILE_NOT_FOUND
+	if validate_error != OK:
+		return validate_error
+	var recovery_error: Error = _recover_transaction_files([file_name])
+	if recovery_error != OK:
+		return recovery_error
 
-	var path: String = _get_full_path(file_name)
-	var temp_path: String = _get_full_path(_get_temp_filename(file_name))
-	var backup_path: String = _get_full_path(_get_backup_filename(file_name))
-	var transaction_path: String = _get_full_path(_get_transaction_filename(file_name))
+	var descriptor: Dictionary = _make_family_descriptor(file_name)
+	var path: String = GFVariantData.get_option_string(descriptor, "payload_path")
+	var temp_path: String = GFVariantData.get_option_string(descriptor, "candidate_path")
+	var backup_path: String = GFVariantData.get_option_string(descriptor, "backup_path")
+	var transaction_path: String = GFVariantData.get_option_string(descriptor, "transaction_path")
+	var transaction_pending_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"transaction_pending_path"
+	)
+	var transaction_commit_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"transaction_commit_path"
+	)
+	var transaction_commit_pending_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"transaction_commit_pending_path"
+	)
+	var resource_stage_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"resource_stage_path"
+	)
 	var has_storage_family: bool = (
 		FileAccess.file_exists(path)
 		or FileAccess.file_exists(temp_path)
 		or FileAccess.file_exists(backup_path)
 		or FileAccess.file_exists(transaction_path)
+		or FileAccess.file_exists(transaction_pending_path)
+		or FileAccess.file_exists(transaction_commit_path)
+		or FileAccess.file_exists(transaction_commit_pending_path)
+		or FileAccess.file_exists(resource_stage_path)
 	)
 	if not has_storage_family:
 		return ERR_FILE_NOT_FOUND
 
-	var delete_error: Error = OK
-	if FileAccess.file_exists(path):
-		delete_error = DirAccess.remove_absolute(path)
-	_cleanup_transaction_files([file_name])
-	return delete_error
+	for sidecar_path: String in [
+		backup_path,
+		transaction_commit_pending_path,
+		transaction_commit_path,
+		transaction_pending_path,
+		transaction_path,
+		temp_path,
+		resource_stage_path,
+	]:
+		var sidecar_error: Error = _remove_absolute_file(sidecar_path)
+		if sidecar_error != OK:
+			return sidecar_error
+	return _remove_absolute_file(path)
 
 
 # --- 公共方法（纯数据存取） ---
@@ -571,15 +652,21 @@ func save_data(file_name: String, data: Dictionary) -> Error:
 
 	init()
 	_wait_for_async_tasks_for_file(file_name)
-	_recover_transaction_files([file_name])
+	var prepare_error: Error = _prepare_family_for_write(file_name)
+	if prepare_error != OK:
+		return prepare_error
+	var marker_error: Error = _write_transaction_markers([file_name], false)
+	if marker_error != OK:
+		return marker_error
 
 	var temp_file_name: String = _get_temp_filename(file_name)
 	var write_error: Error = _write_json(temp_file_name, data)
 	if write_error != OK:
-		_cleanup_transaction_files([file_name])
-		return write_error
+		var cleanup_error: Error = _cleanup_transaction_files([file_name])
+		return write_error if cleanup_error == OK else cleanup_error
 
-	return _commit_transaction([file_name])
+	var commit_error: Error = _commit_transaction([file_name], true)
+	return commit_error
 
 
 ## 以同一个事务保存多个纯字典文件。
@@ -592,7 +679,7 @@ func save_data(file_name: String, data: Dictionary) -> Error:
 ## [br]
 ## @return Godot 的 `Error` 结果码。
 ## [br]
-## @schema files: Dictionary，键为存储相对文件名，值为要序列化并保存的 Dictionary 载荷。
+## @schema files: Dictionary，键必须是未经改写的 String portable logical identity，值为要序列化并保存的 Dictionary 载荷。
 func save_data_group(files: Dictionary) -> Error:
 	if not _io_admission_open:
 		return ERR_UNAVAILABLE
@@ -603,7 +690,10 @@ func save_data_group(files: Dictionary) -> Error:
 	var file_names: Array[String] = []
 	var payloads_by_file: Dictionary = {}
 	for raw_file_name: Variant in files.keys():
-		var raw_file_name_text: String = GFVariantData.to_text(raw_file_name)
+		if not raw_file_name is String:
+			push_error("[GFStorageUtility] save_data_group 失败：文件名键必须是 String。")
+			return ERR_INVALID_PARAMETER
+		var raw_file_name_text: String = raw_file_name
 		if not _validate_public_file_name(raw_file_name_text, "save_data_group"):
 			return ERR_INVALID_PARAMETER
 		var file_name: String = _canonicalize_storage_file_name(raw_file_name_text, "file_name")
@@ -620,20 +710,31 @@ func save_data_group(files: Dictionary) -> Error:
 		payloads_by_file[file_name] = GFVariantData.as_dictionary(payload_value)
 
 	init()
+	var readiness_error: Error = _ensure_storage_ready()
+	if readiness_error != OK:
+		return readiness_error
 	for file_name: String in file_names:
 		_wait_for_async_tasks_for_file(file_name)
-	_recover_transaction_files(file_names)
+	for file_name: String in file_names:
+		var claim_error: Error = _family_store.claim_family_for_framework(
+			_make_family_descriptor(file_name)
+		)
+		if claim_error != OK:
+			return claim_error
+	var recovery_error: Error = _recover_transaction_files(file_names)
+	if recovery_error != OK:
+		return recovery_error
 	var marker_error: Error = _write_transaction_markers(file_names, false)
 	if marker_error != OK:
-		_cleanup_transaction_files(file_names)
-		return marker_error
+		var cleanup_error: Error = _cleanup_transaction_files(file_names)
+		return marker_error if cleanup_error == OK else cleanup_error
 
 	for file_name: String in file_names:
 		var temp_file_name: String = _get_temp_filename(file_name)
 		var write_error: Error = _write_json(temp_file_name, GFVariantData.get_option_dictionary(payloads_by_file, file_name))
 		if write_error != OK:
-			_cleanup_transaction_files(file_names)
-			return write_error
+			var cleanup_error: Error = _cleanup_transaction_files(file_names)
+			return write_error if cleanup_error == OK else cleanup_error
 
 	return _commit_transaction(file_names, true)
 
@@ -665,11 +766,21 @@ func load_data(file_name: String) -> GFStorageReadResult:
 
 	init()
 	_wait_for_async_tasks_for_file(file_name)
-	_recover_transaction_files([file_name])
+	var prepare_error: Error = _prepare_family_for_read(file_name)
+	if prepare_error != OK:
+		var failure_kind: GFStorageReadResult.FailureKind = _classify_load_failure(
+			prepare_error
+		)
+		last_load_result = _make_load_failure(
+			"File not found" if prepare_error == ERR_FILE_NOT_FOUND else "Storage family unavailable",
+			prepare_error,
+			failure_kind
+		)
+		return last_load_result.duplicate_result()
 	return _read_json(file_name)
 
 
-## 规范化并校验一个数据文件名。
+## 校验一个已经 canonical 的 portable logical 数据文件名。
 ##
 ## 返回值与异步队列的同文件锁使用相同路径规则，可用于建立稳定所有权键。
 ## [br]
@@ -679,7 +790,7 @@ func load_data(file_name: String) -> GFStorageReadResult:
 ## [br]
 ## @param file_name: 待校验文件名。
 ## [br]
-## @return 合法时返回当前 Storage root 内的规范相对文件名；非法时返回空字符串。
+## @return 输入本身满足 portable-ascii-v1 时原样返回；不会改写别名，非法时返回空字符串。
 func canonicalize_data_file_name(file_name: String) -> String:
 	if not _validate_public_file_name(file_name, "canonicalize_data_file_name"):
 		return ""
@@ -929,14 +1040,25 @@ func _make_async_operation(operation_kind: StringName) -> GFStorageAsyncOperatio
 
 
 func _make_async_target_family(canonical_file_name: String) -> Dictionary:
-	var final_path: String = _get_full_path(canonical_file_name)
+	var storage_root_path: String = _get_save_base_path()
+	var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+		storage_root_path,
+		canonical_file_name
+	)
 	return {
-		"storage_root_path": _get_save_base_path(),
-		"file_key": final_path,
-		"final_path": final_path,
-		"temp_path": _get_full_path(_get_temp_filename(canonical_file_name)),
-		"backup_path": _get_full_path(_get_backup_filename(canonical_file_name)),
-		"transaction_path": _get_full_path(_get_transaction_filename(canonical_file_name)),
+		"storage_root_path": storage_root_path,
+		"family_id": GFVariantData.get_option_string(descriptor, "family_id"),
+		"file_key": GFVariantData.get_option_string(descriptor, "file_key"),
+		"catalog_path": GFVariantData.get_option_string(descriptor, "catalog_path"),
+		"owner_path": GFVariantData.get_option_string(descriptor, "owner_path"),
+		"final_path": GFVariantData.get_option_string(descriptor, "payload_path"),
+		"temp_path": GFVariantData.get_option_string(descriptor, "candidate_path"),
+		"backup_path": GFVariantData.get_option_string(descriptor, "backup_path"),
+		"transaction_path": GFVariantData.get_option_string(descriptor, "transaction_path"),
+		"transaction_pending_path": GFVariantData.get_option_string(descriptor, "transaction_pending_path"),
+		"transaction_commit_path": GFVariantData.get_option_string(descriptor, "transaction_commit_path"),
+		"transaction_commit_pending_path": GFVariantData.get_option_string(descriptor, "transaction_commit_pending_path"),
+		"resource_stage_path": GFVariantData.get_option_string(descriptor, "resource_stage_path"),
 	}
 
 
@@ -988,11 +1110,18 @@ func _enqueue_async_save(
 		"file_name": file_name,
 		"storage_file_name": canonical_file_name,
 		"storage_root_path": GFVariantData.get_option_string(target_family, "storage_root_path"),
+		"family_id": GFVariantData.get_option_string(target_family, "family_id"),
 		"file_key": GFVariantData.get_option_string(target_family, "file_key"),
+		"catalog_path": GFVariantData.get_option_string(target_family, "catalog_path"),
+		"owner_path": GFVariantData.get_option_string(target_family, "owner_path"),
 		"final_path": GFVariantData.get_option_string(target_family, "final_path"),
 		"temp_path": GFVariantData.get_option_string(target_family, "temp_path"),
 		"backup_path": GFVariantData.get_option_string(target_family, "backup_path"),
 		"transaction_path": GFVariantData.get_option_string(target_family, "transaction_path"),
+		"transaction_pending_path": GFVariantData.get_option_string(target_family, "transaction_pending_path"),
+		"transaction_commit_path": GFVariantData.get_option_string(target_family, "transaction_commit_path"),
+		"transaction_commit_pending_path": GFVariantData.get_option_string(target_family, "transaction_commit_pending_path"),
+		"resource_stage_path": GFVariantData.get_option_string(target_family, "resource_stage_path"),
 		"transaction_id": _make_async_transaction_id(),
 		"data": data.duplicate(true),
 		"codec_options": _get_codec_options(),
@@ -1086,11 +1215,18 @@ func _enqueue_async_payload_save(
 		"file_name": file_name,
 		"storage_file_name": canonical_file_name,
 		"storage_root_path": GFVariantData.get_option_string(target_family, "storage_root_path"),
+		"family_id": GFVariantData.get_option_string(target_family, "family_id"),
 		"file_key": target_file_key,
+		"catalog_path": GFVariantData.get_option_string(target_family, "catalog_path"),
+		"owner_path": GFVariantData.get_option_string(target_family, "owner_path"),
 		"final_path": GFVariantData.get_option_string(target_family, "final_path"),
 		"temp_path": GFVariantData.get_option_string(target_family, "temp_path"),
 		"backup_path": GFVariantData.get_option_string(target_family, "backup_path"),
 		"transaction_path": GFVariantData.get_option_string(target_family, "transaction_path"),
+		"transaction_pending_path": GFVariantData.get_option_string(target_family, "transaction_pending_path"),
+		"transaction_commit_path": GFVariantData.get_option_string(target_family, "transaction_commit_path"),
+		"transaction_commit_pending_path": GFVariantData.get_option_string(target_family, "transaction_commit_pending_path"),
+		"resource_stage_path": GFVariantData.get_option_string(target_family, "resource_stage_path"),
 		"transaction_id": _make_async_transaction_id(),
 		"data": payload,
 		"codec_options": codec_options,
@@ -1141,11 +1277,18 @@ func _enqueue_async_load(
 		"file_name": file_name,
 		"storage_file_name": canonical_file_name,
 		"storage_root_path": GFVariantData.get_option_string(target_family, "storage_root_path"),
+		"family_id": GFVariantData.get_option_string(target_family, "family_id"),
 		"file_key": GFVariantData.get_option_string(target_family, "file_key"),
+		"catalog_path": GFVariantData.get_option_string(target_family, "catalog_path"),
+		"owner_path": GFVariantData.get_option_string(target_family, "owner_path"),
 		"final_path": GFVariantData.get_option_string(target_family, "final_path"),
 		"temp_path": GFVariantData.get_option_string(target_family, "temp_path"),
 		"backup_path": GFVariantData.get_option_string(target_family, "backup_path"),
 		"transaction_path": GFVariantData.get_option_string(target_family, "transaction_path"),
+		"transaction_pending_path": GFVariantData.get_option_string(target_family, "transaction_pending_path"),
+		"transaction_commit_path": GFVariantData.get_option_string(target_family, "transaction_commit_path"),
+		"transaction_commit_pending_path": GFVariantData.get_option_string(target_family, "transaction_commit_pending_path"),
+		"resource_stage_path": GFVariantData.get_option_string(target_family, "resource_stage_path"),
 		"codec_options": _get_codec_options(),
 		"operation": operation,
 	})
@@ -1207,10 +1350,41 @@ func _has_pending_async_task_for_file(file_name: String) -> bool:
 func _ensure_storage_helpers() -> void:
 	if _path_policy == null:
 		_path_policy = _StoragePathPolicy.new(self)
+	if _family_store == null:
+		_family_store = _GF_STORAGE_FAMILY_STORE_SCRIPT.new()
+		var storage_root_path: String = GFStorageFamilyStore.make_storage_root_path_for_framework(
+			save_dir_name
+		)
+		if not storage_root_path.is_empty():
+			var _configured: bool = _family_store.configure_for_framework(storage_root_path)
 	if _file_ops == null:
 		_file_ops = _StorageFileOps.new(self, _path_policy)
 	if _transaction_manager == null:
-		_transaction_manager = _StorageTransactionManager.new(self, _path_policy, _file_ops)
+		_transaction_manager = _StorageTransactionManager.new(
+			self,
+			_path_policy,
+			_file_ops,
+			_family_store
+		)
+
+
+func _ensure_storage_ready() -> Error:
+	_ensure_storage_helpers()
+	var storage_root_path: String = _get_save_base_path()
+	if storage_root_path.is_empty():
+		return ERR_INVALID_PARAMETER
+	if not _family_store.configure_for_framework(storage_root_path):
+		return ERR_INVALID_PARAMETER
+	_storage_root_frozen = true
+	var layout_error: Error = _family_store.ensure_layout_for_framework()
+	if layout_error != OK:
+		return layout_error
+	if not _storage_reconciled:
+		var recovery_error: Error = _transaction_manager._recover_all_catalog_transactions()
+		if recovery_error != OK:
+			return recovery_error
+		_storage_reconciled = true
+	return OK
 
 
 func _release_storage_helpers() -> void:
@@ -1222,7 +1396,9 @@ func _release_storage_helpers() -> void:
 		_path_policy._dispose()
 	_transaction_manager = null
 	_file_ops = null
+	_family_store = null
 	_path_policy = null
+	_storage_reconciled = false
 
 
 func _ensure_directory_absolute(path: String) -> Error:
@@ -1231,6 +1407,22 @@ func _ensure_directory_absolute(path: String) -> Error:
 	if DirAccess.dir_exists_absolute(path):
 		return OK
 	return DirAccess.make_dir_recursive_absolute(path)
+
+
+func _classify_load_failure(error: Error) -> GFStorageReadResult.FailureKind:
+	match error:
+		OK:
+			return GFStorageReadResult.FailureKind.NONE
+		ERR_INVALID_PARAMETER:
+			return GFStorageReadResult.FailureKind.INVALID_REQUEST
+		ERR_FILE_NOT_FOUND:
+			return GFStorageReadResult.FailureKind.NOT_FOUND
+		ERR_FILE_CORRUPT:
+			return GFStorageReadResult.FailureKind.CORRUPT
+		ERR_UNAVAILABLE:
+			return GFStorageReadResult.FailureKind.UNAVAILABLE
+		_:
+			return GFStorageReadResult.FailureKind.IO_FAILED
 
 
 func _begin_dir_listing(dir: DirAccess) -> Error:
@@ -1282,8 +1474,20 @@ func _get_task_storage_root_path(task: Dictionary) -> String:
 	return GFVariantData.get_option_string(task, "storage_root_path")
 
 
+func _get_task_family_id(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "family_id")
+
+
 func _get_task_file_key(task: Dictionary) -> String:
 	return GFVariantData.get_option_string(task, "file_key")
+
+
+func _get_task_catalog_path(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "catalog_path")
+
+
+func _get_task_owner_path(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "owner_path")
 
 
 func _get_task_final_path(task: Dictionary) -> String:
@@ -1300,6 +1504,22 @@ func _get_task_backup_path(task: Dictionary) -> String:
 
 func _get_task_transaction_path(task: Dictionary) -> String:
 	return GFVariantData.get_option_string(task, "transaction_path")
+
+
+func _get_task_transaction_pending_path(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "transaction_pending_path")
+
+
+func _get_task_transaction_commit_path(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "transaction_commit_path")
+
+
+func _get_task_transaction_commit_pending_path(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "transaction_commit_pending_path")
+
+
+func _get_task_resource_stage_path(task: Dictionary) -> String:
+	return GFVariantData.get_option_string(task, "resource_stage_path")
 
 
 func _get_task_transaction_id(task: Dictionary) -> String:
@@ -1410,6 +1630,9 @@ func _start_async_task(task: Dictionary) -> void:
 			_get_task_temp_path(task),
 			_get_task_backup_path(task),
 			_get_task_transaction_path(task),
+			_get_task_transaction_pending_path(task),
+			_get_task_transaction_commit_path(task),
+			_get_task_transaction_commit_pending_path(task),
 			_get_task_transaction_id(task),
 			_get_task_dictionary_reference(task, "data"),
 			_get_task_dictionary(task, "codec_options")
@@ -1433,39 +1656,59 @@ func _start_async_task(task: Dictionary) -> void:
 func _recover_frozen_async_transaction(task: Dictionary) -> Error:
 	var storage_file_name: String = _get_task_storage_file_name(task)
 	var storage_root_path: String = _get_task_storage_root_path(task)
-	var final_path: String = _get_task_final_path(task)
-	var temp_path: String = _get_task_temp_path(task)
-	var backup_path: String = _get_task_backup_path(task)
-	var transaction_path: String = _get_task_transaction_path(task)
 	_ensure_storage_helpers()
-	if (
-		storage_file_name.is_empty()
-		or storage_root_path.is_empty()
-		or not _path_policy._is_valid_frozen_storage_root_path(storage_root_path)
-		or final_path.is_empty()
-		or temp_path.is_empty()
-		or backup_path.is_empty()
-		or transaction_path.is_empty()
-		or _get_task_file_key(task) != final_path
+	if storage_file_name.is_empty() or not _path_policy._is_valid_frozen_storage_root_path(
+		storage_root_path
 	):
 		return ERR_INVALID_PARAMETER
-	var frozen_path_policy: _FrozenStoragePathPolicy = _FrozenStoragePathPolicy.new(
-		storage_root_path
+	var expected: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+		storage_root_path,
+		storage_file_name
 	)
+	if (
+		expected.is_empty()
+		or _get_task_family_id(task) != GFVariantData.get_option_string(expected, "family_id")
+		or _get_task_file_key(task) != GFVariantData.get_option_string(expected, "file_key")
+		or _get_task_catalog_path(task) != GFVariantData.get_option_string(expected, "catalog_path")
+		or _get_task_owner_path(task) != GFVariantData.get_option_string(expected, "owner_path")
+		or _get_task_final_path(task) != GFVariantData.get_option_string(expected, "payload_path")
+		or _get_task_temp_path(task) != GFVariantData.get_option_string(expected, "candidate_path")
+		or _get_task_backup_path(task) != GFVariantData.get_option_string(expected, "backup_path")
+		or _get_task_transaction_path(task) != GFVariantData.get_option_string(expected, "transaction_path")
+		or _get_task_transaction_pending_path(task) != GFVariantData.get_option_string(expected, "transaction_pending_path")
+		or _get_task_transaction_commit_path(task) != GFVariantData.get_option_string(expected, "transaction_commit_path")
+		or _get_task_transaction_commit_pending_path(task) != GFVariantData.get_option_string(expected, "transaction_commit_pending_path")
+		or _get_task_resource_stage_path(task) != GFVariantData.get_option_string(expected, "resource_stage_path")
+	):
+		return ERR_INVALID_PARAMETER
+	var frozen_family_store: GFStorageFamilyStore = _GF_STORAGE_FAMILY_STORE_SCRIPT.new()
+	if not frozen_family_store.configure_for_framework(storage_root_path):
+		return ERR_INVALID_PARAMETER
+	var layout_error: Error = frozen_family_store.ensure_layout_for_framework()
+	if layout_error != OK:
+		return layout_error
+	var family_error: Error
+	if _get_task_type(task) == &"save":
+		family_error = frozen_family_store.claim_family_for_framework(expected)
+	else:
+		family_error = frozen_family_store.validate_family_for_framework(expected)
+	if family_error != OK:
+		return family_error
 	var frozen_transaction_manager: _StorageTransactionManager = _StorageTransactionManager.new(
 		self,
-		frozen_path_policy,
-		_file_ops
+		_FrozenStoragePathPolicy.new(storage_root_path),
+		_file_ops,
+		frozen_family_store
 	)
 	var recovery_error: Error = frozen_transaction_manager._recover_frozen_file_family(
 		storage_file_name,
-		final_path,
-		temp_path,
-		backup_path,
-		transaction_path
+		_get_task_final_path(task),
+		_get_task_temp_path(task),
+		_get_task_backup_path(task),
+		_get_task_transaction_path(task),
+		_get_task_transaction_commit_path(task)
 	)
 	frozen_transaction_manager._dispose()
-	frozen_path_policy._dispose()
 	return recovery_error
 
 
@@ -1493,15 +1736,17 @@ func _emit_async_start_failed(
 		)
 		save_completed.emit(file_name, error)
 	elif task_type == &"load":
-		push_error("[GFStorageUtility] 异步读取失败：%s，原因：%s，错误码：%s" % [
-			file_name,
-			failure_reason,
-			error,
-		])
+		if error != ERR_FILE_NOT_FOUND:
+			push_error("[GFStorageUtility] 异步读取失败：%s，原因：%s，错误码：%s" % [
+				file_name,
+				failure_reason,
+				error,
+			])
+		var failure_kind: GFStorageReadResult.FailureKind = _classify_load_failure(error)
 		var failed_result: GFStorageReadResult = _make_load_failure(
 			"%s: %s" % [failure_reason, error_string(error)],
 			error,
-			GFStorageReadResult.FailureKind.IO_FAILED
+			failure_kind
 		)
 		last_load_result = failed_result.duplicate_result()
 		_complete_async_operation(operation, failed_result.error_code, failed_result)
@@ -1627,15 +1872,30 @@ static func _make_transaction_marker(
 	file_key: String,
 	transaction_id: String,
 	committed: bool,
-	had_final: bool
+	had_final_by_file: Dictionary
 ) -> Dictionary:
+	var sorted_file_names: Array[String] = file_names.duplicate()
+	sorted_file_names.sort()
+	var members: Array[Dictionary] = []
+	for member_file_name: String in sorted_file_names:
+		members.append({
+			"logical_path": member_file_name,
+			"family_id": GFStorageFamilyStore.make_family_id_for_framework(member_file_name),
+			"had_final": GFVariantData.get_option_bool(
+				had_final_by_file,
+				member_file_name
+			),
+		})
 	return {
+		"schema": _TRANSACTION_COMMIT_SCHEMA if committed else _TRANSACTION_PREPARE_SCHEMA,
 		"schema_version": _TRANSACTION_MARKER_SCHEMA_VERSION,
 		"transaction_id": transaction_id,
-		"file_key": file_key,
-		"files": file_names.duplicate(),
+		"owner": {
+			"logical_path": file_key,
+			"family_id": GFStorageFamilyStore.make_family_id_for_framework(file_key),
+		},
+		"members": members,
 		"committed": committed,
-		"had_final": had_final,
 	}
 
 
@@ -1645,37 +1905,57 @@ static func _is_valid_single_file_transaction_marker(
 ) -> bool:
 	if marker.size() != 6:
 		return false
-	var schema_value: Variant = marker.get("schema_version")
-	var transaction_value: Variant = marker.get("transaction_id")
-	var file_key_value: Variant = marker.get("file_key")
-	var files_value: Variant = marker.get("files")
 	var committed_value: Variant = marker.get("committed")
-	var had_final_value: Variant = marker.get("had_final")
-	if (
-		not transaction_value is String
-		or not file_key_value is String
-		or not files_value is Array
-		or not committed_value is bool
-		or not had_final_value is bool
+	if not committed_value is bool:
+		return false
+	var committed: bool = committed_value
+	var schema_value: Variant = marker.get("schema")
+	if not schema_value is String or schema_value != (
+		_TRANSACTION_COMMIT_SCHEMA if committed else _TRANSACTION_PREPARE_SCHEMA
 	):
 		return false
-	var schema_version: int = GFVariantData.to_exact_int(schema_value, -1)
+	var schema_version_value: Variant = marker.get("schema_version")
+	var transaction_value: Variant = marker.get("transaction_id")
+	var owner_value: Variant = marker.get("owner")
+	var members_value: Variant = marker.get("members")
+	if (
+		not transaction_value is String
+		or not owner_value is Dictionary
+		or not members_value is Array
+	):
+		return false
+	var schema_version: int = GFVariantData.to_exact_int(schema_version_value, -1)
 	var marker_transaction_id: String = transaction_value
-	var marker_file_key: String = file_key_value
+	var owner: Dictionary = owner_value
+	var owner_logical_path_value: Variant = owner.get("logical_path")
+	var owner_family_id_value: Variant = owner.get("family_id")
 	if (
 		schema_version != _TRANSACTION_MARKER_SCHEMA_VERSION
 		or marker_transaction_id.is_empty()
-		or marker_file_key != file_name
+		or owner.size() != 2
+		or not owner_logical_path_value is String
+		or not owner_family_id_value is String
+		or owner_logical_path_value != file_name
+		or owner_family_id_value != GFStorageFamilyStore.make_family_id_for_framework(file_name)
 	):
 		return false
-	var files: Array = files_value
-	if files.size() != 1:
+	var members: Array = members_value
+	if members.size() != 1:
 		return false
-	var only_file_value: Variant = files[0]
-	if not only_file_value is String:
+	var only_member_value: Variant = members[0]
+	if not only_member_value is Dictionary:
 		return false
-	var only_file_name: String = only_file_value
-	return only_file_name == file_name
+	var only_member: Dictionary = only_member_value
+	var member_logical_path_value: Variant = only_member.get("logical_path")
+	var member_family_id_value: Variant = only_member.get("family_id")
+	return (
+		only_member.size() == 3
+		and member_logical_path_value is String
+		and member_family_id_value is String
+		and member_logical_path_value == file_name
+		and member_family_id_value == GFStorageFamilyStore.make_family_id_for_framework(file_name)
+		and only_member.get("had_final") is bool
+	)
 
 
 func _save_data_thread(
@@ -1684,6 +1964,9 @@ func _save_data_thread(
 	temp_path: String,
 	backup_path: String,
 	transaction_path: String,
+	transaction_pending_path: String,
+	transaction_commit_path: String,
+	transaction_commit_pending_path: String,
 	transaction_id: String,
 	data: Dictionary,
 	codec_options: Dictionary
@@ -1712,80 +1995,130 @@ func _save_data_thread(
 			GFStorageAsyncResult.WriteFailureKind.ENCODE_FAILED,
 			validation_report
 		)
-	var write_error: Error = _write_buffer_absolute(temp_path, bytes)
-	if write_error != OK:
-		_remove_absolute_file_if_exists(temp_path)
-		return _make_thread_save_result(
-			write_error,
-			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
-			validation_report
-		)
-
 	var had_final: bool = FileAccess.file_exists(final_path)
-	var marker_error: Error = _write_plain_json_absolute(
+	var had_final_by_file: Dictionary = {file_name: had_final}
+	var prepare_record: Dictionary = _make_transaction_marker(
+		[file_name],
+		file_name,
+		transaction_id,
+		false,
+		had_final_by_file
+	)
+	var marker_error: Error = _publish_single_transaction_record_absolute(
 		transaction_path,
-		_make_transaction_marker(
-			[file_name],
-			file_name,
-			transaction_id,
-			false,
-			had_final
-		)
+		transaction_pending_path,
+		prepare_record,
+		file_name
 	)
 	if marker_error != OK:
-		_remove_absolute_file_if_exists(temp_path)
 		return _make_thread_save_result(
 			marker_error,
 			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
 			validation_report
 		)
 
-	var backed_up: bool = false
-	var committed: bool = false
+	var write_error: Error = _write_buffer_absolute(temp_path, bytes)
+	if write_error != OK:
+		var cleanup_error: Error = _abort_single_absolute_transaction(
+			temp_path,
+			backup_path,
+			transaction_path,
+			transaction_pending_path,
+			transaction_commit_path,
+			transaction_commit_pending_path
+		)
+		return _make_thread_save_result(
+			write_error if cleanup_error == OK else cleanup_error,
+			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
+			validation_report
+		)
+
 	if had_final:
 		var backup_error: Error = DirAccess.rename_absolute(final_path, backup_path)
 		if backup_error != OK:
-			_remove_absolute_file_if_exists(temp_path)
-			_remove_absolute_file_if_exists(transaction_path)
+			var rollback_error: Error = _rollback_single_absolute_transaction(
+				final_path,
+				temp_path,
+				backup_path,
+				transaction_path,
+				transaction_pending_path,
+				transaction_commit_path,
+				transaction_commit_pending_path,
+				had_final
+			)
 			return _make_thread_save_result(
-				backup_error,
+				backup_error if rollback_error == OK else rollback_error,
 				GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
 				validation_report
 			)
-		backed_up = true
 
 	var commit_error: Error = DirAccess.rename_absolute(temp_path, final_path)
 	if commit_error != OK:
-		_rollback_absolute_transaction(final_path, temp_path, backup_path, backed_up, committed)
-		_remove_absolute_file_if_exists(transaction_path)
-		return _make_thread_save_result(
-			commit_error,
-			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
-			validation_report
-		)
-	committed = true
-
-	var complete_marker_error: Error = _write_plain_json_absolute(
-		transaction_path,
-		_make_transaction_marker(
-			[file_name],
-			file_name,
-			transaction_id,
-			true,
+		var rollback_error: Error = _rollback_single_absolute_transaction(
+			final_path,
+			temp_path,
+			backup_path,
+			transaction_path,
+			transaction_pending_path,
+			transaction_commit_path,
+			transaction_commit_pending_path,
 			had_final
 		)
-	)
-	if complete_marker_error != OK:
-		_rollback_absolute_transaction(final_path, temp_path, backup_path, backed_up, committed)
-		_remove_absolute_file_if_exists(transaction_path)
 		return _make_thread_save_result(
-			complete_marker_error,
+			commit_error if rollback_error == OK else rollback_error,
 			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
 			validation_report
 		)
 
-	_remove_absolute_file_if_exists(backup_path)
-	_remove_absolute_file_if_exists(transaction_path)
+	var commit_record: Dictionary = _make_transaction_marker(
+		[file_name],
+		file_name,
+		transaction_id,
+		true,
+		had_final_by_file
+	)
+	var complete_marker_error: Error = _publish_single_transaction_record_absolute(
+		transaction_commit_path,
+		transaction_commit_pending_path,
+		commit_record,
+		file_name
+	)
+	if complete_marker_error != OK:
+		var rollback_error: Error = _rollback_single_absolute_transaction(
+			final_path,
+			temp_path,
+			backup_path,
+			transaction_path,
+			transaction_pending_path,
+			transaction_commit_path,
+			transaction_commit_pending_path,
+			had_final
+		)
+		return _make_thread_save_result(
+			complete_marker_error if rollback_error == OK else rollback_error,
+			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
+			validation_report
+		)
+
+	var terminal_error: Error = _validate_single_committed_absolute_transaction(
+		final_path,
+		temp_path
+	)
+	if terminal_error != OK:
+		return _make_thread_save_result(
+			terminal_error,
+			GFStorageAsyncResult.WriteFailureKind.IO_FAILED,
+			validation_report
+		)
+	var _cleanup_error: Error = _finalize_single_absolute_transaction(
+		final_path,
+		temp_path,
+		backup_path,
+		transaction_path,
+		transaction_pending_path,
+		transaction_commit_path,
+		transaction_commit_pending_path
+	)
 	return _make_thread_save_result(
 		OK,
 		GFStorageAsyncResult.WriteFailureKind.NONE,
@@ -2469,25 +2802,253 @@ func _remove_absolute_file_if_exists(path: String) -> void:
 	_file_ops._remove_absolute_file_if_exists(path)
 
 
-func _rollback_absolute_transaction(
+func _remove_absolute_file(path: String) -> Error:
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	if not FileAccess.file_exists(path):
+		return OK
+	return DirAccess.remove_absolute(path)
+
+
+func _publish_single_transaction_record_absolute(
+	path: String,
+	pending_path: String,
+	record: Dictionary,
+	file_name: String
+) -> Error:
+	if not _is_valid_single_file_transaction_marker(record, file_name):
+		return ERR_INVALID_DATA
+	if FileAccess.file_exists(path):
+		return OK if _single_transaction_records_match(
+			record,
+			_read_transaction_record_absolute(path),
+			file_name
+		) else ERR_FILE_CORRUPT
+	if FileAccess.file_exists(pending_path):
+		if not _single_transaction_records_match(
+			record,
+			_read_transaction_record_absolute(pending_path),
+			file_name
+		):
+			return ERR_FILE_CORRUPT
+	else:
+		var write_error: Error = _write_plain_json_absolute(pending_path, record)
+		if write_error != OK:
+			return write_error
+		if not _single_transaction_records_match(
+			record,
+			_read_transaction_record_absolute(pending_path),
+			file_name
+		):
+			return ERR_FILE_CORRUPT
+	var publish_error: Error = DirAccess.rename_absolute(pending_path, path)
+	if publish_error == OK:
+		return OK
+	if not FileAccess.file_exists(path):
+		return publish_error
+	if not _single_transaction_records_match(
+		record,
+		_read_transaction_record_absolute(path),
+		file_name
+	):
+		return ERR_FILE_CORRUPT
+	var _pending_cleanup_error: Error = _remove_absolute_file(pending_path)
+	return OK
+
+
+func _read_transaction_record_absolute(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {}
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {}
+	if file.get_length() <= 0 or file.get_length() > 64 * 1024:
+		file.close()
+		return {}
+	var content: String = file.get_as_text()
+	var read_error: Error = file.get_error()
+	file.close()
+	if read_error != OK:
+		return {}
+	var parsed: Variant = JSON.parse_string(content)
+	return GFVariantData.as_dictionary(parsed) if parsed is Dictionary else {}
+
+
+func _single_transaction_records_match(
+	expected: Dictionary,
+	actual: Dictionary,
+	file_name: String
+) -> bool:
+	return (
+		_is_valid_single_file_transaction_marker(expected, file_name)
+		and _is_valid_single_file_transaction_marker(actual, file_name)
+		and GFVariantData.get_option_string(expected, "transaction_id")
+		== GFVariantData.get_option_string(actual, "transaction_id")
+		and GFVariantData.get_option_bool(expected, "committed")
+		== GFVariantData.get_option_bool(actual, "committed")
+		and GFVariantData.get_option_dictionary(expected, "owner")
+		== GFVariantData.get_option_dictionary(actual, "owner")
+		and GFVariantData.get_option_array(expected, "members")
+		== GFVariantData.get_option_array(actual, "members")
+	)
+
+
+func _abort_single_absolute_transaction(
+	temp_path: String,
+	backup_path: String,
+	transaction_path: String,
+	transaction_pending_path: String,
+	transaction_commit_path: String,
+	transaction_commit_pending_path: String
+) -> Error:
+	if FileAccess.file_exists(backup_path) or FileAccess.file_exists(transaction_commit_path):
+		return ERR_FILE_CORRUPT
+	for cleanup_path: String in [
+		temp_path,
+		transaction_commit_pending_path,
+		transaction_pending_path,
+		transaction_path,
+	]:
+		var cleanup_error: Error = _remove_absolute_file(cleanup_path)
+		if cleanup_error != OK:
+			return cleanup_error
+	return OK
+
+
+func _rollback_single_absolute_transaction(
 	final_path: String,
 	temp_path: String,
 	backup_path: String,
-	backed_up: bool,
-	committed: bool
-) -> void:
-	if committed or backed_up:
-		_remove_absolute_file_if_exists(final_path)
-	_remove_absolute_file_if_exists(temp_path)
-	if backed_up and FileAccess.file_exists(backup_path):
-		var restore_error: Error = DirAccess.rename_absolute(backup_path, final_path)
-		if restore_error != OK:
-			push_warning("[GFStorageUtility] 回滚事务恢复备份失败：%s -> %s，错误码：%s" % [backup_path, final_path, restore_error])
+	transaction_path: String,
+	transaction_pending_path: String,
+	transaction_commit_path: String,
+	transaction_commit_pending_path: String,
+	had_final: bool
+) -> Error:
+	if had_final:
+		if FileAccess.file_exists(backup_path):
+			var remove_new_final: Error = _remove_absolute_file(final_path)
+			if remove_new_final != OK:
+				return remove_new_final
+			var restore_error: Error = DirAccess.rename_absolute(backup_path, final_path)
+			if restore_error != OK:
+				return restore_error
+		elif not FileAccess.file_exists(final_path):
+			return ERR_FILE_CORRUPT
+	else:
+		if FileAccess.file_exists(backup_path):
+			return ERR_FILE_CORRUPT
+		var remove_new_file: Error = _remove_absolute_file(final_path)
+		if remove_new_file != OK:
+			return remove_new_file
+	var remove_candidate: Error = _remove_absolute_file(temp_path)
+	if remove_candidate != OK:
+		return remove_candidate
+	if FileAccess.file_exists(final_path) != had_final:
+		return ERR_FILE_CORRUPT
+	for evidence_path: String in [
+		transaction_commit_pending_path,
+		transaction_commit_path,
+		transaction_pending_path,
+		transaction_path,
+	]:
+		var cleanup_error: Error = _remove_absolute_file(evidence_path)
+		if cleanup_error != OK:
+			return cleanup_error
+	return OK
+
+
+func _finalize_single_absolute_transaction(
+	_final_path: String,
+	_temp_path: String,
+	backup_path: String,
+	transaction_path: String,
+	transaction_pending_path: String,
+	transaction_commit_path: String,
+	transaction_commit_pending_path: String
+) -> Error:
+	for cleanup_path: String in [
+		backup_path,
+		transaction_pending_path,
+		transaction_path,
+		transaction_commit_pending_path,
+		transaction_commit_path,
+	]:
+		var cleanup_error: Error = _remove_absolute_file(cleanup_path)
+		if cleanup_error != OK:
+			return cleanup_error
+	return OK
+
+
+func _validate_single_committed_absolute_transaction(
+	final_path: String,
+	temp_path: String
+) -> Error:
+	return OK if FileAccess.file_exists(final_path) and not FileAccess.file_exists(
+		temp_path
+	) else ERR_FILE_CORRUPT
 
 
 func _get_save_base_path() -> String:
 	_ensure_storage_helpers()
 	return _path_policy._get_save_base_path()
+
+
+func _make_family_descriptor(file_name: String) -> Dictionary:
+	_ensure_storage_helpers()
+	return GFStorageFamilyStore.make_family_descriptor_for_framework(
+		_get_save_base_path(),
+		file_name
+	)
+
+
+func _prepare_family_for_write(file_name: String) -> Error:
+	var readiness_error: Error = _ensure_storage_ready()
+	if readiness_error != OK:
+		return readiness_error
+	var descriptor: Dictionary = _make_family_descriptor(file_name)
+	if descriptor.is_empty():
+		return ERR_INVALID_PARAMETER
+	var claim_error: Error = _family_store.claim_family_for_framework(descriptor)
+	if claim_error != OK:
+		return claim_error
+	var recovery_error: Error = _recover_transaction_files([file_name])
+	return recovery_error
+
+
+func _prepare_family_for_read(file_name: String) -> Error:
+	var readiness_error: Error = _ensure_storage_ready()
+	if readiness_error != OK:
+		return readiness_error
+	var descriptor: Dictionary = _make_family_descriptor(file_name)
+	if descriptor.is_empty():
+		return ERR_INVALID_PARAMETER
+	var validate_error: Error = _family_store.validate_family_for_framework(descriptor)
+	if validate_error != OK:
+		return validate_error
+	var recovery_error: Error = _recover_transaction_files([file_name])
+	if recovery_error != OK:
+		return recovery_error
+	return OK if FileAccess.file_exists(
+		GFVariantData.get_option_string(descriptor, "payload_path")
+	) else ERR_FILE_NOT_FOUND
+
+
+func _resolve_internal_storage_path(file_name: String) -> String:
+	var storage_root_path: String = _get_save_base_path()
+	if storage_root_path.is_empty():
+		return ""
+	if GFStorageFamilyStore.is_valid_private_relative_path_for_framework(file_name):
+		return (
+			"user://" + file_name
+			if storage_root_path == "user://"
+			else storage_root_path + "/" + file_name
+		)
+	var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+		storage_root_path,
+		file_name
+	)
+	return GFVariantData.get_option_string(descriptor, "payload_path")
 
 
 func _get_full_path(file_name: String) -> String:
@@ -2496,20 +3057,21 @@ func _get_full_path(file_name: String) -> String:
 
 
 func _get_resource_temp_filename(file_name: String) -> String:
-	var extension: String = file_name.get_extension()
-	if extension.is_empty():
-		return _get_temp_filename(file_name)
-	var suffix: String = ".%s" % extension
-	return "%s%s%s" % [file_name.trim_suffix(suffix), _TEMP_SUFFIX, suffix]
+	return GFVariantData.get_option_string(
+		_make_family_descriptor(file_name),
+		"resource_stage_relative_path"
+	)
 
 
 func _is_resource_load_extension_allowed(path: String) -> bool:
-	var extension: String = path.get_extension().to_lower()
+	var extension: String = path.get_extension()
 	if extension.is_empty():
 		return false
 	for allowed_extension: String in allowed_resource_load_extensions:
-		var normalized_extension: String = allowed_extension.strip_edges().trim_prefix(".").to_lower()
-		if normalized_extension == extension:
+		if (
+			GFStorageFamilyStore.is_valid_extension_filter_for_framework(allowed_extension)
+			and allowed_extension == extension
+		):
 			return true
 	return false
 
@@ -2670,20 +3232,33 @@ func _canonicalize_storage_file_name(path: String, label: String = "file_name") 
 
 
 func _validate_public_file_name(file_name: String, operation: String) -> bool:
-	if file_name.strip_edges().is_empty():
+	if file_name.is_empty():
 		push_error("[GFStorageUtility] %s 失败：file_name 为空。" % operation)
 		return false
-	if not _is_safe_storage_path(file_name, "file_name"):
+	if not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(file_name):
+		push_error("[GFStorageUtility] %s 失败：file_name 不满足 portable logical path profile。" % operation)
 		return false
 	return not _get_save_base_path().is_empty()
 
 
-func _validate_public_directory_name(directory_name: String, operation: String) -> bool:
+func _validate_public_resource_file_name(file_name: String, operation: String) -> bool:
+	if not _validate_public_file_name(file_name, operation):
+		return false
+	var extension: String = file_name.get_extension()
 	if (
-		not directory_name.is_empty()
-		and directory_name != "."
-		and not _is_safe_storage_path(directory_name, "directory_name")
+		extension.is_empty()
+		or not GFStorageFamilyStore.is_valid_extension_filter_for_framework(extension)
 	):
+		push_error(
+			"[GFStorageUtility] %s 失败：Resource logical path 必须包含 canonical lowercase 扩展名。"
+			% operation
+		)
+		return false
+	return true
+
+
+func _validate_public_directory_name(directory_name: String, operation: String) -> bool:
+	if not GFStorageFamilyStore.is_valid_logical_directory_path_for_framework(directory_name):
 		push_error("[GFStorageUtility] %s 失败：directory_name 非法。" % operation)
 		return false
 	return not _get_save_base_path().is_empty()
@@ -2700,7 +3275,7 @@ func _is_safe_storage_path(path: String, label: String) -> bool:
 
 
 func _get_async_file_key(file_name: String) -> String:
-	return _get_full_path(file_name)
+	return GFVariantData.get_option_string(_make_family_descriptor(file_name), "file_key")
 
 
 func _remove_file_if_exists(path: String) -> void:
@@ -2723,24 +3298,39 @@ func _get_transaction_filename(file_name: String) -> String:
 	return _transaction_manager._get_transaction_filename(file_name)
 
 
-func _cleanup_transaction_files(file_names: Array[String]) -> void:
+func _get_transaction_pending_filename(file_name: String) -> String:
 	_ensure_storage_helpers()
-	_transaction_manager._cleanup_transaction_files(file_names)
+	return _transaction_manager._get_transaction_pending_filename(file_name)
 
 
-func _recover_transaction_files(file_names: Array[String]) -> void:
+func _get_transaction_commit_filename(file_name: String) -> String:
 	_ensure_storage_helpers()
-	_transaction_manager._recover_transaction_files(file_names)
+	return _transaction_manager._get_transaction_commit_filename(file_name)
 
 
-func _recover_transaction_group(file_names: Array[String]) -> void:
+func _get_transaction_commit_pending_filename(file_name: String) -> String:
 	_ensure_storage_helpers()
-	var _recovery_error: Error = _transaction_manager._recover_transaction_group(file_names)
+	return _transaction_manager._get_transaction_commit_pending_filename(file_name)
 
 
-func _recover_transaction_file(file_name: String) -> void:
+func _cleanup_transaction_files(file_names: Array[String]) -> Error:
 	_ensure_storage_helpers()
-	_transaction_manager._recover_transaction_file(file_name)
+	return _transaction_manager._cleanup_transaction_files(file_names)
+
+
+func _recover_transaction_files(file_names: Array[String]) -> Error:
+	_ensure_storage_helpers()
+	return _transaction_manager._recover_transaction_files(file_names)
+
+
+func _recover_transaction_group(file_names: Array[String]) -> Error:
+	_ensure_storage_helpers()
+	return _transaction_manager._recover_transaction_group(file_names)
+
+
+func _recover_transaction_file(file_name: String) -> Error:
+	_ensure_storage_helpers()
+	return _transaction_manager._recover_transaction_file(file_name)
 
 
 func _commit_transaction(file_names: Array[String], markers_prepared: bool = false) -> Error:
@@ -2748,19 +3338,14 @@ func _commit_transaction(file_names: Array[String], markers_prepared: bool = fal
 	return _transaction_manager._commit_transaction(file_names, markers_prepared)
 
 
-func _rollback_transaction(file_names: Array[String], transaction_state: Dictionary) -> void:
+func _rollback_transaction(file_names: Array[String], transaction_state: Dictionary) -> Error:
 	_ensure_storage_helpers()
-	_transaction_manager._rollback_transaction(file_names, transaction_state)
+	return _transaction_manager._rollback_transaction(file_names, transaction_state)
 
 
 func _write_transaction_markers(file_names: Array[String], committed: bool) -> Error:
 	_ensure_storage_helpers()
 	return _transaction_manager._write_transaction_markers(file_names, committed)
-
-
-func _cleanup_transaction_markers(file_names: Array[String]) -> void:
-	_ensure_storage_helpers()
-	_transaction_manager._cleanup_transaction_markers(file_names)
 
 
 func _read_transaction_marker(file_name: String) -> Dictionary:
@@ -2804,8 +3389,6 @@ func _ensure_parent_directory(path: String) -> Error:
 
 
 func _read_json(file_name: String) -> GFStorageReadResult:
-	_recover_transaction_files([file_name])
-
 	var path: String = _get_full_path(file_name)
 	if not FileAccess.file_exists(path):
 		last_load_result = _make_load_failure(
@@ -3136,26 +3719,12 @@ class _StoragePathPolicy:
 
 	func _get_save_base_path() -> String:
 		var save_dir_name: String = _get_string_property("save_dir_name")
-		if save_dir_name.is_empty():
-			return "user://"
-		if _is_absolute_storage_path(save_dir_name):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % save_dir_name)
-			return ""
-		if _contains_parent_segment(save_dir_name):
-			push_error("[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：%s" % save_dir_name)
-			return ""
-		if _has_invalid_storage_root_character(save_dir_name):
-			push_error("[GFStorageUtility] save_dir_name 包含不支持的字符：%s" % save_dir_name)
-			return ""
-		var normalized_save_dir_name: String = save_dir_name.replace("\\", "/").simplify_path()
-		if (
-			normalized_save_dir_name.is_empty()
-			or normalized_save_dir_name == "."
-			or normalized_save_dir_name != save_dir_name
-		):
-			push_error("[GFStorageUtility] save_dir_name 必须是规范相对目录：%s" % save_dir_name)
-			return ""
-		return "user://" + normalized_save_dir_name
+		var storage_root_path: String = GFStorageFamilyStore.make_storage_root_path_for_framework(
+			save_dir_name
+		)
+		if storage_root_path.is_empty():
+			push_error("[GFStorageUtility] save_dir_name 必须满足 portable logical directory profile。")
+		return storage_root_path
 
 	func _is_absolute_storage_path(path: String) -> bool:
 		return path.replace("\\", "/").is_absolute_path()
@@ -3176,34 +3745,19 @@ class _StoragePathPolicy:
 		if not storage_root_path.begins_with("user://"):
 			return false
 		var relative_root: String = storage_root_path.trim_prefix("user://")
-		if (
-			relative_root.is_empty()
-			or relative_root.begins_with("/")
-			or relative_root.contains("\\")
-			or _contains_parent_segment(relative_root)
-			or _has_invalid_storage_root_character(relative_root)
-		):
-			return false
-		return relative_root == relative_root.simplify_path()
+		return GFStorageFamilyStore.is_valid_logical_directory_path_for_framework(relative_root)
 
 	func _get_full_path(file_name: String) -> String:
-		if _is_absolute_storage_path(file_name):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % file_name)
+		if (
+			not GFStorageFamilyStore.is_valid_private_relative_path_for_framework(file_name)
+			and not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(file_name)
+		):
 			return ""
-
-		file_name = _sanitize_storage_relative_path(file_name, "file_name")
-		if file_name.is_empty():
-			return ""
-		var storage_root_path: String = _get_save_base_path()
-		if storage_root_path.is_empty():
-			return ""
-		if storage_root_path == "user://":
-			return "user://" + file_name
-		return storage_root_path + "/" + file_name
+		var resolved: Variant = _owner.call("_resolve_internal_storage_path", file_name)
+		return GFVariantData.to_text(resolved)
 
 	func _get_full_directory_path_from_normalized(directory_name: String) -> String:
-		if _is_absolute_storage_path(directory_name):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % directory_name)
+		if not GFStorageFamilyStore.is_valid_logical_directory_path_for_framework(directory_name):
 			return ""
 		var storage_root_path: String = _get_save_base_path()
 		if storage_root_path.is_empty() or directory_name.is_empty():
@@ -3213,45 +3767,25 @@ class _StoragePathPolicy:
 		return storage_root_path.path_join(directory_name)
 
 	func _normalize_storage_directory_name(directory_name: String) -> String:
-		if directory_name.is_empty() or directory_name == ".":
+		if directory_name.is_empty():
 			return ""
-		if _is_absolute_storage_path(directory_name):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % directory_name)
-			return "_invalid_storage_directory"
-
-		var original_path: String = directory_name
-		var normalized: String = directory_name.replace("\\", "/").simplify_path()
-		if normalized == ".":
-			return ""
-		if _is_parent_directory_path(normalized):
-			push_error("[GFStorageUtility] 已拒绝跨目录路径（directory_name）：%s" % original_path)
-			return "_invalid_storage_directory"
-		if normalized.is_empty() or normalized == "." or normalized == "..":
-			push_error("[GFStorageUtility] directory_name 为空。")
-			return "_invalid_storage_directory"
-		return normalized
+		return directory_name if GFStorageFamilyStore.is_valid_logical_directory_path_for_framework(
+			directory_name
+		) else "_invalid_storage_directory"
 
 	func _normalize_extension_filter(extension_filter: String) -> String:
-		return extension_filter.strip_edges().trim_prefix(".").to_lower()
+		return extension_filter if GFStorageFamilyStore.is_valid_extension_filter_for_framework(
+			extension_filter
+		) else "_invalid_extension_filter"
 
 	func _file_matches_extension(file_name: String, extension_filter: String) -> bool:
-		return extension_filter.is_empty() or file_name.get_extension().to_lower() == extension_filter
+		return extension_filter.is_empty() or file_name.get_extension() == extension_filter
 
 	func _sanitize_storage_relative_path(path: String, label: String) -> String:
-		var original_path: String = path
-		if _contains_parent_segment(path):
-			push_error("[GFStorageUtility] 已拒绝跨目录路径（%s）：%s" % [label, original_path])
+		if not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(path):
+			push_error("[GFStorageUtility] %s 不满足 portable logical path profile。" % label)
 			return ""
-		var normalized: String = path.replace("\\", "/").simplify_path()
-		if normalized == ".":
-			normalized = ""
-		if _is_parent_directory_path(normalized):
-			push_error("[GFStorageUtility] 已拒绝跨目录路径（%s）：%s" % [label, original_path])
-			return ""
-		if normalized.is_empty() or normalized == "." or normalized == "..":
-			push_error("[GFStorageUtility] %s 为空。" % label)
-			return ""
-		return normalized
+		return path
 
 	func _is_parent_directory_path(path: String) -> bool:
 		return path == ".." or path.begins_with("../") or path.contains("/../")
@@ -3263,29 +3797,13 @@ class _StoragePathPolicy:
 		return false
 
 	func _canonicalize_file_name(path: String, label: String) -> String:
-		if _is_absolute_storage_path(path):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
-			return ""
 		return _sanitize_storage_relative_path(path, label)
 
 	func _is_safe_storage_path(path: String, label: String) -> bool:
-		if _is_absolute_storage_path(path):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
-			return false
-
-		if _contains_parent_segment(path):
-			push_error("[GFStorageUtility] 已拒绝跨目录路径（%s）：%s" % [label, path])
-			return false
-		var normalized: String = path.replace("\\", "/").simplify_path()
-		if normalized == ".":
-			normalized = ""
-		if _is_parent_directory_path(normalized):
-			push_error("[GFStorageUtility] 已拒绝跨目录路径（%s）：%s" % [label, path])
-			return false
-		if normalized.is_empty() or normalized == "." or normalized == "..":
-			push_error("[GFStorageUtility] %s 为空。" % label)
-			return false
-		return true
+		if GFStorageFamilyStore.is_valid_logical_file_path_for_framework(path):
+			return true
+		push_error("[GFStorageUtility] %s 不满足 portable logical path profile。" % label)
+		return false
 
 
 class _FrozenStoragePathPolicy extends _StoragePathPolicy:
@@ -3298,20 +3816,19 @@ class _FrozenStoragePathPolicy extends _StoragePathPolicy:
 		return _storage_root_path
 
 	func _get_full_path(file_name: String) -> String:
-		if _is_absolute_storage_path(file_name):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % file_name)
-			return ""
-		file_name = _sanitize_storage_relative_path(file_name, "file_name")
-		if file_name.is_empty():
-			return ""
-		if _storage_root_path == "user://":
-			return "user://" + file_name
-		return _storage_root_path + "/" + file_name
+		if GFStorageFamilyStore.is_valid_private_relative_path_for_framework(file_name):
+			return (
+				"user://" + file_name
+				if _storage_root_path == "user://"
+				else _storage_root_path + "/" + file_name
+			)
+		var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+			_storage_root_path,
+			file_name
+		)
+		return GFVariantData.get_option_string(descriptor, "payload_path")
 
 	func _canonicalize_file_name(path: String, label: String) -> String:
-		if _is_absolute_storage_path(path):
-			push_error("[GFStorageUtility] 已禁用绝对路径：%s" % path)
-			return ""
 		return _sanitize_storage_relative_path(path, label)
 
 
@@ -3367,11 +3884,14 @@ class _StorageFileOps:
 			return
 
 	func _remove_absolute_if_exists(path: String) -> void:
-		if not FileAccess.file_exists(path):
-			return
-		var remove_error: Error = DirAccess.remove_absolute(path)
+		var remove_error: Error = _remove_absolute(path)
 		if remove_error != OK:
-			push_warning("[GFStorageUtility] 删除文件失败：%s，错误码：%s" % [path, remove_error])
+			push_warning("[GFStorageUtility] 删除文件失败：错误码：%s" % remove_error)
+
+	func _remove_absolute(path: String) -> Error:
+		if not FileAccess.file_exists(path):
+			return OK
+		return DirAccess.remove_absolute(path)
 
 	func _ensure_absolute_parent_directory(path: String) -> Error:
 		if path.is_empty():
@@ -3386,9 +3906,6 @@ class _StorageFileOps:
 	func _ensure_parent_directory(path: String) -> Error:
 		if path.is_empty():
 			return ERR_INVALID_PARAMETER
-		if not _get_bool_property("create_directories_for_nested_paths"):
-			return OK
-
 		var base_dir: String = path.get_base_dir()
 		if base_dir.is_empty() or base_dir == "user://":
 			return OK
@@ -3480,59 +3997,193 @@ class _StorageFileOps:
 
 
 class _StorageTransactionManager:
-	const _TEMP_SUFFIX: String = ".tmp"
-	const _BACKUP_SUFFIX: String = ".bak"
-	const _TRANSACTION_SUFFIX: String = ".txn"
-
 	var _owner: Object
 	var _path_policy: _StoragePathPolicy
 	var _file_ops: _StorageFileOps
+	var _family_store: GFStorageFamilyStore
 	var _next_transaction_id: int = 1
 
-	func _init(p_owner: Object, p_path_policy: _StoragePathPolicy, p_file_ops: _StorageFileOps) -> void:
+	func _init(
+		p_owner: Object,
+		p_path_policy: _StoragePathPolicy,
+		p_file_ops: _StorageFileOps,
+		p_family_store: GFStorageFamilyStore
+	) -> void:
 		_owner = p_owner
 		_path_policy = p_path_policy
 		_file_ops = p_file_ops
+		_family_store = p_family_store
 
 	func _dispose() -> void:
 		_owner = null
 		_path_policy = null
 		_file_ops = null
+		_family_store = null
 
 	func _get_temp_filename(file_name: String) -> String:
-		return file_name + _TEMP_SUFFIX
+		return GFVariantData.get_option_string(
+			GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			),
+			"candidate_relative_path"
+		)
 
 	func _get_backup_filename(file_name: String) -> String:
-		return file_name + _BACKUP_SUFFIX
+		return GFVariantData.get_option_string(
+			GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			),
+			"backup_relative_path"
+		)
 
 	func _get_transaction_filename(file_name: String) -> String:
-		return file_name + _TRANSACTION_SUFFIX
+		return GFVariantData.get_option_string(
+			GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			),
+			"transaction_relative_path"
+		)
 
-	func _cleanup_transaction_files(file_names: Array[String]) -> void:
+	func _get_transaction_pending_filename(file_name: String) -> String:
+		return GFVariantData.get_option_string(
+			GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			),
+			"transaction_pending_relative_path"
+		)
+
+	func _get_transaction_commit_filename(file_name: String) -> String:
+		return GFVariantData.get_option_string(
+			GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			),
+			"transaction_commit_relative_path"
+		)
+
+	func _get_transaction_commit_pending_filename(file_name: String) -> String:
+		return GFVariantData.get_option_string(
+			GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			),
+			"transaction_commit_pending_relative_path"
+		)
+
+	func _cleanup_transaction_files(file_names: Array[String]) -> Error:
 		file_names = _unique_file_names(file_names)
 		for file_name: String in file_names:
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_temp_filename(file_name)))
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_transaction_filename(file_name)))
+			if (
+				FileAccess.file_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
+				or FileAccess.file_exists(_path_policy._get_full_path(_get_transaction_commit_filename(file_name)))
+			):
+				return ERR_FILE_CORRUPT
+			for cleanup_path: String in [
+				_path_policy._get_full_path(_get_temp_filename(file_name)),
+				GFVariantData.get_option_string(
+					GFStorageFamilyStore.make_family_descriptor_for_framework(
+						_path_policy._get_save_base_path(),
+						file_name
+					),
+					"resource_stage_path"
+				),
+			]:
+				var cleanup_error: Error = _file_ops._remove_absolute(cleanup_path)
+				if cleanup_error != OK:
+					return cleanup_error
+		return _cleanup_prepare_records(file_names)
 
-	func _recover_transaction_files(file_names: Array[String]) -> void:
+	func _recover_all_catalog_transactions() -> Error:
+		var descriptors_result: Dictionary = (
+			_family_store.list_claimed_family_descriptors_for_framework()
+		)
+		var descriptors_error: Error = GFVariantData.get_option_int(
+			descriptors_result,
+			"error",
+			OK
+		) as Error
+		if descriptors_error != OK:
+			return descriptors_error
+		for descriptor_value: Variant in GFVariantData.get_option_array(
+			descriptors_result,
+			"descriptors"
+		):
+			var descriptor: Dictionary = GFVariantData.as_dictionary(descriptor_value)
+			var logical_path: String = GFVariantData.get_option_string(
+				descriptor,
+				"logical_path"
+			)
+			var recovery_error: Error = _recover_transaction_file(logical_path)
+			if recovery_error != OK:
+				return recovery_error
+		return OK
+
+	func _recover_transaction_files(file_names: Array[String]) -> Error:
 		file_names = _unique_file_names(file_names)
 		var recovered_files: Dictionary = {}
 		for file_name: String in file_names:
+			var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			)
+			var family_error: Error = _family_store.validate_family_for_framework(descriptor)
+			if family_error == ERR_FILE_NOT_FOUND:
+				continue
+			if family_error != OK:
+				return family_error
+			var pending_error: Error = _reconcile_pending_records_for_file(file_name)
+			if pending_error != OK:
+				return pending_error
+			var record_error: Error = _validate_final_transaction_records_for_file(
+				file_name
+			)
+			if record_error != OK:
+				return record_error
 			var marker: Dictionary = _read_transaction_marker(file_name)
+			if marker.is_empty():
+				marker = _read_transaction_commit_marker(file_name)
 			if marker.is_empty():
 				continue
 
 			var transaction_files: Array[String] = _discover_transaction_marker_files(marker, file_name)
-			var _recovery_error: Error = _recover_transaction_group(transaction_files)
+			if transaction_files.is_empty():
+				return ERR_FILE_CORRUPT
+			var recovery_error: Error = _recover_transaction_group(transaction_files)
+			if recovery_error != OK:
+				return recovery_error
 			for transaction_file_name: String in transaction_files:
 				recovered_files[transaction_file_name] = true
 
 		for file_name: String in file_names:
 			if not recovered_files.has(file_name):
-				_recover_transaction_file(file_name)
+				var recovery_error: Error = _recover_transaction_file(file_name)
+				if recovery_error != OK:
+					return recovery_error
+		return OK
 
 	func _recover_frozen_file_family(
+		file_name: String,
+		final_path: String,
+		temp_path: String,
+		backup_path: String,
+		transaction_path: String,
+		transaction_commit_path: String
+	) -> Error:
+		if (
+			_path_policy._get_full_path(file_name) != final_path
+			or _path_policy._get_full_path(_get_temp_filename(file_name)) != temp_path
+			or _path_policy._get_full_path(_get_backup_filename(file_name)) != backup_path
+			or _path_policy._get_full_path(_get_transaction_filename(file_name)) != transaction_path
+			or _path_policy._get_full_path(_get_transaction_commit_filename(file_name)) != transaction_commit_path
+		):
+			return ERR_INVALID_PARAMETER
+		return _recover_transaction_file(file_name)
+
+	func _recover_single_file_family(
 		file_name: String,
 		final_path: String,
 		temp_path: String,
@@ -3546,178 +4197,329 @@ class _StorageTransactionManager:
 			or _path_policy._get_full_path(_get_transaction_filename(file_name)) != transaction_path
 		):
 			return ERR_INVALID_PARAMETER
-
-		var marker: Dictionary = _read_transaction_marker_absolute(transaction_path)
-		if _has_absolute_marker_member(marker):
-			return ERR_UNAUTHORIZED
-		var transaction_files: Array[String] = _discover_transaction_marker_files(marker, file_name)
-		if transaction_files.size() > 1:
-			return _recover_transaction_group(transaction_files)
-		return _recover_single_file_family(
-			file_name,
-			final_path,
-			temp_path,
-			backup_path,
-			transaction_path
-		)
-
-	func _recover_single_file_family(
-		file_name: String,
-		final_path: String,
-		temp_path: String,
-		backup_path: String,
-		transaction_path: String
-	) -> Error:
-		var marker: Dictionary = _read_transaction_marker_absolute(transaction_path)
-		if GFStorageUtility._is_valid_single_file_transaction_marker(marker, file_name):
-			var committed: bool = GFVariantData.get_option_bool(marker, "committed")
-			var had_final: bool = GFVariantData.get_option_bool(marker, "had_final")
-			if committed:
-				if not FileAccess.file_exists(final_path) and FileAccess.file_exists(temp_path):
-					var promote_error: Error = _file_ops._move_file(temp_path, final_path)
-					if promote_error != OK:
-						return promote_error
-				_file_ops._remove_file_if_exists(temp_path)
-				_file_ops._remove_file_if_exists(backup_path)
-				_file_ops._remove_file_if_exists(transaction_path)
-				return OK
-
-			if FileAccess.file_exists(backup_path):
-				_file_ops._remove_file_if_exists(final_path)
-				var restore_error: Error = _file_ops._move_file(backup_path, final_path)
-				if restore_error != OK:
-					return restore_error
-			elif not had_final:
-				_file_ops._remove_file_if_exists(final_path)
-			_file_ops._remove_file_if_exists(temp_path)
-			_file_ops._remove_file_if_exists(transaction_path)
-			return OK
-
-		var has_final: bool = FileAccess.file_exists(final_path)
-		var has_temp: bool = FileAccess.file_exists(temp_path)
-		var has_backup: bool = FileAccess.file_exists(backup_path)
-		if has_backup and (not has_final or has_temp):
-			if has_final:
-				_file_ops._remove_file_if_exists(final_path)
-			var restore_error: Error = _file_ops._move_file(backup_path, final_path)
-			if restore_error != OK:
-				return restore_error
-			_file_ops._remove_file_if_exists(temp_path)
-			_file_ops._remove_file_if_exists(transaction_path)
-			return OK
-		if has_backup and has_final:
-			_file_ops._remove_file_if_exists(backup_path)
-		if has_temp and not has_final and not has_backup:
-			var promote_error: Error = _file_ops._move_file(temp_path, final_path)
-			if promote_error != OK:
-				return promote_error
-		elif has_temp and has_final:
-			_file_ops._remove_file_if_exists(temp_path)
-		_file_ops._remove_file_if_exists(transaction_path)
-		return OK
+		return _recover_transaction_group([file_name])
 
 	func _recover_transaction_group(file_names: Array[String]) -> Error:
 		file_names = _unique_file_names(file_names)
+		file_names.sort()
 		if file_names.is_empty():
 			return ERR_INVALID_PARAMETER
-
-		var should_keep_new_files: bool = _is_transaction_group_committed(file_names)
-		var recovery_error: Error = OK
-		if should_keep_new_files:
-			for file_name: String in file_names:
-				var final_path: String = _path_policy._get_full_path(file_name)
-				var temp_path: String = _path_policy._get_full_path(_get_temp_filename(file_name))
-				if not FileAccess.file_exists(final_path) and FileAccess.file_exists(temp_path):
-					var promote_error: Error = _file_ops._move_file(temp_path, final_path)
-					if promote_error != OK:
-						push_error("[GFStorageUtility] 恢复已提交事务文件失败：%s，错误码：%s" % [final_path, promote_error])
-						if recovery_error == OK:
-							recovery_error = promote_error
-						continue
-			if recovery_error != OK:
-				return recovery_error
-			for file_name: String in file_names:
-				_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_temp_filename(file_name)))
-				_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
-				_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_transaction_filename(file_name)))
-			return OK
-
 		for file_name: String in file_names:
-			var marker: Dictionary = _read_transaction_marker(file_name)
-			var final_path: String = _path_policy._get_full_path(file_name)
-			var backup_path: String = _path_policy._get_full_path(_get_backup_filename(file_name))
-			var had_final: bool = GFVariantData.get_option_bool(marker, "had_final", true)
+			var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			)
+			var family_error: Error = _family_store.validate_family_for_framework(descriptor)
+			if family_error != OK:
+				return family_error
+			var pending_error: Error = _reconcile_pending_records_for_file(file_name)
+			if pending_error != OK:
+				return pending_error
+			var record_error: Error = _validate_final_transaction_records_for_file(
+				file_name
+			)
+			if record_error != OK:
+				return record_error
 
-			if FileAccess.file_exists(backup_path):
-				_file_ops._remove_file_if_exists(final_path)
-				var restore_error: Error = _file_ops._move_file(backup_path, final_path)
-				if restore_error != OK:
-					push_error("[GFStorageUtility] 回滚事务文件失败：%s，错误码：%s" % [final_path, restore_error])
-					if recovery_error == OK:
-						recovery_error = restore_error
-			elif not had_final:
-				_file_ops._remove_file_if_exists(final_path)
+		var transaction_reference: Dictionary = _find_transaction_reference(file_names)
+		if transaction_reference.is_empty():
+			return _validate_stable_group_without_evidence(file_names)
+		if _get_transaction_marker_files(
+			transaction_reference,
+			GFVariantData.get_option_string(
+				GFVariantData.get_option_dictionary(transaction_reference, "owner"),
+				"logical_path"
+			),
+			file_names
+		) != file_names:
+			return ERR_FILE_CORRUPT
 
-		if recovery_error != OK:
-			return recovery_error
+		var prepare_count: int = 0
+		var commit_count: int = 0
 		for file_name: String in file_names:
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_temp_filename(file_name)))
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_transaction_filename(file_name)))
+			var prepare: Dictionary = _read_transaction_marker(file_name)
+			if not prepare.is_empty():
+				if not _markers_share_snapshot(transaction_reference, prepare, file_name, false):
+					return ERR_FILE_CORRUPT
+				prepare_count += 1
+			var commit: Dictionary = _read_transaction_commit_marker(file_name)
+			if not commit.is_empty():
+				if not _markers_share_snapshot(transaction_reference, commit, file_name, true):
+					return ERR_FILE_CORRUPT
+				commit_count += 1
+
+		if commit_count == file_names.size():
+			return _finalize_committed_group(file_names)
+		if commit_count > 0:
+			if prepare_count == file_names.size():
+				return _rollback_group_from_record(file_names, transaction_reference)
+			if prepare_count == 0 and _group_matches_committed_cleanup(
+				file_names,
+				transaction_reference
+			):
+				return _finalize_committed_group(file_names)
+			return ERR_FILE_CORRUPT
+		if prepare_count == file_names.size():
+			return _rollback_group_from_record(file_names, transaction_reference)
+		if prepare_count > 0 and _group_matches_rolled_back_state(
+			file_names,
+			transaction_reference
+		):
+			return _cleanup_prepare_records(file_names)
+		return ERR_FILE_CORRUPT
+
+	func _recover_transaction_file(file_name: String) -> Error:
+		var pending_error: Error = _reconcile_pending_records_for_file(file_name)
+		if pending_error != OK:
+			return pending_error
+		var record_error: Error = _validate_final_transaction_records_for_file(file_name)
+		if record_error != OK:
+			return record_error
+		var marker: Dictionary = _read_transaction_marker(file_name)
+		if marker.is_empty():
+			marker = _read_transaction_commit_marker(file_name)
+		if marker.is_empty():
+			return _validate_stable_group_without_evidence([file_name])
+		var transaction_files: Array[String] = _discover_transaction_marker_files(marker, file_name)
+		if transaction_files.is_empty():
+			return ERR_FILE_CORRUPT
+		return _recover_transaction_group(transaction_files)
+
+	func _reconcile_pending_records_for_file(file_name: String) -> Error:
+		for committed: bool in [false, true]:
+			var final_path: String = _path_policy._get_full_path(
+				_get_transaction_commit_filename(file_name)
+				if committed
+				else _get_transaction_filename(file_name)
+			)
+			var pending_path: String = _path_policy._get_full_path(
+				_get_transaction_commit_pending_filename(file_name)
+				if committed
+				else _get_transaction_pending_filename(file_name)
+			)
+			if not FileAccess.file_exists(pending_path):
+				continue
+			var pending: Dictionary = _read_transaction_marker_absolute(pending_path)
+			if pending.is_empty() or (
+				not _is_valid_marker_for_member(pending, file_name)
+				or GFVariantData.get_option_bool(pending, "committed") != committed
+			):
+				return ERR_FILE_CORRUPT
+			if FileAccess.file_exists(final_path):
+				var final_record: Dictionary = _read_transaction_marker_absolute(final_path)
+				if pending.is_empty() or not _transaction_records_match(final_record, pending):
+					return ERR_FILE_CORRUPT
+				var remove_stale_pending: Error = _file_ops._remove_absolute(pending_path)
+				if remove_stale_pending != OK:
+					return remove_stale_pending
+				continue
+			if committed and not FileAccess.file_exists(
+				_path_policy._get_full_path(_get_transaction_filename(file_name))
+			):
+				return ERR_FILE_CORRUPT
+			var promote_error: Error = DirAccess.rename_absolute(pending_path, final_path)
+			if promote_error != OK:
+				if not FileAccess.file_exists(final_path):
+					return promote_error
+				var promoted: Dictionary = _read_transaction_marker_absolute(final_path)
+				if not _transaction_records_match(pending, promoted):
+					return ERR_FILE_CORRUPT
+				var remove_raced_pending: Error = _file_ops._remove_absolute(pending_path)
+				if remove_raced_pending != OK:
+					return remove_raced_pending
 		return OK
 
-	func _recover_transaction_file(file_name: String) -> void:
-		var final_path: String = _path_policy._get_full_path(file_name)
-		var temp_path: String = _path_policy._get_full_path(_get_temp_filename(file_name))
-		var backup_path: String = _path_policy._get_full_path(_get_backup_filename(file_name))
-		var has_final: bool = FileAccess.file_exists(final_path)
-		var has_temp: bool = FileAccess.file_exists(temp_path)
-		var has_backup: bool = FileAccess.file_exists(backup_path)
+	func _validate_final_transaction_records_for_file(file_name: String) -> Error:
+		for committed: bool in [false, true]:
+			var record_path: String = _path_policy._get_full_path(
+				_get_transaction_commit_filename(file_name)
+				if committed
+				else _get_transaction_filename(file_name)
+			)
+			if not FileAccess.file_exists(record_path):
+				continue
+			var record: Dictionary = _read_transaction_marker_absolute(record_path)
+			if (
+				record.is_empty()
+				or not _is_valid_marker_for_member(record, file_name)
+				or GFVariantData.get_option_bool(record, "committed") != committed
+			):
+				return ERR_FILE_CORRUPT
+		return OK
 
-		if has_backup and (not has_final or has_temp):
-			if has_final:
-				_file_ops._remove_file_if_exists(final_path)
+	func _find_transaction_reference(file_names: Array[String]) -> Dictionary:
+		for file_name: String in file_names:
+			var prepare: Dictionary = _read_transaction_marker(file_name)
+			if not prepare.is_empty():
+				return prepare
+			var commit: Dictionary = _read_transaction_commit_marker(file_name)
+			if not commit.is_empty():
+				return commit
+		return {}
 
-			var restore_error: Error = _file_ops._move_file(backup_path, final_path)
-			if restore_error != OK:
-				push_error("[GFStorageUtility] 恢复备份文件失败：%s，错误码：%s" % [final_path, restore_error])
-				return
+	func _validate_stable_group_without_evidence(file_names: Array[String]) -> Error:
+		for file_name: String in file_names:
+			for sidecar_path: String in [
+				_path_policy._get_full_path(_get_temp_filename(file_name)),
+				_path_policy._get_full_path(_get_backup_filename(file_name)),
+			]:
+				if FileAccess.file_exists(sidecar_path):
+					return ERR_FILE_CORRUPT
+			var resource_stage_path: String = GFVariantData.get_option_string(
+				GFStorageFamilyStore.make_family_descriptor_for_framework(
+					_path_policy._get_save_base_path(),
+					file_name
+				),
+				"resource_stage_path"
+			)
+			var cleanup_error: Error = _file_ops._remove_absolute(resource_stage_path)
+			if cleanup_error != OK:
+				return cleanup_error
+		return OK
 
-			_file_ops._remove_file_if_exists(temp_path)
-			return
+	func _group_matches_committed_cleanup(
+		file_names: Array[String],
+		_reference: Dictionary
+	) -> bool:
+		for file_name: String in file_names:
+			if not FileAccess.file_exists(_path_policy._get_full_path(file_name)):
+				return false
+			if (
+				FileAccess.file_exists(_path_policy._get_full_path(_get_temp_filename(file_name)))
+				or FileAccess.file_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
+			):
+				return false
+		return true
 
-		if has_backup and has_final:
-			_file_ops._remove_file_if_exists(backup_path)
-			has_backup = false
+	func _group_matches_rolled_back_state(
+		file_names: Array[String],
+		transaction_reference: Dictionary
+	) -> bool:
+		for file_name: String in file_names:
+			var final_exists: bool = FileAccess.file_exists(
+				_path_policy._get_full_path(file_name)
+			)
+			if final_exists != _get_marker_had_final(transaction_reference, file_name):
+				return false
+			if (
+				FileAccess.file_exists(_path_policy._get_full_path(_get_temp_filename(file_name)))
+				or FileAccess.file_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
+			):
+				return false
+		return true
 
-		if has_temp and not has_final and not has_backup:
-			var promote_error: Error = _file_ops._move_file(temp_path, final_path)
-			if promote_error != OK:
-				push_error("[GFStorageUtility] 恢复临时文件失败：%s，错误码：%s" % [final_path, promote_error])
-			return
+	func _finalize_committed_group(file_names: Array[String]) -> Error:
+		var terminal_error: Error = _validate_committed_group_state(file_names)
+		if terminal_error != OK:
+			return terminal_error
+		return _cleanup_committed_group_evidence(file_names)
 
-		if has_temp and has_final:
-			_file_ops._remove_file_if_exists(temp_path)
+	func _validate_committed_group_state(file_names: Array[String]) -> Error:
+		for file_name: String in file_names:
+			if not FileAccess.file_exists(_path_policy._get_full_path(file_name)):
+				return ERR_FILE_CORRUPT
+			if FileAccess.file_exists(_path_policy._get_full_path(_get_temp_filename(file_name))):
+				return ERR_FILE_CORRUPT
+		return OK
+
+	func _cleanup_committed_group_evidence(file_names: Array[String]) -> Error:
+		for file_name: String in file_names:
+			for cleanup_path: String in [
+				_path_policy._get_full_path(_get_backup_filename(file_name)),
+				GFVariantData.get_option_string(
+					GFStorageFamilyStore.make_family_descriptor_for_framework(
+						_path_policy._get_save_base_path(),
+						file_name
+					),
+					"resource_stage_path"
+				),
+			]:
+				var cleanup_error: Error = _file_ops._remove_absolute(cleanup_path)
+				if cleanup_error != OK:
+					return cleanup_error
+		var prepare_cleanup_error: Error = _cleanup_prepare_records(file_names)
+		if prepare_cleanup_error != OK:
+			return prepare_cleanup_error
+		return _cleanup_commit_records(file_names)
+
+	func _rollback_group_from_record(
+		file_names: Array[String],
+		transaction_reference: Dictionary
+	) -> Error:
+		for file_name: String in file_names:
+			var final_path: String = _path_policy._get_full_path(file_name)
+			var temp_path: String = _path_policy._get_full_path(_get_temp_filename(file_name))
+			var backup_path: String = _path_policy._get_full_path(_get_backup_filename(file_name))
+			var had_final: bool = _get_marker_had_final(transaction_reference, file_name)
+			if had_final:
+				if FileAccess.file_exists(backup_path):
+					var remove_new_final: Error = _file_ops._remove_absolute(final_path)
+					if remove_new_final != OK:
+						return remove_new_final
+					var restore_error: Error = _file_ops._move_file(backup_path, final_path)
+					if restore_error != OK:
+						return restore_error
+				elif not FileAccess.file_exists(final_path):
+					return ERR_FILE_CORRUPT
+			else:
+				if FileAccess.file_exists(backup_path):
+					return ERR_FILE_CORRUPT
+				var remove_new_file: Error = _file_ops._remove_absolute(final_path)
+				if remove_new_file != OK:
+					return remove_new_file
+			var remove_candidate: Error = _file_ops._remove_absolute(temp_path)
+			if remove_candidate != OK:
+				return remove_candidate
+			var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			)
+			var remove_resource_stage: Error = _file_ops._remove_absolute(
+				GFVariantData.get_option_string(descriptor, "resource_stage_path")
+			)
+			if remove_resource_stage != OK:
+				return remove_resource_stage
+		if not _group_matches_rolled_back_state(file_names, transaction_reference):
+			return ERR_FILE_CORRUPT
+		var commit_cleanup_error: Error = _cleanup_commit_records(file_names)
+		if commit_cleanup_error != OK:
+			return commit_cleanup_error
+		return _cleanup_prepare_records(file_names)
+
+	func _cleanup_prepare_records(file_names: Array[String]) -> Error:
+		for file_name: String in file_names:
+			for path: String in [
+				_path_policy._get_full_path(_get_transaction_pending_filename(file_name)),
+				_path_policy._get_full_path(_get_transaction_filename(file_name)),
+			]:
+				var cleanup_error: Error = _file_ops._remove_absolute(path)
+				if cleanup_error != OK:
+					return cleanup_error
+		return OK
+
+	func _cleanup_commit_records(file_names: Array[String]) -> Error:
+		for file_name: String in file_names:
+			for path: String in [
+				_path_policy._get_full_path(_get_transaction_commit_pending_filename(file_name)),
+				_path_policy._get_full_path(_get_transaction_commit_filename(file_name)),
+			]:
+				var cleanup_error: Error = _file_ops._remove_absolute(path)
+				if cleanup_error != OK:
+					return cleanup_error
+		return OK
 
 	func _commit_transaction(file_names: Array[String], markers_prepared: bool = false) -> Error:
 		file_names = _unique_file_names(file_names)
+		file_names.sort()
 		if file_names.is_empty():
 			return ERR_INVALID_PARAMETER
 		if markers_prepared:
 			if not _is_transaction_group_in_state(file_names, false):
-				_cleanup_transaction_files(file_names)
 				return ERR_INVALID_DATA
 		else:
 			var marker_error: Error = _write_transaction_markers(file_names, false)
 			if marker_error != OK:
-				_cleanup_transaction_files(file_names)
 				return marker_error
-
-		var transaction_state: Dictionary = {}
-		for file_name: String in file_names:
-			transaction_state[file_name] = {
-				"backed_up": false,
-				"committed": false,
-			}
 
 		for file_name: String in file_names:
 			var backup_path: String = _path_policy._get_full_path(_get_backup_filename(file_name))
@@ -3725,87 +4527,216 @@ class _StorageTransactionManager:
 			if FileAccess.file_exists(final_path):
 				var backup_error: Error = _file_ops._move_file(final_path, backup_path)
 				if backup_error != OK:
-					_rollback_transaction(file_names, transaction_state)
-					return backup_error
-				transaction_state[file_name]["backed_up"] = true
+					var rollback_error: Error = _recover_transaction_group(file_names)
+					return backup_error if rollback_error == OK else rollback_error
 
 		for file_name: String in file_names:
 			var temp_path: String = _path_policy._get_full_path(_get_temp_filename(file_name))
 			var final_path: String = _path_policy._get_full_path(file_name)
 			var commit_error: Error = _file_ops._move_file(temp_path, final_path)
 			if commit_error != OK:
-				_rollback_transaction(file_names, transaction_state)
-				_cleanup_transaction_markers(file_names)
-				return commit_error
-			transaction_state[file_name]["committed"] = true
+				var rollback_error: Error = _recover_transaction_group(file_names)
+				return commit_error if rollback_error == OK else rollback_error
 
 		var complete_marker_error: Error = _write_transaction_markers(file_names, true)
 		if complete_marker_error != OK:
-			_rollback_transaction(file_names, transaction_state)
-			_cleanup_transaction_markers(file_names)
-			return complete_marker_error
+			var rollback_error: Error = _recover_transaction_group(file_names)
+			return complete_marker_error if rollback_error == OK else rollback_error
 
-		for file_name: String in file_names:
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_transaction_filename(file_name)))
-
+		var terminal_error: Error = _validate_committed_group_state(file_names)
+		if terminal_error != OK:
+			return terminal_error
+		var cleanup_error: Error = _cleanup_committed_group_evidence(file_names)
+		if cleanup_error != OK:
+			push_warning(
+				"[GFStorageUtility] 事务已提交，但证据清理尚未收敛，错误码：%s。" % cleanup_error
+			)
 		return OK
 
-	func _rollback_transaction(file_names: Array[String], transaction_state: Dictionary) -> void:
-		for file_name: String in file_names:
-			var final_path: String = _path_policy._get_full_path(file_name)
-			var temp_path: String = _path_policy._get_full_path(_get_temp_filename(file_name))
-			var backup_path: String = _path_policy._get_full_path(_get_backup_filename(file_name))
-			var state: Dictionary = GFVariantData.as_dictionary(GFVariantData.get_option_value(transaction_state, file_name, {}))
-			var committed: bool = GFVariantData.get_option_bool(state, "committed", false)
-			var backed_up: bool = GFVariantData.get_option_bool(state, "backed_up", false)
-
-			if committed or backed_up:
-				_file_ops._remove_file_if_exists(final_path)
-			_file_ops._remove_file_if_exists(temp_path)
-
-			if backed_up and FileAccess.file_exists(backup_path):
-				var restore_error: Error = _file_ops._move_file(backup_path, final_path)
-				if restore_error != OK:
-					push_error("[GFStorageUtility] 回滚文件失败：%s，错误码：%s" % [final_path, restore_error])
+	func _rollback_transaction(
+		file_names: Array[String],
+		_transaction_state: Dictionary
+	) -> Error:
+		file_names = _unique_file_names(file_names)
+		file_names.sort()
+		var transaction_reference: Dictionary = _find_transaction_reference(file_names)
+		if transaction_reference.is_empty():
+			return ERR_FILE_CORRUPT
+		return _rollback_group_from_record(file_names, transaction_reference)
 
 	func _write_transaction_markers(file_names: Array[String], committed: bool) -> Error:
 		file_names = _unique_file_names(file_names)
+		file_names.sort()
 		if file_names.is_empty() or file_names.size() > GFStorageUtility._MAX_TRANSACTION_FILES:
 			return ERR_INVALID_PARAMETER
-		var transaction_id: String = ""
+		var transaction_id: String
+		var had_final_by_file: Dictionary = {}
 		if committed:
-			var first_marker: Dictionary = _read_transaction_marker(file_names[0])
-			transaction_id = GFVariantData.get_option_string(first_marker, "transaction_id")
-		if transaction_id.is_empty():
+			var first_prepare: Dictionary = _read_transaction_marker(file_names[0])
+			if not _is_valid_marker_for_member(first_prepare, file_names[0]):
+				return ERR_FILE_CORRUPT
+			transaction_id = GFVariantData.get_option_string(first_prepare, "transaction_id")
+			for file_name: String in file_names:
+				var prepare_marker: Dictionary = _read_transaction_marker(file_name)
+				if not _markers_share_snapshot(first_prepare, prepare_marker, file_name, false):
+					return ERR_FILE_CORRUPT
+				had_final_by_file[file_name] = _get_marker_had_final(first_prepare, file_name)
+		else:
 			transaction_id = "%d:%d" % [Time.get_ticks_usec(), _next_transaction_id]
 			_next_transaction_id += 1
+			for file_name: String in file_names:
+				had_final_by_file[file_name] = FileAccess.file_exists(
+					_path_policy._get_full_path(file_name)
+				)
 		for file_name: String in file_names:
-			var existing_marker: Dictionary = _read_transaction_marker(file_name)
-			var had_final: bool = GFVariantData.get_option_bool(
-				existing_marker,
-				"had_final",
-				FileAccess.file_exists(_path_policy._get_full_path(file_name))
-			)
 			var marker: Dictionary = GFStorageUtility._make_transaction_marker(
 				file_names,
 				file_name,
 				transaction_id,
 				committed,
-				had_final
+				had_final_by_file
 			)
-			var error: Error = _file_ops._write_plain_json(_get_transaction_filename(file_name), marker)
+			var marker_path: String = _path_policy._get_full_path(
+				_get_transaction_commit_filename(file_name)
+				if committed
+				else _get_transaction_filename(file_name)
+			)
+			var pending_path: String = _path_policy._get_full_path(
+				_get_transaction_commit_pending_filename(file_name)
+				if committed
+				else _get_transaction_pending_filename(file_name)
+			)
+			var error: Error = _publish_transaction_record(marker_path, pending_path, marker)
 			if error != OK:
+				if not committed:
+					var _aborted: Error = _abort_partial_prepare(file_names, transaction_id)
 				return error
 		return OK
-
-	func _cleanup_transaction_markers(file_names: Array[String]) -> void:
-		for file_name: String in file_names:
-			_file_ops._remove_file_if_exists(_path_policy._get_full_path(_get_transaction_filename(file_name)))
 
 	func _read_transaction_marker(file_name: String) -> Dictionary:
 		var path: String = _path_policy._get_full_path(_get_transaction_filename(file_name))
 		return _read_transaction_marker_absolute(path)
+
+	func _read_transaction_commit_marker(file_name: String) -> Dictionary:
+		var path: String = _path_policy._get_full_path(
+			_get_transaction_commit_filename(file_name)
+		)
+		return _read_transaction_marker_absolute(path)
+
+	func _publish_transaction_record(
+		path: String,
+		pending_path: String,
+		record: Dictionary
+	) -> Error:
+		var owner: Dictionary = GFVariantData.get_option_dictionary(record, "owner")
+		var owner_file_name: String = GFVariantData.get_option_string(owner, "logical_path")
+		if not _is_valid_marker_for_member(record, owner_file_name):
+			return ERR_INVALID_DATA
+		if FileAccess.file_exists(path):
+			return OK if _transaction_records_match(
+				record,
+				_read_transaction_marker_absolute(path)
+			) else ERR_FILE_CORRUPT
+		if FileAccess.file_exists(pending_path):
+			var pending_record: Dictionary = _read_transaction_marker_absolute(pending_path)
+			if not _transaction_records_match(record, pending_record):
+				return ERR_FILE_CORRUPT
+		else:
+			var write_error: Error = _file_ops._write_plain_json_absolute(
+				pending_path,
+				record
+			)
+			if write_error != OK:
+				return write_error
+			if not _transaction_records_match(
+				record,
+				_read_transaction_marker_absolute(pending_path)
+			):
+				return ERR_FILE_CORRUPT
+		var publish_error: Error = DirAccess.rename_absolute(pending_path, path)
+		if publish_error == OK:
+			return OK
+		if not FileAccess.file_exists(path):
+			return publish_error
+		if not _transaction_records_match(
+			record,
+			_read_transaction_marker_absolute(path)
+		):
+			return ERR_FILE_CORRUPT
+		var _pending_cleanup_error: Error = _file_ops._remove_absolute(pending_path)
+		return OK
+
+	func _abort_partial_prepare(file_names: Array[String], transaction_id: String) -> Error:
+		for file_name: String in file_names:
+			if (
+				FileAccess.file_exists(_path_policy._get_full_path(_get_temp_filename(file_name)))
+				or FileAccess.file_exists(_path_policy._get_full_path(_get_backup_filename(file_name)))
+				or FileAccess.file_exists(_path_policy._get_full_path(_get_transaction_commit_filename(file_name)))
+			):
+				return ERR_FILE_CORRUPT
+		for file_name: String in file_names:
+			var prepare_path: String = _path_policy._get_full_path(
+				_get_transaction_filename(file_name)
+			)
+			if FileAccess.file_exists(prepare_path):
+				var prepare: Dictionary = _read_transaction_marker_absolute(prepare_path)
+				if GFVariantData.get_option_string(prepare, "transaction_id") != transaction_id:
+					return ERR_FILE_CORRUPT
+				var remove_prepare_error: Error = _file_ops._remove_absolute(prepare_path)
+				if remove_prepare_error != OK:
+					return remove_prepare_error
+			var remove_pending_error: Error = _file_ops._remove_absolute(
+				_path_policy._get_full_path(_get_transaction_pending_filename(file_name))
+			)
+			if remove_pending_error != OK:
+				return remove_pending_error
+		return OK
+
+	func _transaction_records_match(expected: Dictionary, actual: Dictionary) -> bool:
+		var expected_owner: Dictionary = GFVariantData.get_option_dictionary(
+			expected,
+			"owner"
+		)
+		var owner_file_name: String = GFVariantData.get_option_string(
+			expected_owner,
+			"logical_path"
+		)
+		if not _is_valid_marker_for_member(expected, owner_file_name):
+			return false
+		if not _is_valid_marker_for_member(actual, owner_file_name):
+			return false
+		return (
+			GFVariantData.get_option_string(expected, "transaction_id")
+			== GFVariantData.get_option_string(actual, "transaction_id")
+			and GFVariantData.get_option_bool(expected, "committed")
+			== GFVariantData.get_option_bool(actual, "committed")
+			and GFVariantData.get_option_dictionary(expected, "owner")
+			== GFVariantData.get_option_dictionary(actual, "owner")
+			and GFVariantData.get_option_array(expected, "members")
+			== GFVariantData.get_option_array(actual, "members")
+		)
+
+	func _markers_share_snapshot(
+		transaction_reference: Dictionary,
+		candidate: Dictionary,
+		candidate_owner: String,
+		expected_committed: bool
+	) -> bool:
+		return (
+			_is_valid_marker_for_member(candidate, candidate_owner)
+			and GFVariantData.get_option_bool(candidate, "committed") == expected_committed
+			and GFVariantData.get_option_string(transaction_reference, "transaction_id")
+			== GFVariantData.get_option_string(candidate, "transaction_id")
+			and GFVariantData.get_option_array(transaction_reference, "members")
+			== GFVariantData.get_option_array(candidate, "members")
+		)
+
+	func _get_marker_had_final(marker: Dictionary, file_name: String) -> bool:
+		for member_value: Variant in GFVariantData.get_option_array(marker, "members"):
+			var member: Dictionary = GFVariantData.as_dictionary(member_value)
+			if GFVariantData.get_option_string(member, "logical_path") == file_name:
+				return GFVariantData.get_option_bool(member, "had_final")
+		return false
 
 	func _read_transaction_marker_absolute(path: String) -> Dictionary:
 		if not FileAccess.file_exists(path):
@@ -3813,15 +4744,18 @@ class _StorageTransactionManager:
 
 		var file: FileAccess = FileAccess.open(path, FileAccess.READ)
 		if file == null:
-			push_error("[GFStorageUtility] 无法读取事务标记：%s，错误码：%s" % [path, FileAccess.get_open_error()])
 			return {}
-
+		if file.get_length() <= 0 or file.get_length() > 64 * 1024:
+			file.close()
+			return {}
 		var content: String = file.get_as_text()
+		var read_error: Error = file.get_error()
 		file.close()
+		if read_error != OK:
+			return {}
 		var parsed: Variant = JSON.parse_string(content)
 		if parsed is Dictionary:
 			return GFVariantData.as_dictionary(parsed)
-		push_warning("[GFStorageUtility] 事务标记格式无效，将按单文件恢复处理：%s" % path)
 		return {}
 
 	func _get_transaction_marker_files(
@@ -3830,71 +4764,35 @@ class _StorageTransactionManager:
 		allowed_file_names: Array[String] = []
 	) -> Array[String]:
 		fallback_file_name = _canonicalize_marker_file_name(fallback_file_name)
-		if fallback_file_name.is_empty():
-			return []
-		var fallback_result: Array[String] = [fallback_file_name]
-		if (
-			GFVariantData.get_option_int(
-				marker,
-				"schema_version",
-				-1
-			) != GFStorageUtility._TRANSACTION_MARKER_SCHEMA_VERSION
-			or GFVariantData.get_option_string(marker, "transaction_id").is_empty()
-			or _canonicalize_marker_file_name(GFVariantData.get_option_string(marker, "file_key")) != fallback_file_name
+		if fallback_file_name.is_empty() or not _is_valid_marker_for_member(
+			marker,
+			fallback_file_name
 		):
-			return fallback_result
-		var allowed_keys: Dictionary = {}
-		var canonical_allowed_file_names: Array[String] = _unique_file_names(allowed_file_names)
-		if canonical_allowed_file_names.is_empty():
-			canonical_allowed_file_names.append(fallback_file_name)
-		for allowed_file_name: String in canonical_allowed_file_names:
-			allowed_keys[allowed_file_name] = true
+			return []
 		var result: Array[String] = []
-		var raw_files: Variant = GFVariantData.get_option_value(marker, "files", [])
-		if raw_files is Array:
-			for raw_file: Variant in raw_files:
-				var file_name: String = _canonicalize_marker_file_name(GFVariantData.to_text(raw_file))
-				if file_name.is_empty() or not allowed_keys.has(file_name):
-					return fallback_result
-				if not result.has(file_name):
-					result.append(file_name)
-				if result.size() > GFStorageUtility._MAX_TRANSACTION_FILES:
-					return fallback_result
-
-		if result.is_empty() or not result.has(fallback_file_name):
-			return fallback_result
+		for member_value: Variant in GFVariantData.get_option_array(marker, "members"):
+			var member: Dictionary = GFVariantData.as_dictionary(member_value)
+			result.append(GFVariantData.get_option_string(member, "logical_path"))
+		var canonical_allowed_file_names: Array[String] = _unique_file_names(allowed_file_names)
+		canonical_allowed_file_names.sort()
+		if not canonical_allowed_file_names.is_empty() and result != canonical_allowed_file_names:
+			return []
 		return result
 
 	func _discover_transaction_marker_files(marker: Dictionary, fallback_file_name: String) -> Array[String]:
-		fallback_file_name = _canonicalize_marker_file_name(fallback_file_name)
-		if fallback_file_name.is_empty():
+		var declared_files: Array[String] = _get_transaction_marker_files(
+			marker,
+			fallback_file_name
+		)
+		if declared_files.is_empty():
 			return []
-		var fallback_result: Array[String] = [fallback_file_name]
-		var raw_files: Variant = GFVariantData.get_option_value(marker, "files", [])
-		if not (raw_files is Array):
-			return fallback_result
-		var declared_files: Array[String] = []
-		for raw_file: Variant in raw_files:
-			var file_name: String = _canonicalize_marker_file_name(GFVariantData.to_text(raw_file))
-			if file_name.is_empty() or declared_files.has(file_name):
-				return fallback_result
-			declared_files.append(file_name)
-			if declared_files.size() > GFStorageUtility._MAX_TRANSACTION_FILES:
-				return fallback_result
-		if declared_files.is_empty() or not declared_files.has(fallback_file_name):
-			return fallback_result
-
-		var transaction_id: String = GFVariantData.get_option_string(marker, "transaction_id")
-		if transaction_id.is_empty():
-			return fallback_result
 		for file_name: String in declared_files:
-			var member_marker: Dictionary = marker if file_name == fallback_file_name else _read_transaction_marker(file_name)
-			if (
-				member_marker.is_empty()
-				or GFVariantData.get_option_string(member_marker, "transaction_id") != transaction_id
-				or _get_transaction_marker_files(member_marker, file_name, declared_files) != declared_files
-			):
-				return fallback_result
+			var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			)
+			if _family_store.validate_family_for_framework(descriptor) != OK:
+				return []
 		return declared_files
 
 	func _is_transaction_group_committed(file_names: Array[String]) -> bool:
@@ -3902,25 +4800,121 @@ class _StorageTransactionManager:
 
 	func _is_transaction_group_in_state(file_names: Array[String], committed: bool) -> bool:
 		file_names = _unique_file_names(file_names)
+		file_names.sort()
 		if file_names.is_empty():
 			return false
-		var transaction_id: String = ""
+		var transaction_reference: Dictionary = {}
 		for file_name: String in file_names:
-			var marker: Dictionary = _read_transaction_marker(file_name)
+			var marker: Dictionary = (
+				_read_transaction_commit_marker(file_name)
+				if committed
+				else _read_transaction_marker(file_name)
+			)
 			var marker_files: Array[String] = _get_transaction_marker_files(marker, file_name, file_names)
-			var marker_transaction_id: String = GFVariantData.get_option_string(marker, "transaction_id")
 			if (
 				marker.is_empty()
-				or GFVariantData.get_option_bool(marker, "committed", false) != committed
+				or GFVariantData.get_option_bool(marker, "committed") != committed
 				or marker_files != file_names
-				or marker_transaction_id.is_empty()
 			):
 				return false
-			if transaction_id.is_empty():
-				transaction_id = marker_transaction_id
-			elif transaction_id != marker_transaction_id:
+			if transaction_reference.is_empty():
+				transaction_reference = marker
+			elif not _markers_share_snapshot(transaction_reference, marker, file_name, committed):
+				return false
+			if not committed and FileAccess.file_exists(
+				_path_policy._get_full_path(_get_transaction_commit_filename(file_name))
+			):
 				return false
 		return true
+
+	func _validate_transaction_group(file_names: Array[String]) -> Error:
+		file_names = _unique_file_names(file_names)
+		file_names.sort()
+		if file_names.is_empty():
+			return ERR_INVALID_PARAMETER
+		var transaction_reference: Dictionary = {}
+		for file_name: String in file_names:
+			var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+				_path_policy._get_save_base_path(),
+				file_name
+			)
+			var family_error: Error = _family_store.validate_family_for_framework(descriptor)
+			if family_error != OK:
+				return family_error
+			var marker: Dictionary = _read_transaction_marker(file_name)
+			if not _is_valid_marker_for_member(marker, file_name):
+				return ERR_FILE_CORRUPT
+			if GFVariantData.get_option_bool(marker, "committed"):
+				return ERR_FILE_CORRUPT
+			if _get_transaction_marker_files(marker, file_name, file_names) != file_names:
+				return ERR_FILE_CORRUPT
+			if transaction_reference.is_empty():
+				transaction_reference = marker
+			elif not _markers_share_snapshot(transaction_reference, marker, file_name, false):
+				return ERR_FILE_CORRUPT
+		return OK
+
+	func _is_valid_marker_for_member(marker: Dictionary, file_name: String) -> bool:
+		if marker.size() != 6:
+			return false
+		var committed_value: Variant = marker.get("committed")
+		if not committed_value is bool:
+			return false
+		var committed: bool = committed_value
+		var schema_value: Variant = marker.get("schema")
+		var transaction_id_value: Variant = marker.get("transaction_id")
+		var expected_schema: String = (
+			GFStorageUtility._TRANSACTION_COMMIT_SCHEMA
+			if committed
+			else GFStorageUtility._TRANSACTION_PREPARE_SCHEMA
+		)
+		if not schema_value is String or not transaction_id_value is String:
+			return false
+		var schema: String = schema_value
+		var transaction_id: String = transaction_id_value
+		if (
+			schema != expected_schema
+			or GFVariantData.to_exact_int(marker.get("schema_version"), -1) != GFStorageUtility._TRANSACTION_MARKER_SCHEMA_VERSION
+			or transaction_id.is_empty()
+		):
+			return false
+		var owner_value: Variant = marker.get("owner")
+		var members_value: Variant = marker.get("members")
+		if not owner_value is Dictionary or not members_value is Array:
+			return false
+		var owner: Dictionary = GFVariantData.as_dictionary(owner_value)
+		var owner_logical_path_value: Variant = owner.get("logical_path")
+		var owner_family_id_value: Variant = owner.get("family_id")
+		if (
+			owner.size() != 2
+			or not owner_logical_path_value is String
+			or not owner_family_id_value is String
+			or owner_logical_path_value != file_name
+			or owner_family_id_value != GFStorageFamilyStore.make_family_id_for_framework(file_name)
+		):
+			return false
+		var previous_file_name: String = ""
+		var member_count: int = 0
+		var has_owner: bool = false
+		for member_value: Variant in GFVariantData.get_option_array(marker, "members"):
+			var member: Dictionary = GFVariantData.as_dictionary(member_value)
+			var member_logical_path_value: Variant = member.get("logical_path")
+			var member_family_id_value: Variant = member.get("family_id")
+			if not member_logical_path_value is String or not member_family_id_value is String:
+				return false
+			var member_file_name: String = member_logical_path_value
+			if (
+				member.size() != 3
+				or not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(member_file_name)
+				or member_family_id_value != GFStorageFamilyStore.make_family_id_for_framework(member_file_name)
+				or not member.get("had_final") is bool
+				or (not previous_file_name.is_empty() and member_file_name <= previous_file_name)
+			):
+				return false
+			previous_file_name = member_file_name
+			member_count += 1
+			has_owner = has_owner or member_file_name == file_name
+		return member_count > 0 and member_count <= GFStorageUtility._MAX_TRANSACTION_FILES and has_owner
 
 	func _unique_file_names(file_names: Array[String]) -> Array[String]:
 		var result: Array[String] = []
@@ -3930,26 +4924,7 @@ class _StorageTransactionManager:
 				result.append(file_name)
 		return result
 
-	func _has_absolute_marker_member(marker: Dictionary) -> bool:
-		var raw_files: Variant = GFVariantData.get_option_value(marker, "files", [])
-		if not (raw_files is Array):
-			return false
-		for raw_file: Variant in raw_files:
-			var file_name: String = _canonicalize_marker_file_name(
-				GFVariantData.to_text(raw_file)
-			)
-			if _path_policy._is_absolute_storage_path(file_name):
-				return true
-		return false
-
 	func _canonicalize_marker_file_name(file_name: String) -> String:
-		if file_name.is_empty():
-			return ""
-		if _path_policy._is_absolute_storage_path(file_name):
-			return file_name.replace("\\", "/").simplify_path()
-		if _path_policy._contains_parent_segment(file_name):
-			return ""
-		var normalized: String = file_name.replace("\\", "/").simplify_path()
-		if normalized.is_empty() or normalized == "." or normalized == "..":
-			return ""
-		return normalized
+		return file_name if GFStorageFamilyStore.is_valid_logical_file_path_for_framework(
+			file_name
+		) else ""

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "catalog_version": "1.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "d1332342a5d8b796486e70184811fabade5c17e90c75c20068181d32e86bbd1c",
+  "source_digest": "f90fd727a085bdb192d650f96c921653b625826c47c78dc19e1fd817fda31a09",
   "class_count": 789,
   "package_count": 52,
   "packages": [
@@ -81468,7 +81468,7 @@
           "kind": "var",
           "name": "save_dir_name",
           "signature": "var save_dir_name: String = \"saves\"",
-          "summary": "保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。",
+          "summary": "Storage root 的 portable logical 目录名；为空时使用 `user://`。",
           "visibility": "public"
         },
         {
@@ -81557,13 +81557,6 @@
         },
         {
           "kind": "var",
-          "name": "create_directories_for_nested_paths",
-          "signature": "var create_directories_for_nested_paths: bool = true",
-          "summary": "写入嵌套相对路径时是否自动创建目录。",
-          "visibility": "public"
-        },
-        {
-          "kind": "var",
           "name": "max_async_thread_count",
           "signature": "var max_async_thread_count: int = 4",
           "summary": "同时运行的异步存取线程数量。小于 1 时会被钳制为 1。",
@@ -81648,20 +81641,6 @@
         },
         {
           "kind": "func",
-          "name": "ensure_directory",
-          "signature": "func ensure_directory(directory_name: String = \"\") -> Error",
-          "summary": "确保存储相对目录存在。",
-          "visibility": "public"
-        },
-        {
-          "kind": "func",
-          "name": "get_storage_directory_path",
-          "signature": "func get_storage_directory_path(directory_name: String = \"\") -> String",
-          "summary": "获取存储目录路径，不创建目录。",
-          "visibility": "public"
-        },
-        {
-          "kind": "func",
           "name": "list_files",
           "signature": "func list_files( directory_name: String = \"\", extension_filter: String = \"\", recursive: bool = false, options: Dictionary = {} ) -> PackedStringArray",
           "summary": "枚举指定存储目录下的文件。",
@@ -81669,9 +81648,16 @@
         },
         {
           "kind": "func",
+          "name": "has_file",
+          "signature": "func has_file(file_name: String) -> bool",
+          "summary": "判断一个 logical file 是否存在 committed payload。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "delete_file",
           "signature": "func delete_file(file_name: String) -> Error",
-          "summary": "删除一个存储文件。",
+          "summary": "删除一个精确 logical family 的 committed payload 与私有事务证据。",
           "visibility": "public"
         },
         {
@@ -81699,7 +81685,7 @@
           "kind": "func",
           "name": "canonicalize_data_file_name",
           "signature": "func canonicalize_data_file_name(file_name: String) -> String",
-          "summary": "规范化并校验一个数据文件名。",
+          "summary": "校验一个已经 canonical 的 portable logical 数据文件名。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFSaveSlotStorageAdapter.xml
+++ b/docs/api_catalog/classes/GFSaveSlotStorageAdapter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveSlotStorageAdapter" path="addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd" module="extensions/save" extends="Resource" classDigest="13383be300833197cfd7f9a726debc310357154c26b1335b4ffe726e5cae1ab5">
+<class name="GFSaveSlotStorageAdapter" path="addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd" module="extensions/save" extends="Resource" classDigest="679d34f99d6500a529607d041e1ec54235877e7cf70a127d17abafafd9c440b4">
 	<description>GFSaveSlotStorageAdapter: Save 扩展的通用槽位存储适配器。
 把逻辑槽位索引映射到可配置的数据/元数据文件名，并通过 GFStorageUtility
 的通用字典事务 API 完成持久化。该类不定义项目存档字段，也不绑定 UI。</description>
@@ -109,7 +109,7 @@
 		<member kind="method" name="build_slot_file_plan">
 			<signature>func build_slot_file_plan(slot_index: int) -&gt; Dictionary:</signature>
 			<description>构建并校验一个槽位的文件计划。
-该方法不要求先配置 Storage，可供同步桥在访问任一后端前完成模板预检。</description>
+该方法不要求先配置 Storage，可供同步桥在访问任一后端前完成 portable logical identity 模板预检。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">slot_index: 槽位索引；必须大于等于 0。</tag>
@@ -182,7 +182,7 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">槽位摘要数组。</tag>
-				<tag name="schema">return: Array[Dictionary]，每项包含 slot_index、slot_id、metadata 和 modified_time。</tag>
+				<tag name="schema">return: Array[Dictionary]，每项包含 slot_index、slot_id、metadata，以及来自 metadata.updated_at_unix 的领域更新时间 modified_time: int；它不是文件系统 mtime。</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFStorageUtility.xml
+++ b/docs/api_catalog/classes/GFStorageUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="1362022a7a63c35105242627cddef6fa42ca7244f236a0494ca651b7f834a1e3">
+<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="ea7315824a3fac61bdc1b32c15ff581a2faee9ab41ceb5c9859bdce1adddd9f0">
 	<description>GFStorageUtility: 基于 `user://` 的轻量存档系统。
 支持槽位存档、元数据分离读取、`Resource` 存取，
 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。
@@ -79,8 +79,9 @@
 			</tags>
 		</member>
 		<member kind="property" name="save_dir_name">
-			<signature>var save_dir_name: String = "saves"</signature>
-			<description>保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。</description>
+			<signature>var save_dir_name: String = "saves":</signature>
+			<description>Storage root 的 portable logical 目录名；为空时使用 `user://`。
+首次 activation、显式 `init()` 或合法 I/O 尝试后冻结；非法配置失败关闭。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">3.17.0</tag>
@@ -174,13 +175,6 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">6.0.0</tag>
-			</tags>
-		</member>
-		<member kind="property" name="create_directories_for_nested_paths">
-			<signature>var create_directories_for_nested_paths: bool = true</signature>
-			<description>写入嵌套相对路径时是否自动创建目录。</description>
-			<tags>
-				<tag name="api">public</tag>
 			</tags>
 		</member>
 		<member kind="property" name="max_async_thread_count">
@@ -288,46 +282,37 @@
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
-		<member kind="method" name="ensure_directory">
-			<signature>func ensure_directory(directory_name: String = "") -&gt; Error:</signature>
-			<description>确保存储相对目录存在。</description>
-			<tags>
-				<tag name="api">public</tag>
-				<tag name="param">directory_name: 相对存储目录；为空时只确保根存储目录存在。</tag>
-				<tag name="return">Godot 的 `Error` 结果码。</tag>
-			</tags>
-		</member>
-		<member kind="method" name="get_storage_directory_path">
-			<signature>func get_storage_directory_path(directory_name: String = "") -&gt; String:</signature>
-			<description>获取存储目录路径，不创建目录。</description>
-			<tags>
-				<tag name="api">public</tag>
-				<tag name="param">directory_name: 相对存储目录；为空时返回根存储目录。</tag>
-				<tag name="return">按当前路径策略解析后的目录路径。</tag>
-				<tag name="since">4.4.0</tag>
-			</tags>
-		</member>
 		<member kind="method" name="list_files">
 			<signature>func list_files( directory_name: String = "", extension_filter: String = "", recursive: bool = false, options: Dictionary = {} ) -&gt; PackedStringArray:</signature>
 			<description>枚举指定存储目录下的文件。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">directory_name: 相对存储目录；为空时枚举根存储目录。</tag>
-				<tag name="param">extension_filter: 可选扩展名过滤，允许传入 `"json"` 或 `".json"`。</tag>
+				<tag name="param">extension_filter: 可选 canonical lowercase 扩展名过滤，不包含点号。</tag>
 				<tag name="param">recursive: 是否递归枚举子目录。</tag>
 				<tag name="param">options: 可选参数，支持 `max_scan_depth` 与 `max_file_count`。</tag>
-				<tag name="return">当前 Storage root 内的规范相对文件路径数组。</tag>
+				<tag name="return">从已校验 catalog 投影的 committed portable logical file identity 数组。</tag>
 				<tag name="schema">options: Dictionary，包含 max_scan_depth: int 和 max_file_count: int。</tag>
 				<tag name="since">2.3.0</tag>
 			</tags>
 		</member>
-		<member kind="method" name="delete_file">
-			<signature>func delete_file(file_name: String) -&gt; Error:</signature>
-			<description>删除一个存储文件。
-同时清理同名事务临时文件、备份文件和事务标记，避免删除后被遗留事务恢复。</description>
+		<member kind="method" name="has_file">
+			<signature>func has_file(file_name: String) -&gt; bool:</signature>
+			<description>判断一个 logical file 是否存在 committed payload。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">file_name: 存储相对文件路径。</tag>
+				<tag name="param">file_name: portable logical file identity。</tag>
+				<tag name="return">catalog、owner 与 payload 均有效时返回 true。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="delete_file">
+			<signature>func delete_file(file_name: String) -&gt; Error:</signature>
+			<description>删除一个精确 logical family 的 committed payload 与私有事务证据。
+该方法不会扫描或收养 Storage root 下的旧版可见文件；immutable catalog/owner claim 会保留。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">file_name: portable logical file identity。</tag>
 				<tag name="return">Godot 的 `Error` 结果码；文件不存在时返回 `ERR_FILE_NOT_FOUND`。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
@@ -350,7 +335,7 @@
 				<tag name="api">public</tag>
 				<tag name="param">files: 文件名到字典载荷的映射。</tag>
 				<tag name="return">Godot 的 `Error` 结果码。</tag>
-				<tag name="schema">files: Dictionary，键为存储相对文件名，值为要序列化并保存的 Dictionary 载荷。</tag>
+				<tag name="schema">files: Dictionary，键必须是未经改写的 String portable logical identity，值为要序列化并保存的 Dictionary 载荷。</tag>
 				<tag name="since">8.0.0</tag>
 			</tags>
 		</member>
@@ -366,12 +351,12 @@
 		</member>
 		<member kind="method" name="canonicalize_data_file_name">
 			<signature>func canonicalize_data_file_name(file_name: String) -&gt; String:</signature>
-			<description>规范化并校验一个数据文件名。
+			<description>校验一个已经 canonical 的 portable logical 数据文件名。
 返回值与异步队列的同文件锁使用相同路径规则，可用于建立稳定所有权键。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">file_name: 待校验文件名。</tag>
-				<tag name="return">合法时返回当前 Storage root 内的规范相对文件名；非法时返回空字符串。</tag>
+				<tag name="return">输入本身满足 portable-ascii-v1 时原样返回；不会改写别名，非法时返回空字符串。</tag>
 				<tag name="since">10.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="e238562480f263582b4041c0f17fb0ad1d9f50b2e49e1c9e972b360f3f45a551" classCount="813" methodCount="7428">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="fdbab000785e1706e9dcdd79ff41afae45c4bf4eb311e68419ace4bc9ed3121b" classCount="813" methodCount="7427">
 	<module id="kernel" label="Kernel" classCount="74" methodCount="799">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -76,7 +76,7 @@
 		<class name="GFUtility" path="classes/GFUtility.xml" sourcePath="addons/gf/kernel/base/gf_utility.gd" extends="Object" />
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 	</module>
-	<module id="standard" label="Standard" classCount="454" methodCount="4593">
+	<module id="standard" label="Standard" classCount="454" methodCount="4592">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -27,6 +27,7 @@
 - Save Profile 新增一次性 opaque `GFSaveProfileRequest`：`take_ownership()` 分别接管 document metadata、Provider context 与 result metadata，不提供 payload getter；合法边界只做 O(1) claim，成功后调用方必须放弃三个输入图的全部嵌套 alias。
 - Save Profile 新增 `GFSaveSectionSnapshot` 与 `GFSaveSectionSnapshotOperation`：Provider 通过 `begin_save_snapshot()` / `_begin_save_snapshot()` 在主线程按 work unit 分片生成不可变 section Snapshot；固定且很小的载荷可用 `make_completed_snapshot()`，大型载荷必须实现有界 Operation。
 - Storage 新增 `GFStoragePayloadTransfer` 与 `save_payload_request_async()`：以 opaque 单所有者句柄逻辑移交纯 Variant 载荷，并允许同一冻结绑定上的 timeout-detached attempt 与有界重试共享只读 Snapshot。
+- `GFStorageUtility` 新增 `has_file(logical_path)`；Storage 内部新增分片 catalog 与 opaque UUID family store，把 portable logical identity、owner 和 committed payload 建立可双向审计的稳定映射。
 - `GFSaveProfileUtility` 新增全局准备 work budget、单 profile slice budget 和软时间 budget；`GFSaveProfileResult` 新增准备耗时、Storage attempt 累计耗时与准备 work units 诊断。
 - 新增 `GFSaveProfileTransactionCoordinator`、`GFSaveProfileTransactionOperation` 与
   `GFSaveProfileTransactionResult`：在单 Profile 原语之上按精确有序 Provider 身份管理
@@ -37,7 +38,7 @@
   写入结果未知时冻结 domain，等待底层证据 settled 后通过显式严格重读收敛。
 - 新增 `GFSaveSectionMutation` 与 `GFSaveProfileMutationRequest`：用 move-only 候选 section
   清单替代事务内任意回调，固定 Provider 顺序并在确定失败时逆序恢复。
-- `GFSaveSlotStorageAdapter` 新增 `build_slot_file_plan()`：无需配置 Storage 即可返回已校验的数据/元数据文件名和规范目标，供同步入口在访问 backend 前复用同一模板安全规则。
+- `GFSaveSlotStorageAdapter` 新增 `build_slot_file_plan()`：无需配置 Storage 即可返回已校验的数据/元数据文件名和 portable logical target，供同步入口在访问 backend 前复用同一模板安全规则。
 - `GFStorageAsyncResult` 新增 `WriteFailureKind` 与隔离的 worker 载荷预检报告，区分非法请求、不可持久化载荷、编码、线程、生命周期和 IO 故障。
 - `GFArchitecture` 新增统一的 `resolve_module_access()`、模块类型与查询作用域枚举；Access Generator 可按精确模块脚本路径冻结 inherited/local、required 与 require-ready 策略，生成结果不再依赖运行时隐式选择。
 - 新增 `GFUIPanelAsyncOperation`：为每次底层异步 push/replace 冻结单调 serial、路径、层级和操作类型，并以弱面板引用暴露唯一终态；`GFUIRouterUtility` 的异步打开选项新增 owner 与 `GFAsyncScope` 生命周期锚点。
@@ -51,6 +52,7 @@
 ### 🔄 机制更改 (Changed)
 
 - `GFStorageUtility` 的所有运行时文件与目录入口统一使用规范相对身份，并在词法上解析到当前 Storage root；同步、异步、payload transfer、目录管理和事务恢复不再存在可动态扩大的绝对路径授权，非法非空 `save_dir_name` 也不再退化到 `user://` 根。需要任意本机路径的可信编辑器或离线迁移工具改由自身 `FileAccess` / `DirAccess` 边界负责；该约束不是宿主 symlink、junction 或挂载点沙箱。
+- `GFStorageUtility` 采用 `portable-ascii-v1` logical identity 与 `.gf-storage/v1` 私有布局：输入必须原样满足小写 ASCII segment 规则，不再归一化别名；SHA-256 分片 catalog 与 reciprocal owner record 绑定 domain-separated UUID v8 family，payload、candidate、backup、prepare/commit evidence 和 Resource stage 全部位于 family namespace。同步/异步事务先发布 immutable prepare，再写 candidate，final 切换后发布独立 commit evidence；partial prepare、partial commit、rollback 和证据清理按 exact family 状态恢复，任何歧义失败关闭。首次 activation、显式 `init()` 或首次合法 I/O 尝试会冻结 root，quiesce 排空已接纳工作，`list_files()` 从 catalog 投影并在 drain 后重新恢复 committed view；同一 root 当前要求 single writer。
 - AI Developer 的 package 状态只从完整闭合且版本一致的正式 lockfile 产生可信事实；无效 lockfile 不再向 Snapshot/Capability readiness 泄露 package ID。项目路径授权改为保留词法身份并拒绝根内 link/reparse，Agent 规则读入增加单文件与调用级预算，托管块替换保持 marker 外字节并以源 SHA-256 拒绝计划后的普通并发编辑。Platform/Storage 模板共用受控文件读取边界，Storage 正常保存路径不再重复遍历同一 payload 图。
 - 维护契约现在区分普通发布、真实冻结与 tag-origin hotfix，并在 tag 前以同一不可变产物 manifest 运行完整 `release` suite；参考工程同步默认只读，明确区分 `--plan` 与 `--apply`，统一遵守路径优先级，并以有界、带 SHA-256 的二进制精确 payload manifest 拒绝源/目标重叠、link/reparse、特殊文件、捕获期漂移和跨平台路径碰撞。Copy 同步改为异常可回滚的完整树替换，Link 同步不再删除未知既有目标，机器输出只暴露逻辑路径及稳定规则 ID。维护 CLI 只自动清理本次命令拥有的成功日志，历史/legacy 清理由显式预览后的 `log-hygiene` 负责；`path-hygiene` 同时强制 GF 自有 GDScript 使用无 BOM 严格 UTF-8、LF、末尾换行与 Tab 缩进。
 - 正式 API Catalog / Reference 生成链现在完整收集多行 `signal`、`enum`、`const` 与 `var`，字符串、转义和注释中的括号不再改变声明边界；未闭合声明、重复或大小写冲突 owner/anchor、错误 owner section 以及候选树中的坏链接会在事务写入前失败关闭。`sourceDigest` 的语义 payload 边界和当前尚未纳入 Catalog 的 `Gf` AutoLoad 例外也已显式记录，避免把 parser 自证误当作完整源码 provenance。
@@ -153,6 +155,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复公开 logical 文件名以 `.tmp`、`.bak` 或 `.txn` 结尾时与另一文件事务 sidecar 共享物理路径、可能跨 file key 误读或误删的问题；每个 logical identity 现在映射到独立 opaque family，旧 root 可见文件不会被运行时猜测收养。
 - 修复 `GFObjectPoolUtility` 的同步、分批与时间预算预热在并发、回调重入或运行中缩小上限时可共同写穿 `max_available_per_scene` 的问题；同一场景现在共享当前生命周期的在途容量预留，变更上限、归还节点或 dispose/init 会在提交前重新验收并丢弃过期候选。普通 acquire 也会冻结生命周期与 parent authority，并在场景构造、状态 setter 和根/子节点 hook 的每个外部边界复核当前代次；旧调用栈不再继续激活、通知或发布已归还、已释放或跨生命周期的节点树。
 - 修复项目 Installer 主动取消并返回后仍保持 running、并发 `Gf.init()` 永久等待且半注册模块未回滚的问题；取消与 timeout 等失败入口现在统一在 Architecture 失败结算中先回滚再恰好一次唤醒等待方，terminal 回调不能重开或提交 Installer，detached 旧 continuation 收尾前继续阻止重试和迟到写入。
 - 修复 `GFUIUtility` 在 panel 入树并执行 `_ready()` 后才捕获 previous focus，导致 modal 在 `_ready()` 主动取得焦点时无法恢复外部焦点的问题；现在会从目标 `CanvasLayer` 的 `Viewport` 在入树前捕获。
@@ -269,6 +272,7 @@
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
 - 移除 `GFStorageUtility.allow_absolute_paths`；运行时 Storage 不再提供重新启用任意绝对路径的开关，也不保留 deprecated alias。
+- 移除 `GFStorageUtility.get_storage_directory_path()`、`ensure_directory()` 与 `create_directories_for_nested_paths`；runtime Storage 不再暴露或让调用方管理物理目录，目录只保留为 logical catalog selector。
 - 移除 `play_bgm_with_options()` 的 `loop` / `playback_region` 通用选项，并保留事件 metadata/options 中的同名键；继续传入会在资源加载和后端派发前失败关闭，类型化区间只能来自 `GFAudioClip.playback_region`。
 - 移除框架内部 `gf_threaded_resource_coordinator.gd` 与 `gf_threaded_resource_operation.gd`；不保留双轨协调实现，统一由公开 `GFResourceBroker` / `GFResourceLease` 承担跨 Utility 所有权与 admission。
 - 移除 `GFSaveProfileUtility.save_profile(profile_id, metadata, context)` 字典重载；保存调用统一改用一次性 `GFSaveProfileRequest`，不保留隐式复制兼容路径。
@@ -280,7 +284,8 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
-- `GFStorageUtility.allow_absolute_paths` 已移除；`list_files()` 只返回 Storage root 内的规范相对路径，`canonicalize_data_file_name()`、`GFStorageAsyncOperation.get_file_name()` 与 `GFStorageAsyncResult.get_file_name()` 不再产生绝对路径身份。
+- `GFStorageUtility.allow_absolute_paths`、`get_storage_directory_path()`、`ensure_directory()` 与 `create_directories_for_nested_paths` 已移除；新增 `has_file()`。`list_files()` 只接受 portable logical directory 与不带点号的 lowercase extension token，并只返回 catalog 中存在 committed payload 的规范相对 logical identity；`canonicalize_data_file_name()` 只接受已经 canonical 的输入，不再改写分隔符、大小写或路径别名；`GFStorageAsyncOperation.get_file_name()` 与 `GFStorageAsyncResult.get_file_name()` 同样只暴露 logical identity，不再产生绝对路径身份。`save_dir_name` 必须在 activation、`init()` 或首次 I/O 前配置，Storage root 一经加载即冻结；切换 root 必须创建新的 Utility。
+- `GFSaveSlotStorageAdapter.list_slots()` 的 `modified_time` 不再读取物理文件系统 mtime，改为 metadata 中的领域时间 `updated_at_unix`；字段缺失时固定为 `0`。`build_slot_file_plan()` 现在按同一 portable logical identity 规则预检模板，不会静默规范化别名。
 - `GFLogSink.tick(delta)`、`GFLogUtility.tick(delta)` 及内置 timed sink 覆写是新的 11.0.0 公开时间推进契约；`GFAnalyticsUtility.get_dropped_event_count()` 是新的 11.0.0 聚合丢弃观察 API。Analytics 内置 HTTP 非 2xx 失败报告新增 `response_code`，`error` 收紧为不含正文的稳定 `HTTP {status}`。
 - `GFConfigAccessGenerator.build_source_with_report()` 与 `GFConfigPipelineArtifactManifest.make_source_receipt_validation_report()` 是新的 11.0.0 公开 API。Reader/Layout/Validation Stage 的内置契约版本和实现版本已升级；Stage descriptor 新增 `implementation_dependencies`。`build_table()` / `build_database()` 的表结果新增 `source_receipt`，`export_profile()` 新增 `source_validation_report`，访问器生成结果新增 input/emitted/skipped 计数与 `issues`，JSON 导出 options 新增 `max_nodes` / `max_output_bytes` 并收紧 `max_depth` 到绝对上限。
 - 本轮有意移除 10.x 已公开的通用 `loop` 输入与 `current_bgm_loop` 快照字段，开发身份进入 `11.0.0-dev.0` 主版本迁移线；不提供双轨兼容分支。
@@ -391,7 +396,7 @@
 29. 大型列表把项目 `ScrollContainer` 的直接子内容根、行工厂、bind/unbind、稳定 identity 和 owner 交给 `GFVirtualListBinder`；内容根不能是接管子节点位置的 `Container`。排序、过滤或数据内容提交后显式调用 `invalidate_items()`，只使用稳定且有界的标量 identity；若在 Binder callback 内失效，当前结果会是非成功 `STATUS_DEFERRED`，副作用已开始时 active 可被安全清空，调用方应以结果索引为准等待下一轮重建。需要切换 `layout_axis`、`fill_cross_axis`、`auto_measure` 或 callback 内的预算时，先更新配置并调用 `request_sync()`，当前同步轮仍使用入口快照，下一轮才采用新值。`scroll_to_item()` 返回 `false` 表示操作快照或最终整数偏移未能完整提交，调用方不要把它当作部分成功。Binder 会按每段轴所有权恢复接管前的最小尺寸。owner 退出前让 Binder 自动或显式 `dispose()`，不得重挂载或释放 Binder-owned Control。
 30. 表格结构化过滤改为继承 `GFTableRowPredicate`，返回 `GFTableRowPredicateResult`，再用 `GFTableRowPredicateRegistration.create()` 批量事务注册。将 `row_id_column`、`case_sensitive_filter` 与 `selection_model` 直接赋值迁移到 `set_row_id_column()`、`set_filter_case_sensitive()` 与 `set_selection_model()`，并通过 getter 读取已提交配置。更新所有 `view_changed` 连接以接收 revision 与 visible count；只有 rebuild result 成功且 committed，或收到 `view_changed` 时，才更新 VirtualList count 与 Binder identity，失败时继续展示上一份已提交投影。谓词实例的项目参数改变后显式调用 `refresh_view()`，不要依赖框架观察任意成员写入。经 `GFTableDataView.commit_cell_value()` 或批量入口写入的行必须可安全隔离；把带任意副作用的 `value_setter` 移到项目事务层，提交完成后再用新的 source 行调用 `set_rows()`。
 31. Spatial Canvas 输入转发改为检查 `InputDisposition`：只有 `CONSUMED` 才停止项目路由。创建并校验 `GFSpatialCanvasInputPolicy` 来替代硬编码按键；嵌套滚动界面用 modifier-gated 或 parent-only wheel，让未匹配滚轮继续 GUI 冒泡。需要禁用单指时使用 `TouchPrimaryBehavior.NONE`，并分别决定 raw 多指 pan 与 pinch zoom；若二者也都关闭，首触点不会被 Canvas 捕获。取消行为使用只含非指针事件的项目 InputMap action，不得与鼠标、触摸或位置手势复用；项目运行时修改 InputMap 后，超出事件预算或变成指针映射的取消 action 会失败关闭。
-32. 删除对 `GFStorageUtility.allow_absolute_paths` 的赋值，并把传给 Storage 的文件名、目录名统一改为当前 Storage root 内的规范相对路径。可信编辑器或离线迁移工具若需要外部路径，直接在工具层使用 `FileAccess` / `DirAccess`，不要向运行时 Utility 重新注入绝对路径能力。
+32. 删除对 `GFStorageUtility.allow_absolute_paths`、`create_directories_for_nested_paths`、`get_storage_directory_path()` 与 `ensure_directory()` 的使用。把文件名改为原样 canonical 的小写 ASCII logical path；不要传反斜杠、大写、Unicode、空段、`.` / `..`、设备名或 `.json` 形式的扩展过滤器。项目维护的编辑器或离线迁移工具若需要任意外部路径，直接在工具层使用 `FileAccess` / `DirAccess`，不要向 runtime Utility 重新注入绝对路径能力。存在性检查改用 `has_file()`，枚举改用 catalog-backed `list_files()`。在 activation、`init()` 或首次 I/O 前完成 `save_dir_name` 配置；root 冻结后需要切换时创建新的 Utility。把槽位 UI 对 `list_slots().modified_time` 的解释改为 metadata `updated_at_unix` 的领域更新时间，缺失值按 `0` 处理。旧 root 可见文件不能自动迁移；先用版本锁定的离线/编辑器工具验证旧 final 与 sidecar 所有权，再通过新 Storage API 重写。每个 Storage root 只保留一个活动 writer Utility/进程；当前没有跨 Utility/进程 lease。私有 namespace 是 GF 公共寻址与所有权边界，不是抵御同进程 `FileAccess`、symlink、junction 或 mount 重定向的安全沙箱。
 33. 读取扩展选择诊断的项目工具改为检查 `status` 与 `paths_allowed`；如需展示工具贡献错误，同时读取 `tool_contribution_errors`。
 34. 依赖“未发现禁用扩展引用”作安全判断的工具改用 `GFExtensionUsageAudit.find_references_to_root_report()`，并在 `ok=false` 或 `partial_scan=true` 时失败关闭。
 35. 检查传给 `GFTimeUtility`、`GFTimerUtility` 和相关调度入口的秒数来源；`NaN` 与无穷不再进入状态或形成 pending timer，应在项目输入边界修正数据并处理返回 `0`。
@@ -420,7 +425,7 @@
 58. 检查 Physics 自定义 field/provider：回调中修改 Probe 的位置、组合模式、fallback 或分组只会影响下一次采样；不要依赖同步重入同一 Probe 获取中间结果。duck provider 同帧修改私有状态后调用 `invalidate_cache()` 或关闭缓存。处理 SUM/HIGHEST_PRIORITY 的零向量失败关闭结果，不要把它解释为可继续施力的溢出值；如需 lockstep，项目应先固定候选顺序并使用自己的确定性数值方案。
 59. 检查所有 SaveGraph apply/load 调用：失败时除 `ok` / `errors` 外读取 `atomicity_restored`；为 `false` 时停止使用可能部分提交的场景状态，并按项目恢复策略消费 `rollback_failures`。不要依赖 `include_pipeline_trace` 才发现回滚失败，也不要在 Source callback 内同步重入同一个 Utility。
 60. 修正自定义 SaveGraph payload 的 `format_version` 为精确当前整数，并保证同一 `GFPersistPropertiesSource` 的 property、local 与 registry Serializer ID 唯一；已记录 pipeline error 的采集现在整体失败，调用方不得把空 payload 当作成功快照。
-61. 自定义槽位模板在保存或同步前调用 `build_slot_file_plan()` 并处理失败；两个模板都必须含 `{index}`，且规范相对目标不能相同。自定义 Storage 若返回 `ok=true` 与 `IntegrityStatus.INVALID`，Graph/Slot 读取入口现在仍会拒绝该结果。
+61. 自定义槽位模板在保存或同步前调用 `build_slot_file_plan()` 并处理失败；两个模板都必须含 `{index}`、原样满足 portable logical identity 规则，且 data/metadata target 不能相同。自定义 Storage 若返回 `ok=true` 与 `IntegrityStatus.INVALID`，Graph/Slot 读取入口现在仍会拒绝该结果。
 62. TurnBased teardown 可重复调用 `stop(true)` 清理并封存队列，不必在 stopped 状态另调 `clear_actions()`；自定义 action comparator 改为无副作用的确定严格弱序，并显式处理 non-finite/平局。为 phase 的 timer/动画/网络 completion 在 stop/timeout 时断开旧回调，不要让 context-only `finish(context)` 跨同 Context restart；同一可变 Context 也不要同时交给两个 Flow System。
 63. 自定义 Config Pipeline Stage 在 descriptor 中列出所有会影响输出的 `implementation_dependencies`，并把 Reader/Layout 输入输出契约迁移到 `reader_result@2` / `layout_result@2`。消费访问器报告时改用 `emitted_schema_count` 判断实际发射数并处理 `issues`；消费导出报告时检查 `source_validation_report`。JSON 导出的项目上限改用 `max_depth`、`max_nodes`、`max_output_bytes` 收紧框架默认值，不要再用零或负数表达无界。批量产物路径统一改为显式 `res://` 或 `user://`。
 64. 自定义 `GFLogSink` 若有依赖时间的缓冲行为，覆写 `tick(delta)`；脱离 Architecture 单独使用 `GFLogUtility` 时，由项目每帧显式调用 `tick(delta)`。不要再依赖“下一条日志”触发非零 interval。

--- a/docs/zh/extensions/save-graph/serializers-slots.md
+++ b/docs/zh/extensions/save-graph/serializers-slots.md
@@ -84,7 +84,7 @@ slot_store.save_slot(workflow.active_slot_index, document, metadata.to_dict())
 var cards := workflow.build_cards_from_slot_store(slot_store, [1, 2, 3])
 ```
 
-`GFSaveSlotStorageAdapter` 位于 Save 扩展包内，是推荐的通用槽位持久化入口。`save_slot()` 只接受通过校验的 `GFSaveDocument`，并要求 metadata 中已有的 schema 身份与文档一致；数据文件和元数据文件通过 `GFStorageUtility.save_data_group()` 同事务提交。`build_slot_file_plan()` 可在未 setup Storage 时预检 `{index}`、相对规范路径和 data/metadata 冲突。`load_slot()` 返回 `GFSaveDocumentReadResult`，把底层存储结果、迁移结果、最终校验报告和错误分开，不用空字典表达失败；`load_slot()`、`load_slot_metadata()` 与 `list_slots()` 都拒绝 Storage 明确标记为完整性无效的内容。
+`GFSaveSlotStorageAdapter` 位于 Save 扩展包内，是推荐的通用槽位持久化入口。`save_slot()` 只接受通过校验的 `GFSaveDocument`，并要求 metadata 中已有的 schema 身份与文档一致；数据文件和元数据文件通过 `GFStorageUtility.save_data_group()` 同事务提交。`build_slot_file_plan()` 可在未 setup Storage 时预检 `{index}`、原样满足 `portable-ascii-v1` 的 logical identity 和 data/metadata 冲突，不会替调用方规范化别名。`load_slot()` 返回 `GFSaveDocumentReadResult`，把底层存储结果、迁移结果、最终校验报告和错误分开，不用空字典表达失败；`load_slot()`、`load_slot_metadata()` 与 `list_slots()` 都拒绝 Storage 明确标记为完整性无效的内容。
 
 ```gdscript
 var loaded := slot_store.load_slot(active_slot, schema, migration_registry)
@@ -109,4 +109,4 @@ var sync_result := bridge.sync_slot(active_slot, slot_store, local_backend, remo
 
 槽位工作流内部使用 `GFSaveSlotMetadata` 描述槽位 ID、展示名、schema、版本、标签、耗时和自定义元数据；`validate_metadata()` 返回标准校验报告字典，用 `kind`、统计、摘要和下一步建议描述元数据结构问题。空槽不会默认生成 `Slot N` 这类展示名；如果项目需要统一占位名，可以显式设置 `empty_display_name_template`，或在 UI 渲染层自行映射。
 
-`GFSaveSlotCard` 是给项目读档 UI 消费的轻量 DTO，包含空槽、当前选中、兼容性、非本地化 `status_id`、修改时间和原始 metadata 副本。卡片会从整数 `slot_index`、整数/字符串 `slot_id`、metadata 里的 `slot_id` 或兜底逻辑 ID 中反推整数索引，兼容默认 `slot_3` 这类逻辑标识。它们都不绑定具体 UI 卡片布局，也不定义项目的存档字段、状态文案或按钮行为。
+`GFSaveSlotCard` 是给项目读档 UI 消费的轻量 DTO，包含空槽、当前选中、兼容性、非本地化 `status_id`、修改时间和原始 metadata 副本。`GFSaveSlotStorageAdapter.list_slots()` 的 `modified_time` 来自 metadata 的 `updated_at_unix`，表示领域层最后更新时间，不是 Storage family payload 的文件系统 mtime；缺失时为 `0`。卡片会从整数 `slot_index`、整数/字符串 `slot_id`、metadata 里的 `slot_id` 或兜底逻辑 ID 中反推整数索引，兼容默认 `slot_3` 这类逻辑标识。它们都不绑定具体 UI 卡片布局，也不定义项目的存档字段、状态文案或按钮行为。

--- a/docs/zh/reference/api/classes/GFSaveSlotStorageAdapter.md
+++ b/docs/zh/reference/api/classes/GFSaveSlotStorageAdapter.md
@@ -217,7 +217,7 @@ func get_metadata_file_name(slot_index: int) -> String:
 func build_slot_file_plan(slot_index: int) -> Dictionary:
 ```
 
-构建并校验一个槽位的文件计划。 该方法不要求先配置 Storage，可供同步桥在访问任一后端前完成模板预检。
+构建并校验一个槽位的文件计划。 该方法不要求先配置 Storage，可供同步桥在访问任一后端前完成 portable logical identity 模板预检。
 
 参数：
 
@@ -370,4 +370,4 @@ func list_slots() -> Array[Dictionary]:
 
 结构：
 
-- `return`: Array[Dictionary]，每项包含 slot_index、slot_id、metadata 和 modified_time。
+- `return`: Array[Dictionary]，每项包含 slot_index、slot_id、metadata，以及来自 metadata.updated_at_unix 的领域更新时间 modified_time: int；它不是文件系统 mtime。

--- a/docs/zh/reference/api/classes/GFStorageUtility.md
+++ b/docs/zh/reference/api/classes/GFStorageUtility.md
@@ -22,7 +22,7 @@
 | 常量 | [`DEFAULT_MAX_LIST_DEPTH`](#member-gfstorageutility-constants-default_max_list_depth) | `const DEFAULT_MAX_LIST_DEPTH: int = 32` |
 | 常量 | [`DEFAULT_MAX_LISTED_FILES`](#member-gfstorageutility-constants-default_max_listed_files) | `const DEFAULT_MAX_LISTED_FILES: int = 10000` |
 | 属性 | [`encrypt_key`](#member-gfstorageutility-properties-encrypt_key) | `var encrypt_key: int = 42` |
-| 属性 | [`save_dir_name`](#member-gfstorageutility-properties-save_dir_name) | `var save_dir_name: String = "saves"` |
+| 属性 | [`save_dir_name`](#member-gfstorageutility-properties-save_dir_name) | `var save_dir_name: String = "saves":` |
 | 属性 | [`codec`](#member-gfstorageutility-properties-codec) | `var codec: GFStorageCodec = GFStorageCodec.new()` |
 | 属性 | [`file_format`](#member-gfstorageutility-properties-file_format) | `var file_format: GFStorageCodec.Format = GFStorageCodec.Format.JSON` |
 | 属性 | [`use_compression`](#member-gfstorageutility-properties-use_compression) | `var use_compression: bool = false` |
@@ -35,7 +35,6 @@
 | 属性 | [`allowed_resource_load_extensions`](#member-gfstorageutility-properties-allowed_resource_load_extensions) | `var allowed_resource_load_extensions: PackedStringArray = PackedStringArray(["tres", "res"])` |
 | 属性 | [`allowed_resource_load_type_hints`](#member-gfstorageutility-properties-allowed_resource_load_type_hints) | `var allowed_resource_load_type_hints: PackedStringArray = PackedStringArray()` |
 | 属性 | [`require_resource_load_type_hint`](#member-gfstorageutility-properties-require_resource_load_type_hint) | `var require_resource_load_type_hint: bool = true` |
-| 属性 | [`create_directories_for_nested_paths`](#member-gfstorageutility-properties-create_directories_for_nested_paths) | `var create_directories_for_nested_paths: bool = true` |
 | 属性 | [`max_async_thread_count`](#member-gfstorageutility-properties-max_async_thread_count) | `var max_async_thread_count: int = 4:` |
 | 属性 | [`save_version`](#member-gfstorageutility-properties-save_version) | `var save_version: int = 1:` |
 | 属性 | [`strict_schema_migrations`](#member-gfstorageutility-properties-strict_schema_migrations) | `var strict_schema_migrations: bool = false` |
@@ -48,9 +47,8 @@
 | 方法 | [`begin_quiesce`](#member-gfstorageutility-methods-begin_quiesce) | `func begin_quiesce(scope: GFAsyncScope) -> GFAsyncCompletion:` |
 | 方法 | [`save_resource`](#member-gfstorageutility-methods-save_resource) | `func save_resource(file_name: String, resource: Resource) -> Error:` |
 | 方法 | [`load_resource`](#member-gfstorageutility-methods-load_resource) | `func load_resource(file_name: String, type_hint: String = "") -> Resource:` |
-| 方法 | [`ensure_directory`](#member-gfstorageutility-methods-ensure_directory) | `func ensure_directory(directory_name: String = "") -> Error:` |
-| 方法 | [`get_storage_directory_path`](#member-gfstorageutility-methods-get_storage_directory_path) | `func get_storage_directory_path(directory_name: String = "") -> String:` |
 | 方法 | [`list_files`](#member-gfstorageutility-methods-list_files) | `func list_files( directory_name: String = "", extension_filter: String = "", recursive: bool = false, options: Dictionary = {} ) -> PackedStringArray:` |
+| 方法 | [`has_file`](#member-gfstorageutility-methods-has_file) | `func has_file(file_name: String) -> bool:` |
 | 方法 | [`delete_file`](#member-gfstorageutility-methods-delete_file) | `func delete_file(file_name: String) -> Error:` |
 | 方法 | [`save_data`](#member-gfstorageutility-methods-save_data) | `func save_data(file_name: String, data: Dictionary) -> Error:` |
 | 方法 | [`save_data_group`](#member-gfstorageutility-methods-save_data_group) | `func save_data_group(files: Dictionary) -> Error:` |
@@ -196,10 +194,10 @@ var encrypt_key: int = 42
 - 首次版本：`3.17.0`
 
 ```gdscript
-var save_dir_name: String = "saves"
+var save_dir_name: String = "saves":
 ```
 
-保存子目录名；为空时直接写入 `user://`。非空值必须是规范相对目录，非法配置会失败关闭。
+Storage root 的 portable logical 目录名；为空时使用 `user://`。 首次 activation、显式 `init()` 或合法 I/O 尝试后冻结；非法配置失败关闭。
 
 <a id="member-gfstorageutility-properties-codec"></a>
 
@@ -349,18 +347,6 @@ var require_resource_load_type_hint: bool = true
 ```
 
 `load_resource()` 是否要求调用方传入非空 `type_hint`。
-
-<a id="member-gfstorageutility-properties-create_directories_for_nested_paths"></a>
-
-### `create_directories_for_nested_paths`
-
-- API：`public`
-
-```gdscript
-var create_directories_for_nested_paths: bool = true
-```
-
-写入嵌套相对路径时是否自动创建目录。
 
 <a id="member-gfstorageutility-properties-max_async_thread_count"></a>
 
@@ -557,47 +543,6 @@ func load_resource(file_name: String, type_hint: String = "") -> Resource:
 
 返回：读取到的资源实例；不存在时返回 `null`。
 
-<a id="member-gfstorageutility-methods-ensure_directory"></a>
-
-### `ensure_directory`
-
-- API：`public`
-
-```gdscript
-func ensure_directory(directory_name: String = "") -> Error:
-```
-
-确保存储相对目录存在。
-
-参数：
-
-| 名称 | 说明 |
-|---|---|
-| `directory_name` | 相对存储目录；为空时只确保根存储目录存在。 |
-
-返回：Godot 的 `Error` 结果码。
-
-<a id="member-gfstorageutility-methods-get_storage_directory_path"></a>
-
-### `get_storage_directory_path`
-
-- API：`public`
-- 首次版本：`4.4.0`
-
-```gdscript
-func get_storage_directory_path(directory_name: String = "") -> String:
-```
-
-获取存储目录路径，不创建目录。
-
-参数：
-
-| 名称 | 说明 |
-|---|---|
-| `directory_name` | 相对存储目录；为空时返回根存储目录。 |
-
-返回：按当前路径策略解析后的目录路径。
-
 <a id="member-gfstorageutility-methods-list_files"></a>
 
 ### `list_files`
@@ -616,15 +561,36 @@ func list_files( directory_name: String = "", extension_filter: String = "", rec
 | 名称 | 说明 |
 |---|---|
 | `directory_name` | 相对存储目录；为空时枚举根存储目录。 |
-| `extension_filter` | 可选扩展名过滤，允许传入 \`"json"\` 或 \`".json"\`。 |
+| `extension_filter` | 可选 canonical lowercase 扩展名过滤，不包含点号。 |
 | `recursive` | 是否递归枚举子目录。 |
 | `options` | 可选参数，支持 \`max_scan_depth\` 与 \`max_file_count\`。 |
 
-返回：当前 Storage root 内的规范相对文件路径数组。
+返回：从已校验 catalog 投影的 committed portable logical file identity 数组。
 
 结构：
 
 - `options`: Dictionary，包含 max_scan_depth: int 和 max_file_count: int。
+
+<a id="member-gfstorageutility-methods-has_file"></a>
+
+### `has_file`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func has_file(file_name: String) -> bool:
+```
+
+判断一个 logical file 是否存在 committed payload。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `file_name` | portable logical file identity。 |
+
+返回：catalog、owner 与 payload 均有效时返回 true。
 
 <a id="member-gfstorageutility-methods-delete_file"></a>
 
@@ -637,13 +603,13 @@ func list_files( directory_name: String = "", extension_filter: String = "", rec
 func delete_file(file_name: String) -> Error:
 ```
 
-删除一个存储文件。 同时清理同名事务临时文件、备份文件和事务标记，避免删除后被遗留事务恢复。
+删除一个精确 logical family 的 committed payload 与私有事务证据。 该方法不会扫描或收养 Storage root 下的旧版可见文件；immutable catalog/owner claim 会保留。
 
 参数：
 
 | 名称 | 说明 |
 |---|---|
-| `file_name` | 存储相对文件路径。 |
+| `file_name` | portable logical file identity。 |
 
 返回：Godot 的 `Error` 结果码；文件不存在时返回 `ERR_FILE_NOT_FOUND`。
 
@@ -695,7 +661,7 @@ func save_data_group(files: Dictionary) -> Error:
 
 结构：
 
-- `files`: Dictionary，键为存储相对文件名，值为要序列化并保存的 Dictionary 载荷。
+- `files`: Dictionary，键必须是未经改写的 String portable logical identity，值为要序列化并保存的 Dictionary 载荷。
 
 <a id="member-gfstorageutility-methods-load_data"></a>
 
@@ -729,7 +695,7 @@ func load_data(file_name: String) -> GFStorageReadResult:
 func canonicalize_data_file_name(file_name: String) -> String:
 ```
 
-规范化并校验一个数据文件名。 返回值与异步队列的同文件锁使用相同路径规则，可用于建立稳定所有权键。
+校验一个已经 canonical 的 portable logical 数据文件名。 返回值与异步队列的同文件锁使用相同路径规则，可用于建立稳定所有权键。
 
 参数：
 
@@ -737,7 +703,7 @@ func canonicalize_data_file_name(file_name: String) -> String:
 |---|---|
 | `file_name` | 待校验文件名。 |
 
-返回：合法时返回当前 Storage root 内的规范相对文件名；非法时返回空字符串。
+返回：输入本身满足 portable-ascii-v1 时原样返回；不会改写别名，非法时返回空字符串。
 
 <a id="member-gfstorageutility-methods-save_data_async"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 74 | 1108 | [Kernel](#module-kernel) |
-| Standard | 454 | 7272 | [Standard](#module-standard) |
+| Standard | 454 | 7270 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -267,7 +267,7 @@
 | [`GFSteeringMath`](GFSteeringMath.md#gfsteeringmath) | 运行时服务 (`runtime_service`) | `RefCounted` | 16 | `addons/gf/standard/foundation/math/gf_steering_math.gd` |
 | [`GFStorageFailoverBackend`](GFStorageFailoverBackend.md#gfstoragefailoverbackend) | 运行时服务 (`runtime_service`) | `GFStorageBackend` | 16 | `addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd` |
 | [`GFStorageSyncUtility`](GFStorageSyncUtility.md#gfstoragesyncutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 11 | `addons/gf/standard/utilities/storage/gf_storage_sync_utility.gd` |
-| [`GFStorageUtility`](GFStorageUtility.md#gfstorageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 52 | `addons/gf/standard/utilities/storage/gf_storage_utility.gd` |
+| [`GFStorageUtility`](GFStorageUtility.md#gfstorageutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 50 | `addons/gf/standard/utilities/storage/gf_storage_utility.gd` |
 | [`GFSupportReportUtility`](GFSupportReportUtility.md#gfsupportreportutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 32 | `addons/gf/standard/utilities/debug/gf_support_report_utility.gd` |
 | [`GFSupportReportWorkflow`](GFSupportReportWorkflow.md#gfsupportreportworkflow) | 运行时服务 (`runtime_service`) | `GFUtility` | 23 | `addons/gf/standard/utilities/debug/gf_support_report_workflow.gd` |
 | [`GFSurfaceScatterSampler3D`](GFSurfaceScatterSampler3D.md#gfsurfacescattersampler3d) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/standard/foundation/math/gf_surface_scatter_sampler_3d.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -8,15 +8,15 @@
 
 - 源码根目录：`addons/gf`
 - 公开类：`813`
-- 公开成员：`12043`
-- 公开方法：`7428`
+- 公开成员：`12041`
+- 公开方法：`7427`
 
 ## 模块
 
 | 模块 | 类 | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---|
 | Kernel | 74 | 1108 | 799 | [kernel.md](kernel.md) |
-| Standard | 454 | 7272 | 4593 | [standard.md](standard.md) |
+| Standard | 454 | 7270 | 4592 | [standard.md](standard.md) |
 | Action Queue | 16 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 188 | 3435 | 2319 |
+| [运行时服务](#category-runtime_service) | 188 | 3433 | 2318 |
 | [协议与扩展点](#category-protocol) | 25 | 342 | 270 |
 | [资源定义](#category-resource_definition) | 122 | 1572 | 797 |
 | [运行时句柄](#category-runtime_handle) | 50 | 887 | 560 |

--- a/docs/zh/standard/utilities/io/storage-snapshot/integrity-migrations/index.md
+++ b/docs/zh/standard/utilities/io/storage-snapshot/integrity-migrations/index.md
@@ -2,7 +2,7 @@
 
 这一组文档说明 `GFStorageUtility` 的写入策略、完整性校验、旧存档兼容和版本迁移链。
 
-`GFStorageUtility` 的本地写入路径、文件操作和事务提交/恢复共用同一套内部策略。槽位存档、纯字典存档和异步纯字典存档会遵循一致的路径规整、目录创建、临时文件、备份文件与事务标记规则。
+`GFStorageUtility` 的 logical identity、family claim、文件操作和事务提交/恢复共用同一套内部策略。槽位存档、纯字典存档和异步纯字典存档都会先通过相同的 portable path admission，再写入 catalog 授权的私有 family，并使用不可变 prepare/commit evidence 收敛事务。
 
 ## 阅读入口
 
@@ -12,4 +12,4 @@
 
 ## 使用边界
 
-项目层不应依赖 `.tmp`、`.bak`、`.txn` 这些内部文件。恢复流程会在下次读取、写入或槽位检查时自动收敛。
+`.tmp`、`.bak`、`.txn` 是合法的普通 logical leaf 后缀，各自映射到独立 family；项目层不能把它们解释成物理事务 sidecar。真正的 candidate、backup、resource stage 与 prepare/commit evidence 只存在于 `.gf-storage/v1` 私有 namespace，恢复流程会在 activation、后续读写或 committed-view 枚举前收敛。

--- a/docs/zh/standard/utilities/io/storage-snapshot/integrity-migrations/legacy-compatibility.md
+++ b/docs/zh/standard/utilities/io/storage-snapshot/integrity-migrations/legacy-compatibility.md
@@ -6,7 +6,7 @@
 
 JSON 读取默认保留解析出的数字类型。如果旧存档列表或元数据依赖把接近整数的 float 归一为 int，可临时开启 `GFStorageUtility.normalize_json_numbers` 或 `GFStorageCodec.normalize_json_numbers` 后读出并重写。
 
-11.0 移除了 `GFStorageUtility.allow_absolute_paths`。运行时 Storage 只接受规范相对路径并在词法上解析到当前 Storage root；绝对路径、包含 `..` 的跨目录路径和非法非空 `save_dir_name` 始终 fail closed，不再提供可重新开启的兼容开关。这是 GF API 边界，不替代宿主文件系统对 symlink、junction 或挂载点的隔离。
+11.0 移除了 `GFStorageUtility.allow_absolute_paths`。运行时 Storage 只接受未经改写、已经满足 `portable-ascii-v1` 的 logical identity，并通过 `.gf-storage/v1` 分片 catalog 映射到当前 Storage root 内的私有 family；绝对路径、路径别名、包含 `..` 的跨目录路径和非法非空 `save_dir_name` 始终 fail closed，不再提供可重新开启的兼容开关。旧版直接位于 Storage root 的可见文件不会被自动扫描、领养或迁移，必须由显式离线/编辑器迁移工具读取并重写为新 family。这是 GF API 边界，不替代宿主文件系统对 symlink、junction 或挂载点的隔离。
 
 可信编辑器工具或一次性迁移脚本确实需要访问外部路径时，应在独立工具边界直接使用 `FileAccess` / `DirAccess`，并自行承担来源授权、路径固定和生命周期清理；不要把该能力重新包装进运行时 Storage。
 

--- a/docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md
+++ b/docs/zh/standard/utilities/io/storage-snapshot/storage-utility.md
@@ -1,12 +1,12 @@
 # 本地存档管理器
 
-`GFStorageUtility` 是基于 Godot `user://` 的本地持久化工具。它负责把字典和 `Resource` 文件写入项目可写目录，并在读取时执行 codec 解码、完整性校验、事务恢复和版本迁移。字典读取统一返回 `GFStorageReadResult`，调用方必须检查 `ok`，不能再用空字典猜测“合法空载荷”还是“读取失败”。
+`GFStorageUtility` 是基于 Godot `user://` 的本地持久化工具。它把调用方提供的 portable logical path 映射到 Storage root 内的私有 family namespace，通过分片 catalog、双向 owner 记录和 opaque UUID family 管理字典与 `Resource`，并在读取时执行 codec 解码、完整性校验、事务恢复和版本迁移。字典读取统一返回 `GFStorageReadResult`，调用方必须检查 `ok`，不能再用空字典猜测“合法空载荷”还是“读取失败”。
 
 底层 storage 不作为项目槽位门面。项目需要槽位工作流时，应由项目自有的 slot adapter 把槽位身份映射到可配置文件名，再通过 `GFStorageUtility.save_data_group()` 让数据与 metadata 同事务落盘；标准层不规定槽位编号、命名、预览字段或 UI 语义。
 
 `GFStorageCodec` 提供 JSON/Binary 编码、可选压缩、SHA-256 完整性校验、轻量 XOR 混淆和框架存储元信息。物理文档只接受当前 schema 和精确字段集合，业务数据始终位于独立 `payload`，即使包含 `__gf_storage_document`、`payload`、`data` 或 `_meta` 等相似键也会完整往返。未知物理字段、错误格式、未来版本、缺失完整性摘要或摘要不匹配会产生明确失败结果，不会回退成另一种格式继续猜测。这里的混淆只用于降低误编辑概率，不能用于保护敏感数据。
 
-同时原生支持 Godot 的 `Resource` 类型保存，例如 `.tres` 或 `.res`。读取 Resource 会进入 Godot `ResourceLoader`，因此默认关闭；项目必须先显式启用 `allow_resource_loads`，配置 `allowed_resource_load_type_hints` 与扩展名 allowlist，并用存储路径策略收窄加载边界。`load_resource()` 会在加载后再次确认实际资源实例匹配 `type_hint`，这个入口只面向项目生成或项目已确认来源与格式的本地文件，不是沙盒化的资源导入器；对用户下载、导入或可被篡改的资源，项目层应先做来源检查、格式转换，或改用纯 `Dictionary` / JSON 载荷。
+同时原生支持 Godot 的 `Resource` 类型保存，例如 `.tres` 或 `.res`。Resource logical path 必须带有 1 到 16 字节的 canonical lowercase 扩展名；无扩展名或无法稳定映射的扩展会在 claim 前被拒绝。读取 Resource 会进入 Godot `ResourceLoader`，因此默认关闭；项目必须先显式启用 `allow_resource_loads`，配置 `allowed_resource_load_type_hints` 与扩展名 allowlist，并用存储路径策略收窄加载边界。`load_resource()` 会在加载后再次确认实际资源实例匹配 `type_hint`，这个入口只面向项目生成或项目已确认来源与格式的本地文件，不是沙盒化的资源导入器；对用户下载、导入或可被篡改的资源，项目层应先做来源检查、格式转换，或改用纯 `Dictionary` / JSON 载荷。
 
 `GFStorageCodec` 的 JSON 格式会自动通过 `GFVariantJsonCodec` 把 Vector、Color、PackedArray、AABB、Transform 和 `NaN` / `INF` / `-INF` 等值转换为 JSON 安全标记，再在读取时恢复为 Godot Variant；不会把非有限值直接交给 `JSON.stringify()` 后静默变成 `null`。若编码超过 Variant 遍历预算，codec 会把它视为编码失败，`GFStorageUtility` 的同步与异步事务都会拒绝提交并保留已有文件，不会把内部 `TraversalLimit` 标记当作业务存档落盘。需要保存 Resource 或 Node 引用时，仍应使用 `GFVariantReferenceCodec` 的显式引用标记，或由 SaveGraph 属性序列化器代为处理。
 
@@ -69,7 +69,7 @@ else:
 永久放弃源 `Dictionary` 及全部嵌套 `Array` / `Dictionary` alias；GDScript 不会替框架
 执行语言级 move，继续访问这些 alias 会破坏跨线程只读不变量。
 
-首次合法请求会冻结 Storage 实例、规范文件名、canonical target file-family identity
+首次合法请求会冻结 Storage 实例、原样合法的 portable logical path、canonical target file-family identity
 和 codec options；Utility 的存储目录或 codec 配置发生变化后，旧 transfer 不会漂移到
 新目标，也不能伪装成同一 retry binding。同一 transfer 可以让超时后仍在运行的
 detached attempt 与有界重试分别取得只读 lease；重试复用同一个逻辑 Snapshot，不重新
@@ -87,11 +87,14 @@ Float/Vector/Color 也必须先通过预算才能开始扫描。携带 Object、
 类型元数据的空 typed Array/Dictionary 同样会被拒绝，不能借空容器把对象约束带入
 worker。
 
-启动前的既有事务 recovery 与目录初始化属于独立前置生命周期，不受这条“新写入尚未
-提交”的保证覆盖。异步单文件写入与同步事务共用同一个 marker schema；单文件入口
-发现经过交叉校验的多文件 marker 时，会先核对并恢复完整成员集合，再开始该成员的
-异步 I/O。若进程在 committed marker 已落盘但 cleanup 尚未完成时退出，后续 recovery
-会保留新 final，而不是把已提交代次误判为回滚。`dispose()` 会先关闭新的异步 admission，
+启动前的既有事务 recovery 与 layout 初始化属于独立前置生命周期，不受这条“新写入尚未
+提交”的保证覆盖。同步与异步写入都先原子发布不可变 prepare record，再创建 candidate；
+只有 final 已完成切换后才发布独立、不可变的 commit evidence。单文件入口发现经过交叉
+校验的多文件 record 时，会先核对并恢复完整成员集合，再开始该成员的异步 I/O。只有完整
+commit evidence 集合才提交新代次；部分 prepare、部分 commit、部分证据清理和 rollback
+重试都按物理状态与每成员 `had_final` 快照收敛，任何歧义、损坏或缺失恢复证据都失败关闭。
+若进程在 commit evidence 已落盘但 cleanup 尚未完成时退出，后续 recovery 会保留新 final，
+而不是把已提交代次误判为回滚。`dispose()` 会先关闭新的异步 admission，
 再 drain 活动 attempt 并拒绝终态回调中的重入提交，所有 transfer lease 仍须在终态前收敛。
 `GFStorageAsyncResult.get_write_failure_kind()` 区分请求、载荷、编码、线程、生命周期和
 IO 故障；`get_write_validation_report()` 只暴露有界的结构索引、类型和预算计数，不
@@ -160,16 +163,20 @@ if not async_result.is_successful():
 
 9.0 的物理存储文档是有意收紧的契约，不会把旧明文 JSON 或旧 envelope 当成当前格式。需要保留既有玩家数据的项目应在升级发布前使用独立、版本锁定的一次性导入器读取旧文件，验证后写成当前文档，再移除导入入口；不要在主读取路径长期保留格式猜测。
 
-`save_data_group()` 会先把所有成员规范化成唯一 file-family 身份；`group/a.json` 与 `group//a.json` 这类别名会在写入前被拒绝。事务 journal 带版本、transaction id、精确文件集合和数量上限，恢复时磁盘 marker 只能引用本次调用已经授权的 canonical 文件，不能扩大到请求范围之外。提交失败会按同一 file-family 集合恢复备份。
+`save_data_group()` 要求所有成员本身已经是唯一 portable logical identity；`group/a.json` 与 `group//a.json`、大小写别名或反斜杠输入不会被偷偷归一，而是在任何 claim 或写入前被拒绝。事务 record 带版本、transaction id、精确排序成员、opaque family ID、每成员原 final 状态和数量上限，恢复时磁盘证据只能引用 catalog 已授权的精确 family，不能扩大到请求范围之外。提交失败会按同一 family 集合恢复备份，并在物理状态确认收敛前保留恢复证据。
 
 ## 文件管理
 
-除槽位和字典读写外，`get_storage_directory_path()`、`ensure_directory()`、`list_files()` 与 `delete_file()` 可用于管理同一存储根目录下的通用文件，例如列出本地缩略图、缓存 manifest 或项目自定义资源文件。
+运行时文件管理只公开 logical API：`has_file()` 判断 committed payload，`list_files()` 从 catalog 投影 logical identity，`delete_file()` 删除一个精确 family。框架不再公开 Storage 物理根、目录创建或嵌套目录开关；logical 目录只是 selector，不对应调用方可管理的物理目录。项目 slot adapter 应使用受控模板与 logical API，不能扫描或拼接内部事务、备份和 family 路径。
 
-`get_storage_directory_path()` 只解析路径，不创建目录；需要目录实际存在时再调用 `ensure_directory()`。这些 API 复用 `GFStorageUtility` 的路径安全策略：所有运行时入口只接受规范相对路径，并在词法上解析到当前 Storage root；绝对路径、`..` 跨目录路径和非法非空 `save_dir_name` 始终失败关闭，不会退化到 `user://` 根。纯字典读写和多文件事务 API 会直接拒绝空 `file_name` 或任意非法成员，而不是写入内部兜底文件名。需要读取任意本机路径的可信编辑器或离线迁移工具，应在自己的工具能力边界内直接使用 `FileAccess` / `DirAccess`，不能重新扩大运行时 Storage 的权限。
+`portable-ascii-v1` 不做 `replace()`、`simplify_path()`、大小写折叠或 Unicode 规范化。文件路径由 1 到 16 个 `/` 分隔的 segment 组成，总长最多 255 个 ASCII 字节；每段 1 到 64 字节，首尾必须是小写字母或数字，中间只允许 `[a-z0-9._-]`，并拒绝 Windows 设备名 stem。空字符串只可作为根目录 selector；反斜杠、空段、`.`、`..`、大写、Unicode、控制字符、尾点/空格和非 canonical 输入都在副作用前失败关闭。`.tmp`、`.bak`、`.txn` 只是普通 logical leaf 后缀，各自拥有独立 family，不再与事务 sidecar 冲突。
 
-这是一条 GF API 的词法身份与所有权边界，不是宿主文件系统安全沙箱：同进程代码仍可直接调用 `FileAccess` / `DirAccess`，宿主预先建立的 symlink、junction、挂载点或等价重定向也不在该保证内。涉及不可信宿主环境时，应由平台沙箱和文件系统权限提供实际隔离。
+物理布局固定在 Storage root 的 `.gf-storage/v1` 私有 namespace：框架内部协作者 `GFStorageFamilyStore` 负责冻结 layout manifest 的 path profile 与 identity algorithm；SHA-256 分片 catalog 把 logical identity 绑定到 domain-separated UUID v8 family；family 内 owner 记录反向绑定 logical digest、family ID 和 payload leaf。catalog 与 owner 必须精确互证，错误 shard、未知字段、损坏 record、未知 family entry、无证据 candidate/backup 或事务歧义全部失败关闭。删除 payload 会保留 immutable catalog/owner tombstone，因此同一 logical identity 始终归属于同一 family；`list_files()` 的扫描成本随已 claim identity 数增长，`max_file_count` 只限制返回数量，不是 catalog 工作量预算。
 
-递归枚举默认限制深度和返回数量，可通过 `list_files(..., { "max_scan_depth": 64, "max_file_count": 20000 })` 调整。枚举结果返回存储相对路径，适合交给 `load_data()`、显式启用后的 `load_resource()` 或项目自己的读取流程继续处理。
+旧版在 Storage root 可见位置写入的文件永远不会被运行时自动收养、读取、列出或删除。由于旧 `.tmp` / `.bak` / `.txn` 可同时是合法业务文件和旧 sidecar，运行时无法安全猜测其所有权；需要导入旧数据时，使用版本锁定的编辑器或离线迁移工具显式读取、验证并写入新 logical API，然后移除迁移能力。
 
-项目 slot adapter 枚举槽位时应使用自己的受控文件模板，不要把内部事务文件、备份文件或项目临时文件混入读档 UI。
+首次 activation、显式 `init()` 或首次合法 I/O 尝试会冻结当前 `save_dir_name`，加载 layout 并全量收敛 catalog 中的事务；损坏 layout 会让 activation 失败并关闭 I/O admission。`begin_quiesce()` 关闭新准入并等待已接纳异步工作排空。`list_files()` 还会先等待当前 Utility 的异步任务，再重新执行 root recovery，因而只投影该实例可证明的 committed view。同一 Storage root 只允许一个活动 writer Utility/进程；当前没有跨 Utility 或跨进程 lease，违反 single-writer 约束时不承诺线性化。
+
+这是一条 GF API 的词法身份、catalog ownership 与单 writer 边界，不是宿主文件系统安全沙箱：同进程代码仍可直接调用 `FileAccess` / `DirAccess`，宿主预先建立的 symlink、junction、挂载点或等价重定向也不在该保证内。涉及不可信宿主环境时，应由平台沙箱和文件系统权限提供实际隔离。需要任意本机路径的可信编辑器或离线工具，应在自己的能力边界内直接使用 Godot 文件 API，不能重新扩大 runtime Storage。
+
+递归枚举默认限制 logical 深度和返回数量，可通过 `list_files(..., { "max_scan_depth": 64, "max_file_count": 20000 })` 调整。扩展名过滤器使用不带点号的 canonical lowercase token，例如 `"json"`；`.json` 会被拒绝。枚举结果可直接交给 `load_data()`、显式启用后的 `load_resource()` 或项目自己的 logical 读取流程。

--- a/packages/standard/gf.standard.storage.json
+++ b/packages/standard/gf.standard.storage.json
@@ -23,6 +23,8 @@
     "addons/gf/standard/utilities/storage/gf_storage_backend.gd.uid",
     "addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd",
     "addons/gf/standard/utilities/storage/gf_storage_failover_backend.gd.uid",
+    "addons/gf/standard/utilities/storage/gf_storage_family_store.gd",
+    "addons/gf/standard/utilities/storage/gf_storage_family_store.gd.uid",
     "addons/gf/standard/utilities/storage/gf_storage_payload_transfer.gd",
     "addons/gf/standard/utilities/storage/gf_storage_payload_transfer.gd.uid",
     "addons/gf/standard/utilities/storage/gf_storage_codec.gd",

--- a/tests/gf_core/extensions/save/test_gf_save_graph_utility.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_graph_utility.gd
@@ -361,7 +361,7 @@ func test_save_scope_rejects_unsafe_values_at_persisted_boundary() -> void:
 	var save_error: Error = _utility.save_scope("unsafe_graph.sav", _scope, {"unsafe": unsafe_object})
 
 	assert_eq(save_error, ERR_INVALID_DATA, "Save Graph 的持久化入口不得把 Object 静默转换为 null。")
-	assert_false(FileAccess.file_exists(storage.get_storage_directory_path("").path_join("unsafe_graph.sav")))
+	assert_false(storage.has_file("unsafe_graph.sav"))
 	assert_push_error("[GFSaveGraphUtility] save_scope 失败：payload")
 	var _delete_result: Error = storage.delete_file("unsafe_graph.sav")
 	_utility.release_dependencies()

--- a/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_utility.gd
@@ -714,15 +714,28 @@ func test_registered_profile_uses_compiled_identity_after_resource_mutation() ->
 	assert_true(operation.get_result().is_successful())
 
 
-func test_registration_rejects_duplicate_canonical_storage_targets() -> void:
+func test_registration_rejects_duplicate_exact_storage_targets() -> void:
 	var first: GFSaveProfile = _make_profile(&"test.path.first", _make_provider(&"state", 1))
-	first.file_name = "slot\\data.sav"
+	first.file_name = "slot/data.sav"
 	var second: GFSaveProfile = _make_profile(&"test.path.second", _make_provider(&"state", 2))
 	second.file_name = "slot/data.sav"
 	assert_true(_register(first))
 	var report: Dictionary = _utility.register_profile(second)
 	assert_false(GFVariantData.get_option_bool(report, "registered"))
 	assert_true(_report_contains_issue(report, &"duplicate_storage_target"))
+
+
+func test_registration_rejects_noncanonical_storage_target_before_claim() -> void:
+	var profile: GFSaveProfile = _make_profile(&"test.path.invalid", _make_provider(&"state", 1))
+	profile.file_name = "slot\\data.sav"
+
+	var report: Dictionary = _utility.register_profile(profile)
+
+	assert_false(GFVariantData.get_option_bool(report, "registered"))
+	assert_true(_report_contains_issue(report, &"invalid_storage_path"))
+	assert_push_error(
+		"[GFStorageUtility] canonicalize_data_file_name 失败：file_name 不满足 portable logical path profile。"
+	)
 
 
 func test_save_is_explicitly_rejected_while_load_is_active() -> void:

--- a/tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd
@@ -2,21 +2,78 @@
 extends GutTest
 
 
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload(
+	"res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd"
+)
+
+
 var _storage: GFStorageUtility
+var _save_dir_name: String = ""
+
+
+class CorruptMetadataStorageUtility extends GFStorageUtility:
+	var corrupt_file_name: String = ""
+
+	func load_data(file_name: String) -> GFStorageReadResult:
+		if file_name == corrupt_file_name:
+			return GFStorageReadResult.new().configure_failure(
+				"Injected corrupt slot metadata.",
+				ERR_FILE_CORRUPT,
+				{},
+				GFStorageReadResult.IntegrityStatus.INVALID,
+				0,
+				GFStorageReadResult.FailureKind.CORRUPT
+			)
+		return super.load_data(file_name)
 
 
 func before_each() -> void:
+	_save_dir_name = "gf-save-slot-workflow-" + GFUuid.generate_v4()
 	_storage = GFStorageUtility.new()
-	_storage.save_dir_name = "test_workflow_slot_build"
+	_storage.save_dir_name = _save_dir_name
 	_storage.init()
 
 
 func after_each() -> void:
 	if _storage != null:
-		for file_name: String in _storage.list_files("", "", true):
-			var _delete_result: Error = _storage.delete_file(file_name)
 		_storage.dispose()
 		_storage = null
+	if not _save_dir_name.is_empty():
+		var storage_root_path: String = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+			_save_dir_name
+		)
+		assert_true(
+			storage_root_path.begins_with("user://gf-save-slot-workflow-"),
+			"测试清理只能作用于本例 UUID root。"
+		)
+		if storage_root_path.begins_with("user://gf-save-slot-workflow-"):
+			assert_eq(_remove_owned_test_tree(storage_root_path), OK)
+	_save_dir_name = ""
+
+
+func _remove_owned_test_tree(path: String) -> Error:
+	if FileAccess.file_exists(path):
+		return DirAccess.remove_absolute(path)
+	if not DirAccess.dir_exists_absolute(path):
+		return OK
+	var directory: DirAccess = DirAccess.open(path)
+	if directory == null:
+		return DirAccess.get_open_error()
+	for file_name: String in directory.get_files():
+		var remove_file_error: Error = DirAccess.remove_absolute(path.path_join(file_name))
+		if remove_file_error != OK:
+			return remove_file_error
+	for directory_name: String in directory.get_directories():
+		var child_path: String = path.path_join(directory_name)
+		var remove_directory_error: Error = (
+			DirAccess.remove_absolute(child_path)
+			if directory.is_link(directory_name)
+			else _remove_owned_test_tree(child_path)
+		)
+		if remove_directory_error != OK:
+			return remove_directory_error
+	directory = null
+	return DirAccess.remove_absolute(path)
 
 
 func test_get_slot_id_for_index_replaces_template() -> void:
@@ -133,9 +190,35 @@ func test_save_slot_storage_adapter_round_trips_slots_and_cards() -> void:
 	assert_eq(GFVariantData.get_option_int(metadata, "updated_at_unix"), 1700000010, "缺省更新时间应使用适配器时钟。")
 	assert_eq(summaries.size(), 1, "slot adapter 应枚举完整槽位。")
 	assert_eq(GFVariantData.get_option_int(summaries[0], "slot_index"), 2, "slot summary 应包含槽位索引。")
+	assert_eq(GFVariantData.get_option_int(summaries[0], "modified_time"), 1700000010, "slot summary 应复用已读取 metadata 的更新时间。")
 	assert_false(cards[0].is_empty, "已有槽位应构建为非空卡片。")
 	assert_eq(cards[0].display_name, "手动二", "卡片应读取元数据显示名。")
 	assert_true(cards[1].is_empty, "缺失槽位应构建为空卡片。")
+
+
+func test_save_slot_storage_adapter_uses_zero_when_domain_update_time_is_missing() -> void:
+	var adapter: GFSaveSlotStorageAdapter = GFSaveSlotStorageAdapter.new().setup(_storage)
+	var slot_index: int = 10
+	assert_eq(
+		_storage.save_data_group({
+			adapter.get_data_file_name(slot_index): {"legacy": true},
+			adapter.get_metadata_file_name(slot_index): {
+				"slot_id": "legacy_10",
+				"display_name": "Legacy",
+			},
+		}),
+		OK,
+		"测试夹具应能写入没有 updated_at_unix 的完整旧槽位。"
+	)
+
+	var summaries: Array[Dictionary] = adapter.list_slots()
+
+	assert_eq(summaries.size(), 1)
+	assert_eq(
+		GFVariantData.get_option_int(summaries[0], "modified_time", -1),
+		0,
+		"缺少领域更新时间时 modified_time 必须稳定回退为 0。"
+	)
 
 
 func test_save_slot_storage_adapter_supports_custom_file_templates() -> void:
@@ -175,32 +258,42 @@ func test_save_slot_storage_adapter_rejects_data_metadata_path_collision() -> vo
 	assert_push_error("[GFSaveSlotStorageAdapter] save_slot 失败：数据与元数据模板解析到同一存储目标")
 
 
-func test_save_slot_storage_adapter_rejects_canonical_target_alias_collision() -> void:
+func test_save_slot_storage_adapter_rejects_noncanonical_template_before_writing() -> void:
 	var adapter: GFSaveSlotStorageAdapter = GFSaveSlotStorageAdapter.new().setup(_storage)
 	adapter.data_file_template = "slot_{index}.sav"
 	adapter.metadata_file_template = "./slot_{index}.sav"
 
 	var save_error: Error = adapter.save_slot(7, _make_slot_document({"hp": 10}))
 
-	assert_eq(save_error, ERR_INVALID_PARAMETER, "语法不同但指向同一最终文件的模板必须在写入前拒绝。")
-	assert_false(FileAccess.file_exists(_storage.get_storage_directory_path("").path_join("slot_7.sav")), "碰撞校验失败时不得写入任一存储目标。")
-	assert_push_error("[GFSaveSlotStorageAdapter] save_slot 失败：数据与元数据模板解析到同一存储目标")
+	assert_eq(save_error, ERR_INVALID_PARAMETER, "非规范 logical identity 必须在写入前拒绝。")
+	assert_false(_storage.has_file("slot_7.sav"), "模板校验失败时不得写入任一 logical target。")
+	assert_push_error_count(1, "无 Storage 的模板预检应在 backend 准入前报告一次有界诊断。")
+
+
+func test_save_slot_storage_adapter_excludes_missing_metadata_from_summaries() -> void:
+	var adapter: GFSaveSlotStorageAdapter = GFSaveSlotStorageAdapter.new().setup(_storage)
+	assert_eq(adapter.save_slot(5, _make_slot_document({"hp": 10}), {"display_name": "Healthy"}), OK)
+	assert_eq(_storage.delete_file(adapter.get_metadata_file_name(5)), OK)
+
+	var summaries: Array[Dictionary] = adapter.list_slots()
+
+	assert_eq(summaries.size(), 0, "metadata 缺失的半槽位不得伪装成健康非空槽位。")
 
 
 func test_save_slot_storage_adapter_excludes_corrupt_metadata_from_summaries() -> void:
 	var adapter: GFSaveSlotStorageAdapter = GFSaveSlotStorageAdapter.new().setup(_storage)
 	assert_eq(adapter.save_slot(5, _make_slot_document({"hp": 10}), {"display_name": "Healthy"}), OK)
-	var metadata_path: String = _storage.get_storage_directory_path("").path_join(adapter.get_metadata_file_name(5))
-	var file: FileAccess = FileAccess.open(metadata_path, FileAccess.WRITE)
-	assert_not_null(file, "测试应能覆盖 metadata 文件。")
-	if file != null:
-		assert_true(file.store_string("{ malformed"), "测试应能写入损坏 metadata。")
-		file.close()
+	var corrupt_storage: CorruptMetadataStorageUtility = CorruptMetadataStorageUtility.new()
+	corrupt_storage.save_dir_name = _save_dir_name
+	corrupt_storage.corrupt_file_name = adapter.get_metadata_file_name(5)
+	_storage.dispose()
+	_storage = corrupt_storage
+	_storage.init()
+	adapter = GFSaveSlotStorageAdapter.new().setup(_storage)
 
 	var summaries: Array[Dictionary] = adapter.list_slots()
 
-	assert_eq(summaries.size(), 0, "无法解码的 metadata 不得伪装成健康非空槽位。")
-	assert_push_error("[GFStorageUtility] 读取数据失败")
+	assert_eq(summaries.size(), 0, "类型化 CORRUPT metadata 不得伪装成健康非空槽位。")
 
 
 func test_save_slot_storage_adapter_reports_partial_delete_as_failure() -> void:
@@ -210,7 +303,7 @@ func test_save_slot_storage_adapter_reports_partial_delete_as_failure() -> void:
 	var delete_error: Error = adapter.delete_slot(6)
 
 	assert_eq(delete_error, ERR_FILE_NOT_FOUND, "缺少 metadata 的半槽位不能报告完整删除成功。")
-	assert_false(FileAccess.file_exists(_storage.get_storage_directory_path("").path_join(adapter.get_data_file_name(6))))
+	assert_false(_storage.has_file(adapter.get_data_file_name(6)))
 
 
 func test_save_slot_storage_adapter_rejects_unsafe_persisted_values() -> void:

--- a/tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_slot_workflow.gd
@@ -59,6 +59,7 @@ func _remove_owned_test_tree(path: String) -> Error:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return DirAccess.get_open_error()
+	directory.include_hidden = true
 	for file_name: String in directory.get_files():
 		var remove_file_error: Error = DirAccess.remove_absolute(path.path_join(file_name))
 		if remove_file_error != OK:

--- a/tests/gf_core/package_focused_gut_mapping.json
+++ b/tests/gf_core/package_focused_gut_mapping.json
@@ -258,8 +258,10 @@
       "res://tests/gf_core/standard/utilities/history/test_gf_snapshot_history_utility.gd",
       "res://tests/gf_core/standard/utilities/storage/test_gf_safe_resource_codec.gd",
       "res://tests/gf_core/standard/utilities/storage/test_gf_storage_codec.gd",
+      "res://tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd",
       "res://tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd",
       "res://tests/gf_core/standard/utilities/storage/test_gf_storage_sync_utility.gd",
+      "res://tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd",
       "res://tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd"
     ],
     "gf.standard.storage.editor": [

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd
@@ -338,6 +338,40 @@ func test_claim_staging_recovers_owner_only_and_rejects_physical_work() -> void:
 	assert_false(FileAccess.file_exists(blocked_catalog_path))
 
 
+func test_claim_staging_discards_empty_or_truncated_owner_write() -> void:
+	assert_eq(_ensure_layout(), OK)
+	for case_name: String in ["empty", "truncated"]:
+		var descriptor: Dictionary = _descriptor(
+			"slots/recover-incomplete-%s.json" % case_name
+		)
+		var family_path: String = GFVariantData.get_option_string(
+			descriptor,
+			"family_path"
+		)
+		var staging_path: String = family_path + ".claim-" + GFUuid.generate_v4()
+		assert_eq(DirAccess.make_dir_recursive_absolute(staging_path), OK)
+		if case_name == "truncated":
+			assert_eq(_write_text(staging_path.path_join("owner.json"), "{"), OK)
+
+		assert_eq(
+			_claim_family(descriptor),
+			OK,
+			"未发布的 %s claim staging 应作为可恢复崩溃窗口丢弃。" % case_name
+		)
+		assert_false(DirAccess.dir_exists_absolute(staging_path))
+		assert_true(DirAccess.dir_exists_absolute(family_path))
+		assert_true(
+			FileAccess.file_exists(
+				GFVariantData.get_option_string(descriptor, "owner_path")
+			)
+		)
+		assert_true(
+			FileAccess.file_exists(
+				GFVariantData.get_option_string(descriptor, "catalog_path")
+			)
+		)
+
+
 func test_owner_and_catalog_records_fail_closed_on_reciprocal_corruption() -> void:
 	var descriptor: Dictionary = _descriptor("slots/corrupt-owner.json")
 	assert_eq(_claim_family(descriptor), OK)

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd
@@ -638,6 +638,7 @@ func _remove_tree(path: String) -> Error:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return ERR_FILE_CANT_OPEN
+	directory.include_hidden = true
 	var begin_error: Error = directory.list_dir_begin()
 	if begin_error != OK:
 		return begin_error

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd
@@ -1,0 +1,654 @@
+## 测试 GFStorageFamilyStore 的 portable identity、私有布局与 catalog fail-closed 语义。
+extends GutTest
+
+
+# --- 常量 ---
+
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload(
+	"res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd"
+)
+
+
+# --- 私有变量 ---
+
+var _save_dir_name: String = ""
+var _storage_root_path: String = ""
+var _store: RefCounted
+
+
+# --- Godot 生命周期方法 ---
+
+func before_each() -> void:
+	_save_dir_name = "gf-family-store-" + GFUuid.generate_v4()
+	_storage_root_path = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+		_save_dir_name
+	)
+	_store = _GF_STORAGE_FAMILY_STORE_SCRIPT.new()
+	assert_true(
+		GFVariantData.to_bool(
+			_store.call("configure_for_framework", _storage_root_path)
+		),
+		"测试 family store 应绑定独立 portable user:// root。"
+	)
+
+
+func after_each() -> void:
+	var cleanup_error: Error = _remove_tree(_storage_root_path)
+	assert_eq(cleanup_error, OK, "测试结束后应完整删除独立 Storage root。")
+	_store = null
+	_storage_root_path = ""
+	_save_dir_name = ""
+
+
+# --- 公共方法 ---
+
+func test_portable_logical_file_path_accepts_exact_boundaries() -> void:
+	var sixteen_segments: String = "/".join(PackedStringArray([
+		"a", "b", "c", "d", "e", "f", "g", "h",
+		"i", "j", "k", "l", "m", "n", "o", "p",
+	]))
+	var sixty_four_byte_segment: String = "a".repeat(64)
+	var two_hundred_fifty_five_byte_path: String = "%s/%s/%s/%s" % [
+		"a".repeat(64),
+		"b".repeat(64),
+		"c".repeat(64),
+		"d".repeat(60),
+	]
+
+	for logical_path: String in [
+		"a",
+		"a.json",
+		"nested/file-name_1.tmp",
+		"multiple.dots.are-valid.txn",
+		sixteen_segments,
+		sixty_four_byte_segment,
+		two_hundred_fifty_five_byte_path,
+	]:
+		assert_true(
+			_GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_logical_file_path_for_framework(
+				logical_path
+			),
+			"portable file identity 应原样接受合法边界：%s" % logical_path
+		)
+
+
+func test_portable_logical_file_path_rejects_rewriting_and_platform_aliases() -> void:
+	var invalid_paths: Array[String] = [
+		"",
+		"Upper.json",
+		"中文.json",
+		"nested\\file.json",
+		"/leading.json",
+		"trailing.json/",
+		"double//slash.json",
+		"./file.json",
+		"nested/../file.json",
+		".hidden",
+		"trailing.",
+		"_leading.json",
+		"trailing_",
+		"-leading.json",
+		"trailing-",
+		"stream:alternate",
+		"con",
+		"con.json",
+		"prn.data",
+		"aux",
+		"nul.save",
+		"com1.json",
+		"com9.slot",
+		"lpt1",
+		"lpt9.backup",
+		"a".repeat(65),
+		"a".repeat(256),
+		"/".join(PackedStringArray([
+			"a", "b", "c", "d", "e", "f", "g", "h", "i",
+			"j", "k", "l", "m", "n", "o", "p", "q",
+		])),
+	]
+
+	for logical_path: String in invalid_paths:
+		assert_false(
+			_GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_logical_file_path_for_framework(
+				logical_path
+			),
+			"portable file identity 不得改写或接受平台别名：%s" % logical_path
+		)
+
+
+func test_directory_and_extension_selectors_have_distinct_strict_grammars() -> void:
+	for directory_name: String in ["", "a", "nested/slot-data"]:
+		assert_true(
+			_GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_logical_directory_path_for_framework(
+				directory_name
+			),
+			"空串仅在 directory selector 表示根，其他目录必须保持 canonical。"
+		)
+	for directory_name: String in [".", "..", "Nested", "nested/", "nested//child"]:
+		assert_false(
+			_GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_logical_directory_path_for_framework(
+				directory_name
+			),
+			"directory selector 不得折叠、改写或大小写归一化。"
+		)
+
+	for extension_filter: String in ["", "j", "json", "save_data", "save-data", "a".repeat(16)]:
+		assert_true(
+			_GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_extension_filter_for_framework(
+				extension_filter
+			),
+			"canonical extension token 应被接受：%s" % extension_filter
+		)
+	for extension_filter: String in [
+		".json", "JSON", "-json", "_json", "json.tmp", "中文", "a".repeat(17),
+	]:
+		assert_false(
+			_GF_STORAGE_FAMILY_STORE_SCRIPT.is_valid_extension_filter_for_framework(
+				extension_filter
+			),
+			"extension filter 不得被隐式 trim、去点或转小写：%s" % extension_filter
+		)
+
+
+func test_descriptor_uses_exact_domain_hash_and_uuid_v8_bits() -> void:
+	var logical_path: String = "slots/player.json"
+	var descriptor: Dictionary = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_family_descriptor_for_framework(
+		_storage_root_path,
+		logical_path
+	)
+	var expected_digest: String = _make_expected_identity_digest(logical_path)
+	var expected_family_id: String = _make_expected_uuid_v8(expected_digest)
+
+	assert_false(descriptor.is_empty())
+	assert_eq(GFVariantData.get_option_string(descriptor, "logical_path"), logical_path)
+	assert_eq(
+		GFVariantData.get_option_string(descriptor, "logical_sha256"),
+		expected_digest,
+		"identity hash 必须精确绑定 domain、NUL 分隔符与原样 logical path。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(descriptor, "family_id"),
+		expected_family_id,
+		"UUID v8 只应覆盖 version/variant 位并保留其余 digest 位。"
+	)
+	var family_id: String = GFVariantData.get_option_string(descriptor, "family_id")
+	assert_eq(family_id.substr(14, 1), "8")
+	assert_true("89ab".contains(family_id.substr(19, 1)))
+	assert_true(
+		GFVariantData.get_option_string(descriptor, "catalog_relative_path").begins_with(
+			".gf-storage/v1/catalog/%s/%s/" % [
+				expected_digest.substr(0, 2),
+				expected_digest.substr(2, 2),
+			]
+		)
+	)
+	assert_true(
+		GFVariantData.get_option_string(descriptor, "family_relative_path").begins_with(
+			".gf-storage/v1/families/"
+		)
+	)
+
+
+func test_descriptor_is_deterministic_and_suffix_names_own_distinct_families() -> void:
+	var logical_paths: Array[String] = [
+		"family.json",
+		"family.json.tmp",
+		"family.json.bak",
+		"family.json.txn",
+	]
+	var family_ids: Dictionary = {}
+	var catalog_paths: Dictionary = {}
+	var family_paths: Dictionary = {}
+
+	for logical_path: String in logical_paths:
+		var first: Dictionary = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_family_descriptor_for_framework(
+			_storage_root_path,
+			logical_path
+		)
+		var second: Dictionary = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_family_descriptor_for_framework(
+			_storage_root_path,
+			logical_path
+		)
+		assert_eq(first, second, "descriptor 必须是无磁盘副作用的确定性纯计算。")
+		family_ids[GFVariantData.get_option_string(first, "family_id")] = true
+		catalog_paths[GFVariantData.get_option_string(first, "catalog_path")] = true
+		family_paths[GFVariantData.get_option_string(first, "family_path")] = true
+
+	assert_eq(family_ids.size(), logical_paths.size(), "sidecar 样式名称必须拥有独立 UUID family。")
+	assert_eq(catalog_paths.size(), logical_paths.size())
+	assert_eq(family_paths.size(), logical_paths.size())
+	assert_false(DirAccess.dir_exists_absolute(_storage_root_path), "纯 descriptor 计算不得创建 root。")
+
+
+func test_layout_and_family_claim_are_idempotent() -> void:
+	var descriptor: Dictionary = _descriptor("slots/idempotent.json")
+
+	assert_eq(_ensure_layout(), OK)
+	assert_eq(_ensure_layout(), OK)
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_validate_family(descriptor), OK)
+	assert_true(FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "catalog_path")))
+	assert_true(FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "owner_path")))
+	assert_false(
+		FileAccess.file_exists(_storage_root_path.path_join("slots/idempotent.json")),
+		"logical path 不得成为 root 下的可见物理 payload。"
+	)
+
+
+func test_exact_layout_and_catalog_pending_files_are_promoted_idempotently() -> void:
+	assert_eq(_ensure_layout(), OK)
+	var layout_path: String = _storage_root_path.path_join(
+		".gf-storage/v1/layout.json"
+	)
+	var layout_pending_path: String = layout_path + ".pending-" + GFUuid.generate_v4()
+	assert_eq(DirAccess.rename_absolute(layout_path, layout_pending_path), OK)
+
+	assert_eq(_ensure_layout(), OK)
+	assert_true(FileAccess.file_exists(layout_path))
+	assert_false(FileAccess.file_exists(layout_pending_path))
+
+	var descriptor: Dictionary = _descriptor("slots/pending-catalog.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), "payload"), OK)
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	var catalog_pending_path: String = catalog_path + ".pending-" + GFUuid.generate_v4()
+	assert_eq(DirAccess.rename_absolute(catalog_path, catalog_pending_path), OK)
+
+	_assert_list_result(
+		"",
+		"",
+		true,
+		0,
+		0,
+		PackedStringArray(["slots/pending-catalog.json"])
+	)
+	assert_true(FileAccess.file_exists(catalog_path))
+	assert_false(FileAccess.file_exists(catalog_pending_path))
+
+
+func test_invalid_exact_pending_files_fail_closed_without_cleanup_or_adoption() -> void:
+	assert_eq(_ensure_layout(), OK)
+	var layout_path: String = _storage_root_path.path_join(
+		".gf-storage/v1/layout.json"
+	)
+	var invalid_layout_pending: String = layout_path + ".pending-" + GFUuid.generate_v4()
+	assert_eq(_write_text(invalid_layout_pending, "{}"), OK)
+
+	assert_eq(_ensure_layout(), ERR_FILE_CORRUPT)
+	assert_true(FileAccess.file_exists(layout_path))
+	assert_true(
+		FileAccess.file_exists(invalid_layout_pending),
+		"损坏 pending 必须保留为可诊断冲突，不得静默删除。"
+	)
+	assert_eq(DirAccess.remove_absolute(invalid_layout_pending), OK)
+	assert_eq(_ensure_layout(), OK)
+
+	var descriptor: Dictionary = _descriptor("slots/invalid-pending.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), "payload"), OK)
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	var invalid_catalog_pending: String = catalog_path + ".pending-" + GFUuid.generate_v4()
+	assert_eq(_write_text(invalid_catalog_pending, "{}"), OK)
+
+	var list_result: Dictionary = _list_files("", "", true, 0, 0)
+	assert_eq(GFVariantData.get_option_int(list_result, "error", OK), ERR_FILE_CORRUPT)
+	assert_eq(GFVariantData.get_option_packed_string_array(list_result, "files"), PackedStringArray())
+	assert_true(FileAccess.file_exists(catalog_path))
+	assert_true(FileAccess.file_exists(invalid_catalog_pending))
+
+
+func test_claim_staging_recovers_owner_only_and_rejects_physical_work() -> void:
+	var recoverable: Dictionary = _descriptor("slots/recover-staging.json")
+	assert_eq(_claim_family(recoverable), OK)
+	var recoverable_catalog_path: String = GFVariantData.get_option_string(
+		recoverable,
+		"catalog_path"
+	)
+	var recoverable_family_path: String = GFVariantData.get_option_string(
+		recoverable,
+		"family_path"
+	)
+	var recoverable_staging_path: String = (
+		recoverable_family_path + ".claim-" + GFUuid.generate_v4()
+	)
+	assert_eq(DirAccess.remove_absolute(recoverable_catalog_path), OK)
+	assert_eq(
+		DirAccess.rename_absolute(recoverable_family_path, recoverable_staging_path),
+		OK
+	)
+
+	assert_eq(_claim_family(recoverable), OK)
+	assert_true(DirAccess.dir_exists_absolute(recoverable_family_path))
+	assert_false(DirAccess.dir_exists_absolute(recoverable_staging_path))
+	assert_true(FileAccess.file_exists(recoverable_catalog_path))
+
+	var blocked: Dictionary = _descriptor("slots/blocked-staging.json")
+	assert_eq(_claim_family(blocked), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(blocked, "payload_path"), "payload"), OK)
+	var blocked_catalog_path: String = GFVariantData.get_option_string(blocked, "catalog_path")
+	var blocked_family_path: String = GFVariantData.get_option_string(blocked, "family_path")
+	var blocked_staging_path: String = blocked_family_path + ".claim-" + GFUuid.generate_v4()
+	assert_eq(DirAccess.remove_absolute(blocked_catalog_path), OK)
+	assert_eq(DirAccess.rename_absolute(blocked_family_path, blocked_staging_path), OK)
+
+	assert_eq(_claim_family(blocked), ERR_FILE_CORRUPT)
+	assert_false(DirAccess.dir_exists_absolute(blocked_family_path))
+	assert_true(DirAccess.dir_exists_absolute(blocked_staging_path))
+	assert_false(FileAccess.file_exists(blocked_catalog_path))
+
+
+func test_owner_and_catalog_records_fail_closed_on_reciprocal_corruption() -> void:
+	var descriptor: Dictionary = _descriptor("slots/corrupt-owner.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), "payload"), OK)
+	assert_eq(
+		_write_text(
+			GFVariantData.get_option_string(descriptor, "owner_path"),
+			'{"schema":"gf.storage.family-owner","unknown":true}'
+		),
+		OK
+	)
+
+	assert_eq(_validate_family(descriptor), ERR_FILE_CORRUPT)
+	assert_false(_has_file(descriptor))
+	var list_result: Dictionary = _list_files("", "", true, 0, 0)
+	assert_eq(GFVariantData.get_option_int(list_result, "error", OK), ERR_FILE_CORRUPT)
+	assert_eq(GFVariantData.get_option_packed_string_array(list_result, "files"), PackedStringArray())
+
+
+func test_catalog_identity_mismatch_never_adopts_the_family_owner() -> void:
+	var descriptor: Dictionary = _descriptor("slots/corrupt-catalog.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), "payload"), OK)
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	var catalog_value: Variant = JSON.parse_string(FileAccess.get_file_as_string(catalog_path))
+	assert_true(catalog_value is Dictionary, "claim 生成的 catalog 应是 JSON Dictionary。")
+	if not catalog_value is Dictionary:
+		return
+	var catalog: Dictionary = catalog_value
+	catalog["family_id"] = "00000000-0000-8000-8000-000000000000"
+	assert_eq(_write_text(catalog_path, JSON.stringify(catalog, "\t")), OK)
+
+	assert_eq(_validate_family(descriptor), ERR_FILE_CORRUPT)
+	assert_false(_has_file(descriptor))
+	var list_result: Dictionary = _list_files("", "", true, 0, 0)
+	assert_eq(GFVariantData.get_option_int(list_result, "error", OK), ERR_FILE_CORRUPT)
+	assert_eq(GFVariantData.get_option_packed_string_array(list_result, "files"), PackedStringArray())
+
+
+func test_wrong_catalog_shard_and_unknown_catalog_entry_fail_closed() -> void:
+	var descriptor: Dictionary = _descriptor("slots/wrong-shard.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), "payload"), OK)
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	var logical_sha256: String = GFVariantData.get_option_string(descriptor, "logical_sha256")
+	var wrong_first_shard: String = "ff" if logical_sha256.substr(0, 2) != "ff" else "ee"
+	var wrong_catalog_path: String = (
+		_storage_root_path
+		.path_join(".gf-storage/v1/catalog")
+		.path_join(wrong_first_shard)
+		.path_join(logical_sha256.substr(2, 2))
+		.path_join(logical_sha256 + ".json")
+	)
+	assert_eq(DirAccess.make_dir_recursive_absolute(wrong_catalog_path.get_base_dir()), OK)
+	assert_eq(DirAccess.rename_absolute(catalog_path, wrong_catalog_path), OK)
+
+	var wrong_shard_result: Dictionary = _list_files("", "", true, 0, 0)
+	assert_eq(GFVariantData.get_option_int(wrong_shard_result, "error", OK), ERR_FILE_CORRUPT)
+	assert_eq(GFVariantData.get_option_packed_string_array(wrong_shard_result, "files"), PackedStringArray())
+
+	assert_eq(DirAccess.rename_absolute(wrong_catalog_path, catalog_path), OK)
+	var catalog_leaf_directory: String = catalog_path.get_base_dir()
+	assert_eq(
+		_write_text(catalog_leaf_directory.path_join("unknown.pending-entry"), "{}"),
+		OK
+	)
+	var unknown_entry_result: Dictionary = _list_files(
+		"", "", true, 0, 0
+	)
+	assert_eq(
+		GFVariantData.get_option_int(unknown_entry_result, "error", OK),
+		ERR_FILE_CORRUPT,
+		"catalog namespace 的未知条目不得被静默跳过。"
+	)
+	assert_eq(GFVariantData.get_option_packed_string_array(unknown_entry_result, "files"), PackedStringArray())
+
+
+func test_unknown_family_entry_invalidates_catalog_authority() -> void:
+	var descriptor: Dictionary = _descriptor("slots/unknown-family-entry.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), "payload"), OK)
+	assert_eq(
+		_write_text(
+			GFVariantData.get_option_string(descriptor, "family_path").path_join("intruder.bin"),
+			"unknown"
+		),
+		OK
+	)
+
+	assert_eq(_validate_family(descriptor), ERR_FILE_CORRUPT)
+	assert_false(_has_file(descriptor))
+	var list_result: Dictionary = _list_files("", "", true, 0, 0)
+	assert_eq(GFVariantData.get_option_int(list_result, "error", OK), ERR_FILE_CORRUPT)
+
+
+func test_claim_recovers_only_clean_owner_without_catalog() -> void:
+	var recoverable: Dictionary = _descriptor("slots/recover-owner.json")
+	assert_eq(_claim_family(recoverable), OK)
+	assert_eq(DirAccess.remove_absolute(GFVariantData.get_option_string(recoverable, "catalog_path")), OK)
+
+	assert_eq(
+		_claim_family(recoverable),
+		OK,
+		"只有 owner 且尚无 payload/sidecar 时可以补回 catalog。"
+	)
+	assert_eq(_validate_family(recoverable), OK)
+
+	var blocked: Dictionary = _descriptor("slots/blocked-owner.json")
+	assert_eq(_claim_family(blocked), OK)
+	assert_eq(_write_text(GFVariantData.get_option_string(blocked, "payload_path"), "payload"), OK)
+	assert_eq(DirAccess.remove_absolute(GFVariantData.get_option_string(blocked, "catalog_path")), OK)
+	assert_eq(
+		_claim_family(blocked),
+		ERR_FILE_CORRUPT,
+		"owner-only 恢复不得采用已经出现物理工作的 family。"
+	)
+
+
+func test_catalog_without_family_is_never_adopted() -> void:
+	var descriptor: Dictionary = _descriptor("slots/catalog-only.json")
+	assert_eq(_claim_family(descriptor), OK)
+	assert_eq(DirAccess.remove_absolute(GFVariantData.get_option_string(descriptor, "owner_path")), OK)
+	assert_eq(DirAccess.remove_absolute(GFVariantData.get_option_string(descriptor, "family_path")), OK)
+
+	assert_eq(_claim_family(descriptor), ERR_FILE_CORRUPT)
+	assert_true(FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "catalog_path")))
+
+
+func test_list_projects_only_valid_claimed_families_with_committed_payloads() -> void:
+	var payload_paths: Array[String] = [
+		"a.json",
+		"nested/c.json",
+		"nested/deeper/d.tmp",
+	]
+	for logical_path: String in payload_paths:
+		var descriptor: Dictionary = _descriptor(logical_path)
+		assert_eq(_claim_family(descriptor), OK)
+		assert_eq(_write_text(GFVariantData.get_option_string(descriptor, "payload_path"), logical_path), OK)
+	var empty_family: Dictionary = _descriptor("b.tres")
+	assert_eq(_claim_family(empty_family), OK)
+	assert_eq(_write_text(_storage_root_path.path_join("legacy.json"), "legacy"), OK)
+
+	_assert_list_result("", "", false, 0, 0, PackedStringArray(["a.json"]))
+	_assert_list_result(
+		"",
+		"",
+		true,
+		0,
+		0,
+		PackedStringArray(["a.json", "nested/c.json", "nested/deeper/d.tmp"])
+	)
+	_assert_list_result(
+		"nested",
+		"",
+		false,
+		0,
+		0,
+		PackedStringArray(["nested/c.json"])
+	)
+	_assert_list_result(
+		"",
+		"json",
+		true,
+		0,
+		0,
+		PackedStringArray(["a.json", "nested/c.json"])
+	)
+	_assert_list_result(
+		"",
+		"",
+		true,
+		1,
+		0,
+		PackedStringArray(["a.json", "nested/c.json"])
+	)
+	_assert_list_result(
+		"",
+		"",
+		true,
+		0,
+		2,
+		PackedStringArray(["a.json", "nested/c.json"])
+	)
+
+
+# --- 私有/辅助方法 ---
+
+func _ensure_layout() -> Error:
+	var result: Variant = _store.call("ensure_layout_for_framework")
+	return GFVariantData.to_exact_int(result, ERR_BUG) as Error
+
+
+func _claim_family(descriptor: Dictionary) -> Error:
+	var result: Variant = _store.call("claim_family_for_framework", descriptor)
+	return GFVariantData.to_exact_int(result, ERR_BUG) as Error
+
+
+func _validate_family(descriptor: Dictionary) -> Error:
+	var result: Variant = _store.call("validate_family_for_framework", descriptor)
+	return GFVariantData.to_exact_int(result, ERR_BUG) as Error
+
+
+func _list_files(
+	directory_name: String,
+	extension_filter: String,
+	recursive: bool,
+	max_scan_depth: int,
+	max_file_count: int
+) -> Dictionary:
+	return GFVariantData.as_dictionary(
+		_store.call(
+			"list_files_for_framework",
+			directory_name,
+			extension_filter,
+			recursive,
+			max_scan_depth,
+			max_file_count
+		)
+	)
+
+
+func _has_file(descriptor: Dictionary) -> bool:
+	return GFVariantData.to_bool(_store.call("has_file_for_framework", descriptor))
+
+
+func _descriptor(logical_path: String) -> Dictionary:
+	return _GF_STORAGE_FAMILY_STORE_SCRIPT.make_family_descriptor_for_framework(
+		_storage_root_path,
+		logical_path
+	)
+
+
+func _make_expected_uuid_v8(digest: String) -> String:
+	var raw: String = digest.substr(0, 32)
+	var variant_value: int = ("0123456789abcdef".find(raw.substr(16, 1)) & 0x3) | 0x8
+	return "%s-%s-8%s-%s%s-%s" % [
+		raw.substr(0, 8),
+		raw.substr(8, 4),
+		raw.substr(13, 3),
+		"0123456789abcdef".substr(variant_value, 1),
+		raw.substr(17, 3),
+		raw.substr(20, 12),
+	]
+
+
+func _make_expected_identity_digest(logical_path: String) -> String:
+	var hashing_context: HashingContext = HashingContext.new()
+	assert_eq(hashing_context.start(HashingContext.HASH_SHA256), OK)
+	assert_eq(
+		hashing_context.update("gf.storage.family/v1".to_utf8_buffer()),
+		OK
+	)
+	assert_eq(hashing_context.update(PackedByteArray([0])), OK)
+	assert_eq(hashing_context.update(logical_path.to_utf8_buffer()), OK)
+	return hashing_context.finish().hex_encode()
+
+
+func _assert_list_result(
+	directory_name: String,
+	extension_filter: String,
+	recursive: bool,
+	max_scan_depth: int,
+	max_file_count: int,
+	expected_files: PackedStringArray
+) -> void:
+	var result: Dictionary = _list_files(
+		directory_name,
+		extension_filter,
+		recursive,
+		max_scan_depth,
+		max_file_count
+	)
+	assert_eq(GFVariantData.get_option_int(result, "error", ERR_BUG), OK)
+	assert_eq(GFVariantData.get_option_packed_string_array(result, "files"), expected_files)
+
+
+func _write_text(path: String, text: String) -> Error:
+	var directory_error: Error = DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	if directory_error != OK:
+		return directory_error
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		return FileAccess.get_open_error()
+	var _stored: bool = file.store_string(text) != null
+	file.flush()
+	var write_error: Error = file.get_error()
+	file.close()
+	return write_error
+
+
+func _remove_tree(path: String) -> Error:
+	if path.is_empty():
+		return ERR_INVALID_PARAMETER
+	if FileAccess.file_exists(path):
+		return DirAccess.remove_absolute(path)
+	if not DirAccess.dir_exists_absolute(path):
+		return OK
+	var directory: DirAccess = DirAccess.open(path)
+	if directory == null:
+		return ERR_FILE_CANT_OPEN
+	var begin_error: Error = directory.list_dir_begin()
+	if begin_error != OK:
+		return begin_error
+	var entries: Array[String] = []
+	var entry: String = directory.get_next()
+	while not entry.is_empty():
+		entries.append(entry)
+		entry = directory.get_next()
+	directory.list_dir_end()
+	for child_name: String in entries:
+		var child_error: Error = _remove_tree(path.path_join(child_name))
+		if child_error != OK:
+			return child_error
+	return DirAccess.remove_absolute(path)

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd.uid
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_family_store.gd.uid
@@ -1,0 +1,1 @@
+uid://d0jylar7n283w

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd
@@ -2,6 +2,15 @@
 extends GutTest
 
 
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload(
+	"res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd"
+)
+
+const _STORAGE_ROOTS: Array[String] = [
+	"test_storage_payload_transfer",
+	"test_storage_payload_transfer_frozen_a",
+	"test_storage_payload_transfer_frozen_b",
+]
 const _FILES: Array[String] = [
 	"test_transfer_success.json",
 	"test_transfer_invalid_payload.json",
@@ -15,6 +24,7 @@ const _FILES: Array[String] = [
 	"test_transfer_uncommitted_recovery.json",
 	"test_transfer_path_freeze.json",
 	"test_transfer_path_blocker.json",
+	"test_transfer_legacy_visible.json",
 ]
 
 
@@ -34,44 +44,236 @@ class MalformedPayloadTransfer extends GFStoragePayloadTransfer:
 
 class CleanupPreservingStorage extends GFStorageUtility:
 	var preserve_committed_artifacts: bool = false
+	var preserved_paths: Dictionary = {}
 
-	func _remove_absolute_file_if_exists(path: String) -> void:
-		if (
-			preserve_committed_artifacts
-			and (path.ends_with(".bak") or path.ends_with(".txn"))
-		):
-			return
-		super._remove_absolute_file_if_exists(path)
+	func _remove_absolute_file(path: String) -> Error:
+		if preserve_committed_artifacts and preserved_paths.has(path):
+			return OK
+		if path.is_empty():
+			return ERR_INVALID_PARAMETER
+		if not FileAccess.file_exists(path):
+			return OK
+		return DirAccess.remove_absolute(path)
 
 
 var _storage: GFStorageUtility
+var _additional_storages: Array[GFStorageUtility] = []
+
+
+func _make_family_descriptor(save_dir_name: String, file_name: String) -> Dictionary:
+	var storage_root_path: String = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+		save_dir_name
+	)
+	return _GF_STORAGE_FAMILY_STORE_SCRIPT.make_family_descriptor_for_framework(
+		storage_root_path,
+		file_name
+	)
+
+
+func _cleanup_file_family(save_dir_name: String, file_name: String) -> void:
+	var descriptor: Dictionary = _make_family_descriptor(save_dir_name, file_name)
+	if descriptor.is_empty():
+		return
+	for path_key: String in [
+		"payload_path",
+		"candidate_path",
+		"backup_path",
+		"transaction_path",
+		"transaction_pending_path",
+		"transaction_commit_path",
+		"transaction_commit_pending_path",
+		"resource_stage_path",
+		"owner_path",
+	]:
+		var path: String = GFVariantData.get_option_string(descriptor, path_key)
+		if FileAccess.file_exists(path):
+			var _remove_path_result: Error = DirAccess.remove_absolute(path)
+	var family_path: String = GFVariantData.get_option_string(descriptor, "family_path")
+	for legacy_leaf: String in [
+		"payload.json.tmp",
+		"payload.json.bak",
+		"payload.json.txn",
+		"transaction.json",
+	]:
+		var legacy_path: String = family_path.path_join(legacy_leaf)
+		if FileAccess.file_exists(legacy_path):
+			var _remove_legacy_result: Error = DirAccess.remove_absolute(legacy_path)
+	if DirAccess.dir_exists_absolute(family_path):
+		var _remove_family_result: Error = DirAccess.remove_absolute(family_path)
+	var catalog_path: String = GFVariantData.get_option_string(descriptor, "catalog_path")
+	if FileAccess.file_exists(catalog_path):
+		var _remove_catalog_result: Error = DirAccess.remove_absolute(catalog_path)
+
+
+func _cleanup_legacy_visible_files(save_dir_name: String, file_name: String) -> void:
+	var storage_root_path: String = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+		save_dir_name
+	)
+	for suffix: String in ["", ".tmp", ".bak", ".txn"]:
+		var visible_path: String = storage_root_path.path_join(file_name + suffix)
+		if FileAccess.file_exists(visible_path):
+			var _remove_visible_result: Error = DirAccess.remove_absolute(visible_path)
+
+
+func _remove_owned_directory_tree(path: String) -> Error:
+	if not DirAccess.dir_exists_absolute(path):
+		return OK
+	var directory: DirAccess = DirAccess.open(path)
+	if directory == null:
+		return DirAccess.get_open_error()
+	for file_name: String in directory.get_files():
+		var remove_file_error: Error = DirAccess.remove_absolute(path.path_join(file_name))
+		if remove_file_error != OK:
+			return remove_file_error
+	for directory_name: String in directory.get_directories():
+		var child_path: String = path.path_join(directory_name)
+		var remove_directory_error: Error = (
+			DirAccess.remove_absolute(child_path)
+			if directory.is_link(directory_name)
+			else _remove_owned_directory_tree(child_path)
+		)
+		if remove_directory_error != OK:
+			return remove_directory_error
+	directory = null
+	return DirAccess.remove_absolute(path)
+
+
+func _cleanup_owned_private_namespace(save_dir_name: String) -> Error:
+	if not _STORAGE_ROOTS.has(save_dir_name):
+		return ERR_UNAUTHORIZED
+	var storage_root_path: String = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+		save_dir_name
+	).simplify_path()
+	var private_root_name: String = ".gf-storage"
+	var private_root_path: String = storage_root_path.path_join(private_root_name).simplify_path()
+	if (
+		storage_root_path.is_empty()
+		or storage_root_path == "user://"
+		or private_root_path.get_base_dir() != storage_root_path
+		or private_root_path.get_file() != private_root_name
+	):
+		return ERR_UNAUTHORIZED
+	return _remove_owned_directory_tree(private_root_path)
+
+
+func _cleanup_known_test_artifacts() -> Error:
+	for save_dir_name: String in _STORAGE_ROOTS:
+		var private_cleanup_error: Error = _cleanup_owned_private_namespace(save_dir_name)
+		if private_cleanup_error != OK:
+			return private_cleanup_error
+		for file_name: String in _FILES:
+			_cleanup_file_family(save_dir_name, file_name)
+			_cleanup_legacy_visible_files(save_dir_name, file_name)
+	return OK
+
+
+func _read_plain_json_file(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {}
+	var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(path))
+	return GFVariantData.as_dictionary(parsed)
+
+
+func _write_legacy_visible_data_file(file_name: String, data: Dictionary) -> String:
+	var path: String = _storage._get_save_base_path().path_join(file_name)
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "测试夹具应能写入 legacy visible payload。")
+	if file == null:
+		return path
+	var bytes: PackedByteArray = _storage._get_codec().encode(
+		data,
+		_storage._get_codec_options()
+	)
+	var _store_buffer_result: Variant = file.store_buffer(bytes)
+	var write_error: Error = file.get_error()
+	file.close()
+	assert_eq(write_error, OK, "测试夹具应完整写入 legacy visible payload。")
+	return path
+
+
+func _assert_transaction_records_absent(
+	storage_utility: GFStorageUtility,
+	file_name: String
+) -> void:
+	var descriptor: Dictionary = _make_family_descriptor(
+		storage_utility.save_dir_name,
+		file_name
+	)
+	for path_key: String in [
+		"transaction_path",
+		"transaction_pending_path",
+		"transaction_commit_path",
+		"transaction_commit_pending_path",
+	]:
+		assert_false(
+			FileAccess.file_exists(GFVariantData.get_option_string(descriptor, path_key)),
+			"事务收敛后不应残留 %s。" % path_key
+		)
+
+
+func _assert_single_member_transaction_record(
+	record: Dictionary,
+	descriptor: Dictionary,
+	committed: bool,
+	had_final: bool
+) -> void:
+	var logical_path: String = GFVariantData.get_option_string(descriptor, "logical_path")
+	var family_id: String = GFVariantData.get_option_string(descriptor, "family_id")
+	assert_eq(record.size(), 6, "v2 transaction record 必须使用固定六字段 envelope。")
+	assert_eq(
+		GFVariantData.get_option_string(record, "schema"),
+		"gf.storage.transaction-commit" if committed else "gf.storage.transaction-prepare"
+	)
+	assert_eq(GFVariantData.get_option_int(record, "schema_version"), 2)
+	assert_false(GFVariantData.get_option_string(record, "transaction_id").is_empty())
+	assert_true(record.get("committed") is bool)
+	assert_eq(GFVariantData.get_option_bool(record, "committed"), committed)
+	assert_eq(
+		GFVariantData.get_option_dictionary(record, "owner"),
+		{
+			"logical_path": logical_path,
+			"family_id": family_id,
+		}
+	)
+	var members: Array = GFVariantData.get_option_array(record, "members")
+	assert_eq(members.size(), 1)
+	if members.size() != 1:
+		return
+	assert_eq(
+		GFVariantData.as_dictionary(members[0]),
+		{
+			"logical_path": logical_path,
+			"family_id": family_id,
+			"had_final": had_final,
+		}
+	)
 
 
 func before_each() -> void:
+	assert_eq(
+		_cleanup_known_test_artifacts(),
+		OK,
+		"setup 必须只清理本测试白名单内的 private namespace。"
+	)
 	_storage = GFStorageUtility.new()
-	_storage.save_dir_name = "test_saves"
+	_storage.save_dir_name = "test_storage_payload_transfer"
 	_storage.encrypt_key = 0
 	_storage.init()
 
 
 func after_each() -> void:
-	if _storage == null:
-		return
-	var original_save_dir_name: String = _storage.save_dir_name
-	for save_dir_name: String in [
-		"test_saves",
-		"test_saves_frozen_a",
-		"test_saves_frozen_b",
-	]:
-		_storage.save_dir_name = save_dir_name
-		for file_name: String in _FILES:
-			for suffix: String in ["", ".tmp", ".bak", ".txn"]:
-				var path: String = _storage._get_full_path(file_name + suffix)
-				if FileAccess.file_exists(path):
-					var _removed: Error = DirAccess.remove_absolute(path)
-	_storage.save_dir_name = original_save_dir_name
-	_storage.dispose()
+	if _storage != null:
+		_storage.dispose()
+	for storage_utility: GFStorageUtility in _additional_storages:
+		if storage_utility != null:
+			storage_utility.dispose()
+	assert_eq(
+		_cleanup_known_test_artifacts(),
+		OK,
+		"teardown 必须完整清理本测试拥有的 private namespace。"
+	)
 	_storage = null
+	_additional_storages.clear()
 
 
 func test_transfer_takes_and_releases_ownership_once_without_public_payload_getter() -> void:
@@ -127,7 +329,7 @@ func test_absolute_path_does_not_claim_transfer() -> void:
 	assert_null(operation.reclaim_failed_payload())
 	assert_true(transfer.release())
 	assert_push_error(
-		"[GFStorageUtility] 已禁用绝对路径：C:/outside/transfer.json"
+		"[GFStorageUtility] save_payload_request_async 失败：file_name 不满足 portable logical path profile。"
 	)
 
 
@@ -178,6 +380,42 @@ func test_successful_attempt_cannot_be_reclaimed_and_release_clears_payload() ->
 	var loaded: GFStorageReadResult = _storage.load_data("test_transfer_success.json")
 	assert_true(loaded.ok)
 	assert_eq(GFVariantData.get_option_int(loaded.payload, "coins"), 42)
+
+
+func test_payload_transfer_does_not_read_or_adopt_legacy_visible_file() -> void:
+	var file_name: String = "test_transfer_legacy_visible.json"
+	var visible_path: String = _write_legacy_visible_data_file(file_name, { "value": 1 })
+	var visible_before: PackedByteArray = FileAccess.get_file_as_bytes(visible_path)
+	var descriptor: Dictionary = _make_family_descriptor(_storage.save_dir_name, file_name)
+
+	var missing_result: GFStorageReadResult = _storage.load_data(file_name)
+
+	assert_false(missing_result.ok, "没有 catalog/owner 的 visible 文件不得成为可读 family。")
+	assert_eq(missing_result.error_code, ERR_FILE_NOT_FOUND)
+	assert_false(
+		FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "catalog_path")),
+		"读取 legacy visible 文件不得隐式创建 catalog。"
+	)
+	assert_eq(FileAccess.get_file_as_bytes(visible_path), visible_before)
+
+	var transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({ "value": 2 })
+	var operation: GFStorageAsyncOperation = _storage.save_payload_request_async(
+		file_name,
+		transfer
+	)
+	await _pump_storage_async_tasks()
+
+	assert_true(operation.get_result().is_successful())
+	assert_true(FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "payload_path")))
+	assert_eq(
+		FileAccess.get_file_as_bytes(visible_path),
+		visible_before,
+		"claim 私有 family 不得修改或领养同名 legacy visible 文件。"
+	)
+	var loaded: GFStorageReadResult = _storage.load_data(file_name)
+	assert_true(loaded.ok)
+	assert_eq(GFVariantData.get_option_int(loaded.payload, "value"), 2)
+	assert_true(transfer.release())
 
 
 func test_invalid_payload_reports_stable_failure_and_reclaims_same_transfer_once() -> void:
@@ -445,49 +683,62 @@ func test_claim_freezes_storage_file_and_codec_binding() -> void:
 	assert_true(transfer.release())
 
 
-func test_claim_freezes_target_family_while_queued_task_keeps_original_path() -> void:
-	_storage.max_async_thread_count = 1
-	_storage.save_dir_name = "test_saves_frozen_a"
+func test_initialized_root_is_frozen_while_queued_task_keeps_original_family() -> void:
+	var storage_utility: GFStorageUtility = GFStorageUtility.new()
+	storage_utility.save_dir_name = "test_storage_payload_transfer_frozen_a"
+	storage_utility.encrypt_key = 0
+	storage_utility.init()
+	storage_utility.max_async_thread_count = 1
+	_additional_storages.append(storage_utility)
 	var blocker_transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({
 		"value": 1,
 	})
-	var blocker_operation: GFStorageAsyncOperation = _storage.save_payload_request_async(
+	var blocker_operation: GFStorageAsyncOperation = storage_utility.save_payload_request_async(
 		"test_transfer_path_blocker.json",
 		blocker_transfer
 	)
 	var target_transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({
 		"value": 2,
 	})
-	var target_operation: GFStorageAsyncOperation = _storage.save_payload_request_async(
+	var target_operation: GFStorageAsyncOperation = storage_utility.save_payload_request_async(
 		"test_transfer_path_freeze.json",
 		target_transfer
 	)
-	assert_eq(_storage._async_queue.size(), 1)
+	assert_eq(storage_utility._async_queue.size(), 1)
 
-	_storage.save_dir_name = "test_saves_frozen_b"
-	var rejected_retry: GFStorageAsyncOperation = _storage.save_payload_request_async(
-		"test_transfer_path_freeze.json",
-		target_transfer
-	)
+	storage_utility.save_dir_name = "test_storage_payload_transfer_frozen_b"
 
-	assert_true(rejected_retry.is_completed())
 	assert_eq(
-		rejected_retry.get_result().get_write_failure_kind(),
-		GFStorageAsyncResult.WriteFailureKind.INVALID_REQUEST
+		storage_utility.save_dir_name,
+		"test_storage_payload_transfer_frozen_a",
+		"初始化后的 Storage root 不得漂移。"
+	)
+	assert_push_error(
+		"[GFStorageUtility] save_dir_name 已在 Storage 初始化后冻结；请为另一个 root 创建新的 Utility。"
 	)
 	assert_eq(target_transfer.get_active_attempt_count(), 1)
-	await _pump_storage_async_tasks()
+	await _pump_specific_storage(storage_utility)
 	assert_true(blocker_operation.get_result().is_successful())
 	assert_true(target_operation.get_result().is_successful())
 
-	_storage.save_dir_name = "test_saves_frozen_a"
-	var loaded: GFStorageReadResult = _storage.load_data("test_transfer_path_freeze.json")
+	var loaded: GFStorageReadResult = storage_utility.load_data("test_transfer_path_freeze.json")
 	assert_true(loaded.ok)
 	assert_eq(GFVariantData.get_option_int(loaded.payload, "value"), 2)
-	_storage.save_dir_name = "test_saves_frozen_b"
+	var frozen_descriptor: Dictionary = _make_family_descriptor(
+		storage_utility.save_dir_name,
+		"test_transfer_path_freeze.json"
+	)
+	var other_descriptor: Dictionary = _make_family_descriptor(
+		"test_storage_payload_transfer_frozen_b",
+		"test_transfer_path_freeze.json"
+	)
+	assert_true(
+		FileAccess.file_exists(GFVariantData.get_option_string(frozen_descriptor, "payload_path")),
+		"queued task 应提交到初始化时冻结的 private family。"
+	)
 	assert_false(
-		FileAccess.file_exists(_storage._get_full_path("test_transfer_path_freeze.json")),
-		"Utility 配置变化不得让已 claim 的 queued task 漂移到新目录。"
+		FileAccess.file_exists(GFVariantData.get_option_string(other_descriptor, "payload_path")),
+		"被拒绝的 root 变更不得创建另一 private family。"
 	)
 	assert_true(blocker_transfer.release())
 	assert_true(target_transfer.release())
@@ -566,62 +817,76 @@ func test_dispose_closes_async_admission_before_terminal_callbacks() -> void:
 
 
 func test_worker_committed_marker_uses_shared_schema_and_recovery_keeps_new_file() -> void:
+	var file_name: String = "test_transfer_committed_recovery.json"
+	_storage.dispose()
+	_storage = null
 	var probe: CleanupPreservingStorage = CleanupPreservingStorage.new()
-	probe.save_dir_name = "test_saves"
+	probe.save_dir_name = "test_storage_payload_transfer"
 	probe.encrypt_key = 0
 	probe.init()
+	_additional_storages.append(probe)
+	var descriptor: Dictionary = _make_family_descriptor(probe.save_dir_name, file_name)
+	probe.preserved_paths[GFVariantData.get_option_string(descriptor, "backup_path")] = true
+	probe.preserved_paths[GFVariantData.get_option_string(descriptor, "transaction_path")] = true
+	probe.preserved_paths[
+		GFVariantData.get_option_string(descriptor, "transaction_commit_path")
+	] = true
 	probe.preserve_committed_artifacts = true
 	var transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({
 		"value": 9,
 	})
 	var operation: GFStorageAsyncOperation = probe.save_payload_request_async(
-		"test_transfer_committed_recovery.json",
+		file_name,
 		transfer
 	)
 	await _pump_specific_storage(probe)
 
 	assert_true(operation.get_result().is_successful())
-	var marker: Dictionary = probe._read_transaction_marker(
-		"test_transfer_committed_recovery.json"
+	var prepare_record: Dictionary = _read_plain_json_file(
+		GFVariantData.get_option_string(descriptor, "transaction_path")
 	)
-	assert_eq(GFVariantData.get_option_int(marker, "schema_version"), 1)
-	assert_false(GFVariantData.get_option_string(marker, "transaction_id").is_empty())
+	var commit_record: Dictionary = _read_plain_json_file(
+		GFVariantData.get_option_string(descriptor, "transaction_commit_path")
+	)
+	_assert_single_member_transaction_record(prepare_record, descriptor, false, false)
+	_assert_single_member_transaction_record(commit_record, descriptor, true, false)
 	assert_eq(
-		GFVariantData.get_option_string(marker, "file_key"),
-		"test_transfer_committed_recovery.json"
+		GFVariantData.get_option_string(prepare_record, "transaction_id"),
+		GFVariantData.get_option_string(commit_record, "transaction_id"),
+		"prepare/commit 必须证明同一个 frozen transaction snapshot。"
 	)
-	assert_true(GFVariantData.get_option_bool(marker, "committed"))
-	assert_false(GFVariantData.get_option_bool(marker, "had_final"))
 	assert_true(transfer.release())
 	probe.preserve_committed_artifacts = false
 	probe.dispose()
+	_storage = GFStorageUtility.new()
+	_storage.save_dir_name = "test_storage_payload_transfer"
+	_storage.encrypt_key = 0
+	_storage.init()
 
-	var load_operation: GFStorageAsyncOperation = _storage.load_data_request_async(
-		"test_transfer_committed_recovery.json"
-	)
+	var load_operation: GFStorageAsyncOperation = _storage.load_data_request_async(file_name)
 	await _pump_storage_async_tasks()
 	var loaded: GFStorageReadResult = load_operation.get_result().get_read_result()
 	assert_true(loaded.ok)
 	assert_eq(GFVariantData.get_option_int(loaded.payload, "value"), 9)
-	assert_false(
-		FileAccess.file_exists(_storage._get_full_path(
-			"test_transfer_committed_recovery.json.txn"
-		))
-	)
+	_assert_transaction_records_absent(_storage, file_name)
 
 
 func test_frozen_async_recovery_rolls_back_valid_uncommitted_marker() -> void:
 	var file_name: String = "test_transfer_uncommitted_recovery.json"
-	assert_eq(_storage.save_data(file_name, {"value": 1}), OK)
+	assert_eq(_storage.save_data(file_name, { "value": 1 }), OK)
+	var descriptor: Dictionary = _make_family_descriptor(_storage.save_dir_name, file_name)
+	var payload_path: String = GFVariantData.get_option_string(descriptor, "payload_path")
+	var backup_path: String = GFVariantData.get_option_string(descriptor, "backup_path")
 	assert_eq(_storage._write_transaction_markers([file_name], false), OK)
+	var prepare_record: Dictionary = _read_plain_json_file(
+		GFVariantData.get_option_string(descriptor, "transaction_path")
+	)
+	_assert_single_member_transaction_record(prepare_record, descriptor, false, true)
 	assert_eq(
-		DirAccess.rename_absolute(
-			_storage._get_full_path(file_name),
-			_storage._get_full_path(file_name + ".bak")
-		),
+		DirAccess.rename_absolute(payload_path, backup_path),
 		OK
 	)
-	assert_eq(_storage._write_json(file_name, {"value": 2}), OK)
+	assert_eq(_storage._write_json(file_name, { "value": 2 }), OK)
 
 	var operation: GFStorageAsyncOperation = _storage.load_data_request_async(file_name)
 	await _pump_storage_async_tasks()
@@ -633,12 +898,8 @@ func test_frozen_async_recovery_rolls_back_valid_uncommitted_marker() -> void:
 		1,
 		"valid uncommitted marker 必须恢复旧 final，而不是保留部分提交的新代次。"
 	)
-	assert_false(
-		FileAccess.file_exists(_storage._get_full_path(file_name + ".txn"))
-	)
-	assert_false(
-		FileAccess.file_exists(_storage._get_full_path(file_name + ".bak"))
-	)
+	_assert_transaction_records_absent(_storage, file_name)
+	assert_false(FileAccess.file_exists(backup_path))
 
 
 func test_release_waits_for_active_attempt_before_clearing_payload() -> void:

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_payload_transfer.gd
@@ -121,6 +121,7 @@ func _remove_owned_directory_tree(path: String) -> Error:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return DirAccess.get_open_error()
+	directory.include_hidden = true
 	for file_name: String in directory.get_files():
 		var remove_file_error: Error = DirAccess.remove_absolute(path.path_join(file_name))
 		if remove_file_error != OK:

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd
@@ -720,6 +720,7 @@ func _remove_tree(path: String) -> Error:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return ERR_FILE_CANT_OPEN
+	directory.include_hidden = true
 	var begin_error: Error = directory.list_dir_begin()
 	if begin_error != OK:
 		return begin_error

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd
@@ -1,0 +1,736 @@
+## 测试 Storage v2 transaction marker 的崩溃恢复、失败关闭与 committed-view 语义。
+extends GutTest
+
+
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload(
+	"res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd"
+)
+
+
+var _save_dir_name: String = ""
+var _storage_root_path: String = ""
+var _storage: GFStorageUtility
+var _storage_instances: Array[GFStorageUtility] = []
+
+
+class DrainMutationStorageUtility extends GFStorageUtility:
+	var inject_during_next_drain: bool = false
+	var injection_file_name: String = ""
+	var injection_payload: Dictionary = {}
+	var injection_error: Error = OK
+
+	func wait_for_async_tasks() -> void:
+		super.wait_for_async_tasks()
+		if not inject_during_next_drain:
+			return
+		inject_during_next_drain = false
+		injection_error = _write_transaction_markers([injection_file_name], false)
+		if injection_error != OK:
+			return
+		injection_error = _write_json(
+			_get_temp_filename(injection_file_name),
+			injection_payload
+		)
+		if injection_error != OK:
+			return
+		injection_error = DirAccess.rename_absolute(
+			_get_full_path(injection_file_name),
+			_get_full_path(_get_backup_filename(injection_file_name))
+		)
+
+
+class CommitInvariantSabotageStorageUtility extends GFStorageUtility:
+	var sabotage_next_committed_validation: bool = false
+	var sabotage_error: Error = OK
+
+	func _validate_single_committed_absolute_transaction(
+		final_path: String,
+		temp_path: String
+	) -> Error:
+		if sabotage_next_committed_validation:
+			sabotage_next_committed_validation = false
+			sabotage_error = DirAccess.rename_absolute(final_path, temp_path)
+			if sabotage_error != OK:
+				return sabotage_error
+		return OK if FileAccess.file_exists(final_path) and not FileAccess.file_exists(
+			temp_path
+		) else ERR_FILE_CORRUPT
+
+
+func before_each() -> void:
+	_save_dir_name = "gf-tx-recovery-" + GFUuid.generate_v4()
+	_storage_root_path = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+		_save_dir_name
+	)
+	_storage = _configure_storage(GFStorageUtility.new(), true)
+
+
+func after_each() -> void:
+	for storage: GFStorageUtility in _storage_instances:
+		if is_instance_valid(storage):
+			storage.dispose()
+	_storage_instances.clear()
+	var cleanup_error: Error = _remove_test_root()
+	assert_eq(cleanup_error, OK, "测试结束后应完整删除本测唯一 Storage root。")
+	_storage = null
+	_storage_root_path = ""
+	_save_dir_name = ""
+
+
+func test_corrupt_final_prepare_record_is_distinct_from_absence_and_fails_closed() -> void:
+	var file_name: String = "tri-state/prepare.json"
+	assert_eq(_storage.save_data(file_name, {"value": 1}), OK)
+	assert_eq(
+		_recover_transaction_files([file_name]),
+		OK,
+		"没有 marker 的稳定 family 应是合法 absent 状态。"
+	)
+	var descriptor: Dictionary = _descriptor(file_name)
+	var prepare_path: String = GFVariantData.get_option_string(descriptor, "transaction_path")
+	assert_eq(_write_text(prepare_path, "{}"), OK)
+	var evidence_before: PackedByteArray = FileAccess.get_file_as_bytes(prepare_path)
+
+	var recovery_error: Error = _recover_transaction_files([file_name])
+
+	assert_eq(recovery_error, ERR_FILE_CORRUPT, "存在但损坏的 final prepare 必须失败关闭。")
+	assert_true(FileAccess.file_exists(prepare_path), "损坏 prepare 必须保留为诊断证据。")
+	assert_eq(FileAccess.get_file_as_bytes(prepare_path), evidence_before, "失败关闭不得改写损坏证据。")
+
+
+func test_corrupt_final_commit_record_is_distinct_from_absence_and_fails_closed() -> void:
+	var file_name: String = "tri-state/commit.json"
+	assert_eq(_storage.save_data(file_name, {"value": 1}), OK)
+	assert_eq(
+		_recover_transaction_files([file_name]),
+		OK,
+		"没有 marker 的稳定 family 应是合法 absent 状态。"
+	)
+	var descriptor: Dictionary = _descriptor(file_name)
+	var commit_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"transaction_commit_path"
+	)
+	assert_eq(_write_text(commit_path, "{}"), OK)
+	var evidence_before: PackedByteArray = FileAccess.get_file_as_bytes(commit_path)
+
+	var recovery_error: Error = _recover_transaction_files([file_name])
+
+	assert_eq(recovery_error, ERR_FILE_CORRUPT, "存在但损坏的 final commit 必须失败关闭。")
+	assert_true(FileAccess.file_exists(commit_path), "损坏 commit 必须保留为诊断证据。")
+	assert_eq(FileAccess.get_file_as_bytes(commit_path), evidence_before, "失败关闭不得改写损坏证据。")
+
+
+func test_final_markers_reject_non_string_identity_fields_and_preserve_evidence() -> void:
+	for test_case: Dictionary in _marker_identity_type_cases():
+		var file_name: String = GFVariantData.get_option_string(test_case, "file_name")
+		var field_path: String = GFVariantData.get_option_string(test_case, "field_path")
+		var field_value: Variant = test_case.get("field_value")
+		assert_eq(_storage.save_data(file_name, { "value": 1 }), OK)
+		assert_eq(_storage._write_transaction_markers([file_name], false), OK)
+		var descriptor: Dictionary = _descriptor(file_name)
+		var marker_path: String = GFVariantData.get_option_string(
+			descriptor,
+			"transaction_path"
+		)
+		var marker: Dictionary = _storage._read_transaction_marker(file_name)
+		var corrupt_marker: Dictionary = _mutate_marker_field(
+			marker,
+			field_path,
+			field_value
+		)
+		assert_eq(_write_json_record(marker_path, corrupt_marker), OK)
+		var evidence_before: PackedByteArray = FileAccess.get_file_as_bytes(marker_path)
+
+		var recovery_error: Error = _recover_transaction_files([file_name])
+
+		assert_eq(
+			recovery_error,
+			ERR_FILE_CORRUPT,
+			"final marker 的非 String 字段必须失败关闭：%s" % field_path
+		)
+		assert_true(FileAccess.file_exists(marker_path), "损坏 final marker 必须保留。")
+		assert_eq(
+			FileAccess.get_file_as_bytes(marker_path),
+			evidence_before,
+			"失败关闭不得改写 final marker：%s" % field_path
+		)
+
+
+func test_pending_markers_reject_non_string_identity_fields_and_preserve_evidence() -> void:
+	for test_case: Dictionary in _marker_identity_type_cases():
+		var file_name: String = GFVariantData.get_option_string(test_case, "file_name")
+		var field_path: String = GFVariantData.get_option_string(test_case, "field_path")
+		var field_value: Variant = test_case.get("field_value")
+		assert_eq(_storage.save_data(file_name, { "value": 1 }), OK)
+		assert_eq(_storage._write_transaction_markers([file_name], false), OK)
+		var descriptor: Dictionary = _descriptor(file_name)
+		var final_path: String = GFVariantData.get_option_string(descriptor, "transaction_path")
+		var pending_path: String = GFVariantData.get_option_string(
+			descriptor,
+			"transaction_pending_path"
+		)
+		var marker: Dictionary = _storage._read_transaction_marker(file_name)
+		var corrupt_marker: Dictionary = _mutate_marker_field(
+			marker,
+			field_path,
+			field_value
+		)
+		assert_eq(_write_json_record(pending_path, corrupt_marker), OK)
+		assert_eq(DirAccess.remove_absolute(final_path), OK)
+		var evidence_before: PackedByteArray = FileAccess.get_file_as_bytes(pending_path)
+
+		var recovery_error: Error = _recover_transaction_files([file_name])
+
+		assert_eq(
+			recovery_error,
+			ERR_FILE_CORRUPT,
+			"pending marker 的非 String 字段必须失败关闭：%s" % field_path
+		)
+		assert_true(FileAccess.file_exists(pending_path), "损坏 pending marker 必须保留。")
+		assert_eq(
+			FileAccess.get_file_as_bytes(pending_path),
+			evidence_before,
+			"失败关闭不得改写 pending marker：%s" % field_path
+		)
+
+
+func test_valid_prepare_pending_is_promoted_then_rolls_back_to_old_generation() -> void:
+	var file_name: String = "pending-prepare/data.json"
+	assert_eq(_storage.save_data(file_name, {"value": 11}), OK)
+	assert_eq(_storage._write_transaction_markers([file_name], false), OK)
+	var descriptor: Dictionary = _descriptor(file_name)
+	var prepare_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"transaction_path"
+	)
+	var prepare_pending_path: String = GFVariantData.get_option_string(
+		descriptor,
+		"transaction_pending_path"
+	)
+	assert_eq(
+		DirAccess.rename_absolute(prepare_path, prepare_pending_path),
+		OK,
+		"应能模拟 prepare pending 已 durable、final record 尚未 publish 的崩溃窗口。"
+	)
+
+	var recovery_error: Error = _recover_transaction_files([file_name])
+
+	assert_eq(recovery_error, OK, "有效 prepare pending 必须先提升，再按未提交事务回滚。")
+	_assert_group_evidence_absent([file_name])
+	assert_eq(GFVariantData.get_option_int(_load_payload(file_name), "value"), 11)
+
+
+func test_valid_commit_pending_in_reciprocal_group_keeps_new_generation() -> void:
+	var data_file_name: String = "pending-commit/data.json"
+	var meta_file_name: String = "pending-commit/meta.json"
+	var file_names: Array[String] = [data_file_name, meta_file_name]
+	_seed_group({
+		data_file_name: {"value": 1},
+		meta_file_name: {"value": 2},
+	})
+	_stage_fully_committed_group(file_names, {
+		data_file_name: {"value": 101},
+		meta_file_name: {"value": 202},
+	})
+	var meta_descriptor: Dictionary = _descriptor(meta_file_name)
+	var commit_path: String = GFVariantData.get_option_string(
+		meta_descriptor,
+		"transaction_commit_path"
+	)
+	var commit_pending_path: String = GFVariantData.get_option_string(
+		meta_descriptor,
+		"transaction_commit_pending_path"
+	)
+	assert_eq(
+		DirAccess.rename_absolute(commit_path, commit_pending_path),
+		OK,
+		"应能模拟 reciprocal group 中一个 commit record 尚停留在 pending 的窗口。"
+	)
+
+	var recovery_error: Error = _recover_transaction_files([data_file_name])
+
+	assert_eq(recovery_error, OK, "有效 commit pending 必须提升并完成 committed group 收敛。")
+	_assert_group_evidence_absent(file_names)
+	assert_eq(GFVariantData.get_option_int(_load_payload(data_file_name), "value"), 101)
+	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "value"), 202)
+
+
+func test_group_transaction_id_rejects_number_and_bool_and_preserves_all_records() -> void:
+	var transaction_id_values: Array[Variant] = [73, true]
+	for case_index: int in transaction_id_values.size():
+		var data_file_name: String = "typed-group-%d/data.json" % case_index
+		var meta_file_name: String = "typed-group-%d/meta.json" % case_index
+		var file_names: Array[String] = [data_file_name, meta_file_name]
+		_seed_group({
+			data_file_name: { "value": 1 },
+			meta_file_name: { "value": 2 },
+		})
+		assert_eq(_storage._write_transaction_markers(file_names, false), OK)
+		var evidence_paths: Array[String] = []
+		var evidence_bytes: Array[PackedByteArray] = []
+		for file_name: String in file_names:
+			var descriptor: Dictionary = _descriptor(file_name)
+			var final_path: String = GFVariantData.get_option_string(
+				descriptor,
+				"transaction_path"
+			)
+			var pending_path: String = GFVariantData.get_option_string(
+				descriptor,
+				"transaction_pending_path"
+			)
+			var marker: Dictionary = _storage._read_transaction_marker(file_name)
+			marker["transaction_id"] = transaction_id_values[case_index]
+			assert_eq(_write_json_record(final_path, marker), OK)
+			assert_eq(_write_json_record(pending_path, marker), OK)
+			evidence_paths.append(final_path)
+			evidence_bytes.append(FileAccess.get_file_as_bytes(final_path))
+			evidence_paths.append(pending_path)
+			evidence_bytes.append(FileAccess.get_file_as_bytes(pending_path))
+
+		var recovery_error: Error = _recover_transaction_files([data_file_name])
+
+		assert_eq(recovery_error, ERR_FILE_CORRUPT, "group transaction_id 必须是 String。")
+		for evidence_index: int in evidence_paths.size():
+			var evidence_path: String = evidence_paths[evidence_index]
+			assert_true(FileAccess.file_exists(evidence_path), "损坏 group record 必须保留。")
+			assert_eq(
+				FileAccess.get_file_as_bytes(evidence_path),
+				evidence_bytes[evidence_index],
+				"失败关闭不得改写任何 reciprocal group record。"
+			)
+
+
+func test_partial_initial_prepare_without_physical_mutation_aborts_cleanly() -> void:
+	var data_file_name: String = "partial-prepare/data.json"
+	var meta_file_name: String = "partial-prepare/meta.json"
+	var file_names: Array[String] = [data_file_name, meta_file_name]
+	_seed_group({
+		data_file_name: {"value": 10},
+		meta_file_name: {"value": 20},
+	})
+	assert_eq(_storage._write_transaction_markers(file_names, false), OK)
+	assert_eq(
+		DirAccess.remove_absolute(
+			GFVariantData.get_option_string(
+				_descriptor(meta_file_name),
+				"transaction_path"
+			)
+		),
+		OK,
+		"应能模拟 initial prepare 只发布了部分成员。"
+	)
+
+	var recovery_error: Error = _recover_transaction_files([data_file_name])
+
+	assert_eq(recovery_error, OK, "物理 payload 未变化时，partial initial prepare 应可安全 abort。")
+	_assert_group_evidence_absent(file_names)
+	assert_eq(GFVariantData.get_option_int(_load_payload(data_file_name), "value"), 10)
+	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "value"), 20)
+
+
+func test_full_commit_with_partial_prepare_cleanup_converges() -> void:
+	var data_file_name: String = "commit-prepare-cleanup/data.json"
+	var meta_file_name: String = "commit-prepare-cleanup/meta.json"
+	var file_names: Array[String] = [data_file_name, meta_file_name]
+	_seed_group({
+		data_file_name: {"value": 1},
+		meta_file_name: {"value": 2},
+	})
+	_stage_fully_committed_group(file_names, {
+		data_file_name: {"value": 101},
+		meta_file_name: {"value": 202},
+	})
+	assert_eq(
+		DirAccess.remove_absolute(
+			GFVariantData.get_option_string(
+				_descriptor(data_file_name),
+				"transaction_path"
+			)
+		),
+		OK,
+		"应能模拟 committed cleanup 只删除了部分 prepare。"
+	)
+
+	var recovery_error: Error = _recover_transaction_files([data_file_name])
+
+	assert_eq(recovery_error, OK, "完整 reciprocal commit set 应支配 partial prepare cleanup。")
+	_assert_group_evidence_absent(file_names)
+	assert_eq(GFVariantData.get_option_int(_load_payload(data_file_name), "value"), 101)
+	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "value"), 202)
+
+
+func test_partial_commit_cleanup_after_prepare_cleanup_converges() -> void:
+	var data_file_name: String = "commit-terminal-cleanup/data.json"
+	var meta_file_name: String = "commit-terminal-cleanup/meta.json"
+	var file_names: Array[String] = [data_file_name, meta_file_name]
+	_seed_group({
+		data_file_name: {"value": 3},
+		meta_file_name: {"value": 4},
+	})
+	_stage_fully_committed_group(file_names, {
+		data_file_name: {"value": 303},
+		meta_file_name: {"value": 404},
+	})
+	for file_name: String in file_names:
+		var descriptor: Dictionary = _descriptor(file_name)
+		assert_eq(
+			DirAccess.remove_absolute(GFVariantData.get_option_string(descriptor, "backup_path")),
+			OK
+		)
+		assert_eq(
+			DirAccess.remove_absolute(
+				GFVariantData.get_option_string(descriptor, "transaction_path")
+			),
+			OK
+		)
+	assert_eq(
+		DirAccess.remove_absolute(
+			GFVariantData.get_option_string(
+				_descriptor(meta_file_name),
+				"transaction_commit_path"
+			)
+		),
+		OK,
+		"应能模拟 prepare 已清空且 commit cleanup 仅完成部分成员。"
+	)
+
+	var recovery_error: Error = _recover_transaction_files([data_file_name])
+
+	assert_eq(recovery_error, OK, "terminal committed physical state 应允许 partial commit cleanup 收敛。")
+	_assert_group_evidence_absent(file_names)
+	assert_eq(GFVariantData.get_option_int(_load_payload(data_file_name), "value"), 303)
+	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "value"), 404)
+
+
+func test_full_prepare_with_partial_commit_rolls_back() -> void:
+	var data_file_name: String = "partial-commit/data.json"
+	var meta_file_name: String = "partial-commit/meta.json"
+	var file_names: Array[String] = [data_file_name, meta_file_name]
+	_seed_group({
+		data_file_name: {"value": 5},
+		meta_file_name: {"value": 6},
+	})
+	_stage_fully_committed_group(file_names, {
+		data_file_name: {"value": 505},
+		meta_file_name: {"value": 606},
+	})
+	assert_eq(
+		DirAccess.remove_absolute(
+			GFVariantData.get_option_string(
+				_descriptor(meta_file_name),
+				"transaction_commit_path"
+			)
+		),
+		OK,
+		"应能模拟 reciprocal commit set 尚未完整发布。"
+	)
+
+	var recovery_error: Error = _recover_transaction_files([data_file_name])
+
+	assert_eq(recovery_error, OK, "full prepare + partial commit 不足以证明提交，必须回滚。")
+	_assert_group_evidence_absent(file_names)
+	assert_eq(GFVariantData.get_option_int(_load_payload(data_file_name), "value"), 5)
+	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "value"), 6)
+
+
+func test_rollback_restore_failure_preserves_evidence_and_retry_succeeds() -> void:
+	var file_name: String = "retry/restore.json"
+	assert_eq(_storage.save_data(file_name, {"value": 7}), OK)
+	assert_eq(_storage._write_transaction_markers([file_name], false), OK)
+	assert_eq(
+		_storage._write_json(_storage._get_temp_filename(file_name), {"value": 707}),
+		OK
+	)
+	var descriptor: Dictionary = _descriptor(file_name)
+	var final_path: String = GFVariantData.get_option_string(descriptor, "payload_path")
+	var backup_path: String = GFVariantData.get_option_string(descriptor, "backup_path")
+	var candidate_path: String = GFVariantData.get_option_string(descriptor, "candidate_path")
+	var prepare_path: String = GFVariantData.get_option_string(descriptor, "transaction_path")
+	assert_eq(DirAccess.rename_absolute(final_path, backup_path), OK)
+	assert_eq(
+		DirAccess.make_dir_absolute(final_path),
+		OK,
+		"同名目录应稳定阻断 backup restore。"
+	)
+	var transaction_reference: Dictionary = _storage._read_transaction_marker(file_name)
+	var rollback_files: Array[String] = [file_name]
+
+	var rollback_error: Error = GFVariantData.to_exact_int(
+		_storage._transaction_manager.call(
+			"_rollback_group_from_record",
+			rollback_files,
+			transaction_reference
+		),
+		ERR_BUG
+	) as Error
+
+	assert_ne(rollback_error, OK, "restore 被阻断时 rollback 必须报告失败。")
+	assert_true(FileAccess.file_exists(prepare_path), "rollback 失败后必须保留 prepare evidence。")
+	assert_true(FileAccess.file_exists(backup_path), "rollback 失败后必须保留 backup evidence。")
+	assert_true(FileAccess.file_exists(candidate_path), "rollback 失败后必须保留 candidate evidence。")
+	assert_eq(DirAccess.remove_absolute(final_path), OK, "解除 restore 阻断应成功。")
+
+	var retry_error: Error = _recover_transaction_files([file_name])
+
+	assert_eq(retry_error, OK, "解除物理故障后必须能凭保留证据幂等重试。")
+	_assert_group_evidence_absent([file_name])
+	assert_eq(GFVariantData.get_option_int(_load_payload(file_name), "value"), 7)
+
+
+func test_activation_fails_and_closes_admission_on_corrupt_layout() -> void:
+	var layout_path: String = _storage_root_path.path_join(".gf-storage/v1/layout.json")
+	assert_true(FileAccess.file_exists(layout_path))
+	assert_eq(_write_text(layout_path, "{}"), OK)
+	_storage.dispose()
+	var activating_storage: GFStorageUtility = _configure_storage(
+		GFStorageUtility.new(),
+		false
+	)
+
+	var completion: GFAsyncCompletion = activating_storage.begin_activation(null)
+
+	assert_true(completion.is_failed(), "corrupt layout 必须让 activation 进入失败终态。")
+	assert_eq(
+		GFVariantData.get_option_int(completion.get_metadata(), "error_code", OK),
+		ERR_FILE_CORRUPT
+	)
+	assert_eq(
+		activating_storage.save_data("probe.json", {"value": 1}),
+		ERR_UNAVAILABLE,
+		"activation readiness 失败后必须关闭新的 I/O admission。"
+	)
+
+
+func test_list_recovers_committed_view_after_drain() -> void:
+	var drain_storage: DrainMutationStorageUtility = DrainMutationStorageUtility.new()
+	_replace_primary_storage(drain_storage)
+	var file_name: String = "list/committed.json"
+	assert_eq(drain_storage.save_data(file_name, {"value": 8}), OK)
+	drain_storage.injection_file_name = file_name
+	drain_storage.injection_payload = {"value": 808}
+	drain_storage.inject_during_next_drain = true
+
+	var files: PackedStringArray = drain_storage.list_files("", "json", true)
+
+	assert_eq(drain_storage.injection_error, OK, "drain fault fixture 应构造完整 prepare 与未完成物理提交。")
+	assert_true(files.has(file_name), "list 必须在 drain 后恢复并投影旧 committed payload。")
+	_assert_group_evidence_absent([file_name])
+	assert_eq(GFVariantData.get_option_int(_load_payload(file_name), "value"), 8)
+
+
+func test_durable_commit_with_invalid_final_candidate_invariant_reports_failure() -> void:
+	var sabotage_storage: CommitInvariantSabotageStorageUtility = (
+		CommitInvariantSabotageStorageUtility.new()
+	)
+	_replace_primary_storage(sabotage_storage)
+	var file_name: String = "async/invariant.json"
+	sabotage_storage.sabotage_next_committed_validation = true
+
+	var operation: GFStorageAsyncOperation = sabotage_storage.save_data_request_async(
+		file_name,
+		{"value": 9}
+	)
+	sabotage_storage.wait_for_async_tasks()
+	var result: GFStorageAsyncResult = operation.get_result()
+	var descriptor: Dictionary = _descriptor(file_name)
+
+	assert_eq(sabotage_storage.sabotage_error, OK, "故障夹具应在 durable commit 后破坏 final/candidate invariant。")
+	assert_false(result.is_successful(), "durable commit 后的终态 invariant 失败不得报告成功。")
+	assert_eq(result.get_error_code(), ERR_FILE_CORRUPT)
+	assert_false(
+		FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "payload_path")),
+		"故障夹具应留下 missing final。"
+	)
+	assert_true(
+		FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "candidate_path")),
+		"故障夹具应留下 candidate 作为冲突证据。"
+	)
+	assert_true(
+		FileAccess.file_exists(
+			GFVariantData.get_option_string(descriptor, "transaction_commit_path")
+		),
+		"调用方失败终态前 commit record 应已 durable。"
+	)
+
+
+func _marker_identity_type_cases() -> Array[Dictionary]:
+	return [
+		{
+			"file_name": "1",
+			"field_path": "owner.logical_path",
+			"field_value": 1,
+		},
+		{
+			"file_name": "true",
+			"field_path": "member.logical_path",
+			"field_value": true,
+		},
+		{
+			"file_name": "typed-owner-family.json",
+			"field_path": "owner.family_id",
+			"field_value": 17,
+		},
+		{
+			"file_name": "typed-member-family.json",
+			"field_path": "member.family_id",
+			"field_value": false,
+		},
+	]
+
+
+func _mutate_marker_field(
+	marker: Dictionary,
+	field_path: String,
+	field_value: Variant
+) -> Dictionary:
+	var result: Dictionary = marker.duplicate(true)
+	if field_path.begins_with("owner."):
+		var owner_record: Dictionary = GFVariantData.get_option_dictionary(result, "owner")
+		owner_record[field_path.trim_prefix("owner.")] = field_value
+		result["owner"] = owner_record
+		return result
+	var members: Array = GFVariantData.get_option_array(result, "members")
+	var member: Dictionary = GFVariantData.as_dictionary(members[0])
+	member[field_path.trim_prefix("member.")] = field_value
+	members[0] = member
+	result["members"] = members
+	return result
+
+
+func _write_json_record(path: String, record: Dictionary) -> Error:
+	return _write_text(path, JSON.stringify(record))
+
+
+func _configure_storage(storage: GFStorageUtility, initialize: bool) -> GFStorageUtility:
+	storage.save_dir_name = _save_dir_name
+	storage.encrypt_key = 0
+	_storage_instances.append(storage)
+	if initialize:
+		storage.init()
+	return storage
+
+
+func _replace_primary_storage(storage: GFStorageUtility) -> void:
+	if _storage != null:
+		_storage.dispose()
+	_storage = _configure_storage(storage, true)
+
+
+func _descriptor(file_name: String) -> Dictionary:
+	return _GF_STORAGE_FAMILY_STORE_SCRIPT.make_family_descriptor_for_framework(
+		_storage_root_path,
+		file_name
+	)
+
+
+func _recover_transaction_files(file_names: Array[String]) -> Error:
+	return GFVariantData.to_exact_int(
+		_storage.call("_recover_transaction_files", file_names),
+		ERR_BUG
+	) as Error
+
+
+func _seed_group(payloads_by_file: Dictionary) -> void:
+	assert_eq(_storage.save_data_group(payloads_by_file), OK, "测试夹具应写入旧 committed generation。")
+
+
+func _stage_fully_committed_group(
+	file_names: Array[String],
+	payloads_by_file: Dictionary
+) -> void:
+	assert_eq(_storage._write_transaction_markers(file_names, false), OK)
+	for file_name: String in file_names:
+		assert_eq(
+			_storage._write_json(
+				_storage._get_temp_filename(file_name),
+				GFVariantData.get_option_dictionary(payloads_by_file, file_name)
+			),
+			OK
+		)
+		assert_eq(
+			DirAccess.rename_absolute(
+				_storage._get_full_path(file_name),
+				_storage._get_full_path(_storage._get_backup_filename(file_name))
+			),
+			OK
+		)
+		assert_eq(
+			DirAccess.rename_absolute(
+				_storage._get_full_path(_storage._get_temp_filename(file_name)),
+				_storage._get_full_path(file_name)
+			),
+			OK
+		)
+	assert_eq(_storage._write_transaction_markers(file_names, true), OK)
+
+
+func _load_payload(file_name: String) -> Dictionary:
+	var result: GFStorageReadResult = _storage.load_data(file_name)
+	assert_true(result.ok, "测试辅助读取应成功：%s；%s" % [file_name, result.error])
+	return result.payload.duplicate(true) if result.ok else {}
+
+
+func _assert_group_evidence_absent(file_names: Array[String]) -> void:
+	for file_name: String in file_names:
+		var descriptor: Dictionary = _descriptor(file_name)
+		for path_key: String in [
+			"candidate_path",
+			"backup_path",
+			"transaction_path",
+			"transaction_pending_path",
+			"transaction_commit_path",
+			"transaction_commit_pending_path",
+			"resource_stage_path",
+		]:
+			assert_false(
+				FileAccess.file_exists(GFVariantData.get_option_string(descriptor, path_key)),
+				"事务收敛后不应残留 %s：%s" % [path_key, file_name]
+			)
+
+
+func _write_text(path: String, text: String) -> Error:
+	var directory_error: Error = DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	if directory_error != OK:
+		return directory_error
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		return FileAccess.get_open_error()
+	var _stored: bool = file.store_string(text) != null
+	file.flush()
+	var write_error: Error = file.get_error()
+	file.close()
+	return write_error
+
+
+func _remove_test_root() -> Error:
+	if (
+		_storage_root_path.is_empty()
+		or _storage_root_path == "user://"
+		or not _storage_root_path.begins_with("user://gf-tx-recovery-")
+	):
+		return ERR_INVALID_PARAMETER
+	return _remove_tree(_storage_root_path)
+
+
+func _remove_tree(path: String) -> Error:
+	if FileAccess.file_exists(path):
+		return DirAccess.remove_absolute(path)
+	if not DirAccess.dir_exists_absolute(path):
+		return OK
+	var directory: DirAccess = DirAccess.open(path)
+	if directory == null:
+		return ERR_FILE_CANT_OPEN
+	var begin_error: Error = directory.list_dir_begin()
+	if begin_error != OK:
+		return begin_error
+	var entries: Array[String] = []
+	var entry: String = directory.get_next()
+	while not entry.is_empty():
+		entries.append(entry)
+		entry = directory.get_next()
+	directory.list_dir_end()
+	for child_name: String in entries:
+		var child_error: Error = _remove_tree(path.path_join(child_name))
+		if child_error != OK:
+			return child_error
+	return DirAccess.remove_absolute(path)

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd.uid
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_transaction_recovery.gd.uid
@@ -1,0 +1,1 @@
+uid://cxdrs4paagxtn

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -112,6 +112,7 @@ func _remove_owned_test_tree(path: String) -> Error:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return DirAccess.get_open_error()
+	directory.include_hidden = true
 	for file_name: String in directory.get_files():
 		var remove_file_error: Error = DirAccess.remove_absolute(path.path_join(file_name))
 		if remove_file_error != OK:

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -2,7 +2,11 @@
 extends GutTest
 
 
+const _GF_STORAGE_FAMILY_STORE_SCRIPT = preload("res://addons/gf/standard/utilities/storage/gf_storage_family_store.gd")
+
+
 var _storage: GFStorageUtility
+var _save_dir_name: String = ""
 
 
 class MigrationOverrideStorageUtility extends GFStorageUtility:
@@ -28,22 +32,55 @@ class FaultyStorageUtility extends GFStorageUtility:
 		return super._write_json(file_name, data)
 
 
-func _cleanup_file_family(file_name: String) -> void:
-	for suffix: String in ["", ".tmp", ".bak", ".txn"]:
-		var path: String = _storage._get_full_path(file_name + suffix)
-		if FileAccess.file_exists(path):
-			var _remove_absolute_result_21: Variant = DirAccess.remove_absolute(path)
+func _write_legacy_visible_data_file(file_name: String, data: Dictionary) -> String:
+	var storage_root: String = _storage._get_save_base_path()
+	var path: String = storage_root.path_join(file_name)
+	var directory_error: Error = DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	assert_eq(directory_error, OK, "测试夹具应能创建 legacy visible file 的父目录。")
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "测试夹具应能直接写入 Storage root。")
+	if file == null:
+		return path
+	var bytes: PackedByteArray = _storage._get_codec().encode(data, _storage._get_codec_options())
+	var _store_buffer_result_43: Variant = file.store_buffer(bytes)
+	var write_error: Error = file.get_error()
+	file.close()
+	assert_eq(write_error, OK, "测试夹具应完整写入 legacy visible file。")
+	return path
 
 
-func _remove_directory_if_exists(directory_name: String) -> void:
-	var path: String = _storage._get_full_path(directory_name)
-	if DirAccess.dir_exists_absolute(path):
-		var _remove_absolute_result_27: Variant = DirAccess.remove_absolute(path)
+func _remove_legacy_visible_file(path: String) -> void:
+	if FileAccess.file_exists(path):
+		var _remove_absolute_result_54: Variant = DirAccess.remove_absolute(path)
+
+
+func _claim_file_family_for_fixture(file_name: String) -> void:
+	assert_eq(
+		_storage._prepare_family_for_write(file_name),
+		OK,
+		"测试夹具应先建立合法 catalog/owner ownership：%s" % file_name
+	)
+
+
+func _assert_transaction_records_absent(file_name: String) -> void:
+	var descriptor: Dictionary = _storage._make_family_descriptor(file_name)
+	for path_key: String in [
+		"transaction_path",
+		"transaction_pending_path",
+		"transaction_commit_path",
+		"transaction_commit_pending_path",
+	]:
+		assert_false(
+			FileAccess.file_exists(GFVariantData.get_option_string(descriptor, path_key)),
+			"事务收敛后不应残留 %s：%s" % [path_key, file_name]
+		)
 
 
 func before_each() -> void:
+	_save_dir_name = "gf-storage-utility-" + GFUuid.generate_v4()
 	_storage = GFStorageUtility.new()
-	_storage.save_dir_name = "test_saves"
+	_storage.save_dir_name = _save_dir_name
+	_cleanup_known_test_artifacts()
 	_storage.init()
 
 
@@ -52,66 +89,52 @@ func _replace_storage(storage: GFStorageUtility) -> void:
 	_storage = storage
 
 
+func _cleanup_known_test_artifacts() -> void:
+	if _save_dir_name.is_empty():
+		return
+	var storage_root_path: String = _GF_STORAGE_FAMILY_STORE_SCRIPT.make_storage_root_path_for_framework(
+		_save_dir_name
+	)
+	assert_true(
+		storage_root_path.begins_with("user://gf-storage-utility-"),
+		"测试清理只能作用于本例 UUID root。"
+	)
+	if not storage_root_path.begins_with("user://gf-storage-utility-"):
+		return
+	assert_eq(_remove_owned_test_tree(storage_root_path), OK)
+
+
+func _remove_owned_test_tree(path: String) -> Error:
+	if FileAccess.file_exists(path):
+		return DirAccess.remove_absolute(path)
+	if not DirAccess.dir_exists_absolute(path):
+		return OK
+	var directory: DirAccess = DirAccess.open(path)
+	if directory == null:
+		return DirAccess.get_open_error()
+	for file_name: String in directory.get_files():
+		var remove_file_error: Error = DirAccess.remove_absolute(path.path_join(file_name))
+		if remove_file_error != OK:
+			return remove_file_error
+	for directory_name: String in directory.get_directories():
+		var child_path: String = path.path_join(directory_name)
+		var remove_directory_error: Error = (
+			DirAccess.remove_absolute(child_path)
+			if directory.is_link(directory_name)
+			else _remove_owned_test_tree(child_path)
+		)
+		if remove_directory_error != OK:
+			return remove_directory_error
+	directory = null
+	return DirAccess.remove_absolute(path)
+
+
 func after_each() -> void:
 	if _storage != null:
-		for file_name: String in [
-			"test_legacy.json",
-			"test_encryption.json",
-			"test_integrity.json",
-			"test_checksum_only.json",
-			"test_missing_checksum.json",
-			"test_missing_checksum_migration.json",
-			"test_plain_json_strict.json",
-			"test_plain_json_migration.json",
-			"test_traversal_limit_preserves_existing.json",
-			"test_traversal_limit_async_preserves_existing.json",
-			"test_json_number_preserve.json",
-			"test_legacy_version.json",
-			"test_migrate_override.json",
-			"test_registered_migration.json",
-			"test_missing_migration_chain.json",
-			"test_branching_migration.json",
-			"test_failed_migration.json",
-			"test_future_version.json",
-			"test_async.json",
-			"test_async_handle.json",
-			"nested/async_signal_alias.json",
-			"test_wait_async.json",
-			"test_quiesce_async.json",
-			"test_quiesce_rejected.json",
-			"recover_from_backup.json",
-			"recover_from_temp.json",
-			"recover_from_stale_temp.json",
-			"recover_committed_async.json",
-			"recover_delete.json",
-			"duplicate_transaction.json",
-			"queued_async.json",
-			"escape.json",
-			"nested/test_nested.json",
-			"managed/a.json",
-			"managed/b.tres",
-			"managed/readme.txt",
-			"managed/nested/c.json",
-			"group/data.json",
-			"group/meta.json",
-			"group/alias.json",
-			"marker_victim.json",
-			"marker_outsider.json",
-			"_invalid_storage_file",
-		]:
-			_cleanup_file_family(file_name)
-
-		_cleanup_file_family("test_resource.tres")
-		_remove_directory_if_exists("managed/nested")
-		_remove_directory_if_exists("managed")
-		_remove_directory_if_exists("escape_dir")
-		_remove_directory_if_exists("preview/nested")
-		_remove_directory_if_exists("preview")
-		_remove_directory_if_exists("_invalid_storage_directory")
-		_remove_directory_if_exists("nested")
-
 		_storage.dispose()
+		_cleanup_known_test_artifacts()
 		_storage = null
+	_save_dir_name = ""
 
 
 func test_encryption() -> void:
@@ -145,7 +168,10 @@ func test_save_data_preserves_existing_file_when_json_traversal_is_incomplete() 
 	assert_eq(save_error, ERR_INVALID_DATA, "JSON 遍历不完整时同步保存必须失败关闭。")
 	assert_eq(FileAccess.get_file_as_bytes(path), before_bytes, "失败保存不得覆盖已有最终文件。")
 	assert_eq(GFVariantData.get_option_int(_load_payload(file_name), "version"), 1, "旧存档应保持可读且内容不变。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path(file_name + ".tmp")), "失败事务不得遗留临时文件。")
+	assert_false(
+		FileAccess.file_exists(_storage._get_full_path(_storage._get_temp_filename(file_name))),
+		"失败事务不得遗留 candidate。"
+	)
 
 
 func test_async_save_preserves_existing_file_when_json_traversal_is_incomplete() -> void:
@@ -171,7 +197,10 @@ func test_async_save_preserves_existing_file_when_json_traversal_is_incomplete()
 	)
 	assert_eq(FileAccess.get_file_as_bytes(path), before_bytes, "失败异步保存不得覆盖已有最终文件。")
 	assert_eq(GFVariantData.get_option_int(_load_payload(file_name), "version"), 1, "旧存档应保持可读且内容不变。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path(file_name + ".tmp")), "失败异步事务不得遗留临时文件。")
+	assert_false(
+		FileAccess.file_exists(_storage._get_full_path(_storage._get_temp_filename(file_name))),
+		"失败异步事务不得遗留 candidate。"
+	)
 
 
 func test_pure_data_api_rejects_empty_file_name() -> void:
@@ -271,8 +300,8 @@ func test_async_request_handle_rejects_invalid_path_without_hanging() -> void:
 	assert_push_error("[GFStorageUtility] load_data_request_async 失败：file_name 为空。")
 
 
-func test_async_request_handle_keeps_legacy_signal_file_name_and_canonical_identity() -> void:
-	var requested_file_name: String = "nested//async_signal_alias.json"
+func test_async_request_handle_and_signal_preserve_exact_canonical_identity() -> void:
+	var requested_file_name: String = "nested/async_signal_alias.json"
 	watch_signals(_storage)
 	var operation: GFStorageAsyncOperation = _storage.save_data_request_async(
 		requested_file_name,
@@ -280,16 +309,16 @@ func test_async_request_handle_keeps_legacy_signal_file_name_and_canonical_ident
 	)
 	await _pump_storage_async_tasks()
 	assert_true(operation.is_completed())
-	assert_eq(operation.get_file_name(), "nested/async_signal_alias.json")
+	assert_eq(operation.get_file_name(), requested_file_name)
 	assert_signal_emitted_with_parameters(_storage, "save_completed", [requested_file_name, OK])
 
 
-func test_save_data_creates_nested_directories() -> void:
+func test_save_data_accepts_nested_logical_identity() -> void:
 	_storage.encrypt_key = 0
 	var err: Error = _storage.save_data("nested/test_nested.json", {"value": 7})
 
-	assert_eq(err, OK, "嵌套相对路径应自动创建目录并写入。")
-	assert_true(FileAccess.file_exists(_storage._get_full_path("nested/test_nested.json")), "嵌套路径文件应存在。")
+	assert_eq(err, OK, "嵌套 logical identity 应映射到独立 private family。")
+	assert_true(_storage.has_file("nested/test_nested.json"), "嵌套 logical identity 应存在 committed payload。")
 	assert_eq(GFVariantData.get_option_int(_load_payload("nested/test_nested.json"), "value"), 7, "嵌套路径数据应可读取。")
 
 
@@ -313,26 +342,245 @@ func test_save_data_group_rejects_unsafe_paths() -> void:
 	})
 
 	assert_eq(err, ERR_INVALID_PARAMETER, "多文件事务应拒绝任意非法路径。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path("group/meta.json")), "路径校验失败时不应写入其它文件。")
-	assert_push_error("[GFStorageUtility] 已拒绝跨目录路径（file_name）：../escape.json")
+	assert_false(_storage.has_file("group/meta.json"), "路径校验失败时不应 claim 或写入其它 family。")
+	assert_push_error("[GFStorageUtility] save_data_group 失败：file_name 不满足 portable logical path profile。")
 
 
-func test_save_data_group_rejects_canonical_path_aliases() -> void:
+func test_save_data_group_rejects_noncanonical_member_before_claiming_any_family() -> void:
 	var err: Error = _storage.save_data_group({
 		"group//alias.json": { "value": 1 },
 		"group/alias.json": { "value": 2 },
 	})
 
-	assert_eq(err, ERR_INVALID_PARAMETER, "同一 canonical file family 的 raw 别名必须在写入前被拒绝。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path("group/alias.json")), "别名冲突不得产生部分写入。")
-	assert_push_error("[GFStorageUtility] save_data_group 失败：文件名解析到同一存储目标 group/alias.json。")
+	assert_eq(err, ERR_INVALID_PARAMETER, "非 canonical member 必须在任何 family claim 前被拒绝。")
+	assert_false(_storage.has_file("group/alias.json"), "preflight 失败不得产生部分写入。")
+	assert_push_error("[GFStorageUtility] save_data_group 失败：file_name 不满足 portable logical path profile。")
+
+
+func test_save_data_group_rejects_non_string_key_before_claiming_any_family() -> void:
+	var coerced_file_name: String = "731923"
+	var files: Dictionary = {
+		731923: { "value": 1 },
+	}
+
+	var err: Error = _storage.save_data_group(files)
+	var descriptor: Dictionary = _storage._make_family_descriptor(coerced_file_name)
+
+	assert_eq(err, ERR_INVALID_PARAMETER, "非 String key 不得被隐式转成 logical identity。")
+	assert_false(
+		FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "catalog_path")),
+		"key preflight 失败不得写入 catalog claim。"
+	)
+	assert_false(
+		FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "owner_path")),
+		"key preflight 失败不得写入 owner record。"
+	)
+	assert_false(
+		FileAccess.file_exists(GFVariantData.get_option_string(descriptor, "payload_path")),
+		"key preflight 失败不得写入 payload。"
+	)
+	assert_false(
+		DirAccess.dir_exists_absolute(GFVariantData.get_option_string(descriptor, "family_path")),
+		"key preflight 失败不得创建 private family。"
+	)
+	assert_push_error("[GFStorageUtility] save_data_group 失败：文件名键必须是 String。")
+
+
+func test_portable_logical_file_path_profile_rejects_noncanonical_identities() -> void:
+	var overlong_segment: String = "a".repeat(65) + ".json"
+	var overlong_path: String = "/".join([
+		"a".repeat(64),
+		"b".repeat(64),
+		"c".repeat(64),
+		"d".repeat(64),
+	])
+	var too_many_segments: String = "/".join(PackedStringArray([
+		"a", "b", "c", "d", "e", "f", "g", "h", "i",
+		"j", "k", "l", "m", "n", "o", "p", "q",
+	]))
+	var invalid_file_names: Array[String] = [
+		"Profile/slot.json",
+		"profile\\slot.json",
+		"profile//slot.json",
+		"profile/./slot.json",
+		"profile/存档.json",
+		"profile/con.json",
+		"profile/aux.backup.json",
+		"profile/lpt9.data",
+		"profile/slot.",
+		".gf-storage/v1/layout.json",
+		overlong_segment,
+		overlong_path,
+		too_many_segments,
+	]
+
+	assert_eq(
+		_storage.canonicalize_data_file_name("portable-profile/slot_01.data.json.tmp"),
+		"portable-profile/slot_01.data.json.tmp",
+		"portable profile 应保留合法 lowercase ASCII identity 的精确字节。"
+	)
+	for file_name: String in invalid_file_names:
+		assert_eq(
+			_storage.canonicalize_data_file_name(file_name),
+			"",
+			"非规范 logical identity 必须 fail closed：%s" % file_name
+		)
+	assert_push_error_count(
+		invalid_file_names.size(),
+		"每个被拒绝的 logical identity 应只产生一条有界诊断。"
+	)
+
+
+func test_portable_logical_path_validation_is_shared_by_sync_entries() -> void:
+	var invalid_directory_name: String = "PortableProfile"
+	var invalid_file_name: String = invalid_directory_name + "/probe.json"
+	var visible_path: String = _write_legacy_visible_data_file(
+		invalid_file_name,
+		{ "value": "must-not-be-adopted" }
+	)
+
+	var canonical_file_name: String = _storage.canonicalize_data_file_name(invalid_file_name)
+	var save_error: Error = _storage.save_data(invalid_file_name, { "value": "must-not-write" })
+	var load_result: GFStorageReadResult = _storage.load_data(invalid_file_name)
+	var delete_error: Error = _storage.delete_file(invalid_file_name)
+	var _rewritten_visible_path: String = _write_legacy_visible_data_file(
+		invalid_file_name,
+		{ "value": "must-not-be-listed" }
+	)
+	var listed_files: PackedStringArray = _storage.list_files(invalid_directory_name, "json", true)
+	var visible_file_survived: bool = FileAccess.file_exists(visible_path)
+	_remove_legacy_visible_file(visible_path)
+
+	assert_eq(canonical_file_name, "", "canonicalize 不得改写非 lowercase ASCII identity。")
+	assert_eq(save_error, ERR_INVALID_PARAMETER, "save 必须在任何文件系统写入前拒绝非规范 identity。")
+	assert_eq(load_result.error_code, ERR_INVALID_PARAMETER, "load 不得领养同名可见物理文件。")
+	assert_eq(
+		load_result.failure_kind,
+		GFStorageReadResult.FailureKind.INVALID_REQUEST,
+		"非规范 identity 应是无效请求，不是 I/O 失败。"
+	)
+	assert_eq(delete_error, ERR_INVALID_PARAMETER, "delete 不得删除同名可见物理文件。")
+	assert_true(listed_files.is_empty(), "list 必须拒绝非规范 logical directory selector。")
+	assert_true(visible_file_survived, "所有非法入口都必须对已有物理文件零修改。")
+	assert_push_error_count(5, "五个同步入口应各拒绝一次，且不产生额外 I/O 诊断。")
+
+
+func test_logical_sidecar_suffix_names_have_independent_file_family_ownership() -> void:
+	_storage.encrypt_key = 0
+	var base_file_name: String = "family_owner.json"
+	var logical_temp_file_name: String = base_file_name + ".tmp"
+	var logical_backup_file_name: String = base_file_name + ".bak"
+	var logical_transaction_file_name: String = base_file_name + ".txn"
+
+	assert_eq(_storage.save_data(base_file_name, { "value": "base-v1" }), OK)
+	assert_eq(_storage.save_data(logical_temp_file_name, { "value": "logical-temp" }), OK)
+	assert_eq(_storage.save_data(logical_backup_file_name, { "value": "logical-backup" }), OK)
+	assert_eq(_storage.save_data(logical_transaction_file_name, { "value": "logical-transaction" }), OK)
+	assert_eq(_storage.save_data(base_file_name, { "value": "base-v2" }), OK)
+
+	assert_eq(GFVariantData.get_option_string(_load_payload(base_file_name), "value"), "base-v2")
+	assert_eq(
+		GFVariantData.get_option_string(_load_payload(logical_temp_file_name), "value"),
+		"logical-temp",
+		"逻辑 .tmp 文件不得被另一个 family 的 recovery 当作临时文件删除。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(_load_payload(logical_backup_file_name), "value"),
+		"logical-backup",
+		"逻辑 .bak 文件不得被另一个 family 的 recovery 当作备份删除。"
+	)
+	assert_eq(
+		GFVariantData.get_option_string(_load_payload(logical_transaction_file_name), "value"),
+		"logical-transaction",
+		"逻辑 .txn 文件不得被另一个 family 的 marker cleanup 删除。"
+	)
+
+	assert_eq(_storage.delete_file(base_file_name), OK, "删除 base family 应只删除该 family。")
+	assert_eq(_storage.load_data(base_file_name).error_code, ERR_FILE_NOT_FOUND)
+	assert_eq(GFVariantData.get_option_string(_load_payload(logical_temp_file_name), "value"), "logical-temp")
+	assert_eq(GFVariantData.get_option_string(_load_payload(logical_backup_file_name), "value"), "logical-backup")
+	assert_eq(GFVariantData.get_option_string(_load_payload(logical_transaction_file_name), "value"), "logical-transaction")
+	assert_eq(_storage.delete_file(logical_temp_file_name), OK)
+	assert_eq(_storage.delete_file(logical_backup_file_name), OK)
+	assert_eq(_storage.delete_file(logical_transaction_file_name), OK)
+
+
+func test_legacy_visible_file_is_never_adopted_by_public_storage_apis() -> void:
+	var logical_file_name: String = "legacy_visible.json"
+	var visible_path: String = _write_legacy_visible_data_file(
+		logical_file_name,
+		{ "value": "legacy-visible" }
+	)
+
+	var load_result: GFStorageReadResult = _storage.load_data(logical_file_name)
+	var listed_files: PackedStringArray = _storage.list_files("", "json", true)
+	var delete_error: Error = _storage.delete_file(logical_file_name)
+	var visible_file_survived: bool = FileAccess.file_exists(visible_path)
+	_remove_legacy_visible_file(visible_path)
+
+	assert_eq(load_result.error_code, ERR_FILE_NOT_FOUND, "没有 catalog claim 的可见旧文件必须视为不存在。")
+	assert_false(listed_files.has(logical_file_name), "list 不得把 Storage root 扫描结果领养为 logical identity。")
+	assert_eq(delete_error, ERR_FILE_NOT_FOUND, "delete 不得删除未被 catalog 领有的可见旧文件。")
+	assert_true(visible_file_survived, "拒绝领养时必须保持 legacy visible file 字节不变。")
+
+
+func test_list_files_projects_logical_catalog_instead_of_physical_tree() -> void:
+	assert_eq(_storage.save_data("catalog/a.json", { "value": "a" }), OK)
+	assert_eq(_storage.save_data("catalog/nested/b.json", { "value": "b" }), OK)
+	var legacy_visible_path: String = _write_legacy_visible_data_file(
+		"catalog/legacy_visible.json",
+		{ "value": "must-not-be-listed" }
+	)
+
+	var listed_files: PackedStringArray = _storage.list_files("catalog", "json", true)
+	_remove_legacy_visible_file(legacy_visible_path)
+
+	assert_eq(
+		listed_files,
+		PackedStringArray(["catalog/a.json", "catalog/nested/b.json"]),
+		"list_files 应从分片 catalog 投影稳定排序的 logical identity，不扫描物理目录。"
+	)
+
+
+func test_list_files_stops_if_completion_callback_disposes_during_drain() -> void:
+	var operation: GFStorageAsyncOperation = _storage.save_data_request_async(
+		"catalog/reentrant.json",
+		{"value": 1}
+	)
+	var connect_error: Error = operation.completed.connect(
+		func(_result: GFStorageAsyncResult) -> void:
+			_storage.dispose()
+	) as Error
+	assert_eq(connect_error, OK)
+
+	var listed_files: PackedStringArray = _storage.list_files("catalog", "json", true)
+
+	assert_true(operation.is_completed(), "list drain 应先收敛已接纳的异步任务。")
+	assert_true(listed_files.is_empty(), "drain 回调关闭 Utility 后不得继续读取已释放 helper。")
+	assert_null(_storage._transaction_manager)
+	assert_null(_storage._family_store)
+
+
+func test_load_failure_classification_preserves_recovery_semantics() -> void:
+	assert_eq(
+		_storage._classify_load_failure(ERR_FILE_CANT_OPEN),
+		GFStorageReadResult.FailureKind.IO_FAILED
+	)
+	assert_eq(
+		_storage._classify_load_failure(ERR_UNAVAILABLE),
+		GFStorageReadResult.FailureKind.UNAVAILABLE
+	)
+	assert_eq(
+		_storage._classify_load_failure(ERR_FILE_CORRUPT),
+		GFStorageReadResult.FailureKind.CORRUPT
+	)
 
 
 func test_storage_paths_reject_parent_segments_before_simplification() -> void:
 	var err: Error = _storage.save_data("group/../escape.json", { "value": 1 })
 
 	assert_eq(err, ERR_INVALID_PARAMETER, "任何原始父目录段都应被路径策略拒绝。")
-	assert_push_error("[GFStorageUtility] 已拒绝跨目录路径（file_name）：group/../escape.json")
+	assert_push_error("[GFStorageUtility] save_data 失败：file_name 不满足 portable logical path profile。")
 
 
 func test_runtime_storage_has_no_absolute_path_escape_hatch() -> void:
@@ -342,7 +590,6 @@ func test_runtime_storage_has_no_absolute_path_escape_hatch() -> void:
 		return GFVariantData.get_option_string(property, "name") == "allow_absolute_paths"
 	), "运行时 Storage 不应保留可重新启用绝对路径的公共能力。")
 	assert_eq(path, "", "绝对路径必须始终 fail closed，不应收敛到存档目录。")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
 
 
 func test_public_storage_file_and_directory_apis_reject_absolute_paths() -> void:
@@ -359,16 +606,7 @@ func test_public_storage_file_and_directory_apis_reject_absolute_paths() -> void
 		ERR_INVALID_PARAMETER,
 		"同步保存不得接受绝对路径。"
 	)
-	assert_eq(
-		_storage.ensure_directory(absolute_directory_name),
-		ERR_INVALID_PARAMETER,
-		"目录管理不得接受绝对路径。"
-	)
-	assert_eq(
-		_storage.get_storage_directory_path(absolute_directory_name),
-		"",
-		"目录解析不得泄漏 root 外的绝对路径。"
-	)
+	assert_false(_storage.has_file(absolute_file_name), "存在性查询不得接受绝对路径。")
 	assert_true(
 		_storage.list_files(absolute_directory_name).is_empty(),
 		"枚举入口不得扫描 root 外的绝对目录。"
@@ -378,15 +616,11 @@ func test_public_storage_file_and_directory_apis_reject_absolute_paths() -> void
 		ERR_INVALID_PARAMETER,
 		"删除入口不得接受绝对路径。"
 	)
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside")
-	assert_push_error("[GFStorageUtility] ensure_directory 失败：directory_name 非法。")
-	assert_push_error("[GFStorageUtility] get_storage_directory_path 失败：directory_name 非法。")
+	assert_push_error("[GFStorageUtility] canonicalize_data_file_name 失败：file_name 不满足 portable logical path profile。")
+	assert_push_error("[GFStorageUtility] save_data 失败：file_name 不满足 portable logical path profile。")
+	assert_push_error("[GFStorageUtility] has_file 失败：file_name 不满足 portable logical path profile。")
 	assert_push_error("[GFStorageUtility] list_files 失败：directory_name 非法。")
+	assert_push_error("[GFStorageUtility] delete_file 失败：file_name 不满足 portable logical path profile。")
 
 
 func test_storage_rejects_cross_platform_absolute_path_forms() -> void:
@@ -413,99 +647,71 @@ func test_storage_rejects_cross_platform_absolute_path_forms() -> void:
 			"",
 			"Windows、POSIX、UNC 与 Godot scheme 绝对路径都必须失败关闭：%s" % absolute_path
 		)
-		assert_push_error("[GFStorageUtility] 已禁用绝对路径：%s" % absolute_path)
+		assert_push_error("[GFStorageUtility] canonicalize_data_file_name 失败：file_name 不满足 portable logical path profile。")
 
 
 func test_invalid_storage_root_configuration_fails_closed() -> void:
-	var invalid_roots: Array[Dictionary] = [
-		{
-			"value": "../escape",
-			"error": "[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：../escape",
-		},
-		{
-			"value": "nested/../escape",
-			"error": "[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：nested/../escape",
-		},
-		{
-			"value": "/outside",
-			"error": "[GFStorageUtility] 已禁用绝对路径：/outside",
-		},
-		{
-			"value": "\\outside",
-			"error": "[GFStorageUtility] 已禁用绝对路径：\\outside",
-		},
-		{
-			"value": "C:/outside",
-			"error": "[GFStorageUtility] 已禁用绝对路径：C:/outside",
-		},
-		{
-			"value": "user://outside",
-			"error": "[GFStorageUtility] 已禁用绝对路径：user://outside",
-		},
-		{
-			"value": ".",
-			"error": "[GFStorageUtility] save_dir_name 必须是规范相对目录：.",
-		},
-		{
-			"value": "nested//outside",
-			"error": "[GFStorageUtility] save_dir_name 必须是规范相对目录：nested//outside",
-		},
-		{
-			"value": "C:drive-relative",
-			"error": "[GFStorageUtility] save_dir_name 包含不支持的字符：C:drive-relative",
-		},
+	var invalid_roots: Array[String] = [
+		"../escape",
+		"nested/../escape",
+		"/outside",
+		"\\outside",
+		"C:/outside",
+		"user://outside",
+		".",
+		"nested//outside",
+		"C:drive-relative",
 	]
+	var root_error: String = "[GFStorageUtility] save_dir_name 必须满足 portable logical directory profile。"
 
-	for invalid_root: Dictionary in invalid_roots:
-		var root_value: String = GFVariantData.get_option_string(invalid_root, "value")
-		var expected_error: String = GFVariantData.get_option_string(invalid_root, "error")
-		_storage.save_dir_name = root_value
-		assert_eq(_storage._get_save_base_path(), "", "非法配置不得退化为 user:// 根：%s" % root_value)
-		assert_push_error(expected_error)
-		assert_eq(_storage._get_full_path("probe.json"), "", "非法 root 不得拼出绝对文件路径。")
-		assert_push_error(expected_error)
-		assert_eq(_storage.get_storage_directory_path(), "", "公开目录解析必须失败关闭。")
-		assert_push_error(expected_error)
-		assert_true(_storage.list_files().is_empty(), "非法 root 不得退化为进程当前目录枚举。")
-		assert_push_error(expected_error)
+	for root_value: String in invalid_roots:
+		var invalid_storage: GFStorageUtility = GFStorageUtility.new()
+		invalid_storage.save_dir_name = root_value
+		assert_eq(invalid_storage._get_save_base_path(), "", "非法配置不得退化为 user:// 根：%s" % root_value)
+		assert_push_error(root_error)
+		assert_eq(invalid_storage._get_full_path("probe.json"), "", "非法 root 不得拼出文件路径。")
+		assert_push_error(root_error)
+		assert_true(invalid_storage.list_files().is_empty(), "非法 root 不得退化为进程当前目录枚举。")
+		assert_push_error(root_error)
 		assert_eq(
-			_storage.ensure_directory(),
+			invalid_storage.save_data("probe.json", { "value": 1 }),
 			ERR_INVALID_PARAMETER,
-			"非法 root 的目录创建不得伪装成成功。"
+			"非法 root 不得接纳写入。"
 		)
-		assert_push_error(expected_error)
-	_storage.save_dir_name = "test_saves"
+		assert_push_error(root_error)
+		invalid_storage.dispose()
 
 
 func test_invalid_storage_root_rejects_all_public_io_before_admission() -> void:
-	var root_error: String = "[GFStorageUtility] 已拒绝跨目录路径（save_dir_name）：../escape"
-	_storage.save_dir_name = "../escape"
+	var invalid_storage: GFStorageUtility = GFStorageUtility.new()
+	invalid_storage.save_dir_name = "../escape"
+	var root_error: String = "[GFStorageUtility] save_dir_name 必须满足 portable logical directory profile。"
 
-	assert_eq(_storage.canonicalize_data_file_name("probe.json"), "")
+	assert_eq(invalid_storage.canonicalize_data_file_name("probe.json"), "")
 	assert_push_error(root_error)
-	assert_eq(_storage.save_data("probe.json", {"value": 1}), ERR_INVALID_PARAMETER)
+	assert_eq(invalid_storage.save_data("probe.json", {"value": 1}), ERR_INVALID_PARAMETER)
 	assert_push_error(root_error)
-	var load_result: GFStorageReadResult = _storage.load_data("probe.json")
+	var load_result: GFStorageReadResult = invalid_storage.load_data("probe.json")
 	assert_eq(load_result.error_code, ERR_INVALID_PARAMETER)
 	assert_eq(load_result.failure_kind, GFStorageReadResult.FailureKind.INVALID_REQUEST)
 	assert_push_error(root_error)
-	assert_eq(_storage.delete_file("probe.json"), ERR_INVALID_PARAMETER)
+	assert_eq(invalid_storage.delete_file("probe.json"), ERR_INVALID_PARAMETER)
 	assert_push_error(root_error)
-	assert_eq(_storage.save_resource("probe.tres", Resource.new()), ERR_INVALID_PARAMETER)
+	assert_eq(invalid_storage.save_resource("probe.tres", Resource.new()), ERR_INVALID_PARAMETER)
 	assert_push_error(root_error)
-	assert_null(_storage.load_resource("probe.tres", "Resource"))
+	assert_null(invalid_storage.load_resource("probe.tres", "Resource"))
 	assert_push_error(root_error)
 	assert_eq(
-		_storage.save_data_group({"probe.json": {"value": 1}}),
+		invalid_storage.save_data_group({"probe.json": {"value": 1}}),
 		ERR_INVALID_PARAMETER
 	)
 	assert_push_error(root_error)
-	assert_eq(_storage.save_data_async("probe.json", {"value": 1}), ERR_INVALID_PARAMETER)
+	assert_eq(invalid_storage.save_data_async("probe.json", {"value": 1}), ERR_INVALID_PARAMETER)
 	assert_push_error(root_error)
-	assert_eq(_storage.load_data_async("probe.json"), ERR_INVALID_PARAMETER)
+	assert_eq(invalid_storage.load_data_async("probe.json"), ERR_INVALID_PARAMETER)
 	assert_push_error(root_error)
 
-	var save_operation: GFStorageAsyncOperation = _storage.save_data_request_async(
+	var save_operation: GFStorageAsyncOperation = invalid_storage.save_data_request_async(
 		"probe.json",
 		{"value": 1}
 	)
@@ -513,14 +719,14 @@ func test_invalid_storage_root_rejects_all_public_io_before_admission() -> void:
 	assert_eq(save_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
 	assert_eq(save_operation.get_file_name(), "")
 	assert_push_error(root_error)
-	var load_operation: GFStorageAsyncOperation = _storage.load_data_request_async("probe.json")
+	var load_operation: GFStorageAsyncOperation = invalid_storage.load_data_request_async("probe.json")
 	assert_true(load_operation.is_completed())
 	assert_eq(load_operation.get_result().get_error_code(), ERR_INVALID_PARAMETER)
 	assert_eq(load_operation.get_file_name(), "")
 	assert_push_error(root_error)
 
 	var transfer: GFStoragePayloadTransfer = GFStoragePayloadTransfer.take_ownership({"value": 1})
-	var payload_operation: GFStorageAsyncOperation = _storage.save_payload_request_async(
+	var payload_operation: GFStorageAsyncOperation = invalid_storage.save_payload_request_async(
 		"probe.json",
 		transfer
 	)
@@ -531,10 +737,10 @@ func test_invalid_storage_root_rejects_all_public_io_before_admission() -> void:
 	assert_push_error(root_error)
 	assert_true(transfer.release())
 
-	assert_true(_storage._async_queue.is_empty())
-	assert_true(_storage._async_tasks.is_empty())
-	assert_true(_storage._async_file_locks.is_empty())
-	_storage.save_dir_name = "test_saves"
+	assert_true(invalid_storage._async_queue.is_empty())
+	assert_true(invalid_storage._async_tasks.is_empty())
+	assert_true(invalid_storage._async_file_locks.is_empty())
+	invalid_storage.dispose()
 
 
 func test_group_resource_and_async_storage_entries_reject_absolute_paths() -> void:
@@ -569,17 +775,16 @@ func test_group_resource_and_async_storage_entries_reject_absolute_paths() -> vo
 	assert_eq(load_operation.get_result().get_file_name(), "")
 	assert_true(_storage._async_queue.is_empty(), "非法绝对路径不得进入异步队列。")
 	assert_true(_storage._async_tasks.is_empty(), "非法绝对路径不得启动 worker。")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
-	assert_push_error("[GFStorageUtility] 已禁用绝对路径：C:/outside/save.json")
+	assert_push_error("[GFStorageUtility] save_resource 失败：file_name 不满足 portable logical path profile。")
+	assert_push_error("[GFStorageUtility] save_data_group 失败：file_name 不满足 portable logical path profile。")
+	assert_push_error("[GFStorageUtility] save_data_request_async 失败：file_name 不满足 portable logical path profile。")
+	assert_push_error("[GFStorageUtility] load_data_request_async 失败：file_name 不满足 portable logical path profile。")
 
 
 func test_parent_directory_path_is_rejected() -> void:
 	var path: String = _storage._get_full_path("../escape.json")
 
 	assert_eq(path, "", "跨目录相对路径应 fail closed，不应收敛到存档目录内。")
-	assert_push_error("[GFStorageUtility] 已拒绝跨目录路径（file_name）：../escape.json")
 
 
 func test_async_saves_to_same_file_are_serialized() -> void:
@@ -709,10 +914,7 @@ func test_dispose_clears_transient_state_and_releases_helpers() -> void:
 	assert_null(_storage._path_policy, "dispose 后应释放路径策略 helper。")
 	assert_null(_storage._file_ops, "dispose 后应释放文件操作 helper。")
 	assert_null(_storage._transaction_manager, "dispose 后应释放事务 helper。")
-
-	var root_path: String = _storage.get_storage_directory_path()
-	assert_eq(root_path, "user://test_saves", "dispose 后再次使用应按需重建 helper。")
-	assert_not_null(_storage._path_policy, "再次使用存储工具时应按需重建路径策略 helper。")
+	assert_null(_storage._family_store, "dispose 后应释放 family store helper。")
 
 
 func test_save_and_load_resource() -> void:
@@ -733,6 +935,36 @@ func test_save_and_load_resource() -> void:
 	var loaded_res: NoiseTexture2D = loaded_resource
 	assert_eq(loaded_res.width, 128, "读取的 Resource 宽度应与保存值一致。")
 	assert_eq(loaded_res.height, 128, "读取的 Resource 高度应与保存值一致。")
+
+
+func test_resource_logical_paths_require_canonical_lowercase_extension() -> void:
+	var no_extension: String = "resource_without_extension"
+	var oversized_extension: String = "resource.abcdefghijklmnopq"
+
+	assert_eq(
+		_storage.save_resource(no_extension, Resource.new()),
+		ERR_INVALID_PARAMETER,
+		"Resource 保存必须有 canonical 扩展名。"
+	)
+	assert_push_error("Resource logical path 必须包含 canonical lowercase 扩展名")
+	assert_null(
+		_storage.load_resource(no_extension, "Resource"),
+		"Resource 读取也必须在 claim 前拒绝无扩展名 logical path。"
+	)
+	assert_push_error("Resource logical path 必须包含 canonical lowercase 扩展名")
+	assert_eq(
+		_storage.save_resource(oversized_extension, Resource.new()),
+		ERR_INVALID_PARAMETER,
+		"Resource 扩展名必须满足有界 extension profile。"
+	)
+	assert_push_error("Resource logical path 必须包含 canonical lowercase 扩展名")
+	assert_eq(
+		_storage._family_store.validate_family_for_framework(
+			_storage._make_family_descriptor(no_extension)
+		),
+		ERR_FILE_NOT_FOUND,
+		"Resource 路径预检失败不得 claim family。"
+	)
 
 
 func test_load_resource_requires_explicit_opt_in_and_type_hint() -> void:
@@ -761,17 +993,20 @@ func test_load_resource_validates_loaded_resource_type_hint() -> void:
 	assert_false(_storage._is_loaded_resource_compatible(resource, "PackedScene"), "加载结果必须匹配传入 type_hint。")
 
 
-func test_file_management_ensure_list_and_delete_files() -> void:
-	assert_eq(_storage.ensure_directory("managed/nested"), OK, "应能显式创建嵌套存储目录。")
-	assert_eq(_storage.ensure_directory("."), OK, "点号目录应视为存储根目录。")
+func test_file_management_lists_and_deletes_logical_files() -> void:
 	assert_eq(_storage.save_data("managed/a.json", { "value": 1 }), OK, "应能写入待枚举 JSON 文件。")
 	assert_eq(_storage.save_data("managed/nested/c.json", { "value": 3 }), OK, "应能写入嵌套 JSON 文件。")
 	assert_eq(_storage.save_data("managed/readme.txt", { "value": 2 }), OK, "应能写入不同扩展名文件。")
 	var res: Resource = Resource.new()
 	assert_eq(_storage.save_resource("managed/b.tres", res), OK, "应能写入 Resource 文件。")
+	assert_true(
+		_storage.list_files("managed", ".json", false).is_empty(),
+		"extension filter 必须是无点号的 canonical lowercase token。"
+	)
+	assert_push_error("[GFStorageUtility] list_files 失败：extension_filter 非法。")
 
 	assert_eq(
-		_storage.list_files("managed", ".json", false),
+		_storage.list_files("managed", "json", false),
 		PackedStringArray(["managed/a.json"]),
 		"非递归枚举只应返回当前目录下匹配扩展名的文件。",
 	)
@@ -785,7 +1020,6 @@ func test_file_management_ensure_list_and_delete_files() -> void:
 		1,
 		"递归枚举应遵守 max_file_count 上限。",
 	)
-	assert_push_warning("[GFStorageUtility] list_files 已达到 max_file_count=1，后续文件已跳过。")
 	assert_eq(
 		_storage.list_files("managed", "tres", true),
 		PackedStringArray(["managed/b.tres"]),
@@ -793,23 +1027,18 @@ func test_file_management_ensure_list_and_delete_files() -> void:
 	)
 
 	assert_eq(_storage.delete_file("managed/a.json"), OK, "应能删除存储相对文件。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path("managed/a.json")), "删除后文件不应继续存在。")
+	assert_false(_storage.has_file("managed/a.json"), "删除后 logical file 不应继续存在。")
 	assert_eq(_storage.delete_file("managed/a.json"), ERR_FILE_NOT_FOUND, "重复删除不存在文件应返回明确错误码。")
 
 
-func test_get_storage_directory_path_has_no_creation_side_effect() -> void:
-	var directory_path: String = _storage.get_storage_directory_path("preview/nested")
-
-	assert_eq(directory_path, "user://test_saves/preview/nested", "目录路径查询应复用存储路径策略。")
-	assert_false(DirAccess.dir_exists_absolute(directory_path), "只查询目录路径不应创建目录。")
+func test_runtime_storage_does_not_expose_physical_directory_management() -> void:
+	assert_false(_storage.has_method("ensure_directory"), "runtime API 不应暴露物理目录创建能力。")
+	assert_false(_storage.has_method("get_storage_directory_path"), "runtime API 不应泄漏 Storage root 物理路径。")
 
 
-func test_file_management_rejects_unsafe_directory_paths() -> void:
-	assert_eq(_storage.ensure_directory("../escape_dir"), ERR_INVALID_PARAMETER, "跨目录目录路径应 fail closed。")
-
-	assert_false(DirAccess.dir_exists_absolute(_storage._get_full_path("escape_dir")), "非法目录不应在存储根目录内创建同名目录。")
-	assert_push_error("[GFStorageUtility] 已拒绝跨目录路径（directory_name）：../escape_dir")
-	assert_push_error("[GFStorageUtility] ensure_directory 失败：directory_name 非法。")
+func test_list_files_rejects_unsafe_directory_selector() -> void:
+	assert_true(_storage.list_files("../escape_dir").is_empty(), "跨目录 selector 应 fail closed。")
+	assert_push_error("[GFStorageUtility] list_files 失败：directory_name 非法。")
 
 
 func test_file_management_rejects_empty_delete_file_path() -> void:
@@ -822,10 +1051,17 @@ func test_delete_file_cleans_transaction_family_and_prevents_recovery() -> void:
 	_storage.encrypt_key = 0
 	var file_name: String = "recover_delete.json"
 	assert_eq(_storage.save_data(file_name, { "value": 1 }), OK, "预置待删除文件应成功。")
-	assert_eq(_storage._write_json(_storage._get_temp_filename(file_name), { "value": 2 }), OK, "应能构造遗留临时文件。")
-	assert_eq(_storage._write_json(_storage._get_backup_filename(file_name), { "value": 3 }), OK, "应能构造遗留备份文件。")
 	var transaction_files: Array[String] = [file_name]
-	assert_eq(_storage._write_transaction_markers(transaction_files, true), OK, "应能构造遗留事务标记。")
+	assert_eq(_storage._write_transaction_markers(transaction_files, false), OK, "应能构造 v2 prepare record。")
+	assert_eq(
+		DirAccess.rename_absolute(
+			_storage._get_full_path(file_name),
+			_storage._get_full_path(_storage._get_backup_filename(file_name))
+		),
+		OK,
+		"应能构造有 prepare record 授权的 backup。"
+	)
+	assert_eq(_storage._write_json(_storage._get_temp_filename(file_name), { "value": 2 }), OK, "应能构造有授权的 candidate。")
 
 	var delete_error: Error = _storage.delete_file(file_name)
 	var load_result: GFStorageReadResult = _storage.load_data(file_name)
@@ -836,87 +1072,49 @@ func test_delete_file_cleans_transaction_family_and_prevents_recovery() -> void:
 	assert_false(FileAccess.file_exists(_storage._get_full_path(file_name)), "正式文件应被删除。")
 	assert_false(FileAccess.file_exists(_storage._get_full_path(_storage._get_temp_filename(file_name))), "临时文件应被删除。")
 	assert_false(FileAccess.file_exists(_storage._get_full_path(_storage._get_backup_filename(file_name))), "备份文件应被删除。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path(_storage._get_transaction_filename(file_name))), "事务标记应被删除。")
+	_assert_transaction_records_absent(file_name)
 
 
-func test_committed_async_marker_preserves_new_generation_after_crash() -> void:
+func test_nonreciprocal_v2_marker_cannot_expand_recovery_to_another_family() -> void:
 	_storage.encrypt_key = 0
-	var file_name: String = "recover_committed_async.json"
-	var final_path: String = _storage._get_full_path(file_name)
-	var backup_path: String = _storage._get_full_path(_storage._get_backup_filename(file_name))
-	var marker_file_name: String = _storage._get_transaction_filename(file_name)
-	assert_eq(_storage.save_data(file_name, { "generation": "old" }), OK, "应能预置旧代次。")
-	assert_eq(
-		DirAccess.rename_absolute(final_path, backup_path),
-		OK,
-		"应能模拟异步保存已备份旧代次。"
-	)
-	assert_eq(_storage._write_json(file_name, { "generation": "new" }), OK, "应能模拟新代次已进入正式路径。")
-	var storage_script: Script = _storage.get_script()
-	var transaction_files: Array[String] = [file_name]
-	var committed_marker: Dictionary = GFVariantData.to_dictionary(storage_script.call(
-		"_make_transaction_marker",
-		transaction_files,
-		file_name,
-		"async:crash-window",
-		true,
-		true
-	))
-	assert_eq(
-		_storage._write_plain_json(
-			marker_file_name,
-			committed_marker
-		),
-		OK,
-		"应能模拟异步保存写完 committed marker 后崩溃。"
-	)
-
-	var loaded: Dictionary = _load_payload(file_name)
-
-	assert_eq(
-		GFVariantData.get_option_string(loaded, "generation"),
-		"new",
-		"提交点后的恢复必须保留新代次，不能回滚到 backup。"
-	)
-	assert_false(FileAccess.file_exists(backup_path), "已提交恢复应清理旧代次备份。")
-	assert_false(
-		FileAccess.file_exists(_storage._get_full_path(marker_file_name)),
-		"已提交恢复应清理事务 marker。"
-	)
-
-
-func test_transaction_marker_cannot_expand_recovery_beyond_requested_files() -> void:
 	var victim_file_name: String = "marker_victim.json"
 	var outsider_file_name: String = "marker_outsider.json"
-	assert_eq(_storage.save_data(outsider_file_name, { "value": 1 }), OK, "应能预置事务范围外文件。")
+	assert_eq(_storage.save_data(victim_file_name, { "value": 2 }), OK, "应能预置 marker owner family。")
+	assert_eq(_storage.save_data(outsider_file_name, { "value": 1 }), OK, "应能预置事务范围外 family。")
 	assert_eq(
 		_storage._write_json(_storage._get_backup_filename(outsider_file_name), { "value": 999 }),
 		OK,
 		"应能构造范围外备份文件。"
 	)
+	var outsider_path: String = _storage._get_full_path(outsider_file_name)
+	var outsider_backup_path: String = _storage._get_full_path(
+		_storage._get_backup_filename(outsider_file_name)
+	)
+	var outsider_before: PackedByteArray = FileAccess.get_file_as_bytes(outsider_path)
+	var outsider_backup_before: PackedByteArray = FileAccess.get_file_as_bytes(outsider_backup_path)
+	var transaction_files: Array[String] = [victim_file_name, outsider_file_name]
 	assert_eq(
-		_storage._write_plain_json(_storage._get_transaction_filename(victim_file_name), {
-			"schema_version": 1,
-			"transaction_id": "forged",
-			"file_key": victim_file_name,
-			"files": [victim_file_name, outsider_file_name],
-			"committed": false,
-			"had_final": false,
-		}),
+		_storage._write_transaction_markers(transaction_files, false),
 		OK,
-		"应能构造不可信事务 marker。"
+		"应能构造完整 v2 prepare marker group。"
 	)
-
-	_storage._recover_transaction_files([victim_file_name])
-
-	assert_true(
-		FileAccess.file_exists(_storage._get_full_path(_storage._get_backup_filename(outsider_file_name))),
-		"请求范围外的备份文件不得被事务恢复流程消费。"
+	var outsider_marker_path: String = _storage._get_full_path(
+		_storage._get_transaction_filename(outsider_file_name)
 	)
 	assert_eq(
-		GFVariantData.get_option_int(_load_payload(outsider_file_name), "value"),
-		1,
-		"marker 不得授权恢复当前请求之外的 file family。"
+		DirAccess.remove_absolute(outsider_marker_path),
+		OK,
+		"应能构造只有 owner marker、缺少成员互证的 v2 group。"
+	)
+
+	var recovery_error: Error = _storage._recover_transaction_files([victim_file_name])
+
+	assert_eq(recovery_error, ERR_FILE_CORRUPT, "缺少 reciprocal marker 的 group 必须 fail closed。")
+	assert_eq(FileAccess.get_file_as_bytes(outsider_path), outsider_before, "范围外 final 不得被修改。")
+	assert_eq(
+		FileAccess.get_file_as_bytes(outsider_backup_path),
+		outsider_backup_before,
+		"范围外 backup 不得被消费。"
 	)
 
 
@@ -924,20 +1122,30 @@ func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> v
 	_storage.encrypt_key = 0
 	var victim_file_name: String = "marker_victim.json"
 	var outsider_file_name: String = "marker_outsider.json"
-	var victim_path: String = _storage._get_full_path(victim_file_name)
-	var outsider_path: String = ProjectSettings.globalize_path(
-		_storage._get_full_path(outsider_file_name)
-	).replace("\\", "/")
-	var declared_files: Array[String] = [victim_file_name, outsider_path]
 	assert_eq(_storage.save_data(victim_file_name, { "value": 1 }), OK, "应能预置相对目标。")
 	assert_eq(_storage.save_data(outsider_file_name, { "value": 2 }), OK, "应能预置范围外文件。")
+	var victim_path: String = _storage._get_full_path(victim_file_name)
+	var victim_backup_path: String = _storage._get_full_path(
+		_storage._get_backup_filename(victim_file_name)
+	)
+	var victim_marker_path: String = _storage._get_full_path(
+		_storage._get_transaction_filename(victim_file_name)
+	)
+	var outsider_path: String = _storage._get_full_path(outsider_file_name)
+	var outsider_backup_path: String = _storage._get_full_path(
+		_storage._get_backup_filename(outsider_file_name)
+	)
+	var unauthorized_member_path: String = ProjectSettings.globalize_path(outsider_path).replace(
+		"\\",
+		"/"
+	)
 	assert_eq(
-		DirAccess.rename_absolute(victim_path, victim_path + ".bak"),
+		DirAccess.rename_absolute(victim_path, victim_backup_path),
 		OK,
 		"应能构造相对目标备份。"
 	)
 	assert_eq(
-		DirAccess.rename_absolute(outsider_path, outsider_path + ".bak"),
+		DirAccess.rename_absolute(outsider_path, outsider_backup_path),
 		OK,
 		"应能构造绝对 sibling 备份。"
 	)
@@ -947,16 +1155,25 @@ func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> v
 		OK,
 		"应能构造绝对 sibling 未提交 final。"
 	)
-	var victim_marker: Dictionary = {
-		"schema_version": 1,
-		"transaction_id": "absolute-sibling",
-		"file_key": victim_file_name,
-		"files": declared_files,
-		"committed": false,
-		"had_final": true,
-	}
-	var outsider_marker: Dictionary = victim_marker.duplicate(true)
-	outsider_marker["file_key"] = outsider_path
+	assert_eq(
+		_storage._write_transaction_markers([victim_file_name], false),
+		OK,
+		"应能构造合法 v2 prepare marker。"
+	)
+	var victim_marker: Dictionary = _storage._read_transaction_marker(victim_file_name)
+	var victim_descriptor: Dictionary = _storage._make_family_descriptor(victim_file_name)
+	victim_marker["members"] = [
+		{
+			"logical_path": victim_file_name,
+			"family_id": GFVariantData.get_option_string(victim_descriptor, "family_id"),
+			"had_final": true,
+		},
+		{
+			"logical_path": unauthorized_member_path,
+			"family_id": "forged-absolute-family",
+			"had_final": true,
+		},
+	]
 	assert_eq(
 		_storage._write_plain_json(
 			_storage._get_transaction_filename(victim_file_name),
@@ -964,11 +1181,6 @@ func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> v
 		),
 		OK,
 		"应能构造相对目标 marker。"
-	)
-	assert_eq(
-		_storage._write_plain_json_absolute(outsider_path + ".txn", outsider_marker),
-		OK,
-		"应能构造互相一致的绝对 sibling marker。"
 	)
 
 	_storage.max_async_thread_count = 1
@@ -984,22 +1196,21 @@ func test_async_group_marker_cannot_expand_to_unapproved_absolute_sibling() -> v
 	assert_false(operation.get_result().is_successful(), "未授权事务成员应让目标读取 fail closed。")
 	assert_eq(
 		operation.get_result().get_error_code(),
-		ERR_UNAUTHORIZED,
-		"冻结的路径策略应稳定报告未授权。"
+		ERR_FILE_CORRUPT,
+		"包含非 portable logical path 的 v2 marker 应稳定报告损坏。"
 	)
 	assert_true(FileAccess.get_file_as_string(victim_path).contains("999"), "拒绝恢复时目标 final 不得被改写。")
-	assert_true(FileAccess.file_exists(victim_path + ".bak"), "拒绝恢复时目标 backup 不得被消费。")
-	assert_true(FileAccess.file_exists(victim_path + ".txn"), "拒绝恢复时目标 marker 不得被删除。")
+	assert_true(FileAccess.file_exists(victim_backup_path), "拒绝恢复时目标 backup 不得被消费。")
+	assert_true(FileAccess.file_exists(victim_marker_path), "拒绝恢复时目标 marker 不得被删除。")
 	assert_true(
 		FileAccess.get_file_as_string(outsider_path).contains("888"),
 		"未授权绝对 sibling 的 final 不得被事务恢复改写。"
 	)
-	assert_true(FileAccess.file_exists(outsider_path + ".bak"), "未授权绝对 sibling 的 backup 不得被消费。")
-	assert_true(FileAccess.file_exists(outsider_path + ".txn"), "未授权绝对 sibling 的 marker 不得被删除。")
+	assert_true(FileAccess.file_exists(outsider_backup_path), "未授权绝对 sibling 的 backup 不得被消费。")
 	assert_push_error(
 		"[GFStorageUtility] 异步读取失败：%s，原因：Transaction recovery failed，错误码：%s" % [
 			victim_file_name,
-			ERR_UNAUTHORIZED,
+			ERR_FILE_CORRUPT,
 		]
 	)
 
@@ -1034,7 +1245,7 @@ func test_frozen_async_task_rejects_absolute_storage_root() -> void:
 func test_save_data_group_removes_orphaned_files_when_member_write_fails() -> void:
 	var faulty_storage: FaultyStorageUtility = FaultyStorageUtility.new()
 	_replace_storage(faulty_storage)
-	_storage.save_dir_name = "test_saves"
+	_storage.save_dir_name = _save_dir_name
 	_storage.init()
 	var data_file_name: String = "group/data.json"
 	var metadata_file_name: String = "group/meta.json"
@@ -1062,7 +1273,7 @@ func test_save_data_group_preserves_existing_files_when_member_write_fails() -> 
 
 	var faulty_storage: FaultyStorageUtility = FaultyStorageUtility.new()
 	_replace_storage(faulty_storage)
-	_storage.save_dir_name = "test_saves"
+	_storage.save_dir_name = _save_dir_name
 	_storage.encrypt_key = 0
 	_storage.init()
 	faulty_storage.fail_on_file_name = _storage._get_temp_filename(metadata_file_name)
@@ -1106,10 +1317,12 @@ func test_data_group_transaction_recovery_rolls_back_partial_commit() -> void:
 		"应能模拟只提交了核心数据。",
 	)
 
-	_storage._recover_transaction_files(file_names)
+	assert_eq(_storage._recover_transaction_files(file_names), OK)
 
 	assert_eq(GFVariantData.get_option_int(_load_payload(data_file_name), "hp"), 10, "未完成事务恢复后应回滚数据文件。")
 	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "level"), 1, "未完成事务恢复后应回滚元数据文件。")
+	for file_name: String in file_names:
+		_assert_transaction_records_absent(file_name)
 
 
 func test_single_member_load_recovers_entire_partially_committed_group() -> void:
@@ -1135,12 +1348,17 @@ func test_single_member_load_recovers_entire_partially_committed_group() -> void
 	assert_eq(_storage._write_json(data_file_name, {"hp": 999}), OK, "应能模拟提交新数据文件。")
 	assert_eq(_storage._write_json(meta_file_name, {"level": 9}), OK, "应能模拟提交新元数据文件。")
 
-	var data_marker: Dictionary = _storage._read_transaction_marker(data_file_name)
-	data_marker["committed"] = true
 	assert_eq(
-		_storage._write_plain_json(_storage._get_transaction_filename(data_file_name), data_marker),
+		_storage._write_transaction_markers(file_names, true),
 		OK,
-		"应能模拟只写完一个 committed marker。"
+		"应能发布完整 v2 commit record set。"
+	)
+	assert_eq(
+		DirAccess.remove_absolute(
+			_storage._get_full_path(_storage._get_transaction_commit_filename(meta_file_name))
+		),
+		OK,
+		"应能模拟只发布一个成员 commit record 后崩溃。"
 	)
 
 	var loaded_data: Dictionary = _load_payload(data_file_name)
@@ -1148,10 +1366,7 @@ func test_single_member_load_recovers_entire_partially_committed_group() -> void
 	assert_eq(GFVariantData.get_option_int(loaded_data, "hp"), 10, "读取任一成员都应把整个未完整提交事务回滚到旧代次。")
 	assert_eq(GFVariantData.get_option_int(_load_payload(meta_file_name), "level"), 1, "同组其它成员不得保留新代次。")
 	for file_name: String in file_names:
-		assert_false(
-			FileAccess.file_exists(_storage._get_full_path(_storage._get_transaction_filename(file_name))),
-			"全组恢复后不应残留事务标记。"
-		)
+		_assert_transaction_records_absent(file_name)
 
 
 func test_async_single_member_load_recovers_entire_partially_committed_group() -> void:
@@ -1188,9 +1403,10 @@ func test_async_single_member_load_recovers_entire_partially_committed_group() -
 	)
 	var operation: GFStorageAsyncOperation = _storage.load_data_request_async(data_file_name)
 	assert_eq(_storage._async_queue.size(), 1, "目标读取应先保持排队，以验证冻结的事务根。")
-	_storage.save_dir_name = "test_saves_after_enqueue"
+	_storage.save_dir_name = _save_dir_name + "-other"
+	assert_eq(_storage.save_dir_name, _save_dir_name, "初始化后的 Storage root 不得发生漂移。")
+	assert_push_error("[GFStorageUtility] save_dir_name 已在 Storage 初始化后冻结；请为另一个 root 创建新的 Utility。")
 	_storage.wait_for_async_tasks()
-	_storage.save_dir_name = "test_saves"
 	var result: GFStorageReadResult = operation.get_result().get_read_result()
 
 	assert_true(blocker.get_result().is_successful(), "占位任务应正常完成。")
@@ -1206,10 +1422,7 @@ func test_async_single_member_load_recovers_entire_partially_committed_group() -
 		"同组其它成员不得保留未提交代次。"
 	)
 	for file_name: String in file_names:
-		assert_false(
-			FileAccess.file_exists(_storage._get_full_path(_storage._get_transaction_filename(file_name))),
-			"异步 I/O 前完成全组恢复后不应残留事务标记。"
-		)
+		_assert_transaction_records_absent(file_name)
 
 
 func test_async_group_recovery_preserves_markers_for_retry_after_restore_failure() -> void:
@@ -1247,7 +1460,6 @@ func test_async_group_recovery_preserves_markers_for_retry_after_restore_failure
 			FileAccess.file_exists(_storage._get_full_path(_storage._get_transaction_filename(file_name))),
 			"任一成员恢复失败后必须保留全组 marker 供幂等重试。"
 		)
-	assert_push_error("[GFStorageUtility] 回滚事务文件失败：")
 	assert_push_error("[GFStorageUtility] 异步读取失败：")
 	assert_eq(DirAccess.remove_absolute(blocked_final_path), OK, "解除模拟故障应成功。")
 
@@ -1263,66 +1475,75 @@ func test_async_group_recovery_preserves_markers_for_retry_after_restore_failure
 		"同组其它成员应保持旧代次。"
 	)
 	for file_name: String in file_names:
-		assert_false(
-			FileAccess.file_exists(_storage._get_full_path(_storage._get_transaction_filename(file_name))),
-			"全组重试成功后才应清理事务标记。"
-		)
+		_assert_transaction_records_absent(file_name)
 
 
-func test_load_data_restores_backup_when_primary_file_is_missing() -> void:
+func test_load_data_rejects_markerless_backup_without_mutation() -> void:
 	_storage.encrypt_key = 0
 	var file_name: String = "recover_from_backup.json"
 	var backup_file_name: String = _storage._get_backup_filename(file_name)
-	assert_eq(_storage._write_json(backup_file_name, {"hp": 77}), OK, "应能预先写入备份文件。")
-
-	var loaded: Dictionary = _load_payload(file_name)
+	assert_eq(_storage.save_data(file_name, { "hp": 77 }), OK, "应能 claim family 并写入已提交 payload。")
 	var final_path: String = _storage._get_full_path(file_name)
 	var backup_path: String = _storage._get_full_path(backup_file_name)
+	assert_eq(DirAccess.rename_absolute(final_path, backup_path), OK, "应能构造 markerless backup。")
+	var backup_before: PackedByteArray = FileAccess.get_file_as_bytes(backup_path)
 
-	assert_eq(GFVariantData.get_option_int(loaded, "hp"), 77, "主文件缺失但存在备份时，应自动恢复最近一次已提交的数据。")
-	assert_true(FileAccess.file_exists(final_path), "恢复后应重新生成主文件。")
-	assert_false(FileAccess.file_exists(backup_path), "恢复完成后不应残留备份文件。")
+	var result: GFStorageReadResult = _storage.load_data(file_name)
+
+	assert_eq(result.error_code, ERR_FILE_CORRUPT, "没有 v2 marker 的 backup 必须视为冲突。")
+	assert_eq(result.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_false(FileAccess.file_exists(final_path), "失败关闭不得猜测并恢复 final。")
+	assert_eq(FileAccess.get_file_as_bytes(backup_path), backup_before, "失败关闭不得消费 backup。")
 
 
-func test_load_data_promotes_temp_file_when_no_committed_file_exists() -> void:
+func test_load_data_rejects_markerless_candidate_without_mutation() -> void:
 	_storage.encrypt_key = 0
 	var file_name: String = "recover_from_temp.json"
 	var temp_file_name: String = _storage._get_temp_filename(file_name)
-	assert_eq(_storage._write_json(temp_file_name, {"hp": 88}), OK, "应能预先写入临时文件。")
-
-	var loaded: Dictionary = _load_payload(file_name)
+	assert_eq(_storage.save_data(file_name, { "hp": 1 }), OK, "应能 claim family。")
+	assert_eq(_storage.delete_file(file_name), OK, "应能留下合法的 empty claimed family。")
+	assert_eq(_storage._write_json(temp_file_name, {"hp": 88}), OK, "应能构造 markerless candidate。")
 	var final_path: String = _storage._get_full_path(file_name)
 	var temp_path: String = _storage._get_full_path(temp_file_name)
+	var candidate_before: PackedByteArray = FileAccess.get_file_as_bytes(temp_path)
 
-	assert_eq(GFVariantData.get_option_int(loaded, "hp"), 88, "仅存在临时文件时，应自动提升为正式文件。")
-	assert_true(FileAccess.file_exists(final_path), "恢复后应生成主文件。")
-	assert_false(FileAccess.file_exists(temp_path), "恢复完成后不应残留临时文件。")
+	var result: GFStorageReadResult = _storage.load_data(file_name)
+
+	assert_eq(result.error_code, ERR_FILE_CORRUPT, "没有 v2 marker 的 candidate 必须视为冲突。")
+	assert_eq(result.failure_kind, GFStorageReadResult.FailureKind.CORRUPT)
+	assert_false(FileAccess.file_exists(final_path), "失败关闭不得提升 candidate。")
+	assert_eq(FileAccess.get_file_as_bytes(temp_path), candidate_before, "失败关闭不得消费 candidate。")
 
 
-func test_load_data_discards_stale_temp_when_primary_file_already_exists() -> void:
+func test_load_data_rejects_markerless_candidate_beside_final_without_mutation() -> void:
 	_storage.encrypt_key = 0
 	var file_name: String = "recover_from_stale_temp.json"
 	var temp_file_name: String = _storage._get_temp_filename(file_name)
-	assert_eq(_storage._write_json(file_name, {"hp": 11}), OK, "应能预先写入主文件。")
-	assert_eq(_storage._write_json(temp_file_name, {"hp": 99}), OK, "应能预先写入悬挂临时文件。")
-
-	var loaded: Dictionary = _load_payload(file_name)
+	assert_eq(_storage.save_data(file_name, { "hp": 11 }), OK, "应能预先写入 committed payload。")
+	assert_eq(_storage._write_json(temp_file_name, {"hp": 99}), OK, "应能构造 markerless candidate。")
+	var final_path: String = _storage._get_full_path(file_name)
 	var temp_path: String = _storage._get_full_path(temp_file_name)
+	var final_before: PackedByteArray = FileAccess.get_file_as_bytes(final_path)
+	var candidate_before: PackedByteArray = FileAccess.get_file_as_bytes(temp_path)
 
-	assert_eq(GFVariantData.get_option_int(loaded, "hp"), 11, "已有主文件时，应优先保留已提交数据。")
-	assert_false(FileAccess.file_exists(temp_path), "恢复完成后应清理悬挂临时文件。")
+	var result: GFStorageReadResult = _storage.load_data(file_name)
+
+	assert_eq(result.error_code, ERR_FILE_CORRUPT, "final 旁的 markerless candidate 必须视为冲突。")
+	assert_eq(FileAccess.get_file_as_bytes(final_path), final_before, "失败关闭不得改写 final。")
+	assert_eq(FileAccess.get_file_as_bytes(temp_path), candidate_before, "失败关闭不得清理 candidate。")
 
 
 func test_transaction_commit_deduplicates_file_names() -> void:
 	_storage.encrypt_key = 0
 	var file_name: String = "duplicate_transaction.json"
+	assert_eq(_storage.save_data(file_name, { "hp": 1 }), OK, "应先建立合法 family ownership。")
 	assert_eq(_storage._write_json(_storage._get_temp_filename(file_name), {"hp": 42}), OK, "应能构造待提交临时文件。")
 
 	var error: Error = _storage._commit_transaction([file_name, file_name])
 
 	assert_eq(error, OK, "事务提交应忽略重复文件名。")
 	assert_eq(GFVariantData.get_option_int(_load_payload(file_name), "hp"), 42, "去重后的事务提交应产生正式文件。")
-	assert_false(FileAccess.file_exists(_storage._get_full_path(_storage._get_transaction_filename(file_name))), "提交完成后不应残留事务标记。")
+	_assert_transaction_records_absent(file_name)
 
 
 func test_integrity_checksum_rejects_tampered_data() -> void:
@@ -1351,7 +1572,7 @@ func test_integrity_checksum_rejects_tampered_data() -> void:
 	assert_false(loaded.ok, "严格校验失败时不应返回被篡改数据。")
 	assert_true(loaded.payload.is_empty(), "失败结果不得暴露可误用的被篡改数据。")
 	assert_signal_emitted(_storage, "data_integrity_failed", "校验失败应发出信号。")
-	assert_push_warning("[GFStorageUtility] 读取数据失败：user://test_saves/test_integrity.json，原因：Integrity checksum mismatch")
+	assert_push_warning("[GFStorageUtility] 读取数据失败：%s，原因：Integrity checksum mismatch" % path)
 
 
 func test_checksum_without_diagnostics_metadata_still_writes_data_version() -> void:
@@ -1378,6 +1599,7 @@ func test_checksum_enabled_rejects_missing_checksum_file_by_default() -> void:
 	_storage.strict_integrity = true
 	var file_name: String = "test_missing_checksum.json"
 	var codec: GFStorageCodec = GFStorageCodec.new()
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _store_buffer_result_509: Variant = file.store_buffer(codec.encode({ "coins": 10 }, { "obfuscation_key": 0 }))
 	file.close()
@@ -1388,7 +1610,9 @@ func test_checksum_enabled_rejects_missing_checksum_file_by_default() -> void:
 	assert_false(loaded.ok, "要求 checksum 时，缺少 checksum 的存档不应返回数据。")
 	assert_eq(loaded.integrity_status, GFStorageReadResult.IntegrityStatus.MISSING, "失败结果应区分缺少 checksum。")
 	assert_signal_emitted(_storage, "data_integrity_failed", "缺少 checksum 应发出完整性失败信号。")
-	assert_push_warning("[GFStorageUtility] 读取数据失败：user://test_saves/test_missing_checksum.json，原因：Integrity checksum missing")
+	assert_push_warning(
+		"[GFStorageUtility] 读取数据失败：%s，原因：Integrity checksum missing" % _storage._get_full_path(file_name)
+	)
 
 
 func test_missing_checksum_file_can_be_allowed_for_migration() -> void:
@@ -1398,6 +1622,7 @@ func test_missing_checksum_file_can_be_allowed_for_migration() -> void:
 	_storage.require_integrity_checksum = false
 	var file_name: String = "test_missing_checksum_migration.json"
 	var codec: GFStorageCodec = GFStorageCodec.new()
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _store_buffer_result_528: Variant = file.store_buffer(codec.encode({ "coins": 10 }, { "obfuscation_key": 0 }))
 	file.close()
@@ -1413,6 +1638,7 @@ func test_missing_checksum_file_can_be_allowed_for_migration() -> void:
 func test_plain_json_without_storage_document_is_rejected() -> void:
 	_storage.encrypt_key = 0
 	var file_name: String = "test_plain_json_strict.json"
+	_claim_file_family_for_fixture(file_name)
 	assert_eq(_storage._write_plain_json(file_name, { "coins": 10 }), OK, "应能构造非 GF 文档 JSON 文件。")
 	watch_signals(_storage)
 
@@ -1520,6 +1746,7 @@ func test_load_data_applies_version_defaults() -> void:
 	var file_name: String = "test_legacy_version.json"
 	var legacy_data: Dictionary = { "stats": {} }
 	var codec: GFStorageCodec = GFStorageCodec.new()
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _store_buffer_result_626: Variant = file.store_buffer(codec.encode(legacy_data, {
 		"obfuscation_key": 0,
@@ -1542,13 +1769,14 @@ func test_load_data_applies_version_defaults() -> void:
 
 func test_load_data_preserves_migrate_data_override_extension_point() -> void:
 	var override_storage: MigrationOverrideStorageUtility = MigrationOverrideStorageUtility.new()
-	override_storage.save_dir_name = "test_saves"
-	override_storage.init()
 	_replace_storage(override_storage)
+	_storage.save_dir_name = _save_dir_name
+	_storage.init()
 	_storage.encrypt_key = 0
 	_storage.save_version = 2
 	_storage.default_values_for_new_keys = {"framework_default": true}
 	var file_name: String = "test_migrate_override.json"
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _stored: Variant = file.store_buffer(GFStorageCodec.new().encode({ "value": 10 }, {
 		"obfuscation_key": 0,
@@ -1584,6 +1812,7 @@ func test_registered_migrations_run_as_version_chain() -> void:
 	), "应能注册 2 -> 3 迁移。")
 	var file_name: String = "test_registered_migration.json"
 	var codec: GFStorageCodec = GFStorageCodec.new()
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _store_buffer_result_654: Variant = file.store_buffer(codec.encode({ "value": 10 }, {
 		"obfuscation_key": 0,
@@ -1604,9 +1833,9 @@ func test_registered_migrations_run_as_version_chain() -> void:
 
 func test_registered_migration_wrong_return_type_fails_without_advancing_version() -> void:
 	var inherited_storage: InheritedMigrationStorageUtility = InheritedMigrationStorageUtility.new()
-	inherited_storage.save_dir_name = "test_saves"
-	inherited_storage.init()
 	_replace_storage(inherited_storage)
+	_storage.save_dir_name = _save_dir_name
+	_storage.init()
 	_storage.encrypt_key = 0
 	_storage.save_version = 2
 	assert_true(_storage.register_migration(1, 2, func(
@@ -1617,6 +1846,7 @@ func test_registered_migration_wrong_return_type_fails_without_advancing_version
 		return 7
 	))
 	var file_name: String = "test_failed_migration.json"
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _stored: Variant = file.store_buffer(GFStorageCodec.new().encode({"value": 10}, {
 		"obfuscation_key": 0,
@@ -1632,7 +1862,7 @@ func test_registered_migration_wrong_return_type_fails_without_advancing_version
 	assert_eq(result.data_version, 1)
 	assert_signal_not_emitted(_storage, "data_migrated")
 	assert_push_error(
-		"[GFStorageUtility] 读取数据失败：user://test_saves/test_failed_migration.json，原因：Migration step 1 -> 2 must return Dictionary."
+		"[GFStorageUtility] 读取数据失败：%s，原因：Migration step 1 -> 2 must return Dictionary." % _storage._get_full_path(file_name)
 	)
 
 
@@ -1652,6 +1882,7 @@ func test_migration_resolver_selects_reachable_shortest_path() -> void:
 		return data
 	), "应能注册目标迁移。")
 	var file_name: String = "test_branching_migration.json"
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _branching_store_result: Variant = file.store_buffer(GFStorageCodec.new().encode({}, {
 		"obfuscation_key": 0,
@@ -1670,6 +1901,7 @@ func test_future_storage_version_is_rejected_by_default() -> void:
 	_storage.encrypt_key = 0
 	_storage.save_version = 2
 	var file_name: String = "test_future_version.json"
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _future_store_result: Variant = file.store_buffer(GFStorageCodec.new().encode({ "future_only": true }, {
 		"obfuscation_key": 0,
@@ -1689,7 +1921,9 @@ func test_future_storage_version_is_rejected_by_default() -> void:
 		"未来版本失败原因应稳定。"
 	)
 	assert_signal_emitted(_storage, "data_integrity_failed", "未来版本拒绝应发出数据失败信号。")
-	assert_push_error("[GFStorageUtility] 读取数据失败：user://test_saves/test_future_version.json，原因：Unsupported future storage version: 5 > 2")
+	assert_push_error(
+		"[GFStorageUtility] 读取数据失败：%s，原因：Unsupported future storage version: 5 > 2" % _storage._get_full_path(file_name)
+	)
 
 
 func test_missing_registered_migration_chain_fails_without_marking_target_version() -> void:
@@ -1701,6 +1935,7 @@ func test_missing_registered_migration_chain_fails_without_marking_target_versio
 	), "应能注册不完整迁移链中的后半段。")
 	var file_name: String = "test_missing_migration_chain.json"
 	var codec: GFStorageCodec = GFStorageCodec.new()
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _store_buffer_result_682: Variant = file.store_buffer(codec.encode({ "value": 10 }, {
 		"obfuscation_key": 0,
@@ -1718,7 +1953,9 @@ func test_missing_registered_migration_chain_fails_without_marking_target_versio
 	assert_signal_emitted(_storage, "data_integrity_failed", "缺失迁移链应发出数据失败信号。")
 	assert_signal_not_emitted(_storage, "data_migrated", "缺失迁移链不应发出迁移成功信号。")
 	assert_push_warning("[GFStorageUtility] 未找到完整迁移链：1 -> 3。")
-	assert_push_error("[GFStorageUtility] 读取数据失败：user://test_saves/test_missing_migration_chain.json，原因：Missing migration chain: 1 -> 3")
+	assert_push_error(
+		"[GFStorageUtility] 读取数据失败：%s，原因：Missing migration chain: 1 -> 3" % _storage._get_full_path(file_name)
+	)
 
 
 func test_strict_schema_migrations_rejects_version_bump_without_registered_steps() -> void:
@@ -1727,6 +1964,7 @@ func test_strict_schema_migrations_rejects_version_bump_without_registered_steps
 	_storage.strict_schema_migrations = true
 	var file_name: String = "test_strict_migration_chain.json"
 	var codec: GFStorageCodec = GFStorageCodec.new()
+	_claim_file_family_for_fixture(file_name)
 	var file: FileAccess = FileAccess.open(_storage._get_full_path(file_name), FileAccess.WRITE)
 	var _store_buffer_result_709: Variant = file.store_buffer(codec.encode({ "value": 10 }, {
 		"obfuscation_key": 0,
@@ -1743,7 +1981,9 @@ func test_strict_schema_migrations_rejects_version_bump_without_registered_steps
 	assert_eq(_storage.last_load_result.error, "Missing migration chain: 1 -> 2", "失败原因应指出缺失链路。")
 	assert_signal_emitted(_storage, "data_integrity_failed", "严格迁移失败应发出数据失败信号。")
 	assert_signal_not_emitted(_storage, "data_migrated", "严格迁移失败不应发出迁移成功信号。")
-	assert_push_error("[GFStorageUtility] 读取数据失败：user://test_saves/test_strict_migration_chain.json，原因：Missing migration chain: 1 -> 2")
+	assert_push_error(
+		"[GFStorageUtility] 读取数据失败：%s，原因：Missing migration chain: 1 -> 2" % _storage._get_full_path(file_name)
+	)
 
 
 func test_storage_backend_default_contract_and_conflict_report_roundtrip() -> void:

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_utility.gd
@@ -387,6 +387,31 @@ func test_save_data_group_rejects_non_string_key_before_claiming_any_family() ->
 	assert_push_error("[GFStorageUtility] save_data_group 失败：文件名键必须是 String。")
 
 
+func test_save_data_group_rejects_oversized_group_before_claiming_any_family() -> void:
+	var files: Dictionary = {}
+	var descriptors: Array[Dictionary] = []
+	for index: int in range(65):
+		var file_name: String = "oversized/member_%02d.json" % index
+		files[file_name] = {"value": index}
+		descriptors.append(_storage._make_family_descriptor(file_name))
+
+	assert_eq(_storage.save_data_group(files), ERR_INVALID_PARAMETER)
+	assert_push_error("[GFStorageUtility] save_data_group 失败：成员数超过上限 64。")
+	for descriptor: Dictionary in descriptors:
+		assert_false(
+			FileAccess.file_exists(
+				GFVariantData.get_option_string(descriptor, "catalog_path")
+			),
+			"超限 group 不得创建 catalog tombstone。"
+		)
+		assert_false(
+			FileAccess.file_exists(
+				GFVariantData.get_option_string(descriptor, "owner_path")
+			),
+			"超限 group 不得创建 owner tombstone。"
+		)
+
+
 func test_portable_logical_file_path_profile_rejects_noncanonical_identities() -> void:
 	var overlong_segment: String = "a".repeat(65) + ".json"
 	var overlong_path: String = "/".join([


### PR DESCRIPTION
## Summary

- move Storage payloads and transaction evidence into a private `.gf-storage/v1` family namespace backed by a sharded catalog and reciprocal owner records
- require strict `portable-ascii-v1` logical identities, keep `.tmp` / `.bak` / `.txn` as independent logical files, and never auto-adopt legacy root-visible files
- make transaction recovery fail closed across prepare/commit crash windows and project `list_files()` from committed catalog state
- migrate Save slot integration to logical `has_file()` and metadata `updated_at_unix`, with generated API references, package metadata, migration docs, and focused recovery tests updated

## Why

The prior sidecar layout allowed a public logical file such as `foo.tmp` to overlap the transaction sidecar for `foo`, creating ambiguous ownership and possible cross-file deletion. The new layout gives each logical identity one auditable family and separates public naming from physical transaction files.

## Developer impact

This is an intentional 11.0 breaking migration: runtime Storage no longer exposes absolute-path or physical-directory APIs, paths must already satisfy the portable profile, `save_dir_name` freezes on activation / `init()` / first valid I/O, and legacy visible files require an explicit offline migration.

## Validation

- `python tools/gf_maintenance.py check --suite full --jobs 3 --json` — 46/46 passed on commit `79c71bad`, 0 not started
- post-rebase focused Storage, recovery, payload-transfer, and Save slot GUT suites
- API Reference / AI Developer index generation checks
- independent runtime, contract, and security review: blocker 0

Refs #87
