### PR TITLE
docs: replace Star History with stable stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ English | [简体中文](README.zh.md)
 [![CI](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml)
 [![Docs](https://readthedocs.org/projects/gf-framework/badge/?version=latest)](https://gf-framework.readthedocs.io/)
 [![Latest release](https://img.shields.io/github/v/release/C76GN/gf-framework?display_name=tag&sort=semver)](https://github.com/C76GN/gf-framework/releases/latest)
+[![GitHub stars](https://img.shields.io/github/stars/C76GN/gf-framework?style=flat&logo=github)](https://github.com/C76GN/gf-framework)
 [![License](https://img.shields.io/github/license/C76GN/gf-framework)](LICENSE.md)
 [![Godot 4.7+](https://img.shields.io/badge/Godot-4.7%2B-478CBF?logo=godotengine&logoColor=white)](https://godotengine.org/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/C76GN/gf-framework)
@@ -20,12 +21,6 @@ GF Framework is a lightweight game architecture framework for Godot 4. It separa
 - Contribution workflow: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 The legacy GitHub Wiki keeps only entry links. Read the Docs is the single official documentation source.
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=C76GN/gf-framework&type=date&legend=top-left)](https://www.star-history.com/?repos=C76GN%2Fgf-framework&type=date&legend=top-left)
-
-The chart is served by Star History. GitHub's current stargazer API policy may require a repository-scoped token for fresh history data; if the image stops updating, open the linked chart and regenerate its README embed from Star History.
 
 ## Requirements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/C76GN/gf-framework/actions/workflows/ci.yml)
 [![文档](https://readthedocs.org/projects/gf-framework/badge/?version=latest)](https://gf-framework.readthedocs.io/)
 [![最新版本](https://img.shields.io/github/v/release/C76GN/gf-framework?display_name=tag&sort=semver)](https://github.com/C76GN/gf-framework/releases/latest)
+[![GitHub Stars](https://img.shields.io/github/stars/C76GN/gf-framework?style=flat&logo=github)](https://github.com/C76GN/gf-framework)
 [![许可证](https://img.shields.io/github/license/C76GN/gf-framework)](LICENSE.md)
 [![Godot 4.7+](https://img.shields.io/badge/Godot-4.7%2B-478CBF?logo=godotengine&logoColor=white)](https://godotengine.org/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/C76GN/gf-framework)
@@ -20,12 +21,6 @@ GF Framework 是一个面向 Godot 4 的轻量级游戏架构框架。它把数�
 - 贡献与协作流程：[`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 旧 GitHub Wiki 只保留入口链接。Read the Docs 是唯一正式文档来源。
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=C76GN/gf-framework&type=date&legend=top-left)](https://www.star-history.com/?repos=C76GN%2Fgf-framework&type=date&legend=top-left)
-
-该图表由 Star History 提供。GitHub 当前的 stargazer API 政策可能要求仓库级 token 才能获取最新历史；如果图片停止更新，可以打开上面的图表链接，并在 Star History 页面重新生成 README 嵌入代码。
 
 ## 环境要求
 


### PR DESCRIPTION
## Summary

- remove the Star History live chart that now renders GitHub's restricted star-data placeholder;
- add a stable GitHub Stars badge to both English and Chinese README entry points;
- keep the badge linked to the repository homepage rather than the restricted stargazers view.

## Validation

- `python tools/check_docs_quality.py --strict` — passed (449 pages);
- `python tools/gf_maintenance.py check --check diff --check path_hygiene --check public_docs_boundary --check public_api_boundary --json` — passed;
- Shields badge endpoint returned HTTP 200 with SVG content.