### PR TITLE
Fix asset group cache ownership

### DIFF
--- a/addons/gf/standard/utilities/assets/gf_asset_utility.gd
+++ b/addons/gf/standard/utilities/assets/gf_asset_utility.gd
@@ -781,22 +781,29 @@ func preload_group_async(
 ## [br]
 ## @api public
 ## [br]
+## @since 1.31.0
+## [br]
 ## @param group_id: 分组标识。
 ## [br]
-## @param remove_unreferenced_cache: 是否移除没有句柄引用的缓存项。
+## @param remove_unreferenced_cache: 是否在没有句柄引用、剩余 pin 或其他分组 membership 时移除缓存项。该选项不会删除其他分组的 membership；未 pin 的分组本身不阻止正常 LRU 淘汰。
 func unload_group(group_id: StringName, remove_unreferenced_cache: bool = false) -> void:
-	var cache_keys: Dictionary = _get_group_path_map(group_id)
-	var pin_counts: Dictionary = _get_group_pin_map(group_id)
-	for cache_key: String in cache_keys.keys():
-		var path: String = _get_public_path_for_cache_key(cache_key)
-		var pin_count: int = _get_count_value(pin_counts, cache_key)
-		for _i: int in range(pin_count):
-			unpin_cache(path)
-		if remove_unreferenced_cache and get_asset_reference_count(path) <= 0:
-			remove_cache(path)
-
+	var cache_keys: Dictionary = _get_group_path_map(group_id).duplicate()
+	var pin_counts: Dictionary = _get_group_pin_map(group_id).duplicate()
 	_erase_dictionary_key(_group_paths, group_id)
 	_erase_dictionary_key(_group_pin_counts, group_id)
+	for cache_key: String in cache_keys.keys():
+		var pin_count: int = _get_count_value(pin_counts, cache_key)
+		for _i: int in range(pin_count):
+			_unpin_cache_key(cache_key)
+		if not remove_unreferenced_cache:
+			continue
+		if _get_count_value(_reference_counts, cache_key) > 0:
+			continue
+		if _get_count_value(_pinned_cache_paths, cache_key) > 0:
+			continue
+		if _is_cache_key_registered_in_any_group(cache_key):
+			continue
+		_remove_cache_by_key(cache_key)
 
 
 ## 驱动异步加载轮询。
@@ -958,16 +965,7 @@ func remove_cache(path: String) -> void:
 	var cache_key: String = _get_cache_key_for_path(path)
 	if cache_key.is_empty():
 		return
-	if _cache.has(cache_key):
-		_cache_diagnostics.record_invalidation(&"manual_remove", cache_key)
-	_release_handles_for_path(path)
-	_erase_dictionary_key(_cache, cache_key)
-	_erase_dictionary_key(_cache_access_order, cache_key)
-	_erase_dictionary_key(_pinned_cache_paths, cache_key)
-	_erase_dictionary_key(_reference_counts, cache_key)
-	_erase_dictionary_key(_owner_reference_counts, cache_key)
-	_remove_path_from_groups(path)
-	_erase_dictionary_key(_resource_identities, cache_key)
+	_remove_cache_by_key(cache_key)
 
 
 ## 清空全部缓存。
@@ -1218,6 +1216,24 @@ func _put_cache_by_key(cache_key: String, path: String, resource: Resource) -> v
 	_evict_lru()
 
 
+func _remove_cache_by_key(
+	cache_key: String,
+	invalidation_reason: StringName = &"manual_remove"
+) -> void:
+	if cache_key.is_empty():
+		return
+	if _cache.has(cache_key):
+		_cache_diagnostics.record_invalidation(invalidation_reason, cache_key)
+	_release_handles_for_cache_key(cache_key)
+	_erase_dictionary_key(_cache, cache_key)
+	_erase_dictionary_key(_cache_access_order, cache_key)
+	_erase_dictionary_key(_pinned_cache_paths, cache_key)
+	_erase_dictionary_key(_reference_counts, cache_key)
+	_erase_dictionary_key(_owner_reference_counts, cache_key)
+	_remove_cache_key_from_groups(cache_key)
+	_erase_dictionary_key(_resource_identities, cache_key)
+
+
 func _get_pending_type_hint(pending_request: Dictionary) -> String:
 	return GFVariantData.get_option_string(pending_request, "type_hint", "")
 
@@ -1310,6 +1326,16 @@ func _get_group_path_map(group_id: StringName) -> Dictionary:
 
 func _get_group_pin_map(group_id: StringName) -> Dictionary:
 	return _get_dictionary_reference(_group_pin_counts, group_id)
+
+
+func _is_cache_key_registered_in_any_group(cache_key: String) -> bool:
+	if cache_key.is_empty():
+		return false
+	for group_paths_value: Variant in _group_paths.values():
+		var group_paths: Dictionary = GFVariantData.as_dictionary(group_paths_value)
+		if group_paths.has(cache_key):
+			return true
+	return false
 
 
 func _get_count_value(source: Dictionary, key: Variant) -> int:
@@ -1838,8 +1864,7 @@ func _release_all_handles() -> void:
 	_handle_refs.clear()
 
 
-func _release_handles_for_path(path: String) -> void:
-	var cache_key: String = _get_cache_key_for_path(path)
+func _release_handles_for_cache_key(cache_key: String) -> void:
 	for index: int in range(_handle_refs.size() - 1, -1, -1):
 		var handle: GFAssetHandle = _get_asset_handle_value(_handle_refs[index].get_ref())
 		if handle == null or handle.is_released():
@@ -1885,8 +1910,7 @@ func _release_owner_id(owner_id: int) -> int:
 	return released_count
 
 
-func _remove_path_from_groups(path: String) -> void:
-	var cache_key: String = _get_cache_key_for_path(path)
+func _remove_cache_key_from_groups(cache_key: String) -> void:
 	if cache_key.is_empty():
 		return
 	for group_id: Variant in _group_paths.keys():

--- a/docs/api_catalog/classes/GFAssetUtility.xml
+++ b/docs/api_catalog/classes/GFAssetUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFAssetUtility" path="addons/gf/standard/utilities/assets/gf_asset_utility.gd" module="standard" extends="GFUtility" classDigest="1cfab593f1be50da2c5bbdde54fd534881f1c4eb6425a944e841205b2601f7ff">
+<class name="GFAssetUtility" path="addons/gf/standard/utilities/assets/gf_asset_utility.gd" module="standard" extends="GFUtility" classDigest="91b2331c8f3ae5e1625fd0bc4dc38d72322fb1b844c0b121a926835be663c9f8">
 	<description>GFAssetUtility: 异步资源加载管理器，带 LRU 缓存。
 封装 Godot 的 threaded `ResourceLoader` 请求，
 用于避免大资源同步加载阻塞主线程，并在完成后统一分发回调与维护缓存。</description>
@@ -311,7 +311,8 @@ set_resource_broker()；本入口只适合单个独立 Utility。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">group_id: 分组标识。</tag>
-				<tag name="param">remove_unreferenced_cache: 是否移除没有句柄引用的缓存项。</tag>
+				<tag name="param">remove_unreferenced_cache: 是否在没有句柄引用、剩余 pin 或其他分组 membership 时移除缓存项。该选项不会删除其他分组的 membership；未 pin 的分组本身不阻止正常 LRU 淘汰。</tag>
+				<tag name="since">1.31.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="tick">

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="6f808d9c8cee8467606b0f259983752acc585e17737c57ffd105a5201f75cf1c" classCount="840" methodCount="7644">
+<apiCatalog schemaVersion="2" name="GF Framework" sourceRoot="addons/gf" sourceDigest="890028dcfb926e44a457995f5002abbcfb3ff0765760a1a1f34b51cdcb416f09" classCount="840" methodCount="7644">
 	<module id="kernel" label="Kernel" classCount="74" methodCount="799">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -179,6 +179,8 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFAssetUtility.unload_group(..., true)` 在句柄引用归零时直接执行全局缓存移除、从而清掉其他分组 membership 与 pin 的问题；分组卸载现在只释放本组账本，并仅在句柄、剩余 pin 和其他分组 membership 全部归零时 eager remove。未 pin membership 仍不改变正常 LRU 语义。
+
 - 修复 Architecture activation 静默恢复 Settings 后 Display 仍停留在 ready 阶段默认值，以及多 target quiesce 在首个同步 Store write 取消 scope 后仍启动后续 I/O；Display 只在加载结果实际替换状态且 `apply_on_ready=true` 时重应用完整状态，已开始的 write 如实结算而未尝试记录保留供显式重试。
 
 - 修复 Viewport 表面输入把合法 `UV=1.0` 投到右/下排他边界、端点特判造成接近 `1.0` 时非单调跳变、双击历史预算淘汰错误推进无关 capture dispatch epoch，以及 `cancel_source()` 遗留已释放指针状态或未使同步旧投递失效的问题；同时修复 Layered Sprite 的 `animation_started` 监听器只改变播放态时吞掉已提交通知，以及帧/配置身份 ABA 后外层重复发布陈旧 `frame_changed` 的问题。

--- a/docs/zh/reference/api/classes/GFAssetUtility.md
+++ b/docs/zh/reference/api/classes/GFAssetUtility.md
@@ -628,6 +628,7 @@ func preload_group_async( group_id: StringName, entries: Array, on_completed: Ca
 ### `unload_group`
 
 - API：`public`
+- 首次版本：`1.31.0`
 
 ```gdscript
 func unload_group(group_id: StringName, remove_unreferenced_cache: bool = false) -> void:
@@ -640,7 +641,7 @@ func unload_group(group_id: StringName, remove_unreferenced_cache: bool = false)
 | 名称 | 说明 |
 |---|---|
 | `group_id` | 分组标识。 |
-| `remove_unreferenced_cache` | 是否移除没有句柄引用的缓存项。 |
+| `remove_unreferenced_cache` | 是否在没有句柄引用、剩余 pin 或其他分组 membership 时移除缓存项。该选项不会删除其他分组的 membership；未 pin 的分组本身不阻止正常 LRU 淘汰。 |
 
 <a id="member-gfassetutility-methods-tick"></a>
 

--- a/docs/zh/standard/utilities/io/assets-jobs-warmup/asset-utility/handles-groups.md
+++ b/docs/zh/standard/utilities/io/assets-jobs-warmup/asset-utility/handles-groups.md
@@ -55,6 +55,8 @@ assets.preload_group_async(
 
 未显式指定 `lane_id` 时，分组 ID 会作为通道名，因此同一组内部可以串行或限流加载，而不同组仍可独立调度。分组只表达资源集合和加载约束，不表达 UI 包、关卡包或主题包的业务含义。
 
+`unload_group(group_id, true)` 只释放指定分组的 membership 与该组建立的 pin。只有同一路径已经没有句柄引用、任何剩余 pin 和其他分组 membership 时，工具才会立即移除缓存；卸载一个分组不会擦除另一个分组的账本。`pin=false` 的 membership 仍然只表示分组归属，不提供缓存保留能力，因此资源在超过容量时仍可被正常 LRU 淘汰；需要稳定保留时应使用分组 pin、手动 pin 或 `GFAssetHandle`。
+
 ## 可保存的预热计划
 
 当预热清单需要放进 `.tres`、编辑器配置或项目级 manifest 时，用 `GFAssetPreloadPlan` 保存计划，再委托 `preload_plan_async()` 执行。计划会保留禁用条目并提供 `validate()` 报告；实际加载仍复用分组预热、缓存 pin 和 lane 限流机制。

--- a/tests/gf_core/standard/utilities/assets/test_gf_asset_utility.gd
+++ b/tests/gf_core/standard/utilities/assets/test_gf_asset_utility.gd
@@ -253,6 +253,232 @@ func test_preload_group_async_registers_and_unloads_group() -> void:
 	assert_false(_utility.is_cached("res://item_a.tres"), "remove_unreferenced_cache 开启时无引用缓存应移除。")
 
 
+func test_unload_group_preserves_other_pinned_group_in_both_orders() -> void:
+	var canonical_path: String = (
+		"res://addons/gf/standard/utilities/assets/gf_resource_identity.gd"
+	)
+	var uid_path: String = _uid_path_for(canonical_path)
+	assert_false(uid_path.is_empty(), "跨别名分组测试资源应存在 Godot UID。")
+	var scenarios: Array[Dictionary] = [
+		{
+			"cache_path": "res://shared_group_a_first.tres",
+			"group_a_path": "res://shared_group_a_first.tres",
+			"group_b_path": "res://shared_group_a_first.tres",
+			"public_path": "res://shared_group_a_first.tres",
+			"group_a": &"shared_a_first_a",
+			"group_b": &"shared_a_first_b",
+			"first_group": &"shared_a_first_a",
+			"remaining_group": &"shared_a_first_b",
+		},
+		{
+			"cache_path": uid_path,
+			"group_a_path": uid_path,
+			"group_b_path": canonical_path,
+			"public_path": canonical_path,
+			"group_a": &"shared_b_first_a",
+			"group_b": &"shared_b_first_b",
+			"first_group": &"shared_b_first_b",
+			"remaining_group": &"shared_b_first_a",
+		},
+	]
+
+	for scenario: Dictionary in scenarios:
+		var cache_path: String = GFVariantData.get_option_string(scenario, "cache_path")
+		var group_a_path: String = GFVariantData.get_option_string(
+			scenario,
+			"group_a_path"
+		)
+		var group_b_path: String = GFVariantData.get_option_string(
+			scenario,
+			"group_b_path"
+		)
+		var public_path: String = GFVariantData.get_option_string(scenario, "public_path")
+		var group_a: StringName = GFVariantData.get_option_string_name(scenario, "group_a")
+		var group_b: StringName = GFVariantData.get_option_string_name(scenario, "group_b")
+		var first_group: StringName = GFVariantData.get_option_string_name(
+			scenario,
+			"first_group"
+		)
+		var remaining_group: StringName = GFVariantData.get_option_string_name(
+			scenario,
+			"remaining_group"
+		)
+		_utility.put_cache(cache_path, Resource.new())
+		_utility.register_group_path(group_a, group_a_path, true)
+		_utility.register_group_path(group_b, group_b_path, true)
+
+		_utility.unload_group(first_group, true)
+
+		assert_true(
+			_utility.get_group_paths(remaining_group).has(public_path),
+			"卸载一个 pinned 分组不得移除另一分组的 canonical membership。"
+		)
+		assert_true(_utility.is_cached(cache_path), "其他 pinned 分组存活时缓存必须保留。")
+		assert_true(_utility.is_cache_pinned(public_path), "其他分组的 pin 必须保留。")
+
+		_utility.unload_group(remaining_group, true)
+
+		assert_false(_utility.is_cached(cache_path), "最后一个无引用 owner 卸载后应 eager remove。")
+
+
+func test_unload_group_preserves_unpinned_group_membership() -> void:
+	var path: String = "res://shared_pinned_unpinned.tres"
+	_utility.put_cache(path, Resource.new())
+	_utility.register_group_path(&"pinned_owner", path, true)
+	_utility.register_group_path(&"membership_owner", path, false)
+
+	_utility.unload_group(&"pinned_owner", true)
+
+	assert_true(
+		_utility.get_group_paths(&"membership_owner").has(path),
+		"未 pin 的其他分组仍然拥有 membership。"
+	)
+	assert_true(_utility.is_cached(path), "正常容量下其他分组 membership 应阻止 eager remove。")
+	assert_false(_utility.is_cache_pinned(path), "已卸载分组的 pin 应被释放。")
+
+	_utility.unload_group(&"membership_owner", true)
+
+	assert_false(_utility.is_cached(path), "最后一个未 pin owner 卸载后应 eager remove。")
+
+
+func test_unload_group_preserves_manual_pin() -> void:
+	var path: String = "res://group_with_manual_pin.tres"
+	_utility.put_cache(path, Resource.new())
+	_utility.pin_cache(path)
+	_utility.register_group_path(&"group_pin", path, true)
+
+	_utility.unload_group(&"group_pin", true)
+
+	assert_true(_utility.is_cached(path), "分组卸载不得移除仍被手动 pin 的缓存。")
+	assert_true(_utility.is_cache_pinned(path), "手动 pin 不得被分组卸载清除。")
+	assert_true(_utility.get_group_paths(&"group_pin").is_empty())
+
+	_utility.unpin_cache(path)
+
+	assert_false(_utility.is_cache_pinned(path))
+	assert_true(_utility.is_cached(path), "手动 unpin 本身不改变显式 remove_cache 语义。")
+
+
+func test_unload_group_preserves_active_handle() -> void:
+	var path: String = "res://group_with_handle.tres"
+	var handle: GFAssetHandle = _utility.acquire_handle(
+		path,
+		null,
+		&"",
+		"",
+		Resource.new()
+	)
+	_utility.register_group_path(&"handle_group", path, true)
+
+	_utility.unload_group(&"handle_group", true)
+
+	assert_not_null(handle)
+	assert_true(handle.is_valid(), "活跃 handle 必须阻止分组 eager remove。")
+	assert_eq(_utility.get_asset_reference_count(path), 1)
+	assert_true(_utility.is_cached(path))
+	assert_true(_utility.is_cache_pinned(path), "handle pin 必须在分组 pin 释放后保留。")
+	assert_true(handle.release())
+
+
+func test_unload_group_releases_repeated_group_pins_without_eager_removal() -> void:
+	var path: String = "res://repeated_group_pin.tres"
+	_utility.put_cache(path, Resource.new())
+	_utility.register_group_path(&"repeated", path, true)
+	_utility.register_group_path(&"repeated", path, true)
+
+	_utility.unload_group(&"repeated", false)
+
+	assert_true(_utility.get_group_paths(&"repeated").is_empty())
+	assert_false(_utility.is_cache_pinned(path), "同组重复 pin 必须按记录次数全部释放。")
+	assert_true(_utility.is_cached(path), "remove_unreferenced_cache=false 必须保留缓存。")
+
+
+func test_unload_group_without_eager_removal_keeps_last_cache() -> void:
+	var path: String = "res://last_group_without_eager_remove.tres"
+	_utility.put_cache(path, Resource.new())
+	_utility.register_group_path(&"last_without_remove", path, true)
+
+	_utility.unload_group(&"last_without_remove", false)
+
+	assert_true(_utility.get_group_paths(&"last_without_remove").is_empty())
+	assert_false(_utility.is_cache_pinned(path))
+	assert_true(_utility.is_cached(path), "关闭 eager remove 时最后一组卸载也应保留缓存。")
+
+
+func test_unload_last_unowned_group_eagerly_removes_cache() -> void:
+	var path: String = "res://last_unowned_group.tres"
+	_utility.put_cache(path, Resource.new())
+	_utility.register_group_path(&"last_owner", path, true)
+
+	_utility.unload_group(&"last_owner", true)
+
+	assert_true(_utility.get_group_paths(&"last_owner").is_empty())
+	assert_false(_utility.is_cache_pinned(path))
+	assert_false(_utility.is_cached(path), "无 handle、pin 或其他分组时应保留 eager remove 语义。")
+
+
+func test_unload_group_eager_remove_does_not_dispatch_public_remove_override() -> void:
+	var spy: RemoveCacheSpyAssetUtility = RemoveCacheSpyAssetUtility.new()
+	_replace_utility(spy)
+	var path: String = "res://group_private_eager_remove.tres"
+	spy.put_cache(path, Resource.new())
+	spy.register_group_path(&"private_remove", path, true)
+
+	spy.unload_group(&"private_remove", true)
+
+	assert_eq(
+		spy.public_remove_call_count,
+		0,
+		"分组内部 eager remove 不得动态派发可覆写的 public remove_cache。"
+	)
+	assert_false(spy.is_cached(path), "内部 cache-key 清理仍应移除最后的无 owner 缓存。")
+
+
+func test_unload_group_selectively_removes_exclusive_path_and_keeps_shared_path() -> void:
+	var shared_path: String = "res://group_selective_shared.tres"
+	var exclusive_path: String = "res://group_selective_exclusive.tres"
+	_utility.put_cache(shared_path, Resource.new())
+	_utility.put_cache(exclusive_path, Resource.new())
+	_utility.register_group_path(&"selective_a", shared_path, true)
+	_utility.register_group_path(&"selective_a", exclusive_path, true)
+	_utility.register_group_path(&"selective_b", shared_path, true)
+
+	_utility.unload_group(&"selective_a", true)
+
+	assert_true(_utility.get_group_paths(&"selective_a").is_empty())
+	assert_true(_utility.get_group_paths(&"selective_b").has(shared_path))
+	assert_true(_utility.is_cached(shared_path), "其他分组共享的路径应保留。")
+	assert_true(_utility.is_cache_pinned(shared_path), "共享路径的剩余分组 pin 应保留。")
+	assert_false(_utility.is_cached(exclusive_path), "同组中无其他 owner 的路径应选择性移除。")
+	assert_false(_utility.is_cache_pinned(exclusive_path))
+
+	_utility.unload_group(&"selective_b", true)
+
+	assert_false(_utility.is_cached(shared_path))
+
+
+func test_unload_group_lru_eviction_preserves_unpinned_group_membership() -> void:
+	var shared_path: String = "res://over_capacity_shared_group.tres"
+	var other_path: String = "res://over_capacity_manual_pin.tres"
+	_utility.max_cache_size = 1
+	_utility.put_cache(shared_path, Resource.new())
+	_utility.register_group_path(&"capacity_pin", shared_path, true)
+	_utility.register_group_path(&"capacity_membership", shared_path, false)
+	_utility.pin_cache(other_path)
+	_utility.put_cache(other_path, Resource.new())
+	assert_eq(_utility.get_cache_count(), 2, "所有超容量条目被 pin 时应暂时保留。")
+
+	_utility.unload_group(&"capacity_pin", true)
+
+	assert_true(
+		_utility.get_group_paths(&"capacity_membership").has(shared_path),
+		"LRU 可淘汰未 pin 缓存，但不得擦除其他分组 membership。"
+	)
+	assert_false(_utility.is_cached(shared_path), "释放最后 pin 后可执行正常 LRU 淘汰。")
+	assert_true(_utility.is_cached(other_path))
+	_utility.unpin_cache(other_path)
+
+
 func test_setting_cache_size_to_zero_clears_existing_cache() -> void:
 	_utility.put_cache("res://a.tres", Resource.new())
 	_utility.put_cache("res://b.tres", Resource.new())
@@ -688,6 +914,14 @@ func _uid_path_for(path: String) -> String:
 
 
 # --- 内部类 ---
+
+class RemoveCacheSpyAssetUtility extends GFAssetUtility:
+	var public_remove_call_count: int = 0
+
+	func remove_cache(path: String) -> void:
+		public_remove_call_count += 1
+		super.remove_cache(path)
+
 
 class FailingAssetUtility extends GFAssetUtility:
 	var _broker: FailingResourceBroker = FailingResourceBroker.new()


### PR DESCRIPTION
## Summary

- make `unload_group()` commit only the selected group's membership and pin ledger
- preserve cache entries while any handle, aggregate pin, or other group membership remains
- keep explicit `remove_cache()` force-purge behavior and normal LRU eviction semantics unchanged
- add shared ownership, canonical alias, manual pin, active handle, repeated pin, selective cleanup, and override-dispatch regressions

## Validation

- focused asset GUT: 48/48 tests, 203 assertions, 0 lifecycle warnings/orphans
- framework suite: 30/30 checks passed
- GDScript LSP: 1,333 files, 0 diagnostics/timeouts
- API/AI/Developer Kit freshness, docs/MkDocs, asset lifecycle, package/source/mapping, warnings, and diff checks passed
- final multi-track audit: Blocker 0 / Should-fix 0

Fixes #108