### PR TITLE
Reject unrestorable dialogue snapshots

### DIFF
--- a/addons/gf/extensions/dialogue/gf_extension.json
+++ b/addons/gf/extensions/dialogue/gf_extension.json
@@ -2,7 +2,7 @@
   "id": "gf.dialogue",
   "display_name": "GF Dialogue",
   "version": "11.0.0-dev.0",
-  "extension_version": "3.0.0",
+  "extension_version": "4.0.0",
   "kind": "extension",
   "description": "Generic dialogue resources, contexts, responses, and runners.",
   "dependencies": ["gf.kernel", "gf.standard"],

--- a/addons/gf/extensions/dialogue/runtime/gf_dialogue_runner.gd
+++ b/addons/gf/extensions/dialogue/runtime/gf_dialogue_runner.gd
@@ -90,7 +90,12 @@ var _current_line: GFDialogueLine = null
 var _is_running: bool = false
 var _architecture_ref: WeakRef = null
 var _resource_fingerprint: String = ""
+var _snapshot_resource_ref: WeakRef = null
 var _session_serial: int = 0
+var _snapshot_transition_serial: int = -1
+var _snapshot_transition_depth: int = 0
+var _snapshot_publication_serial: int = -1
+var _snapshot_publication_transition_depths: Array[int] = []
 
 
 # --- 公共方法 ---
@@ -122,9 +127,13 @@ func start(
 		_end_dialogue()
 		if _is_running or _session_serial != previous_session_serial + 1:
 			return null
+		resource_fingerprint = _get_resource_fingerprint(resource)
+		if resource_fingerprint.is_empty():
+			return null
 	_session_serial += 1
 	_resource = resource
 	_resource_fingerprint = resource_fingerprint
+	_snapshot_resource_ref = weakref(resource)
 	_context = _prepare_context(context)
 
 	var start_line: GFDialogueLine = resource.get_start_line(start_line_id)
@@ -148,34 +157,10 @@ func start(
 func advance(response_id: StringName = &"") -> GFDialogueLine:
 	if not _is_running or _resource == null:
 		return null
-	if response_id != &"":
-		var session_lease: _DialogueSessionLease = _capture_session_lease()
-		if not _apply_response(response_id):
-			if not _is_session_lease_current(session_lease):
-				return null
-			return _current_line
-	elif _current_line != null:
-		if _current_line.has_responses():
-			var session_lease: _DialogueSessionLease = _capture_session_lease()
-			var available_responses: Array[GFDialogueResponse] = (
-				session_lease._line.get_available_responses(session_lease._context)
-			)
-			if not _is_session_lease_current(session_lease):
-				return null
-			var reason: StringName = &"response_required" if not available_responses.is_empty() else &"no_available_response"
-			if not _emit_line_blocked_for_lease(
-				session_lease,
-				session_lease._line.line_id,
-				reason
-			):
-				return null
-			return session_lease._line
-		_current_line_id = _current_line.get_default_next_line_id()
-		_current_line = null
-		if _current_line_id == &"":
-			_end_dialogue()
-			return null
-	return _advance_to_next_text()
+	var transition_serial: int = _begin_snapshot_transition()
+	var reached_line: GFDialogueLine = _advance_for_current_session(response_id)
+	_end_snapshot_transition(transition_serial)
+	return reached_line
 
 
 ## 选择当前行响应并推进。
@@ -231,15 +216,20 @@ func is_running() -> bool:
 ##
 ## 快照只保存 Runner 的当前位置和上下文值，不保存对话资源本体。
 ## 恢复时由调用方重新提供 GFDialogueResource，避免框架绑定项目存档结构。
+## 只有已发布且资源身份一致的 TEXT checkpoint 或已提交的停止状态可创建快照；
+## dialogue_started、推进中的条件与 mutation 回调、自动转换等窗口会返回空 Dictionary。
+## 创建前会重新核对当前资源完整身份；会话开始或恢复后资源内容发生变化也会返回空 Dictionary。
 ## [br]
 ## @api public
 ## [br]
 ## @since 5.0.0
 ## [br]
-## @return: 运行快照。
+## @return: 成功时返回运行快照；当前状态尚不可恢复时返回空 Dictionary。
 ## [br]
 ## @schema return: 包含 schema_version、is_running、current_line_id、resource_fingerprint 和 context_values 字段的 Dictionary。
 func create_runtime_snapshot() -> Dictionary:
+	if not _can_create_runtime_snapshot():
+		return {}
 	return {
 		"schema_version": SNAPSHOT_SCHEMA_VERSION,
 		"is_running": _is_running,
@@ -288,6 +278,7 @@ func restore_runtime_snapshot(
 	if not GFVariantData.get_option_bool(snapshot, "is_running", false):
 		_reset_runtime_state()
 		_resource_fingerprint = snapshot_fingerprint
+		_snapshot_resource_ref = weakref(resource)
 		_context = _prepare_context(context)
 		_context.deserialize_values(context_values)
 		return null
@@ -303,6 +294,7 @@ func restore_runtime_snapshot(
 	_reset_runtime_state()
 	_resource = resource
 	_resource_fingerprint = snapshot_fingerprint
+	_snapshot_resource_ref = weakref(resource)
 	_context = _prepare_context(context)
 	_context.deserialize_values(context_values)
 	_current_line_id = line_id
@@ -350,9 +342,41 @@ func _prepare_context(context: GFDialogueContext = null) -> GFDialogueContext:
 func _reset_runtime_state() -> void:
 	_session_serial += 1
 	_resource = null
+	_snapshot_resource_ref = null
 	_current_line = null
 	_current_line_id = &""
 	_is_running = false
+
+
+func _advance_for_current_session(response_id: StringName) -> GFDialogueLine:
+	if response_id != &"":
+		var session_lease: _DialogueSessionLease = _capture_session_lease()
+		if not _apply_response(response_id):
+			if not _is_session_lease_current(session_lease):
+				return null
+			return _current_line
+	elif _current_line != null:
+		if _current_line.has_responses():
+			var session_lease: _DialogueSessionLease = _capture_session_lease()
+			var available_responses: Array[GFDialogueResponse] = (
+				session_lease._line.get_available_responses(session_lease._context)
+			)
+			if not _is_session_lease_current(session_lease):
+				return null
+			var reason: StringName = &"response_required" if not available_responses.is_empty() else &"no_available_response"
+			if not _emit_line_blocked_for_lease(
+				session_lease,
+				session_lease._line.line_id,
+				reason
+			):
+				return null
+			return session_lease._line
+		_current_line_id = _current_line.get_default_next_line_id()
+		_current_line = null
+		if _current_line_id == &"":
+			_end_dialogue()
+			return null
+	return _advance_to_next_text()
 
 
 func _advance_to_next_text() -> GFDialogueLine:
@@ -392,7 +416,13 @@ func _advance_to_next_text() -> GFDialogueLine:
 			GFDialogueLine.LineKind.TEXT:
 				_current_line = line
 				var reached_lease: _DialogueSessionLease = _capture_session_lease()
+				var publication_serial: int = _session_serial
+				var publication_transition_depth: int = _begin_snapshot_publication()
 				line_reached.emit(line)
+				_end_snapshot_publication(
+					publication_serial,
+					publication_transition_depth
+				)
 				if not _is_session_lease_current(reached_lease):
 					return null
 				return line
@@ -591,6 +621,111 @@ func _is_session_lease_current(session_lease: _DialogueSessionLease) -> bool:
 	)
 
 
+func _can_create_runtime_snapshot() -> bool:
+	if (
+		_resource_fingerprint.is_empty()
+		or _context == null
+	):
+		return false
+	var state_is_restorable: bool = (
+		_resource == null
+		and _current_line == null
+		and _current_line_id == &""
+		and not _is_running
+	) if not _is_running else _is_current_text_checkpoint_consistent()
+	if not state_is_restorable:
+		return false
+	if _is_snapshot_transition_active() and not _is_snapshot_publication_active():
+		return false
+	return _snapshot_resource_identity_is_current()
+
+
+func _is_current_text_checkpoint_consistent() -> bool:
+	if (
+		not _is_running
+		or _resource == null
+		or _current_line == null
+		or _current_line_id == &""
+		or _current_line.kind != GFDialogueLine.LineKind.TEXT
+		or _current_line.line_id != _current_line_id
+	):
+		return false
+	return _resource.get_line(_current_line_id) == _current_line
+
+
+func _snapshot_resource_identity_is_current() -> bool:
+	var snapshot_resource: GFDialogueResource = _get_snapshot_resource_or_null()
+	if snapshot_resource == null:
+		return false
+	var current_fingerprint: String = _get_resource_fingerprint(snapshot_resource, false)
+	return not current_fingerprint.is_empty() and current_fingerprint == _resource_fingerprint
+
+
+func _get_snapshot_resource_or_null() -> GFDialogueResource:
+	if _resource != null:
+		return _resource
+	if _snapshot_resource_ref == null:
+		return null
+	var resource_value: Variant = _snapshot_resource_ref.get_ref()
+	if resource_value is GFDialogueResource:
+		var resource: GFDialogueResource = resource_value
+		return resource
+	return null
+
+
+func _begin_snapshot_transition() -> int:
+	if _snapshot_transition_serial != _session_serial:
+		_snapshot_transition_serial = _session_serial
+		_snapshot_transition_depth = 0
+	_snapshot_transition_depth += 1
+	return _session_serial
+
+
+func _end_snapshot_transition(transition_serial: int) -> void:
+	if (
+		_snapshot_transition_serial != transition_serial
+		or _snapshot_transition_depth <= 0
+	):
+		return
+	_snapshot_transition_depth -= 1
+
+
+func _begin_snapshot_publication() -> int:
+	if _snapshot_publication_serial != _session_serial:
+		_snapshot_publication_serial = _session_serial
+		_snapshot_publication_transition_depths.clear()
+	_snapshot_publication_transition_depths.append(_snapshot_transition_depth)
+	return _snapshot_transition_depth
+
+
+func _end_snapshot_publication(
+	publication_serial: int,
+	publication_transition_depth: int
+) -> void:
+	if (
+		_snapshot_publication_serial != publication_serial
+		or _snapshot_publication_transition_depths.is_empty()
+		or _snapshot_publication_transition_depths.back() != publication_transition_depth
+	):
+		return
+	_snapshot_publication_transition_depths.pop_back()
+
+
+func _is_snapshot_transition_active() -> bool:
+	return (
+		_snapshot_transition_serial == _session_serial
+		and _snapshot_transition_depth > 0
+	)
+
+
+func _is_snapshot_publication_active() -> bool:
+	return (
+		_snapshot_publication_serial == _session_serial
+		and not _snapshot_publication_transition_depths.is_empty()
+		and _snapshot_publication_transition_depths.back() == _snapshot_transition_depth
+	)
+
+
 func _get_architecture_or_null() -> GFArchitecture:
 	if _architecture_ref != null:
 		var architecture: GFArchitecture = _get_architecture_value(_architecture_ref.get_ref())
@@ -606,17 +741,21 @@ func _get_architecture_value(value: Variant) -> GFArchitecture:
 	return null
 
 
-func _get_resource_fingerprint(resource: GFDialogueResource) -> String:
+func _get_resource_fingerprint(
+	resource: GFDialogueResource,
+	report_errors: bool = true
+) -> String:
 	if resource == null:
 		return ""
 	var identity_report: Dictionary = resource.build_identity_report()
 	if not GFVariantData.get_option_bool(identity_report, "ok", false):
-		push_error(
-			"GFDialogueRunner refused an incomplete resource identity (%s at %s)." % [
-				GFVariantData.get_option_string(identity_report, "error", "unknown_error"),
-				GFVariantData.get_option_string(identity_report, "path", "$"),
-			]
-		)
+		if report_errors:
+			push_error(
+				"GFDialogueRunner refused an incomplete resource identity (%s at %s)." % [
+					GFVariantData.get_option_string(identity_report, "error", "unknown_error"),
+					GFVariantData.get_option_string(identity_report, "path", "$"),
+				]
+			)
 		return ""
 	var identity_value: Variant = identity_report.get("value")
 	var encoded_identity_value: Variant = GFVariantJsonCodec.variant_to_json_compatible(
@@ -632,7 +771,8 @@ func _get_resource_fingerprint(resource: GFDialogueResource) -> String:
 	var canonical_identity: Variant = _canonicalize_identity_json(encoded_identity_value)
 	var encoded_identity: String = JSON.stringify(canonical_identity, "", true)
 	if encoded_identity.is_empty():
-		push_error("GFDialogueRunner could not encode the complete resource identity.")
+		if report_errors:
+			push_error("GFDialogueRunner could not encode the complete resource identity.")
 		return ""
 	return encoded_identity.sha256_text()
 

--- a/addons/gf/extensions/dialogue/runtime/gf_dialogue_runner.gd
+++ b/addons/gf/extensions/dialogue/runtime/gf_dialogue_runner.gd
@@ -90,7 +90,7 @@ var _current_line: GFDialogueLine = null
 var _is_running: bool = false
 var _architecture_ref: WeakRef = null
 var _resource_fingerprint: String = ""
-var _snapshot_resource_ref: WeakRef = null
+var _snapshot_resource: GFDialogueResource = null
 var _session_serial: int = 0
 var _snapshot_transition_serial: int = -1
 var _snapshot_transition_depth: int = 0
@@ -133,7 +133,7 @@ func start(
 	_session_serial += 1
 	_resource = resource
 	_resource_fingerprint = resource_fingerprint
-	_snapshot_resource_ref = weakref(resource)
+	_snapshot_resource = resource
 	_context = _prepare_context(context)
 
 	var start_line: GFDialogueLine = resource.get_start_line(start_line_id)
@@ -278,7 +278,7 @@ func restore_runtime_snapshot(
 	if not GFVariantData.get_option_bool(snapshot, "is_running", false):
 		_reset_runtime_state()
 		_resource_fingerprint = snapshot_fingerprint
-		_snapshot_resource_ref = weakref(resource)
+		_snapshot_resource = resource
 		_context = _prepare_context(context)
 		_context.deserialize_values(context_values)
 		return null
@@ -294,7 +294,7 @@ func restore_runtime_snapshot(
 	_reset_runtime_state()
 	_resource = resource
 	_resource_fingerprint = snapshot_fingerprint
-	_snapshot_resource_ref = weakref(resource)
+	_snapshot_resource = resource
 	_context = _prepare_context(context)
 	_context.deserialize_values(context_values)
 	_current_line_id = line_id
@@ -342,7 +342,7 @@ func _prepare_context(context: GFDialogueContext = null) -> GFDialogueContext:
 func _reset_runtime_state() -> void:
 	_session_serial += 1
 	_resource = null
-	_snapshot_resource_ref = null
+	_snapshot_resource = null
 	_current_line = null
 	_current_line_id = &""
 	_is_running = false
@@ -601,6 +601,7 @@ func _try_begin_non_display_step(
 func _end_dialogue() -> void:
 	var ended_resource: GFDialogueResource = _resource
 	_session_serial += 1
+	_snapshot_resource = ended_resource
 	_current_line = null
 	_current_line_id = &""
 	_resource = null
@@ -664,13 +665,7 @@ func _snapshot_resource_identity_is_current() -> bool:
 func _get_snapshot_resource_or_null() -> GFDialogueResource:
 	if _resource != null:
 		return _resource
-	if _snapshot_resource_ref == null:
-		return null
-	var resource_value: Variant = _snapshot_resource_ref.get_ref()
-	if resource_value is GFDialogueResource:
-		var resource: GFDialogueResource = resource_value
-		return resource
-	return null
+	return _snapshot_resource
 
 
 func _begin_snapshot_transition() -> int:

--- a/docs/api_catalog/classes/GFDialogueRunner.xml
+++ b/docs/api_catalog/classes/GFDialogueRunner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFDialogueRunner" path="addons/gf/extensions/dialogue/runtime/gf_dialogue_runner.gd" module="extensions/dialogue" extends="RefCounted" classDigest="c362fce775b158279d6110566f862e5af292b5aa073821b52455c72610e9720f">
+<class name="GFDialogueRunner" path="addons/gf/extensions/dialogue/runtime/gf_dialogue_runner.gd" module="extensions/dialogue" extends="RefCounted" classDigest="d0eb61b59258e14314fb12ff077f8169524c1a12764fea916fc081c282c5994e">
 	<description>GFDialogueRunner: 通用对话资源执行器。
 Runner 只沿 GFDialogueResource 的行、响应、跳转、条件和 mutation 推进，
 并发出结构化事件。显示、输入、存档和业务状态由项目层决定。</description>
@@ -146,10 +146,13 @@ Runner 只沿 GFDialogueResource 的行、响应、跳转、条件和 mutation �
 			<signature>func create_runtime_snapshot() -&gt; Dictionary:</signature>
 			<description>创建可存档的运行快照。
 快照只保存 Runner 的当前位置和上下文值，不保存对话资源本体。
-恢复时由调用方重新提供 GFDialogueResource，避免框架绑定项目存档结构。</description>
+恢复时由调用方重新提供 GFDialogueResource，避免框架绑定项目存档结构。
+只有已发布且资源身份一致的 TEXT checkpoint 或已提交的停止状态可创建快照；
+dialogue_started、推进中的条件与 mutation 回调、自动转换等窗口会返回空 Dictionary。
+创建前会重新核对当前资源完整身份；会话开始或恢复后资源内容发生变化也会返回空 Dictionary。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">运行快照。</tag>
+				<tag name="return">成功时返回运行快照；当前状态尚不可恢复时返回空 Dictionary。</tag>
 				<tag name="schema">return: 包含 schema_version、is_running、current_line_id、resource_fingerprint 和 context_values 字段的 Dictionary。</tag>
 				<tag name="since">5.0.0</tag>
 			</tags>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="b8d22bef096867e6bad9f6422c0ecc1af85e5b5c2285ae4c4c70f1e31d330707" classCount="843" methodCount="7679" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="c1eda8cb9498081c6d2d3a716a3473962b07e770a5b5c74e31f780f0c0e7c733" classCount="843" methodCount="7679" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="75" methodCount="801" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -185,6 +185,8 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFDialogueRunner.create_runtime_snapshot()` 在 `dialogue_started`、推进中的 condition、mutation 与自动转换等窗口仍返回表面合法但无法恢复的五字段字典，以及会话开始后资源内容漂移仍写入旧 fingerprint 的问题；方法现在会在创建前重新核对完整资源身份，并只为资源身份一致的稳定 `TEXT` checkpoint 或已提交停止状态返回原 schema v4 快照，其余状态失败关闭为空 `Dictionary`。`line_reached` 与 `dialogue_ended` 保持为可立即存档的稳定发布点。
+
 - 修复通用 Resource 预览生成器把多输出 CSV 翻译源当作单个 `Translation` 资源加载、从而在编辑器缩略图队列中产生源加载错误的问题；`Translation` 及 `OptimizedTranslation` 现在会在宽泛 Resource fallback 前被明确跳过，未知资源类型的既有兼容策略保持不变。
 
 - 修复 Config Pipeline 的 resource 数据库 `dry_run` 在 `ResourceSaver` 明确不识别目标扩展名时仍报告成功、直到真实保存才失败的问题；规范化后的 resource 目标现在会在 ownership 与任何产物 I/O 前按当前 saver 声明做大小写不敏感预检，dry-run 与真实路由统一返回 `ERR_FILE_UNRECOGNIZED`，显式 JSON 格式的扩展名策略保持不变。
@@ -326,6 +328,7 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
+- `GFDialogueRunner.create_runtime_snapshot()` 的成功五字段 schema 与 `SNAPSHOT_SCHEMA_VERSION = 4` 保持不变；新增失败约定为返回空 `Dictionary`。这会收紧 10.x 中推进中或资源身份已漂移时仍返回成功形状的行为，Dialogue 扩展版本因此升级为 `4.0.0`。
 - 新增公开 `GFBoundedJsonObjectReader`，提供 `parse_object(text, max_bytes, max_depth)`、`read_object(path, max_bytes, max_depth)`，以及 1 MiB/64 层的默认与绝对上限常量。两个入口的预算只能收紧；报告固定包含 `ok`、`data`、`source_path`、`size_bytes`、`error_kind`、`error`、`max_bytes` 和 `max_depth`。框架内部 `GFBoundedJsonReader` 与 `GFExtensionJsonFileReader` 现委托该 primitive，同时分别保留既有四字段报告和六字段累计预算报告。
 - `GFStorageUtility.allow_absolute_paths`、`get_storage_directory_path()`、`ensure_directory()` 与 `create_directories_for_nested_paths` 已移除；新增 `has_file()`。`list_files()` 只接受 portable logical directory 与不带点号的 lowercase extension token，并只返回 catalog 中存在 committed payload 的规范相对 logical identity；`canonicalize_data_file_name()` 只接受已经 canonical 的输入，不再改写分隔符、大小写或路径别名；`GFStorageAsyncOperation.get_file_name()` 与 `GFStorageAsyncResult.get_file_name()` 同样只暴露 logical identity，不再产生绝对路径身份。`save_dir_name` 必须在 activation、`init()` 或首次 I/O 前配置，Storage root 一经加载即冻结；切换 root 必须创建新的 Utility。
 - `GFStorageAsyncOperation` 的操作类型新增 `OPERATION_DELETE`；`GFStorageUtility.delete_file_request_async(logical_path)` 返回 `GFStorageAsyncOperation`，终态由 `GFStorageAsyncResult.get_delete_result()` 读取。新 `GFStorageDeleteResult` 公开 `FailureKind`、`FamilyMember`、`is_successful()`、`get_error_code()`、`get_failure_kind()`、三个成员计数 getter、`get_failed_member()`、`duplicate_result()` 与 `to_dict()`；非 delete 结果的 delete 字段为空，delete 结果不会同时携带 read/write 终态。
@@ -507,3 +510,4 @@
 82. 将扩展 `gf_extension.json` 中的七个编辑器路径字段移入同扩展的 `editor/gf_tool_contribution.json`；文件必须声明 `schema_version: 2` 和与 manifest 一致的 `extension_id`。保留 `installer_paths`、`editor_dock_order` 与 `editor_dock_short_label` 在 manifest，删除旧七字段而不做双写；否则 11.0 会返回指向 Tool Contribution 的迁移错误。直接消费 `GFExtensionSelectionDiscovery.get_snapshot()` 的工具应从 `contribution_paths` 读取这七个字段，或改用对应的 `GFExtensionSettings.get_enabled_*_paths()`；`manifest_paths` 现在只包含 `installer_paths`。项目工具应以 selection report 的 `status` / `tool_contribution_errors` 展示局部问题，不得因 `partial` 状态禁用已验证的 runtime Installer。
 83. 新的项目运行时或工具读取不可信 JSON object 时，先调用 `GFBoundedJsonObjectReader.parse_object()` / `read_object()`，检查 `ok`、`error_kind` 与报告中的实际预算，再消费 `data`；需要恢复 GF typed marker 时，随后调用 `GFVariantJsonCodec.json_compatible_to_variant()` 并保留其遍历预算。不要把 Codec 在 `JSON.parse()` 之后执行的 `max_depth` / `max_nodes` / `max_collection_items` 当作字节或词法深度准入。既有编辑器贡献和扩展发现调用不需要改签名，其兼容 adapter 会保留原报告 schema。
 84. 直接消费生成目录的工具应把 XML Catalog 从 schema v2 迁移到 v3，并接受独立的 class / autoload owner；既有 `classCount` / `methodCount` 仍只统计类，新增的 `autoloadCount` / `autoloadMethodCount` 统计 AutoLoad。直接消费 AI Developer `knowledge/api_index.json` 的工具应把 schema v1 迁移到 v2、catalog version `2.0.0`，保留 `classes` / `class_count` 的原语义并额外读取 `autoloads` / `autoload_count`。不要把两个集合按裸名称无条件覆盖合并，也不要把 `Gf` 伪装成 `class_name`。只调用运行时 `Gf.*` 的项目代码无需迁移。
+85. 所有 Dialogue 存档调用都要先检查 `create_runtime_snapshot().is_empty()`；只持久化非空快照。需要在同步信号中存档时使用 `line_reached` 或 `dialogue_ended`，不要在 `dialogue_started`、由推进调用触发的 condition、mutation 或自动推进回调中缓存中间状态，也不要把空字典送入恢复入口。

--- a/docs/zh/extensions/dialogue/index.md
+++ b/docs/zh/extensions/dialogue/index.md
@@ -46,9 +46,11 @@ runner.advance()
 
 恢复快照只重建当前位置和上下文值，不会重新发出开始、到达行或 mutation 信号，也不会再次执行已经经过的 mutation。调用方可使用 `restore_runtime_snapshot()` 返回的当前行刷新 UI。
 
-当前可恢复 checkpoint 必须位于可展示的 `TEXT` 行。项目应只在 `get_current_line() != null` 时持久化运行快照；`dialogue_started`、`mutation_requested` 或自动跳转等同步回调仍处于推进中的位置，这些位置生成的字典不应作为长期存档。如何正式表达推进中 checkpoint 尚属于后续快照协议决策，Runner 不会猜测或重放 mutation。
+`create_runtime_snapshot()` 只在资源身份一致的稳定 `TEXT` checkpoint，或已经提交的停止状态返回上述五字段快照。`line_reached` 与 `dialogue_ended` 都在稳定状态发布后发出，因此可在对应回调中立即创建快照；`start()`、`advance()` 或 `choose_response()` 返回稳定行后也可以创建。
 
-Runner 在 `start()` 前同步计算完整资源指纹，恢复时要求指纹精确一致。字典插入顺序不会改变指纹，但文本、metadata、payload、行或响应内容的变化都会改变指纹。身份输入必须无循环、不含运行时 Object/Callable/Signal/RID，并受完整复制预算约束；身份不完整或超限时 `start()` 会返回 `null`。因此，当前实现适合对内容完全一致的资源做严格恢复，不应把它当作跨内容修订的存档迁移协议。
+`dialogue_started`、由 `start()` / `advance()` / `choose_response()` 推进触发的 response condition、`mutation_requested`、mutation handler、自动跳转等窗口尚未形成可恢复 checkpoint，此时方法返回空 `Dictionary`，并且不会序列化半完成上下文。独立调用 `get_available_responses()` 只评估当前稳定 checkpoint，不属于推进窗口。调用方必须先检查 `snapshot.is_empty()`，只持久化非空结果；Runner 不会猜测、重放或序列化 continuation。
+
+Runner 在 `start()` 前同步计算完整资源指纹，恢复时要求指纹精确一致；每次创建快照前还会重新计算并核对当前资源身份，因此会话运行中、停止后或恢复停止快照后发生内容漂移都会失败关闭为空字典。字典插入顺序不会改变指纹，但文本、metadata、payload、行或响应内容的变化都会改变指纹。身份输入必须无循环、不含运行时 Object/Callable/Signal/RID，并受完整复制预算约束；身份不完整或超限时 `start()` 会返回 `null`。因此，当前实现适合对内容完全一致的资源做严格恢复，不应把它当作跨内容修订的存档迁移协议。
 
 ## 资源校验与推进边界
 

--- a/docs/zh/reference/api/classes/GFDialogueRunner.md
+++ b/docs/zh/reference/api/classes/GFDialogueRunner.md
@@ -303,9 +303,9 @@ func is_running() -> bool:
 func create_runtime_snapshot() -> Dictionary:
 ```
 
-创建可存档的运行快照。 快照只保存 Runner 的当前位置和上下文值，不保存对话资源本体。 恢复时由调用方重新提供 GFDialogueResource，避免框架绑定项目存档结构。
+创建可存档的运行快照。 快照只保存 Runner 的当前位置和上下文值，不保存对话资源本体。 恢复时由调用方重新提供 GFDialogueResource，避免框架绑定项目存档结构。 只有已发布且资源身份一致的 TEXT checkpoint 或已提交的停止状态可创建快照； dialogue_started、推进中的条件与 mutation 回调、自动转换等窗口会返回空 Dictionary。 创建前会重新核对当前资源完整身份；会话开始或恢复后资源内容发生变化也会返回空 Dictionary。
 
-返回：运行快照。
+返回：成功时返回运行快照；当前状态尚不可恢复时返回空 Dictionary。
 
 结构：
 

--- a/tests/gf_core/extensions/dialogue/test_gf_dialogue_extension.gd
+++ b/tests/gf_core/extensions/dialogue/test_gf_dialogue_extension.gd
@@ -75,6 +75,459 @@ func test_dialogue_runner_emits_mutation_requested_for_response_mutation() -> vo
 	)
 
 
+func test_dialogue_runner_snapshot_requires_a_restorable_session_state() -> void:
+	var idle_runner: GFDialogueRunner = GFDialogueRunner.new()
+	var idle_snapshot: Dictionary = idle_runner.create_runtime_snapshot()
+
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	resource.set_line(_make_text_line(&"start", "Start", &""))
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var started_snapshots: Array[Dictionary] = []
+	var started_callback: Callable = func(_resource: GFDialogueResource) -> void:
+		started_snapshots.append(runner.create_runtime_snapshot())
+	var _started_connection_error: Error = runner.dialogue_started.connect(started_callback) as Error
+
+	var reached: GFDialogueLine = runner.start(resource)
+	if runner.dialogue_started.is_connected(started_callback):
+		runner.dialogue_started.disconnect(started_callback)
+	var stable_snapshot: Dictionary = runner.create_runtime_snapshot()
+	var restored_runner: GFDialogueRunner = GFDialogueRunner.new()
+	var restored: GFDialogueLine = restored_runner.restore_runtime_snapshot(
+		resource,
+		stable_snapshot
+	)
+
+	assert_true(idle_snapshot.is_empty(), "未开始过会话时没有可恢复资源身份，不得返回成功快照。")
+	assert_eq(started_snapshots.size(), 1, "dialogue_started 应同步观察一次快照创建结果。")
+	assert_true(_single_snapshot_is_empty(started_snapshots), "dialogue_started 仍在推进起点，不得返回成功快照。")
+	assert_not_null(reached, "测试资源应到达稳定 TEXT checkpoint。")
+	assert_false(stable_snapshot.is_empty(), "稳定 TEXT checkpoint 应继续返回兼容快照。")
+	var expected_snapshot_keys: Array[String] = [
+		"schema_version",
+		"is_running",
+		"current_line_id",
+		"resource_fingerprint",
+		"context_values",
+	]
+	assert_eq(stable_snapshot.size(), expected_snapshot_keys.size(), "成功快照必须保持既有精确五字段 schema。")
+	for key: String in expected_snapshot_keys:
+		assert_true(stable_snapshot.has(key), "成功快照缺少必需字段 %s。" % key)
+	assert_not_null(restored, "每个成功创建的运行中快照都必须可恢复。")
+	if restored != null:
+		assert_eq(restored.line_id, &"start", "恢复后应回到成功快照的稳定 TEXT 行。")
+
+
+func test_dialogue_runner_rejects_snapshot_during_line_mutation() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"mutate"
+	var mutation_line: GFDialogueLine = GFDialogueLine.new()
+	mutation_line.line_id = &"mutate"
+	mutation_line.kind = GFDialogueLine.LineKind.MUTATION
+	mutation_line.mutation_id = &"mark"
+	mutation_line.next_line_id = &"done"
+	resource.set_line(mutation_line)
+	resource.set_line(_make_text_line(&"done", "Done", &""))
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var signal_snapshots: Array[Dictionary] = []
+	var handler_snapshots: Array[Dictionary] = []
+	var context: GFDialogueContext = GFDialogueContext.new()
+	context.mutation_handler = func(
+		_mutation_id: StringName,
+		_payload: Variant,
+		_subject: Variant,
+		mutation_context: GFDialogueContext
+	) -> bool:
+		var _updated_context: GFDialogueContext = mutation_context.set_value(&"mutated", true)
+		handler_snapshots.append(runner.create_runtime_snapshot())
+		return true
+	var mutation_callback: Callable = func(
+		_mutation_id: StringName,
+		_payload: Variant,
+		_line: GFDialogueLine
+	) -> void:
+		signal_snapshots.append(runner.create_runtime_snapshot())
+	var _mutation_connection_error: Error = runner.mutation_requested.connect(mutation_callback) as Error
+
+	var reached: GFDialogueLine = runner.start(resource, &"", context)
+	if runner.mutation_requested.is_connected(mutation_callback):
+		runner.mutation_requested.disconnect(mutation_callback)
+	context.mutation_handler = Callable()
+	var stable_snapshot: Dictionary = runner.create_runtime_snapshot()
+	var restored: GFDialogueLine = GFDialogueRunner.new().restore_runtime_snapshot(
+		resource,
+		stable_snapshot
+	)
+
+	assert_not_null(reached, "mutation 成功后应到达稳定 TEXT checkpoint。")
+	assert_eq(signal_snapshots.size(), 1, "行 mutation signal 应同步观察一次快照创建结果。")
+	assert_eq(handler_snapshots.size(), 1, "行 mutation handler 应同步观察一次快照创建结果。")
+	assert_true(_single_snapshot_is_empty(signal_snapshots), "行 mutation signal 仍在推进中，不得返回成功快照。")
+	assert_true(_single_snapshot_is_empty(handler_snapshots), "行 mutation handler 已有副作用但未提交 TEXT，不得返回成功快照。")
+	assert_false(stable_snapshot.is_empty(), "mutation 后的稳定 TEXT checkpoint 应可创建快照。")
+	assert_not_null(restored, "mutation 后成功创建的快照必须可恢复。")
+	if restored != null:
+		assert_eq(restored.line_id, &"done", "恢复不得回到已执行的 mutation 行。")
+
+
+func test_dialogue_runner_rejects_snapshot_during_response_mutation() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	var start: GFDialogueLine = _make_text_line(&"start", "Start", &"")
+	var response: GFDialogueResponse = GFDialogueResponse.new()
+	response.response_id = &"pick"
+	response.next_line_id = &"done"
+	response.mutation_id = &"grant"
+	start.responses.append(response)
+	resource.set_line(start)
+	resource.set_line(_make_text_line(&"done", "Done", &""))
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var signal_snapshots: Array[Dictionary] = []
+	var handler_snapshots: Array[Dictionary] = []
+	var context: GFDialogueContext = GFDialogueContext.new()
+	context.mutation_handler = func(
+		_mutation_id: StringName,
+		_payload: Variant,
+		_subject: Variant,
+		mutation_context: GFDialogueContext
+	) -> bool:
+		var _updated_context: GFDialogueContext = mutation_context.set_value(&"granted", true)
+		handler_snapshots.append(runner.create_runtime_snapshot())
+		return true
+	var _start_line: GFDialogueLine = runner.start(resource, &"", context)
+	var mutation_callback: Callable = func(
+		_mutation_id: StringName,
+		_payload: Variant,
+		_line: GFDialogueLine
+	) -> void:
+		signal_snapshots.append(runner.create_runtime_snapshot())
+		var _nested_missing_response: GFDialogueLine = runner.advance(&"missing")
+		signal_snapshots.append(runner.create_runtime_snapshot())
+	var _mutation_connection_error: Error = runner.mutation_requested.connect(mutation_callback) as Error
+
+	var reached: GFDialogueLine = runner.choose_response(&"pick")
+	if runner.mutation_requested.is_connected(mutation_callback):
+		runner.mutation_requested.disconnect(mutation_callback)
+	context.mutation_handler = Callable()
+	var stable_snapshot: Dictionary = runner.create_runtime_snapshot()
+	var restored: GFDialogueLine = GFDialogueRunner.new().restore_runtime_snapshot(
+		resource,
+		stable_snapshot
+	)
+
+	assert_not_null(reached, "响应 mutation 成功后应到达稳定 TEXT checkpoint。")
+	assert_eq(signal_snapshots.size(), 2, "响应 mutation signal 应在嵌套推进前后各观察一次快照创建结果。")
+	assert_eq(handler_snapshots.size(), 1, "响应 mutation handler 应同步观察一次快照创建结果。")
+	if signal_snapshots.size() == 2:
+		assert_true(
+			signal_snapshots[0].is_empty() and signal_snapshots[1].is_empty(),
+			"响应 mutation signal 的嵌套推进返回后仍不得把旧 TEXT 误报为稳定 checkpoint。"
+		)
+	assert_true(_single_snapshot_is_empty(handler_snapshots), "响应 mutation handler 不能把已部分修改的旧 TEXT 持久化。")
+	assert_false(stable_snapshot.is_empty(), "响应推进完成后的 TEXT checkpoint 应可创建快照。")
+	assert_not_null(restored, "响应推进后成功创建的快照必须可恢复。")
+	if restored != null:
+		assert_eq(restored.line_id, &"done", "恢复不得回到 mutation 前的响应行。")
+
+
+func test_dialogue_runner_rejects_snapshot_during_response_condition_evaluation() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	var start: GFDialogueLine = _make_text_line(&"start", "Start", &"")
+	var response: GFDialogueResponse = GFDialogueResponse.new()
+	response.response_id = &"pick"
+	response.condition_id = &"can_pick"
+	start.responses.append(response)
+	resource.set_line(start)
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var condition_snapshots: Array[Dictionary] = []
+	var context: GFDialogueContext = GFDialogueContext.new()
+	context.condition_handler = func(
+		_condition_id: StringName,
+		_payload: Variant,
+		_subject: Variant,
+		_context: GFDialogueContext
+	) -> bool:
+		condition_snapshots.append(runner.create_runtime_snapshot())
+		return true
+	var _start_line: GFDialogueLine = runner.start(resource, &"", context)
+	condition_snapshots.clear()
+
+	var blocked_line: GFDialogueLine = runner.advance()
+	var query_snapshots: Array[Dictionary] = []
+	context.condition_handler = func(
+		_condition_id: StringName,
+		_payload: Variant,
+		_subject: Variant,
+		_context: GFDialogueContext
+	) -> bool:
+		query_snapshots.append(runner.create_runtime_snapshot())
+		return true
+	var available_responses: Array[GFDialogueResponse] = runner.get_available_responses()
+	context.condition_handler = Callable()
+	var stable_snapshot: Dictionary = runner.create_runtime_snapshot()
+	var query_restored: GFDialogueLine = null
+	if query_snapshots.size() == 1:
+		query_restored = GFDialogueRunner.new().restore_runtime_snapshot(
+			resource,
+			query_snapshots[0]
+		)
+	var restored: GFDialogueLine = GFDialogueRunner.new().restore_runtime_snapshot(
+		resource,
+		stable_snapshot
+	)
+
+	assert_not_null(blocked_line, "缺少 response_id 时应继续停在当前 TEXT。")
+	assert_eq(condition_snapshots.size(), 1, "response condition 应在 advance 内同步评估一次。")
+	assert_true(_single_snapshot_is_empty(condition_snapshots), "response condition 评估仍属于 advance 窗口，不得返回成功快照。")
+	assert_eq(available_responses.size(), 1, "独立响应查询应继续返回稳定 checkpoint 的可用响应。")
+	assert_true(_single_snapshot_is_non_empty(query_snapshots), "独立响应查询不推进会话，应允许 condition handler 保存当前 checkpoint。")
+	assert_not_null(query_restored, "独立响应查询回调内创建的成功快照必须可恢复。")
+	if query_restored != null:
+		assert_eq(query_restored.line_id, &"start", "独立响应查询快照应保持当前稳定 TEXT。")
+	assert_false(stable_snapshot.is_empty(), "advance 返回后的原 TEXT 应恢复为稳定 checkpoint。")
+	assert_not_null(restored, "稳定 response checkpoint 快照必须可恢复。")
+	if restored != null:
+		assert_eq(restored.line_id, &"start", "恢复应回到等待响应的 TEXT 行。")
+
+
+func test_dialogue_runner_line_reached_snapshot_is_immediately_restorable() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	resource.set_line(_make_text_line(&"start", "Start", &""))
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var reached_snapshots: Array[Dictionary] = []
+	var reached_callback: Callable = func(_line: GFDialogueLine) -> void:
+		reached_snapshots.append(runner.create_runtime_snapshot())
+	var _reached_connection_error: Error = runner.line_reached.connect(reached_callback) as Error
+
+	var reached: GFDialogueLine = runner.start(resource)
+	if runner.line_reached.is_connected(reached_callback):
+		runner.line_reached.disconnect(reached_callback)
+	var restored: GFDialogueLine = null
+	if reached_snapshots.size() == 1:
+		restored = GFDialogueRunner.new().restore_runtime_snapshot(
+			resource,
+			reached_snapshots[0]
+		)
+
+	assert_not_null(reached, "测试资源应发出稳定 line_reached。")
+	assert_eq(reached_snapshots.size(), 1, "line_reached 应同步创建一次快照。")
+	assert_true(_single_snapshot_is_non_empty(reached_snapshots), "line_reached 已发布稳定 TEXT，应允许立即存档。")
+	assert_not_null(restored, "line_reached 内成功创建的快照必须立即可恢复。")
+	if restored != null:
+		assert_eq(restored.line_id, &"start", "line_reached 快照应恢复到刚发布的 TEXT 行。")
+
+
+func test_dialogue_runner_nested_transition_cannot_reuse_outer_checkpoint_publication() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	var start: GFDialogueLine = _make_text_line(&"start", "Start", &"")
+	var response: GFDialogueResponse = GFDialogueResponse.new()
+	response.response_id = &"pick"
+	response.next_line_id = &"done"
+	response.mutation_id = &"grant"
+	start.responses.append(response)
+	resource.set_line(start)
+	resource.set_line(_make_text_line(&"done", "Done", &""))
+	var context: GFDialogueContext = GFDialogueContext.new()
+	context.mutation_handler = func(
+		_mutation_id: StringName,
+		_payload: Variant,
+		_subject: Variant,
+		_context: GFDialogueContext
+	) -> bool:
+		return true
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var reached_snapshots: Array[Dictionary] = []
+	var mutation_snapshots: Array[Dictionary] = []
+	var post_nested_snapshots: Array[Dictionary] = []
+	var reached_callback: Callable = func(line: GFDialogueLine) -> void:
+		reached_snapshots.append(runner.create_runtime_snapshot())
+		if line.line_id == &"start":
+			var _nested_line: GFDialogueLine = runner.choose_response(&"pick")
+			post_nested_snapshots.append(runner.create_runtime_snapshot())
+	var mutation_callback: Callable = func(
+		_mutation_id: StringName,
+		_payload: Variant,
+		_line: GFDialogueLine
+	) -> void:
+		mutation_snapshots.append(runner.create_runtime_snapshot())
+	var _reached_connection_error: Error = runner.line_reached.connect(reached_callback) as Error
+	var _mutation_connection_error: Error = runner.mutation_requested.connect(mutation_callback) as Error
+
+	var outer_result: GFDialogueLine = runner.start(resource, &"", context)
+	if runner.line_reached.is_connected(reached_callback):
+		runner.line_reached.disconnect(reached_callback)
+	if runner.mutation_requested.is_connected(mutation_callback):
+		runner.mutation_requested.disconnect(mutation_callback)
+	context.mutation_handler = Callable()
+	var first_restored: GFDialogueLine = null
+	var second_restored: GFDialogueLine = null
+	var post_nested_restored: GFDialogueLine = null
+	if reached_snapshots.size() == 2:
+		first_restored = GFDialogueRunner.new().restore_runtime_snapshot(
+			resource,
+			reached_snapshots[0]
+		)
+		second_restored = GFDialogueRunner.new().restore_runtime_snapshot(
+			resource,
+			reached_snapshots[1]
+		)
+	if post_nested_snapshots.size() == 1:
+		post_nested_restored = GFDialogueRunner.new().restore_runtime_snapshot(
+			resource,
+			post_nested_snapshots[0]
+		)
+
+	assert_null(outer_result, "line_reached 内替换当前行后，外层 start 应返回 stale null。")
+	assert_eq(reached_snapshots.size(), 2, "外层与嵌套 line_reached 都应发布一次稳定 checkpoint。")
+	assert_true(
+		reached_snapshots.size() == 2
+		and not reached_snapshots[0].is_empty()
+		and not reached_snapshots[1].is_empty(),
+		"每层 line_reached publication 都应允许自己的稳定 TEXT 快照。"
+	)
+	assert_true(_single_snapshot_is_empty(mutation_snapshots), "嵌套 response mutation 不得借用外层 publication 绕过推进守卫。")
+	assert_true(_single_snapshot_is_non_empty(post_nested_snapshots), "嵌套推进返回后应恢复外层 publication 的稳定快照权限。")
+	assert_not_null(first_restored, "外层已发布的 start checkpoint 应独立可恢复。")
+	assert_not_null(second_restored, "嵌套已发布的 done checkpoint 应独立可恢复。")
+	assert_not_null(post_nested_restored, "嵌套推进返回后的 done checkpoint 必须可恢复。")
+	if first_restored != null:
+		assert_eq(first_restored.line_id, &"start")
+	if second_restored != null:
+		assert_eq(second_restored.line_id, &"done")
+	if post_nested_restored != null:
+		assert_eq(post_nested_restored.line_id, &"done")
+	var current_line: GFDialogueLine = runner.get_current_line()
+	assert_not_null(current_line, "嵌套推进后的 live Runner 应保留新 TEXT。")
+	if current_line != null:
+		assert_eq(current_line.line_id, &"done", "嵌套推进后的 live Runner 应停在新 TEXT。")
+
+
+func test_dialogue_runner_dialogue_ended_snapshot_is_immediately_restorable() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	resource.set_line(_make_text_line(&"start", "Start", &"end"))
+	resource.set_line(_make_end_line(&"end"))
+	var context: GFDialogueContext = GFDialogueContext.new()
+	var _context_with_score: GFDialogueContext = context.set_value(&"score", 9)
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _start_line: GFDialogueLine = runner.start(resource, &"", context)
+	var ended_snapshots: Array[Dictionary] = []
+	var ended_callback: Callable = func(_resource: GFDialogueResource) -> void:
+		ended_snapshots.append(runner.create_runtime_snapshot())
+	var _ended_connection_error: Error = runner.dialogue_ended.connect(ended_callback) as Error
+
+	var ended_line: GFDialogueLine = runner.advance()
+	if runner.dialogue_ended.is_connected(ended_callback):
+		runner.dialogue_ended.disconnect(ended_callback)
+	var restored_context: GFDialogueContext = GFDialogueContext.new()
+	var restored_runner: GFDialogueRunner = GFDialogueRunner.new()
+	var restored: GFDialogueLine = null
+	if ended_snapshots.size() == 1:
+		restored = restored_runner.restore_runtime_snapshot(
+			resource,
+			ended_snapshots[0],
+			restored_context
+		)
+
+	assert_null(ended_line, "END 行应正常结束当前会话。")
+	assert_true(_single_snapshot_is_non_empty(ended_snapshots), "dialogue_ended 已发布 stopped checkpoint，应允许立即存档。")
+	assert_null(restored, "ended snapshot 恢复后不应产生当前行。")
+	assert_false(restored_runner.is_running(), "ended snapshot 恢复后 Runner 应保持停止。")
+	assert_eq(GFVariantData.to_int(restored_context.get_value(&"score")), 9, "ended snapshot 应保留结束时上下文。")
+
+
+func test_dialogue_runner_rejects_inconsistent_text_checkpoint_snapshots() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	var original_line: GFDialogueLine = _make_text_line(&"start", "Start", &"")
+	resource.set_line(original_line)
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _reached: GFDialogueLine = runner.start(resource)
+
+	original_line.kind = GFDialogueLine.LineKind.JUMP
+	var wrong_kind_snapshot: Dictionary = runner.create_runtime_snapshot()
+	original_line.kind = GFDialogueLine.LineKind.TEXT
+	original_line.line_id = &"other"
+	var wrong_id_snapshot: Dictionary = runner.create_runtime_snapshot()
+	original_line.line_id = &"start"
+	resource.set_line(_make_text_line(&"start", "Start", &""))
+	var replaced_line_snapshot: Dictionary = runner.create_runtime_snapshot()
+
+	assert_true(wrong_kind_snapshot.is_empty(), "非 TEXT 当前行不得形成运行中快照。")
+	assert_true(wrong_id_snapshot.is_empty(), "当前行 ID 与游标不一致时不得形成运行中快照。")
+	assert_true(replaced_line_snapshot.is_empty(), "资源同 ID 行实例已被替换时不得持久化旧 checkpoint。")
+
+
+func test_dialogue_runner_rejects_snapshot_after_resource_identity_changes() -> void:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	var start_line: GFDialogueLine = _make_text_line(&"start", "Start", &"end")
+	resource.set_line(start_line)
+	resource.set_line(_make_end_line(&"end"))
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _reached: GFDialogueLine = runner.start(resource)
+
+	start_line.text = "Changed while running"
+	var running_drift_snapshot: Dictionary = runner.create_runtime_snapshot()
+	start_line.text = "Start"
+	var _ended: GFDialogueLine = runner.advance()
+	var stable_ended_snapshot: Dictionary = runner.create_runtime_snapshot()
+	start_line.text = "Changed after end"
+	var ended_drift_snapshot: Dictionary = runner.create_runtime_snapshot()
+	start_line.text = "Start"
+	var restored_ended_runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _restored_ended: GFDialogueLine = restored_ended_runner.restore_runtime_snapshot(
+		resource,
+		stable_ended_snapshot
+	)
+	var restored_ended_stable_snapshot: Dictionary = restored_ended_runner.create_runtime_snapshot()
+	start_line.text = "Changed after ended restore"
+	var restored_ended_drift_snapshot: Dictionary = restored_ended_runner.create_runtime_snapshot()
+
+	assert_true(running_drift_snapshot.is_empty(), "运行中资源内容身份漂移后不得返回旧 fingerprint 快照。")
+	assert_false(stable_ended_snapshot.is_empty(), "资源内容未漂移的停止状态应继续可存档。")
+	assert_true(ended_drift_snapshot.is_empty(), "停止后资源内容身份漂移也不得返回旧 fingerprint 快照。")
+	assert_false(restored_ended_stable_snapshot.is_empty(), "恢复停止快照后必须保留可复核的资源身份。")
+	assert_true(restored_ended_drift_snapshot.is_empty(), "恢复停止快照后仍必须复核当前资源内容身份。")
+
+
+func test_dialogue_replacement_start_revalidates_resource_after_ended_callbacks() -> void:
+	var original: GFDialogueResource = GFDialogueResource.new()
+	original.start_line_id = &"original"
+	original.set_line(_make_text_line(&"original", "Original", &""))
+	var replacement: GFDialogueResource = GFDialogueResource.new()
+	replacement.start_line_id = &"replacement"
+	var replacement_line: GFDialogueLine = _make_text_line(
+		&"replacement",
+		"Replacement",
+		&""
+	)
+	replacement.set_line(replacement_line)
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _original_line: GFDialogueLine = runner.start(original)
+	var ended_callback: Callable = func(_resource: GFDialogueResource) -> void:
+		replacement_line.text = "Changed by old dialogue_ended"
+	var _ended_connection_error: Error = runner.dialogue_ended.connect(ended_callback) as Error
+
+	var reached: GFDialogueLine = runner.start(replacement)
+	if runner.dialogue_ended.is_connected(ended_callback):
+		runner.dialogue_ended.disconnect(ended_callback)
+	var snapshot: Dictionary = runner.create_runtime_snapshot()
+	var restored: GFDialogueLine = GFDialogueRunner.new().restore_runtime_snapshot(
+		replacement,
+		snapshot
+	)
+
+	assert_not_null(reached, "替换 start 应采用旧会话 ended 回调后的资源内容。")
+	assert_false(snapshot.is_empty(), "替换 start 不得缓存 ended 回调前的陈旧资源 fingerprint。")
+	assert_not_null(restored, "替换 start 返回后的成功快照必须可恢复。")
+	if restored != null:
+		assert_eq(restored.line_id, &"replacement")
+
+
 ## 验证对话运行快照可恢复当前行且不会重放 mutation。
 func test_dialogue_runner_restores_runtime_snapshot_without_replaying_mutation() -> void:
 	var resource: GFDialogueResource = GFDialogueResource.new()
@@ -131,6 +584,9 @@ func test_dialogue_runner_restores_runtime_snapshot_without_replaying_mutation()
 	assert_eq(GFVariantData.to_bool(restored_context.get_value(&"visited")), true, "恢复应带回上下文运行值。")
 	assert_eq(GFVariantData.to_int(restored_context.get_value(&"mutation_count")), 1, "恢复应带回 mutation 已写入的上下文值。")
 	assert_true(restored_mutations.is_empty(), "恢复快照不应重新执行 mutation。")
+	var _restored_end_result: GFDialogueLine = restored_runner.advance()
+	var restored_ended_snapshot: Dictionary = restored_runner.create_runtime_snapshot()
+	assert_false(restored_ended_snapshot.is_empty(), "恢复运行快照后正常结束仍应保留可存档资源身份。")
 
 
 ## 验证结束状态快照恢复后不会重新启动对话。
@@ -728,25 +1184,59 @@ func test_dialogue_response_mutation_reentry_preserves_replacement_session() -> 
 		return true
 	var runner: GFDialogueRunner = GFDialogueRunner.new()
 	var replaced: Array[bool] = [false]
+	var replacement_snapshots: Array[Dictionary] = []
+	var post_start_snapshots: Array[Dictionary] = []
+	var line_reached_callback: Callable = func(line: GFDialogueLine) -> void:
+		if line.line_id == &"replacement":
+			replacement_snapshots.append(runner.create_runtime_snapshot())
 	var mutation_requested_callback: Callable = (
 		func(_mutation_id: StringName, _payload: Variant, _line: GFDialogueLine) -> void:
 			if replaced[0]:
 				return
 			replaced[0] = true
 			var _replacement_line: GFDialogueLine = runner.start(replacement)
+			post_start_snapshots.append(runner.create_runtime_snapshot())
 	)
 	var _connected: Error = runner.mutation_requested.connect(
 		mutation_requested_callback
+	) as Error
+	var _line_reached_connected: Error = runner.line_reached.connect(
+		line_reached_callback
 	) as Error
 	var _original_line: GFDialogueLine = runner.start(original, &"", context)
 
 	var stale_result: GFDialogueLine = runner.choose_response(&"pick")
 	runner.mutation_requested.disconnect(mutation_requested_callback)
+	runner.line_reached.disconnect(line_reached_callback)
+	context.mutation_handler = Callable()
+	var restored_replacement: GFDialogueLine = null
+	var restored_post_start: GFDialogueLine = null
+	if replacement_snapshots.size() == 1:
+		restored_replacement = GFDialogueRunner.new().restore_runtime_snapshot(
+			replacement,
+			replacement_snapshots[0]
+		)
+	if post_start_snapshots.size() == 1:
+		restored_post_start = GFDialogueRunner.new().restore_runtime_snapshot(
+			replacement,
+			post_start_snapshots[0]
+		)
 
 	assert_null(stale_result, "旧响应调用链在会话被替换后必须返回 null。")
 	assert_true(runner.is_running(), "旧 mutation 调用链不得结束重入创建的新会话。")
-	assert_eq(runner.get_current_line().line_id, &"replacement", "替换会话必须保持在自己的当前行。")
+	var current_line: GFDialogueLine = runner.get_current_line()
+	assert_not_null(current_line, "替换会话必须保持自己的当前行。")
+	if current_line != null:
+		assert_eq(current_line.line_id, &"replacement", "替换会话必须保持在自己的当前行。")
 	assert_eq(mutation_call_count[0], 0, "mutation_requested 改变会话后不得再调用旧上下文 handler。")
+	assert_true(_single_snapshot_is_non_empty(replacement_snapshots), "新会话 line_reached 不得继承旧会话的推进 barrier。")
+	assert_true(_single_snapshot_is_non_empty(post_start_snapshots), "新会话 start 返回后不得残留旧会话的推进 barrier。")
+	assert_not_null(restored_replacement, "替换会话发布的稳定 checkpoint 必须可独立恢复。")
+	assert_not_null(restored_post_start, "替换会话 start 返回后的 checkpoint 必须可独立恢复。")
+	if restored_replacement != null:
+		assert_eq(restored_replacement.line_id, &"replacement")
+	if restored_post_start != null:
+		assert_eq(restored_post_start.line_id, &"replacement")
 
 
 func test_dialogue_line_mutation_reentry_cannot_end_replacement_session() -> void:
@@ -1199,6 +1689,14 @@ func _count_issue_kind(issues: Array, kind: String) -> int:
 		if GFVariantData.get_option_string(issue_dictionary, "kind") == kind:
 			count += 1
 	return count
+
+
+func _single_snapshot_is_empty(snapshots: Array[Dictionary]) -> bool:
+	return snapshots.size() == 1 and snapshots[0].is_empty()
+
+
+func _single_snapshot_is_non_empty(snapshots: Array[Dictionary]) -> bool:
+	return snapshots.size() == 1 and not snapshots[0].is_empty()
 
 
 func _dictionary_contains_value(root: Dictionary, expected: Variant) -> bool:

--- a/tests/gf_core/extensions/dialogue/test_gf_dialogue_extension.gd
+++ b/tests/gf_core/extensions/dialogue/test_gf_dialogue_extension.gd
@@ -494,6 +494,18 @@ func test_dialogue_runner_rejects_snapshot_after_resource_identity_changes() -> 
 	assert_true(restored_ended_drift_snapshot.is_empty(), "恢复停止快照后仍必须复核当前资源内容身份。")
 
 
+func test_dialogue_runner_retains_stopped_snapshot_resource_without_external_owner() -> void:
+	var ended_runner: GFDialogueRunner = _make_ended_runner_without_external_resource_owner()
+	var ended_snapshot: Dictionary = ended_runner.create_runtime_snapshot()
+	var restored_ended_runner: GFDialogueRunner = (
+		_make_restored_ended_runner_without_external_resource_owner()
+	)
+	var restored_ended_snapshot: Dictionary = restored_ended_runner.create_runtime_snapshot()
+
+	assert_false(ended_snapshot.is_empty(), "停止态 Runner 应自行保留创建快照所需的资源身份。")
+	assert_false(restored_ended_snapshot.is_empty(), "恢复出的停止态 Runner 也应自行保留快照资源身份。")
+
+
 func test_dialogue_replacement_start_revalidates_resource_after_ended_callbacks() -> void:
 	var original: GFDialogueResource = GFDialogueResource.new()
 	original.start_line_id = &"original"
@@ -1672,6 +1684,34 @@ func _make_end_line(line_id: StringName) -> GFDialogueLine:
 	line.line_id = line_id
 	line.kind = GFDialogueLine.LineKind.END
 	return line
+
+
+func _make_ended_runner_without_external_resource_owner() -> GFDialogueRunner:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	resource.set_line(_make_text_line(&"start", "Start", &"end"))
+	resource.set_line(_make_end_line(&"end"))
+	var runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _start_line: GFDialogueLine = runner.start(resource)
+	var _ended_line: GFDialogueLine = runner.advance()
+	return runner
+
+
+func _make_restored_ended_runner_without_external_resource_owner() -> GFDialogueRunner:
+	var resource: GFDialogueResource = GFDialogueResource.new()
+	resource.start_line_id = &"start"
+	resource.set_line(_make_text_line(&"start", "Start", &"end"))
+	resource.set_line(_make_end_line(&"end"))
+	var source_runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _start_line: GFDialogueLine = source_runner.start(resource)
+	var _ended_line: GFDialogueLine = source_runner.advance()
+	var snapshot: Dictionary = source_runner.create_runtime_snapshot()
+	var restored_runner: GFDialogueRunner = GFDialogueRunner.new()
+	var _restored_line: GFDialogueLine = restored_runner.restore_runtime_snapshot(
+		resource,
+		snapshot
+	)
+	return restored_runner
 
 
 func _has_issue_kind(issues: Array, kind: String) -> bool:


### PR DESCRIPTION
## Summary
- make `GFDialogueRunner.create_runtime_snapshot()` fail closed with an empty `Dictionary` unless the runner is at a resource-consistent stable `TEXT` checkpoint or a committed stopped state
- preserve `line_reached` and `dialogue_ended` as immediately restorable publication points while guarding nested and reentrant progression
- revalidate complete resource identity for running, ended, restored-ended, and replacement sessions without changing the five-field snapshot schema or schema version 4
- bump the `gf.dialogue` extension version from 3.0.0 to 4.0.0 for the tightened public behavior, update the migration guidance, and regenerate the formal API reference

## Validation
- focused Dialogue GUT: 53/53 tests, 214 assertions; lifecycle gate clean with 0 warnings and 0 orphans
- full GF validation: 46/46 checks passed, including framework GUT, warnings, LSP, docs/API, package editor, CLI local/network, Godot smoke, and package contracts
- framework LSP: 1,340 scripts, 0 diagnostics, 0 timeouts
- framework static: 25/25 checks passed
- package contract: 12/12 checks passed
- API reference: 843 classes, 1 autoload, 12,481 members; generated references current
- `git diff --check` passed

Closes #137