### PR TITLE
docs: improve repository page and community policies

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Funding links displayed by GitHub's Sponsor button.
+custom: ["https://www.paypal.com/paypalme/C76GN"]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,9 +60,10 @@ appointed representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement through the
-[C76GN GitHub profile](https://github.com/C76GN). All complaints will be
-reviewed and investigated promptly and fairly.
+reported to the community leaders responsible for enforcement by emailing
+[`cl7o6dgyn@gmail.com`](mailto:cl7o6dgyn@gmail.com) with the subject
+`[GF Code of Conduct] Private report`. All complaints will be reviewed and
+investigated promptly and fairly.
 
 Community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contribute to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Respecting differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political
+  attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action
+in response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting through an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through the
+[C76GN GitHub profile](https://github.com/C76GN). All complaints will be
+reviewed and investigated promptly and fairly.
+
+Community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant][homepage], version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 English | [简体中文](README.zh.md)
 
+[![CI](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml)
+[![Docs](https://readthedocs.org/projects/gf-framework/badge/?version=latest)](https://gf-framework.readthedocs.io/)
+[![Latest release](https://img.shields.io/github/v/release/C76GN/gf-framework?display_name=tag&sort=semver)](https://github.com/C76GN/gf-framework/releases/latest)
+[![License](https://img.shields.io/github/license/C76GN/gf-framework)](LICENSE.md)
+[![Godot 4.7+](https://img.shields.io/badge/Godot-4.7%2B-478CBF?logo=godotengine&logoColor=white)](https://godotengine.org/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/C76GN/gf-framework)
+
 GF Framework is a lightweight game architecture framework for Godot 4. It separates data, logic, presentation, runtime services, and pure algorithm helpers so larger projects can keep predictable lifecycles, clear dependency boundaries, and testable gameplay code.
 
 ## Documentation
@@ -13,6 +20,12 @@ GF Framework is a lightweight game architecture framework for Godot 4. It separa
 - Contribution workflow: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 The legacy GitHub Wiki keeps only entry links. Read the Docs is the single official documentation source.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=C76GN/gf-framework&type=date&legend=top-left)](https://www.star-history.com/?repos=C76GN%2Fgf-framework&type=date&legend=top-left)
+
+The chart is served by Star History. GitHub's current stargazer API policy may require a repository-scoped token for fresh history data; if the image stops updating, open the linked chart and regenerate its README embed from Star History.
 
 ## Requirements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,6 +2,13 @@
 
 [English](README.md) | 简体中文
 
+[![CI](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml)
+[![文档](https://readthedocs.org/projects/gf-framework/badge/?version=latest)](https://gf-framework.readthedocs.io/)
+[![最新版本](https://img.shields.io/github/v/release/C76GN/gf-framework?display_name=tag&sort=semver)](https://github.com/C76GN/gf-framework/releases/latest)
+[![许可证](https://img.shields.io/github/license/C76GN/gf-framework)](LICENSE.md)
+[![Godot 4.7+](https://img.shields.io/badge/Godot-4.7%2B-478CBF?logo=godotengine&logoColor=white)](https://godotengine.org/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/C76GN/gf-framework)
+
 GF Framework 是一个面向 Godot 4 的轻量级游戏架构框架。它把数据、逻辑、表现、运行时服务和纯算法基础件拆开管理，让规模更大的项目仍然能保持可预测的生命周期、清晰的依赖边界和可测试的玩法代码。
 
 ## 文档
@@ -13,6 +20,12 @@ GF Framework 是一个面向 Godot 4 的轻量级游戏架构框架。它把数�
 - 贡献与协作流程：[`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 旧 GitHub Wiki 只保留入口链接。Read the Docs 是唯一正式文档来源。
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=C76GN/gf-framework&type=date&legend=top-left)](https://www.star-history.com/?repos=C76GN%2Fgf-framework&type=date&legend=top-left)
+
+该图表由 Star History 提供。GitHub 当前的 stargazer API 政策可能要求仓库级 token 才能获取最新历史；如果图片停止更新，可以打开上面的图表链接，并在 Star History 页面重新生成 README 嵌入代码。
 
 ## 环境要求
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are prioritized for the latest stable release and the current
+`main` branch. Older releases are not backported automatically.
+
+| Version | Supported |
+| --- | --- |
+| Latest stable release | Yes |
+| `main` | Yes |
+| Older releases | No |
+
+For production use, install the latest release published on the
+[Releases page](https://github.com/C76GN/gf-framework/releases).
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities in a public issue, discussion,
+or pull request.
+
+Use GitHub's private vulnerability reporting form:
+
+<https://github.com/C76GN/gf-framework/security/advisories/new>
+
+If private reporting is unavailable, contact the maintainers through the
+[C76GN GitHub profile](https://github.com/C76GN) and clearly mark the message
+as a confidential security report.
+
+Include, where possible:
+
+- the affected version or commit;
+- a concise description of the impact;
+- reproduction steps or a minimal proof of concept;
+- the affected component and configuration; and
+- any suggested mitigation.
+
+Please redact credentials, private source code, personal data, and
+unredacted production logs. The maintainers will acknowledge valid reports
+and coordinate follow-up through GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,10 @@ Use GitHub's private vulnerability reporting form:
 
 <https://github.com/C76GN/gf-framework/security/advisories/new>
 
-If private reporting is unavailable, contact the maintainers through the
-[C76GN GitHub profile](https://github.com/C76GN) and clearly mark the message
-as a confidential security report.
+If private reporting is unavailable, email
+[`cl7o6dgyn@gmail.com`](mailto:cl7o6dgyn@gmail.com) with the subject
+`[GF Security] Confidential vulnerability report`. Please do not include
+secrets or a full exploit in the subject line.
 
 Include, where possible:
 


### PR DESCRIPTION
## Summary

- add CI, documentation, release, license, Godot, Ask DeepWiki, and Star History links to both README entry points;
- add the PayPal Sponsor button link through `.github/FUNDING.yml`;
- add supported-version and private-vulnerability-reporting guidance in `SECURITY.md`;
- add Contributor Covenant 2.1 in `CODE_OF_CONDUCT.md`.

Repository administration was also aligned separately with the GF policy: `GF repository policy` and `GF merge gate` are required on `main`, and stable SemVer tags are protected against deletion and non-fast-forward updates.

## Validation

- `python tools/check_docs_quality.py --strict` — passed (449 pages);
- `python tools/gf_maintenance.py check --check diff --check path_hygiene --check public_docs_boundary --check public_api_boundary --json` — passed;
- local quick-suite execution timed out because an existing Godot/maintenance process occupied the local validation environment; no failure was reported by the completed static checks.