### PR TITLE
Fix turn phase completion ownership

### DIFF
--- a/addons/gf/extensions/turn_based/gf_extension.json
+++ b/addons/gf/extensions/turn_based/gf_extension.json
@@ -2,7 +2,7 @@
   "id": "gf.turn_based",
   "display_name": "GF Turn Based",
   "version": "11.0.0-dev.0",
-  "extension_version": "2.0.1",
+  "extension_version": "3.0.0",
   "kind": "extension",
   "description": "Turn phases, turn actions, contexts, and turn flow system primitives.",
   "dependencies": ["gf.kernel", "gf.standard"],

--- a/addons/gf/extensions/turn_based/resources/gf_turn_phase.gd
+++ b/addons/gf/extensions/turn_based/resources/gf_turn_phase.gd
@@ -40,19 +40,6 @@ var _runtime_by_context_id: Dictionary = {}
 
 # --- 公共方法 ---
 
-## 标记指定上下文的阶段运行完成。
-## [br]
-## @api public
-## [br]
-## @since 8.0.0
-## [br]
-## @param context: 活动 Flow 的上下文；只有一个运行态时可省略。
-func finish(context: GFTurnContext = null) -> void:
-	var runtime: RuntimeState = _resolve_runtime(context)
-	if runtime != null:
-		runtime.finish()
-
-
 ## 查询指定上下文的阶段是否完成。
 ## [br]
 ## @api public
@@ -86,10 +73,15 @@ func _enter(_context: GFTurnContext) -> void:
 ## [br]
 ## @param _context: 回合上下文。
 ## [br]
+## @param _completion: 仅能完成本次阶段运行的一次性句柄；异步回调必须捕获该句柄，而不是稍后按 Context 查找运行态。
+## [br]
 ## @return: 可等待结果。
 ## [br]
 ## @schema return: Variant that is null or a Signal awaited before phase completion.
-func _execute(_context: GFTurnContext) -> Variant:
+func _execute(
+	_context: GFTurnContext,
+	_completion: GFTurnPhaseCompletionHandle
+) -> Variant:
 	return null
 
 
@@ -112,15 +104,32 @@ func _exit(_context: GFTurnContext) -> void:
 ## [br]
 ## @param context: 本次推进持有的回合上下文。
 ## [br]
+## @param lease: 本次推进持有的精确 Context 操作租约。
+## [br]
+## @param owner: 持有租约的 Flow System。
+## [br]
+## @param flow_serial: 持有租约的 Flow generation。
+## [br]
 ## @return: 创建成功时返回独立运行态；上下文无效或已在运行时返回 null。
-func begin_runtime(context: GFTurnContext) -> RuntimeState:
-	if context == null:
+func begin_runtime(
+	context: GFTurnContext,
+	lease: GFTurnContext.FlowOperationLease,
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> RuntimeState:
+	if (
+		context == null
+		or owner == null
+		or not context.is_flow_operation_lease_active(lease, owner, flow_serial)
+	):
 		return null
 	var context_id: int = context.get_instance_id()
 	if _runtime_by_context_id.has(context_id):
 		push_error("[GFTurnPhase] 同一 context 已存在活动运行态。")
 		return null
 	var runtime: RuntimeState = RuntimeState.new()
+	if not runtime.configure_from_flow(context, lease, owner, flow_serial):
+		return null
 	_runtime_by_context_id[context_id] = runtime
 	var _finished_connected: Error = runtime.finished.connect(
 		_on_runtime_finished.bind(context_id, runtime)
@@ -143,21 +152,11 @@ func end_runtime(context: GFTurnContext, runtime: RuntimeState) -> void:
 	var context_id: int = context.get_instance_id()
 	if _get_runtime_value(GFVariantData.get_option_value(_runtime_by_context_id, context_id)) != runtime:
 		return
+	runtime.invalidate_from_flow()
 	var _runtime_erased: bool = _runtime_by_context_id.erase(context_id)
 
 
 # --- 私有/辅助方法 ---
-
-func _resolve_runtime(context: GFTurnContext) -> RuntimeState:
-	if context != null:
-		return _get_runtime(context)
-	if _runtime_by_context_id.is_empty():
-		return null
-	if _runtime_by_context_id.size() > 1:
-		push_error("[GFTurnPhase] finish 失败：存在多个活动运行态，必须提供 context。")
-		return null
-	return _get_runtime_value(_runtime_by_context_id.values()[0])
-
 
 func _get_runtime(context: GFTurnContext) -> RuntimeState:
 	if context == null:
@@ -204,13 +203,124 @@ class RuntimeState extends RefCounted:
 	## @since 8.0.0
 	var is_finished: bool = false
 
-	## 幂等地标记当前运行态完成。
+	var _active: bool = false
+	var _completion_handle: GFTurnPhaseCompletionHandle = null
+	var _context_ref: WeakRef = null
+	var _lease: GFTurnContext.FlowOperationLease = null
+	var _owner_ref: WeakRef = null
+	var _flow_serial: int = -1
+
+	## 绑定本次运行的精确 Context claim，并创建公开 completion handle。
 	## [br]
 	## @api framework_internal
 	## [br]
-	## @since 8.0.0
-	func finish() -> void:
-		if is_finished:
-			return
+	## @since unreleased
+	## [br]
+	## @param context: 本次运行的 Context。
+	## [br]
+	## @param lease: 本次阶段 operation 的精确 claim。
+	## [br]
+	## @param owner: claim 的 Flow System owner。
+	## [br]
+	## @param flow_serial: claim 所属 Flow generation。
+	## [br]
+	## @return: 绑定成功时返回 true。
+	func configure_from_flow(
+		context: GFTurnContext,
+		lease: GFTurnContext.FlowOperationLease,
+		owner: GFTurnFlowSystem,
+		flow_serial: int
+	) -> bool:
+		if (
+			_active
+			or context == null
+			or owner == null
+			or not context.is_flow_operation_lease_active(lease, owner, flow_serial)
+		):
+			return false
+		_context_ref = weakref(context)
+		_lease = lease
+		_owner_ref = weakref(owner)
+		_flow_serial = flow_serial
+		_completion_handle = GFTurnPhaseCompletionHandle.new()
+		if not _completion_handle.configure_from_turn_based(self):
+			_completion_handle = null
+			_context_ref = null
+			_lease = null
+			_owner_ref = null
+			_flow_serial = -1
+			return false
+		_active = true
+		return true
+
+	## 获取传给项目 `_execute()` 的精确 completion handle。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @return: 传给项目 `_execute()` 的精确 completion handle。
+	func get_completion_handle() -> GFTurnPhaseCompletionHandle:
+		return _completion_handle
+
+	## 由 Flow 的 auto_finish 路径完成本次精确运行。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	## [br]
+	## @return: 本次运行仍有效且首次完成时返回 true。
+	func try_complete_from_flow() -> bool:
+		return try_complete_from_turn_based(_completion_handle)
+
+	## 仅供 GFTurnPhaseCompletionHandle 提交本次精确完成权限。
+	## [br]
+	## @api layer_internal
+	## [br]
+	## @layer extensions/turn_based
+	## [br]
+	## @since unreleased
+	## [br]
+	## @param handle: 请求完成本次运行的精确 handle。
+	## [br]
+	## @return: 本次运行仍有效且首次完成时返回 true。
+	func try_complete_from_turn_based(handle: GFTurnPhaseCompletionHandle) -> bool:
+		return _try_complete(handle)
+
+	## 使 completion authority 立即失效；不会释放由 Flow 持有的 Context claim。
+	## [br]
+	## @api framework_internal
+	## [br]
+	## @since unreleased
+	func invalidate_from_flow() -> void:
+		if _completion_handle != null:
+			var _invalidated: bool = _completion_handle.invalidate_from_turn_based(self)
+		_active = false
+		_context_ref = null
+		_lease = null
+		_owner_ref = null
+		_flow_serial = -1
+
+	func _try_complete(handle: GFTurnPhaseCompletionHandle) -> bool:
+		if (
+			not _active
+			or is_finished
+			or handle == null
+			or handle != _completion_handle
+			or _context_ref == null
+			or _owner_ref == null
+		):
+			return false
+		var context_value: Variant = _context_ref.get_ref()
+		var owner_value: Variant = _owner_ref.get_ref()
+		if not (context_value is GFTurnContext) or not (owner_value is GFTurnFlowSystem):
+			return false
+		var context: GFTurnContext = context_value
+		var owner: GFTurnFlowSystem = owner_value
+		if not context.is_flow_operation_lease_active(_lease, owner, _flow_serial):
+			return false
 		is_finished = true
+		_active = false
+		var _invalidated: bool = handle.invalidate_from_turn_based(self)
 		finished.emit()
+		return true

--- a/addons/gf/extensions/turn_based/runtime/gf_turn_context.gd
+++ b/addons/gf/extensions/turn_based/runtime/gf_turn_context.gd
@@ -44,6 +44,10 @@ var metadata: Dictionary = {}
 var _actors: Array[Object] = []
 var _current_actor: Object = null
 var _round_index: int = 0
+var _flow_operation_owner_ref: WeakRef = null
+var _flow_operation_owner_serial: int = -1
+var _flow_operation_leases: Dictionary = {}
+var _next_flow_operation_lease_id: int = 1
 
 
 # --- 公共方法 ---
@@ -140,6 +144,137 @@ func get_actor_value(actor: Object, key: StringName, fallback: Variant = null) -
 
 # --- 框架内部方法 ---
 
+## 尝试为一个 Flow generation 取得精确操作租约。
+## 同一 owner 与 serial 可以同时持有多个 phase/action claim；其他 generation 在最后一张租约释放前会被拒绝。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param owner: 请求 claim 的 Flow System。
+## [br]
+## @param flow_serial: 请求 claim 的 Flow generation。
+## [br]
+## @return: 成功时返回精确租约；Context 正被其他 owner/generation 持有时返回 null。
+func try_acquire_flow_operation_lease(
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> FlowOperationLease:
+	if owner == null or not is_instance_valid(owner):
+		return null
+	if not _flow_operation_leases.is_empty():
+		var current_owner: Object = (
+			_flow_operation_owner_ref.get_ref()
+			if _flow_operation_owner_ref != null
+			else null
+		)
+		if current_owner != owner or _flow_operation_owner_serial != flow_serial:
+			return null
+	else:
+		_flow_operation_owner_ref = weakref(owner)
+		_flow_operation_owner_serial = flow_serial
+
+	var lease_id: int = _next_flow_operation_lease_id
+	_next_flow_operation_lease_id += 1
+	var lease: FlowOperationLease = FlowOperationLease.new()
+	lease._configure(self, owner, flow_serial, lease_id)
+	_flow_operation_leases[lease_id] = lease
+	return lease
+
+
+## 查询精确租约是否仍可执行正常 Flow 写入。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 要验证的精确租约。
+## [br]
+## @param owner: 预期 Flow System owner。
+## [br]
+## @param flow_serial: 预期 Flow generation。
+## [br]
+## @return: 租约仍由该 owner/generation 活动持有时返回 true。
+func is_flow_operation_lease_active(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> bool:
+	return (
+		_is_flow_operation_lease_reserved(lease)
+		and lease._is_active_for(owner, flow_serial)
+	)
+
+
+## 撤销精确租约的后续正常写入，但保留 claim，直到旧 continuation 完成清理。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 要撤销的精确租约。
+## [br]
+## @param owner: 预期 Flow System owner。
+## [br]
+## @return: 首次成功撤销时返回 true。
+func cancel_flow_operation_lease(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem
+) -> bool:
+	if not _is_flow_operation_lease_reserved(lease) or not lease._is_owned_by(owner):
+		return false
+	return lease._cancel()
+
+
+## 精确释放一张 Flow 操作租约。只有最后一张租约释放后才清除 Context owner。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 要释放的精确租约。
+## [br]
+## @param owner: 预期 Flow System owner。
+## [br]
+## @return: 首次成功释放时返回 true。
+func release_flow_operation_lease(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem
+) -> bool:
+	if not _is_flow_operation_lease_reserved(lease) or not lease._is_owned_by(owner):
+		return false
+	var lease_id: int = lease._get_lease_id()
+	var _erased: bool = _flow_operation_leases.erase(lease_id)
+	var released: bool = lease._release()
+	if _flow_operation_leases.is_empty():
+		_flow_operation_owner_ref = null
+		_flow_operation_owner_serial = -1
+	return released
+
+
+## 使用有效租约清理失效参与者。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 本次 Flow operation 的精确租约。
+## [br]
+## @param owner: 租约的 Flow System owner。
+## [br]
+## @param flow_serial: 租约所属 Flow generation。
+## [br]
+## @return: 被移除的失效 actor 数量；租约无效时返回 0。
+func cleanup_invalid_actors_from_flow(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> int:
+	if not is_flow_operation_lease_active(lease, owner, flow_serial):
+		return 0
+	return cleanup_invalid_actors()
+
+
 ## 设置当前行动主体。
 ## [br]
 ## @api framework_internal
@@ -147,8 +282,39 @@ func get_actor_value(actor: Object, key: StringName, fallback: Variant = null) -
 ## @since 8.0.0
 ## [br]
 ## @param actor: 当前行动主体；传入失效对象时归一为空。
-func set_current_actor_from_flow(actor: Object) -> void:
+## [br]
+## @param lease: 本次 action operation 的精确租约。
+## [br]
+## @param owner: 租约的 Flow System owner。
+## [br]
+## @param flow_serial: 租约所属 Flow generation。
+func set_current_actor_from_flow(
+	actor: Object,
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> void:
+	if not is_flow_operation_lease_active(lease, owner, flow_serial):
+		return
 	_current_actor = actor if actor == null or is_instance_valid(actor) else null
+
+
+## 在旧 operation 仍保留精确 claim 时清理 current_actor；取消后的正常写入仍被拒绝。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 仍被本次旧 operation 保留的精确租约。
+## [br]
+## @param owner: 租约的 Flow System owner。
+func clear_current_actor_from_flow(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem
+) -> void:
+	if not _is_flow_operation_lease_reserved(lease) or not lease._is_owned_by(owner):
+		return
+	_current_actor = null
 
 
 ## 重置轮次索引。
@@ -156,7 +322,19 @@ func set_current_actor_from_flow(actor: Object) -> void:
 ## @api framework_internal
 ## [br]
 ## @since 8.0.0
-func reset_round_from_flow() -> void:
+## [br]
+## @param lease: 本次 start operation 的精确租约。
+## [br]
+## @param owner: 租约的 Flow System owner。
+## [br]
+## @param flow_serial: 租约所属 Flow generation。
+func reset_round_from_flow(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> void:
+	if not is_flow_operation_lease_active(lease, owner, flow_serial):
+		return
 	_round_index = 0
 
 
@@ -165,11 +343,33 @@ func reset_round_from_flow() -> void:
 ## @api framework_internal
 ## [br]
 ## @since 8.0.0
-func advance_round_from_flow() -> void:
+## [br]
+## @param lease: 本次 phase operation 的精确租约。
+## [br]
+## @param owner: 租约的 Flow System owner。
+## [br]
+## @param flow_serial: 租约所属 Flow generation。
+func advance_round_from_flow(
+	lease: FlowOperationLease,
+	owner: GFTurnFlowSystem,
+	flow_serial: int
+) -> void:
+	if not is_flow_operation_lease_active(lease, owner, flow_serial):
+		return
 	_round_index += 1
 
 
 # --- 私有/辅助方法 ---
+
+func _is_flow_operation_lease_reserved(lease: FlowOperationLease) -> bool:
+	if lease == null:
+		return false
+	var lease_id: int = lease._get_lease_id()
+	var stored_value: Variant = GFVariantData.get_option_value(
+		_flow_operation_leases,
+		lease_id
+	)
+	return stored_value == lease and lease._is_reserved_for(self)
 
 func _can_invoke_actor_method(
 	actor: Object,
@@ -253,3 +453,69 @@ func _object_matches_class_name(value: Object, expected_class_name: StringName) 
 			return true
 		script_value = script.get_base_script()
 	return false
+
+
+# --- 内部类 ---
+
+## GFTurnContext 内部的一次 Flow 操作租约。
+## [br]
+## @api framework_internal
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class FlowOperationLease extends RefCounted:
+	var _context_ref: WeakRef = null
+	var _owner_ref: WeakRef = null
+	var _flow_serial: int = -1
+	var _lease_id: int = 0
+	var _active: bool = false
+	var _reserved: bool = false
+
+	func _configure(
+		context: GFTurnContext,
+		owner: GFTurnFlowSystem,
+		flow_serial: int,
+		lease_id: int
+	) -> void:
+		_context_ref = weakref(context)
+		_owner_ref = weakref(owner)
+		_flow_serial = flow_serial
+		_lease_id = lease_id
+		_active = true
+		_reserved = true
+
+	func _get_lease_id() -> int:
+		return _lease_id
+
+	func _is_owned_by(owner: GFTurnFlowSystem) -> bool:
+		return (
+			_reserved
+			and _owner_ref != null
+			and _owner_ref.get_ref() == owner
+		)
+
+	func _is_reserved_for(context: GFTurnContext) -> bool:
+		return (
+			_reserved
+			and _context_ref != null
+			and _context_ref.get_ref() == context
+		)
+
+	func _is_active_for(owner: GFTurnFlowSystem, flow_serial: int) -> bool:
+		return _active and _is_owned_by(owner) and _flow_serial == flow_serial
+
+	func _cancel() -> bool:
+		if not _reserved or not _active:
+			return false
+		_active = false
+		return true
+
+	func _release() -> bool:
+		if not _reserved:
+			return false
+		_active = false
+		_reserved = false
+		_context_ref = null
+		_owner_ref = null
+		return true

--- a/addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd
+++ b/addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd
@@ -137,18 +137,27 @@ var _action_order_by_instance_id: Dictionary = {}
 var _restore_pending_actions_on_cancel: bool = false
 var _lifecycle_state: int = _LifecycleState.STOPPED
 var _active_operation_stop_requested: bool = false
+var _active_context_operation_leases: Array[GFTurnContext.FlowOperationLease] = []
+var _is_disposed: bool = false
 
 
 # --- 公共方法 ---
 
 ## 设置上下文。
+## 存在活动 Context operation claim 时会拒绝修改；operation 安全收尾并释放最后一张 claim 后可顺序重试。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param p_context: 新上下文。
 func set_context(p_context: GFTurnContext) -> void:
-	if _is_advancing_phase or _is_resolving_actions:
-		push_warning("[GFTurnFlowSystem] set_context 失败：流程正在推进或解析中。")
+	if (
+		_is_advancing_phase
+		or _is_resolving_actions
+		or not _active_context_operation_leases.is_empty()
+	):
+		push_warning("[GFTurnFlowSystem] set_context 失败：存在活动 Context operation。")
 		return
 	var next_context: GFTurnContext = p_context if p_context != null else GFTurnContext.new()
 	if _context == next_context:
@@ -178,11 +187,16 @@ func set_phases(p_phases: Array[GFTurnPhase]) -> void:
 
 
 ## 开始流程。
+## 若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param reset_indices: 是否重置阶段索引和轮次数据。
 func start(reset_indices: bool = true) -> void:
+	if _is_disposed:
+		return
 	if _lifecycle_state == _LifecycleState.STARTING or _lifecycle_state == _LifecycleState.RUNNING:
 		return
 	if _lifecycle_state == _LifecycleState.STOPPING:
@@ -190,16 +204,26 @@ func start(reset_indices: bool = true) -> void:
 	if _is_advancing_phase or _is_resolving_actions:
 		push_warning("[GFTurnFlowSystem] start 失败：流程正在推进或解析中。")
 		return
+	var active_context: GFTurnContext = _context
+	var next_flow_serial: int = _flow_serial + 1
+	var start_lease: GFTurnContext.FlowOperationLease = _acquire_context_operation_lease(
+		active_context,
+		next_flow_serial
+	)
+	if start_lease == null:
+		push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+		return
 	_lifecycle_state = _LifecycleState.STARTING
+	_flow_serial = next_flow_serial
 	if reset_indices:
 		_current_phase_index = -1
-		_context.reset_round_from_flow()
-	_flow_serial += 1
+		active_context.reset_round_from_flow(start_lease, self, _flow_serial)
 	_restore_pending_actions_on_cancel = false
 	_active_operation_stop_requested = false
 	_is_running = true
 	_lifecycle_state = _LifecycleState.RUNNING
-	flow_started.emit(_context)
+	flow_started.emit(active_context)
+	_release_context_operation_lease(active_context, start_lease)
 
 
 ## 停止流程。
@@ -210,6 +234,7 @@ func start(reset_indices: bool = true) -> void:
 ## [br]
 ## @param should_clear_actions: 是否清空待处理行动。即使流程已经 stopped，true 仍会幂等清理并封存队列；此前的保留策略也会升级为清理。
 func stop(should_clear_actions: bool = true) -> void:
+	_cancel_active_context_operation_leases()
 	if should_clear_actions:
 		_restore_pending_actions_on_cancel = false
 		_clear_actions_internal()
@@ -233,10 +258,29 @@ func stop(should_clear_actions: bool = true) -> void:
 	flow_stopped.emit(stopped_context)
 
 
-## 推进到下一个阶段。
+## 销毁系统，撤销所有在途 operation，并拒绝后续启动、阶段推进、行动入队与行动解析。
+## 在途 continuation 会先完成精确清理，再释放 Context claim。
 ## [br]
 ## @api public
+## [br]
+## @since unreleased
+func dispose() -> void:
+	if _is_disposed:
+		return
+	_is_disposed = true
+	stop(true)
+	super.dispose()
+
+
+## 推进到下一个阶段。
+## 若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、修改阶段/轮次或发出阶段信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
+## [br]
+## @api public
+## [br]
+## @since 3.17.0
 func advance_phase() -> void:
+	if _is_disposed:
+		return
 	if _is_advancing_phase:
 		push_warning("[GFTurnFlowSystem] advance_phase 失败：阶段正在推进中。")
 		return
@@ -246,69 +290,106 @@ func advance_phase() -> void:
 		start(false)
 	if not _is_running:
 		return
-	_is_advancing_phase = true
-	_active_operation_stop_requested = false
 	var flow_serial: int = _flow_serial
 	var active_context: GFTurnContext = _context
-	var _cleanup_before_phase: int = active_context.cleanup_invalid_actors()
+	var phase_lease: GFTurnContext.FlowOperationLease = _acquire_context_operation_lease(
+		active_context,
+		flow_serial
+	)
+	if phase_lease == null:
+		push_warning("[GFTurnFlowSystem] advance_phase 失败：context 正由另一个 flow generation 持有。")
+		return
+	_is_advancing_phase = true
+	_active_operation_stop_requested = false
 
 	var next_phase: Dictionary = _next_valid_phase()
 	if next_phase.is_empty():
-		_is_advancing_phase = false
+		_end_phase_advance(null, active_context, null, phase_lease)
 		return
-	_current_phase_index = GFVariantData.get_option_int(next_phase, "index")
-	if GFVariantData.get_option_bool(next_phase, "wrapped"):
-		active_context.advance_round_from_flow()
-
-	var phase: GFTurnPhase = _phases[_current_phase_index]
+	var next_phase_index: int = GFVariantData.get_option_int(next_phase, "index")
+	var phase: GFTurnPhase = _phases[next_phase_index]
 	if phase == null:
-		_is_advancing_phase = false
+		_end_phase_advance(null, active_context, null, phase_lease)
 		return
-	var phase_runtime: GFTurnPhase.RuntimeState = phase.begin_runtime(active_context)
+	var phase_runtime: GFTurnPhase.RuntimeState = phase.begin_runtime(
+		active_context,
+		phase_lease,
+		self,
+		flow_serial
+	)
 	if phase_runtime == null:
-		_is_advancing_phase = false
+		_end_phase_advance(null, active_context, null, phase_lease)
 		return
+	var _cleanup_before_phase: int = active_context.cleanup_invalid_actors_from_flow(
+		phase_lease,
+		self,
+		flow_serial
+	)
+	_current_phase_index = next_phase_index
+	if GFVariantData.get_option_bool(next_phase, "wrapped"):
+		active_context.advance_round_from_flow(phase_lease, self, flow_serial)
 
 	phase_changed.emit(phase, _current_phase_index)
-	if not _is_active_context_lease(flow_serial, active_context):
-		_end_phase_advance(phase, active_context, phase_runtime)
+	if not _is_active_context_operation_lease(phase_lease, flow_serial, active_context):
+		_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 		return
-	var _cleanup_after_phase_signal: int = active_context.cleanup_invalid_actors()
+	var _cleanup_after_phase_signal: int = active_context.cleanup_invalid_actors_from_flow(
+		phase_lease,
+		self,
+		flow_serial
+	)
 	phase._enter(active_context)
-	if not _is_active_context_lease(flow_serial, active_context):
-		_end_phase_advance(phase, active_context, phase_runtime)
+	if not _is_active_context_operation_lease(phase_lease, flow_serial, active_context):
+		_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 		return
 
-	var result: Variant = phase._execute(active_context)
-	if not _is_active_context_lease(flow_serial, active_context):
-		_end_phase_advance(phase, active_context, phase_runtime)
+	var result: Variant = phase._execute(
+		active_context,
+		phase_runtime.get_completion_handle()
+	)
+	if not _is_active_context_operation_lease(phase_lease, flow_serial, active_context):
+		_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 		return
 	if result is Signal:
 		var result_signal: Signal = result
 		var completed: bool = await _await_signal_safely(
 			result_signal,
-			Callable(self, "_is_active_context_lease").bind(flow_serial, active_context),
+			Callable(self, "_is_active_context_operation_lease").bind(
+				phase_lease,
+				flow_serial,
+				active_context
+			),
 			"[GFTurnFlowSystem] 等待阶段 Signal 超时，阶段推进已中止。"
 		)
-		if not completed or not _is_active_context_lease(flow_serial, active_context):
-			_end_phase_advance(phase, active_context, phase_runtime)
+		if (
+			not completed
+			or not _is_active_context_operation_lease(phase_lease, flow_serial, active_context)
+		):
+			_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 			return
 	if phase.auto_finish:
-		phase_runtime.finish()
-	if not _is_active_context_lease(flow_serial, active_context):
-		_end_phase_advance(phase, active_context, phase_runtime)
+		var _auto_completed: bool = phase_runtime.try_complete_from_flow()
+	if not _is_active_context_operation_lease(phase_lease, flow_serial, active_context):
+		_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 		return
 	if not phase_runtime.is_finished:
 		var completed: bool = await _await_signal_safely(
 			phase_runtime.finished,
-			Callable(self, "_is_active_context_lease").bind(flow_serial, active_context),
+			Callable(self, "_is_active_context_operation_lease").bind(
+				phase_lease,
+				flow_serial,
+				active_context
+			),
 			"[GFTurnFlowSystem] 等待阶段完成超时，阶段推进已中止。"
 		)
-		if not completed or not _is_active_context_lease(flow_serial, active_context):
-			_end_phase_advance(phase, active_context, phase_runtime)
+		if (
+			not completed
+			or not _is_active_context_operation_lease(phase_lease, flow_serial, active_context)
+		):
+			_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 			return
 	phase._exit(active_context)
-	_end_phase_advance(phase, active_context, phase_runtime)
+	_end_phase_advance(phase, active_context, phase_runtime, phase_lease)
 
 
 ## 获取待处理行动的只读快照。
@@ -351,6 +432,8 @@ func clear_actions() -> void:
 ## [br]
 ## @param action: 行动实例。
 func enqueue_action(action: GFTurnAction) -> void:
+	if _is_disposed:
+		return
 	if action == null:
 		return
 	if not action.claim_for_queue():
@@ -362,6 +445,7 @@ func enqueue_action(action: GFTurnAction) -> void:
 
 
 ## 解析当前上下文中的所有行动。
+## 若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、取走队列、写入 current_actor 或调用 action 前失败关闭；最后一张 operation claim 释放后可顺序重试。
 ## [br]
 ## @api public
 ## [br]
@@ -369,17 +453,30 @@ func enqueue_action(action: GFTurnAction) -> void:
 ## [br]
 ## @param order_resolver: 可选排序回调，签名为 func(a, b) -> bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则。
 func resolve_actions(order_resolver: Callable = Callable()) -> void:
+	if _is_disposed:
+		return
 	if _is_resolving_actions:
 		push_warning("[GFTurnFlowSystem] resolve_actions 失败：行动正在解析中。")
 		return
 
 	var flow_serial: int = _flow_serial
 	var active_context: GFTurnContext = _context
+	var action_lease: GFTurnContext.FlowOperationLease = _acquire_context_operation_lease(
+		active_context,
+		flow_serial
+	)
+	if action_lease == null:
+		push_warning("[GFTurnFlowSystem] resolve_actions 失败：context 正由另一个 flow generation 持有。")
+		return
 	var pending_actions: Array[GFTurnAction] = _actions.duplicate()
 	_actions.clear()
 	_is_resolving_actions = true
 	_active_operation_stop_requested = false
-	var _cleanup_invalid_actors_result: int = active_context.cleanup_invalid_actors()
+	var _cleanup_invalid_actors_result: int = active_context.cleanup_invalid_actors_from_flow(
+		action_lease,
+		self,
+		flow_serial
+	)
 	for action: GFTurnAction in pending_actions:
 		_ensure_action_order(action)
 
@@ -388,15 +485,15 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 			pending_actions.sort_custom(order_resolver)
 		else:
 			pending_actions.sort_custom(_sort_action_desc)
-	if not _is_context_lease_current(flow_serial, active_context):
+	if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
 		_restore_unresolved_actions(pending_actions, 0)
-		_finish_action_resolution(active_context)
+		_finish_action_resolution(active_context, action_lease)
 		return
 
 	var action_index: int = 0
 	while action_index < pending_actions.size():
 		var action: GFTurnAction = pending_actions[action_index]
-		if not _is_context_lease_current(flow_serial, active_context):
+		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
 			_restore_unresolved_actions(pending_actions, action_index)
 			break
 		if action == null or action.is_cancelled or _action_has_invalid_actor(action):
@@ -404,24 +501,42 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 			action_index += 1
 			continue
 		_inject_action(action)
+		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
+			_restore_unresolved_actions(pending_actions, action_index)
+			break
 		action.replace_runtime_targets(action.targets)
-		active_context.set_current_actor_from_flow(_variant_to_valid_object(action.actor))
+		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
+			_restore_unresolved_actions(pending_actions, action_index)
+			break
+		active_context.set_current_actor_from_flow(
+			_variant_to_valid_object(action.actor),
+			action_lease,
+			self,
+			flow_serial
+		)
+		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
+			_restore_unresolved_actions(pending_actions, action_index)
+			break
 		var result: Variant = action._resolve(active_context)
 		if result is Signal:
 			var result_signal: Signal = result
 			var completed: bool = await _await_signal_safely(
 				result_signal,
-				Callable(self, "_is_context_lease_current").bind(flow_serial, active_context),
+				Callable(self, "_is_context_operation_lease_current").bind(
+					action_lease,
+					flow_serial,
+					active_context
+				),
 				"[GFTurnFlowSystem] 等待行动 Signal 超时，当前行动已跳过。"
 			)
-			if not _is_context_lease_current(flow_serial, active_context):
+			if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
 				_restore_unresolved_actions(pending_actions, action_index)
 				break
 			if not completed:
 				_consume_action(action)
 				action_index += 1
 				continue
-		if not _is_context_lease_current(flow_serial, active_context):
+		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
 			_consume_action(action)
 			_restore_unresolved_actions(pending_actions, action_index + 1)
 			break
@@ -433,7 +548,7 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 		action_resolved.emit(action)
 		action_index += 1
 
-	_finish_action_resolution(active_context)
+	_finish_action_resolution(active_context, action_lease)
 
 
 # --- 私有/辅助方法 ---
@@ -578,27 +693,82 @@ func _get_time_utility() -> GFTimeUtility:
 func _end_phase_advance(
 	phase: GFTurnPhase,
 	active_context: GFTurnContext,
-	phase_runtime: GFTurnPhase.RuntimeState
+	phase_runtime: GFTurnPhase.RuntimeState,
+	phase_lease: GFTurnContext.FlowOperationLease
 ) -> void:
 	if phase != null:
 		phase.end_runtime(active_context, phase_runtime)
 	_is_advancing_phase = false
 	if not _is_resolving_actions:
 		_active_operation_stop_requested = false
+	_release_context_operation_lease(active_context, phase_lease)
 
 
-func _finish_action_resolution(active_context: GFTurnContext) -> void:
+func _finish_action_resolution(
+	active_context: GFTurnContext,
+	action_lease: GFTurnContext.FlowOperationLease
+) -> void:
 	if active_context != null:
-		active_context.set_current_actor_from_flow(null)
+		active_context.clear_current_actor_from_flow(action_lease, self)
 	_is_resolving_actions = false
 	_restore_pending_actions_on_cancel = false
 	if not _is_advancing_phase:
 		_active_operation_stop_requested = false
+	_release_context_operation_lease(active_context, action_lease)
 
 
-func _is_context_lease_current(serial: int, active_context: GFTurnContext) -> bool:
-	return serial == _flow_serial and active_context == _context
+func _acquire_context_operation_lease(
+	active_context: GFTurnContext,
+	flow_serial: int
+) -> GFTurnContext.FlowOperationLease:
+	if active_context == null:
+		return null
+	var lease: GFTurnContext.FlowOperationLease = (
+		active_context.try_acquire_flow_operation_lease(self, flow_serial)
+	)
+	if lease != null:
+		_active_context_operation_leases.append(lease)
+	return lease
 
 
-func _is_active_context_lease(serial: int, active_context: GFTurnContext) -> bool:
-	return _is_running and _is_context_lease_current(serial, active_context)
+func _cancel_active_context_operation_leases() -> void:
+	for lease: GFTurnContext.FlowOperationLease in _active_context_operation_leases.duplicate():
+		if lease == null:
+			continue
+		var _cancelled: bool = _context.cancel_flow_operation_lease(lease, self)
+
+
+func _release_context_operation_lease(
+	active_context: GFTurnContext,
+	lease: GFTurnContext.FlowOperationLease
+) -> void:
+	if lease == null:
+		return
+	if active_context != null:
+		var _released: bool = active_context.release_flow_operation_lease(lease, self)
+	_active_context_operation_leases.erase(lease)
+
+
+func _is_context_operation_lease_current(
+	lease: GFTurnContext.FlowOperationLease,
+	serial: int,
+	active_context: GFTurnContext
+) -> bool:
+	return (
+		serial == _flow_serial
+		and active_context == _context
+		and active_context != null
+		and active_context.is_flow_operation_lease_active(lease, self, serial)
+	)
+
+
+func _is_active_context_operation_lease(
+	lease: GFTurnContext.FlowOperationLease,
+	serial: int,
+	active_context: GFTurnContext
+) -> bool:
+	return (
+		not _is_disposed
+		and _is_running
+		and _is_context_operation_lease_current(lease, serial, active_context)
+	)

--- a/addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd
+++ b/addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd
@@ -138,6 +138,9 @@ var _restore_pending_actions_on_cancel: bool = false
 var _lifecycle_state: int = _LifecycleState.STOPPED
 var _active_operation_stop_requested: bool = false
 var _active_context_operation_leases: Array[GFTurnContext.FlowOperationLease] = []
+var _is_notifying_flow_started: bool = false
+var _has_pending_start_request: bool = false
+var _pending_start_reset_indices: bool = true
 var _is_disposed: bool = false
 
 
@@ -188,6 +191,7 @@ func set_phases(p_phases: Array[GFTurnPhase]) -> void:
 
 ## 开始流程。
 ## 若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
+## 若本 system 在自身 [signal flow_started] 通知中完成 [method stop]，并在由此发出的 [signal flow_stopped] 回调中再次调用本方法，首个重启请求会等旧 claim 释放后同步重放；重放前的后续 [method stop] 或 [method dispose] 会取消该请求。
 ## [br]
 ## @api public
 ## [br]
@@ -203,6 +207,15 @@ func start(reset_indices: bool = true) -> void:
 		return
 	if _is_advancing_phase or _is_resolving_actions:
 		push_warning("[GFTurnFlowSystem] start 失败：流程正在推进或解析中。")
+		return
+	if (
+		_lifecycle_state == _LifecycleState.STOPPED
+		and _is_notifying_flow_started
+		and not _active_context_operation_leases.is_empty()
+	):
+		if not _has_pending_start_request:
+			_has_pending_start_request = true
+			_pending_start_reset_indices = reset_indices
 		return
 	var active_context: GFTurnContext = _context
 	var next_flow_serial: int = _flow_serial + 1
@@ -222,7 +235,9 @@ func start(reset_indices: bool = true) -> void:
 	_active_operation_stop_requested = false
 	_is_running = true
 	_lifecycle_state = _LifecycleState.RUNNING
+	_is_notifying_flow_started = true
 	flow_started.emit(active_context)
+	_is_notifying_flow_started = false
 	_release_context_operation_lease(active_context, start_lease)
 
 
@@ -234,6 +249,7 @@ func start(reset_indices: bool = true) -> void:
 ## [br]
 ## @param should_clear_actions: 是否清空待处理行动。即使流程已经 stopped，true 仍会幂等清理并封存队列；此前的保留策略也会升级为清理。
 func stop(should_clear_actions: bool = true) -> void:
+	_clear_pending_start_request()
 	_cancel_active_context_operation_leases()
 	if should_clear_actions:
 		_restore_pending_actions_on_cancel = false
@@ -747,6 +763,28 @@ func _release_context_operation_lease(
 	if active_context != null:
 		var _released: bool = active_context.release_flow_operation_lease(lease, self)
 	_active_context_operation_leases.erase(lease)
+	_try_replay_pending_start_request()
+
+
+func _clear_pending_start_request() -> void:
+	_has_pending_start_request = false
+	_pending_start_reset_indices = true
+
+
+func _try_replay_pending_start_request() -> void:
+	if (
+		not _has_pending_start_request
+		or _is_disposed
+		or _is_notifying_flow_started
+		or _lifecycle_state != _LifecycleState.STOPPED
+		or _is_advancing_phase
+		or _is_resolving_actions
+		or not _active_context_operation_leases.is_empty()
+	):
+		return
+	var reset_indices: bool = _pending_start_reset_indices
+	_clear_pending_start_request()
+	start(reset_indices)
 
 
 func _is_context_operation_lease_current(

--- a/addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd
+++ b/addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd
@@ -1,0 +1,79 @@
+## GFTurnPhaseCompletionHandle: 单次阶段运行的完成能力句柄。
+##
+## 有效句柄只会由 GFTurnFlowSystem 传给当前 GFTurnPhase._execute() 调用；项目手工 new() 的实例没有完成权限。
+## 首次对有效运行调用 try_complete() 会完成该阶段；停止、超时、释放、dispose、重启后的旧句柄及重复调用都返回 false，不影响其他代际。
+## [br]
+## @api public
+## [br]
+## @category runtime_handle
+## [br]
+## @since unreleased
+class_name GFTurnPhaseCompletionHandle
+extends RefCounted
+
+
+# --- 私有变量 ---
+
+var _runtime_ref: WeakRef = null
+var _configured: bool = false
+
+
+# --- 公共方法 ---
+
+## 尝试完成创建此句柄的精确阶段运行。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return: 当前主线程首次完成仍有效的精确运行时返回 true；失效、重复或非主线程调用返回 false。
+func try_complete() -> bool:
+	if not Thread.is_main_thread() or _runtime_ref == null:
+		return false
+	var runtime_value: Variant = _runtime_ref.get_ref()
+	if not (runtime_value is RefCounted):
+		return false
+	var runtime: RefCounted = runtime_value
+	if not runtime.has_method(&"try_complete_from_turn_based"):
+		return false
+	var completion_result: Variant = runtime.call(&"try_complete_from_turn_based", self)
+	if completion_result is bool:
+		return completion_result
+	return false
+
+
+# --- 层内方法 ---
+
+## 绑定精确的阶段运行态。句柄只允许初始化一次。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/turn_based
+## [br]
+## @param runtime: 创建此 handle 的精确阶段运行态。
+## [br]
+## @return: 首次成功绑定时返回 true。
+func configure_from_turn_based(runtime: RefCounted) -> bool:
+	if _configured or runtime == null:
+		return false
+	_runtime_ref = weakref(runtime)
+	_configured = true
+	return true
+
+
+## 仅由绑定的阶段运行态撤销此句柄。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/turn_based
+## [br]
+## @param runtime: 请求撤销的精确阶段运行态。
+## [br]
+## @return: 绑定的 runtime 首次成功撤销时返回 true。
+func invalidate_from_turn_based(runtime: RefCounted) -> bool:
+	if runtime == null or _runtime_ref == null:
+		return false
+	if _runtime_ref.get_ref() != runtime:
+		return false
+	_runtime_ref = null
+	return true

--- a/addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd.uid
+++ b/addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd.uid
@@ -1,0 +1,1 @@
+uid://dvuifhfl84uk8

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,8 +2,8 @@
   "schema_version": 2,
   "catalog_version": "2.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "4086ab2c54acaa4a3c47d2472e5cb68d76dc4f8e52ed4bfec41e06e1da6ad026",
-  "class_count": 819,
+  "source_digest": "2606faac835cff13026ce8f2194b74e45899f82e9425b47f66ae85f4b8732b50",
+  "class_count": 820,
   "autoload_count": 1,
   "package_count": 56,
   "packages": [
@@ -90952,6 +90952,13 @@
         },
         {
           "kind": "func",
+          "name": "dispose",
+          "signature": "func dispose() -> void",
+          "summary": "销毁系统，撤销所有在途 operation，并拒绝后续启动、阶段推进、行动入队与行动解析。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "advance_phase",
           "signature": "func advance_phase() -> void",
           "summary": "推进到下一个阶段。",
@@ -91028,13 +91035,6 @@
         },
         {
           "kind": "func",
-          "name": "finish",
-          "signature": "func finish(context: GFTurnContext = null) -> void",
-          "summary": "标记指定上下文的阶段运行完成。",
-          "visibility": "public"
-        },
-        {
-          "kind": "func",
           "name": "is_finished_for",
           "signature": "func is_finished_for(context: GFTurnContext) -> bool",
           "summary": "查询指定上下文的阶段是否完成。",
@@ -91050,7 +91050,7 @@
         {
           "kind": "func",
           "name": "_execute",
-          "signature": "func _execute(_context: GFTurnContext) -> Variant",
+          "signature": "func _execute( _context: GFTurnContext, _completion: GFTurnPhaseCompletionHandle ) -> Variant",
           "summary": "执行阶段逻辑时由 GFTurnFlowSystem 调用。",
           "visibility": "protected"
         },
@@ -91060,6 +91060,26 @@
           "signature": "func _exit(_context: GFTurnContext) -> void",
           "summary": "退出阶段时由 GFTurnFlowSystem 调用。",
           "visibility": "protected"
+        }
+      ]
+    },
+    "GFTurnPhaseCompletionHandle": {
+      "owner_kind": "class",
+      "extends": "RefCounted",
+      "module": "extensions/turn_based",
+      "package_id": "gf.extension.turn_based",
+      "path": "addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd",
+      "summary": "GFTurnPhaseCompletionHandle: 单次阶段运行的完成能力句柄。 有效句柄只会由 GFTurnFlowSystem 传给当前 GFTurnPhase._execute() 调用；项目手工 new() 的实例没有完成权限。 首次对有效运行调用 try_complete() 会完成该阶段；停止、超时、释放、dispose、重启后的旧句柄及重复调用都返回 false，不影响其他代际。",
+      "visibility": "public",
+      "category": "runtime_handle",
+      "since": "unreleased",
+      "members": [
+        {
+          "kind": "func",
+          "name": "try_complete",
+          "signature": "func try_complete() -> bool",
+          "summary": "尝试完成创建此句柄的精确阶段运行。",
+          "visibility": "public"
         }
       ]
     },

--- a/docs/api_catalog/classes/GFTurnFlowSystem.xml
+++ b/docs/api_catalog/classes/GFTurnFlowSystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTurnFlowSystem" path="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" module="extensions/turn_based" extends="GFSystem" classDigest="2fa7c13a7b21fc883de7a74400342035b754e063192e319fbe970542d71f258f">
+<class name="GFTurnFlowSystem" path="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" module="extensions/turn_based" extends="GFSystem" classDigest="1dd11fd080bcc829b36d079e2ff915f644db84ff6e7be07912200f44021ccf7e">
 	<description>GFTurnFlowSystem: 通用回合流程系统。
 提供阶段推进、行动排队和按优先级解析能力。
 它不关心战斗、卡牌、棋盘等具体业务，只调度抽象行动。</description>
@@ -130,7 +130,8 @@
 		<member kind="method" name="start">
 			<signature>func start(reset_indices: bool = true) -&gt; void:</signature>
 			<description>开始流程。
-若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。</description>
+若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
+若本 system 在自身 [signal flow_started] 通知中完成 [method stop]，并在由此发出的 [signal flow_stopped] 回调中再次调用本方法，首个重启请求会等旧 claim 释放后同步重放；重放前的后续 [method stop] 或 [method dispose] 会取消该请求。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">reset_indices: 是否重置阶段索引和轮次数据。</tag>

--- a/docs/api_catalog/classes/GFTurnFlowSystem.xml
+++ b/docs/api_catalog/classes/GFTurnFlowSystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTurnFlowSystem" path="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" module="extensions/turn_based" extends="GFSystem" classDigest="1f907f96cc6ef444d29047e89e0e25ab9b4e65939d2585932cfd56ecea7e6a0b">
+<class name="GFTurnFlowSystem" path="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" module="extensions/turn_based" extends="GFSystem" classDigest="2fa7c13a7b21fc883de7a74400342035b754e063192e319fbe970542d71f258f">
 	<description>GFTurnFlowSystem: 通用回合流程系统。
 提供阶段推进、行动排队和按优先级解析能力。
 它不关心战斗、卡牌、棋盘等具体业务，只调度抽象行动。</description>
@@ -111,10 +111,12 @@
 	<methods>
 		<member kind="method" name="set_context">
 			<signature>func set_context(p_context: GFTurnContext) -&gt; void:</signature>
-			<description>设置上下文。</description>
+			<description>设置上下文。
+存在活动 Context operation claim 时会拒绝修改；operation 安全收尾并释放最后一张 claim 后可顺序重试。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">p_context: 新上下文。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="set_phases">
@@ -127,10 +129,12 @@
 		</member>
 		<member kind="method" name="start">
 			<signature>func start(reset_indices: bool = true) -&gt; void:</signature>
-			<description>开始流程。</description>
+			<description>开始流程。
+若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">reset_indices: 是否重置阶段索引和轮次数据。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="stop">
@@ -142,11 +146,22 @@
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
-		<member kind="method" name="advance_phase">
-			<signature>func advance_phase() -&gt; void:</signature>
-			<description>推进到下一个阶段。</description>
+		<member kind="method" name="dispose">
+			<signature>func dispose() -&gt; void:</signature>
+			<description>销毁系统，撤销所有在途 operation，并拒绝后续启动、阶段推进、行动入队与行动解析。
+在途 continuation 会先完成精确清理，再释放 Context claim。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="advance_phase">
+			<signature>func advance_phase() -&gt; void:</signature>
+			<description>推进到下一个阶段。
+若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、修改阶段/轮次或发出阶段信号前失败关闭；最后一张 operation claim 释放后可顺序重试。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="get_actions">
@@ -185,7 +200,8 @@
 		</member>
 		<member kind="method" name="resolve_actions">
 			<signature>func resolve_actions(order_resolver: Callable = Callable()) -&gt; void:</signature>
-			<description>解析当前上下文中的所有行动。</description>
+			<description>解析当前上下文中的所有行动。
+若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、取走队列、写入 current_actor 或调用 action 前失败关闭；最后一张 operation claim 释放后可顺序重试。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">order_resolver: 可选排序回调，签名为 func(a, b) -&gt; bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则。</tag>

--- a/docs/api_catalog/classes/GFTurnPhase.xml
+++ b/docs/api_catalog/classes/GFTurnPhase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTurnPhase" path="addons/gf/extensions/turn_based/resources/gf_turn_phase.gd" module="extensions/turn_based" extends="Resource" classDigest="cf58c6e176290faab3347845946ea4fca9aaf65bca2ccf403856f81c1d6b42ca">
+<class name="GFTurnPhase" path="addons/gf/extensions/turn_based/resources/gf_turn_phase.gd" module="extensions/turn_based" extends="Resource" classDigest="c01795f933ac9204afc1a728c29fb744cf9e57c4219cf21853cc6da257cb4333">
 	<description>GFTurnPhase: 通用回合阶段基类。
 阶段只提供 _enter/_execute/_exit 生命周期和完成信号，
 不绑定任何具体游戏流程。</description>
@@ -36,15 +36,6 @@
 		</member>
 	</properties>
 	<methods>
-		<member kind="method" name="finish">
-			<signature>func finish(context: GFTurnContext = null) -&gt; void:</signature>
-			<description>标记指定上下文的阶段运行完成。</description>
-			<tags>
-				<tag name="api">public</tag>
-				<tag name="param">context: 活动 Flow 的上下文；只有一个运行态时可省略。</tag>
-				<tag name="since">8.0.0</tag>
-			</tags>
-		</member>
 		<member kind="method" name="is_finished_for">
 			<signature>func is_finished_for(context: GFTurnContext) -&gt; bool:</signature>
 			<description>查询指定上下文的阶段是否完成。</description>
@@ -64,11 +55,12 @@
 			</tags>
 		</member>
 		<member kind="method" name="_execute">
-			<signature>func _execute(_context: GFTurnContext) -&gt; Variant:</signature>
+			<signature>func _execute( _context: GFTurnContext, _completion: GFTurnPhaseCompletionHandle ) -&gt; Variant:</signature>
 			<description>执行阶段逻辑时由 GFTurnFlowSystem 调用。</description>
 			<tags>
 				<tag name="api">protected</tag>
 				<tag name="param">_context: 回合上下文。</tag>
+				<tag name="param">_completion: 仅能完成本次阶段运行的一次性句柄；异步回调必须捕获该句柄，而不是稍后按 Context 查找运行态。</tag>
 				<tag name="return">可等待结果。</tag>
 				<tag name="schema">return: Variant that is null or a Signal awaited before phase completion.</tag>
 				<tag name="since">3.17.0</tag>

--- a/docs/api_catalog/classes/GFTurnPhaseCompletionHandle.xml
+++ b/docs/api_catalog/classes/GFTurnPhaseCompletionHandle.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<class name="GFTurnPhaseCompletionHandle" path="addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd" module="extensions/turn_based" extends="RefCounted" classDigest="156c90a67fa8849f2ed239cffb72b1182aa4892892a2fb52d3d6f5568e2a77d9">
+	<description>GFTurnPhaseCompletionHandle: 单次阶段运行的完成能力句柄。
+有效句柄只会由 GFTurnFlowSystem 传给当前 GFTurnPhase._execute() 调用；项目手工 new() 的实例没有完成权限。
+首次对有效运行调用 try_complete() 会完成该阶段；停止、超时、释放、dispose、重启后的旧句柄及重复调用都返回 false，不影响其他代际。</description>
+	<tags>
+		<tag name="api">public</tag>
+		<tag name="category">runtime_handle</tag>
+		<tag name="since">unreleased</tag>
+	</tags>
+	<signals />
+	<enums />
+	<constants />
+	<properties />
+	<methods>
+		<member kind="method" name="try_complete">
+			<signature>func try_complete() -&gt; bool:</signature>
+			<description>尝试完成创建此句柄的精确阶段运行。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">当前主线程首次完成仍有效的精确运行时返回 true；失效、重复或非主线程调用返回 false。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</methods>
+	<innerClasses />
+</class>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="c1eda8cb9498081c6d2d3a716a3473962b07e770a5b5c74e31f780f0c0e7c733" classCount="843" methodCount="7679" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="eac36b75783638ad9fb5a4e94f820062a702cf055c767e2695b040e207291a1e" classCount="844" methodCount="7680" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="75" methodCount="801" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -858,11 +858,12 @@
 		<class name="GFSaveSource" path="classes/GFSaveSource.xml" sourcePath="addons/gf/extensions/save/core/gf_save_source.gd" extends="Node" />
 		<class name="GFSaveTransactionParticipant" path="classes/GFSaveTransactionParticipant.xml" sourcePath="addons/gf/extensions/save/pipeline/gf_save_transaction_participant.gd" extends="Resource" />
 	</module>
-	<module id="extensions/turn_based" label="Turn Based" classCount="4" methodCount="24" autoloadCount="0" autoloadMethodCount="0">
+	<module id="extensions/turn_based" label="Turn Based" classCount="5" methodCount="25" autoloadCount="0" autoloadMethodCount="0">
 		<class name="GFTurnAction" path="classes/GFTurnAction.xml" sourcePath="addons/gf/extensions/turn_based/runtime/gf_turn_action.gd" extends="RefCounted" />
 		<class name="GFTurnContext" path="classes/GFTurnContext.xml" sourcePath="addons/gf/extensions/turn_based/runtime/gf_turn_context.gd" extends="RefCounted" />
 		<class name="GFTurnFlowSystem" path="classes/GFTurnFlowSystem.xml" sourcePath="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" extends="GFSystem" />
 		<class name="GFTurnPhase" path="classes/GFTurnPhase.xml" sourcePath="addons/gf/extensions/turn_based/resources/gf_turn_phase.gd" extends="Resource" />
+		<class name="GFTurnPhaseCompletionHandle" path="classes/GFTurnPhaseCompletionHandle.xml" sourcePath="addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd" extends="RefCounted" />
 	</module>
 	<module id="tools" label="Tool Packages" classCount="20" methodCount="106" autoloadCount="0" autoloadMethodCount="0">
 		<class name="GFAssetBrowserModel" path="classes/GFAssetBrowserModel.xml" sourcePath="addons/gf/tools/asset_browser/gf_asset_browser_model.gd" extends="RefCounted" />

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="eac36b75783638ad9fb5a4e94f820062a702cf055c767e2695b040e207291a1e" classCount="844" methodCount="7680" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="fa2c38136c5772302e812f59012d07079f00614775bddd10119a2cd6dc59b391" classCount="844" methodCount="7680" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="75" methodCount="801" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -181,7 +181,7 @@
 - Network Contract 批量生成现在先构建确定性全批计划：资源加载、定义校验、大小写不敏感目标唯一性、标识符与源码预算全部在写入前完成，dry-run 与真实保存共享 `plan_fingerprint`。审计路径按规范文本去重并保留 `resource_path`、原始 phase 与聚合 phase，known channel 去重改为线性集合并加入同步入口硬上限。
 - Network Resource 与生成访问器的版本预检改为委托同一个内部纯值校验器；collection 审计改名为诚实的人工边界复核，不再暗示框架会解释项目自有 metadata。当前批次仍只保证完整预检，逐文件保存遇到不可预期 I/O 故障时不承诺整批自动回滚。
 - Physics Probe 现在把一次采样作为入口快照事务：位置、分组、组合模式与 fallback 在 field/provider 回调前冻结，同实例同步递归采样失败关闭为零；同帧缓存加入精确实例身份，不再把同路径替换对象视为旧实例。`STRONGEST` 使用共同尺度比较幅值，SUM 与最高优先级聚合在中间结果失去有限性时失败关闭。
-- TurnBased 的 stop 通知幂等性与 action cleanup policy 现在分离：`stop(true)` 在 already-stopped 或 `stop(false)` 恢复后仍会清理并封存队列；phase/action 双通道只有在最后一个 operation 收尾后才释放共享 stop 证据。行动 target 由 `GFTurnAction` 在唯一边界按实例 ID 线性清洗，默认排序和自定义比较器的输入合同也已明确。
+- TurnBased phase completion 改为 `_execute(context, completion)` 收到的一次性精确句柄；同一 Context 的 flow operation 由 owner claim 保护，不同 system 在首个状态或信号副作用前失败关闭，相同 system 的 phase/action 仍可组合运行。stop 通知幂等性与 action cleanup policy 保持分离：`stop(true)` 在 already-stopped 或 `stop(false)` 恢复后仍会清理并封存队列；phase/action 双通道只有在最后一个 operation 收尾后才释放 Context 与共享 stop 证据。行动 target 由 `GFTurnAction` 在唯一边界按实例 ID 线性清洗，默认排序和自定义比较器的输入合同也已明确。
 
 ### 🐛 Bug 修复 (Fixed)
 
@@ -313,7 +313,7 @@
 - 修复 Interaction 的 Pointer 与 Receiver-to-Receiver 转发对已编码报告再次编码、Area2D/3D 自定义 sender 的空或非 Dictionary 结果产生残缺报告或被静默丢弃、候选回调释放后续 receiver 后访问 previously freed Object、失效 `validation_callback` 静默恢复默认允许，以及同名不兼容项目方法触发脚本错误的问题；每次实际 Area 分发现在都返回并发布完整 JSON-safe 报告。
 - 修复 Network snapshot 生成 `ok=true` 但同版本 applicator 因深度、操作数或非法内容静默拒绝，service discovery 的自定义 `now_seconds` 与内部 elapsed clock 混用而延长 TTL，以及 fixed-tick signal 回调递归推进导致 stack overflow 的问题。
 - 修复 Physics 同路径 field 替换命中陈旧缓存、最高优先级的 32 位哨兵丢弃合法 int64、Vector3 聚合与平方范数溢出、浮力总力携带 Infinity、平方反比与超大浸没半径发生可避免中间溢出，以及 field 回调改写 Probe 后形成混合时点或错误缓存的问题。
-- 修复 TurnBased 在 lifecycle 已 stopped 时让 `stop(true)` 静默跳过清理、`stop(false)` 的在途 restore policy 无法升级、phase/action 双通道先结束者过早清除 stop 证据，以及 `get_actor_value()` 对同名错误 arity/type 方法直接产生脚本错误的问题；action target 的重复 O(n²) 清洗收敛为单次 O(n)。
+- 修复 TurnBased 旧异步回调只凭 Context 完成后来 phase runtime，以及不同 Flow System 在发现共享 Context 冲突前已修改 round、phase、actor 或行动队列的问题。精确 completion handle 在 stop、timeout、dispose、正常收尾或 restart 后立即失效；Context claim 只在最后一个同 owner operation 安全收尾后释放。另修复 lifecycle 已 stopped 时让 `stop(true)` 静默跳过清理、`stop(false)` 的在途 restore policy 无法升级、phase/action 双通道先结束者过早清除 stop 证据，以及 `get_actor_value()` 对同名错误 arity/type 方法直接产生脚本错误的问题；action target 的重复 O(n²) 清洗收敛为单次 O(n)。
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
@@ -415,7 +415,7 @@
 - `GFInteractions.is_method_call_compatible_for_framework()` 是新的框架内部动态协议预检入口。Interaction 的公开方法和信号签名不变，但失效 validator、非法 sender/provider/receiver 协议、Area 非法返回和 Pointer 多按钮的运行时语义均已收紧；`gf.interaction` 的 `extension_version` 因此提升到 `3.0.0`。
 - `GFNetworkSnapshot.make_patch_to()` 会把 `max_depth` 限制到 8，并以 `patch_operation_budget_exceeded` / `generated_patch_not_applicable` 显式拒绝 applicator 无法接受的成功候选。`GFNetworkServiceDiscovery.now_seconds` 只影响记录时间；`GFFixedTickClock.advance()` / `step_once()` 在同实例 signal 重入时无副作用返回。公开签名不变，`gf.network` 的 `extension_version` 提升到 `7.0.0`。
 - Physics 公开签名不变；`GFGravityProbe3D.sample()` / `sample_fields()` / `sample_field_provider()` 现在冻结入口查询状态并在同实例同步重入时返回零，全部重力/浮力公开向量保持有限。该运行语义收紧使 `gf.physics` 的 `extension_version` 提升到 `2.0.0`。
-- TurnBased 公开签名不变；`GFTurnFlowSystem.stop(true)` 现在对 stopped/恢复中队列执行幂等且可升级的清理，`GFTurnContext.get_actor_value()` 只调用接受两个兼容实参的 duck method。默认 non-finite 排序与自定义 comparator 的合同已写明，`gf.turn_based` 的 `extension_version` 从 `2.0.0` 提升到 `2.0.1`。
+- TurnBased 移除基于 Context 查找当前运行态的 `GFTurnPhase.finish()` / `finish(context)`，protected 扩展点从 `_execute(context)` 改为 `_execute(context, completion)`，并新增 `GFTurnPhaseCompletionHandle.try_complete()`。`GFTurnFlowSystem.dispose()` 现在显式终止接纳新 operation；`stop(true)` 继续对 stopped/恢复中队列执行幂等且可升级的清理，`GFTurnContext.get_actor_value()` 只调用接受两个兼容实参的 duck method。默认 non-finite 排序与自定义 comparator 的合同已写明，`gf.turn_based` 的 `extension_version` 从 `2.0.1` 提升到 `3.0.0`。
 
 ### 📘 升级指南 (Migration Guide)
 
@@ -491,7 +491,7 @@
 59. 检查所有 SaveGraph apply/load 调用：失败时除 `ok` / `errors` 外读取 `atomicity_restored`；为 `false` 时停止使用可能部分提交的场景状态，并按项目恢复策略消费 `rollback_failures`。不要依赖 `include_pipeline_trace` 才发现回滚失败，也不要在 Source callback 内同步重入同一个 Utility。
 60. 修正自定义 SaveGraph payload 的 `format_version` 为精确当前整数，并保证同一 `GFPersistPropertiesSource` 的 property、local 与 registry Serializer ID 唯一；已记录 pipeline error 的采集现在整体失败，调用方不得把空 payload 当作成功快照。
 61. 自定义槽位模板在保存或同步前调用 `build_slot_file_plan()` 并处理失败；两个模板都必须含 `{index}`、原样满足 portable logical identity 规则，且 data/metadata target 不能相同。自定义 Storage 若返回 `ok=true` 与 `IntegrityStatus.INVALID`，Graph/Slot 读取入口现在仍会拒绝该结果。
-62. TurnBased teardown 可重复调用 `stop(true)` 清理并封存队列，不必在 stopped 状态另调 `clear_actions()`；自定义 action comparator 改为无副作用的确定严格弱序，并显式处理 non-finite/平局。为 phase 的 timer/动画/网络 completion 在 stop/timeout 时断开旧回调，不要让 context-only `finish(context)` 跨同 Context restart；同一可变 Context 也不要同时交给两个 Flow System。
+62. 将自定义 `GFTurnPhase._execute(context)` 改为 `_execute(context, completion)`。`auto_finish=false` 的 timer、动画、网络或自定义 Signal 回调应捕获本次传入的 `GFTurnPhaseCompletionHandle`，并以 `completion.try_complete()` 的 `true` 结果确认首次提交；删除所有无参 `finish()` 与 `finish(context)` 调用。旧句柄在 stop、timeout、dispose、正常收尾或同 Context restart 后会稳定返回 `false`，不会完成新运行态。多个 Flow System 若同时操作同一 Context，后来者现在会在副作用前失败关闭；最后一张 operation claim 释放后仍可顺序复用该 Context，相同 system 的 phase→action 组合不需要拆分 Context。teardown 可重复调用 `stop(true)` 清理并封存队列；自定义 action comparator 改为无副作用的确定严格弱序，并显式处理 non-finite/平局。
 63. 自定义 Config Pipeline Stage 在 descriptor 中列出所有会影响输出的 `implementation_dependencies`，并把 Reader/Layout 输入输出契约迁移到 `reader_result@2` / `layout_result@2`。消费访问器报告时改用 `emitted_schema_count` 判断实际发射数并处理 `issues`；消费导出报告时检查 `source_validation_report`。JSON 导出的项目上限改用 `max_depth`、`max_nodes`、`max_output_bytes` 收紧框架默认值，不要再用零或负数表达无界。批量产物路径统一改为显式 `res://` 或 `user://`。
 64. 自定义 `GFLogSink` 若有依赖时间的缓冲行为，覆写 `tick(delta)`；脱离 Architecture 单独使用 `GFLogUtility` 时，由项目每帧显式调用 `tick(delta)`。不要再依赖“下一条日志”触发非零 interval。
 65. 若项目从主 `.log` 路径自行推导默认 JSONL 文件名，改为调用 `GFJsonLineLogSink.get_file_path()`；需要跨实例稳定路径时显式设置 `file_path`，并保证目标只有一个活动写入者。

--- a/docs/zh/extensions/network-turnbased/index.md
+++ b/docs/zh/extensions/network-turnbased/index.md
@@ -1,6 +1,6 @@
 # Network 与 TurnBased
 
-Network 扩展提供传输抽象、消息载体、序列化、通道、校验、同步快照、脏字段跟踪、契约生成和有界权威同步协调。TurnBased 扩展提供通用阶段推进和行动解析流程。它们都只定义框架级基础设施，不内置服务器、房间、账号、鉴权、实体复制、参与者字段或行动效果。
+Network 扩展提供传输抽象、消息载体、序列化、通道、校验、同步快照、脏字段跟踪、契约生成和有界权威同步协调。TurnBased 扩展提供通用阶段推进、一次性精确阶段完成和具有 Context 所有权的行动解析流程。它们都只定义框架级基础设施，不内置服务器、房间、账号、鉴权、实体复制、参与者字段或行动效果。
 
 ## 阅读入口
 
@@ -9,7 +9,7 @@ Network 扩展提供传输抽象、消息载体、序列化、通道、校验、
 - [Network 同步协调器](network-sync-coordinator.md)：`GFNetworkSyncCoordinator`、`GFNetworkSimulationAdapter`、全量权威快照、输入 ack 和有界预测纠偏。
 - [Network 契约、生成器与重连策略](network-contracts.md)：`GFNetworkContract`、消息契约、辅助类生成、契约审计、strict validator、重连退避和包体大小限制。
 - [Network Lobby 与平台 Adapter 边界](network-lobby.md)：`GFNetworkLobbyService`、lobby backend、peer identity、邀请事件和平台中立 adapter 规则。
-- [TurnBased 通用回合流程](turn-flow.md)：`GFTurnFlowSystem`、阶段、行动队列、排序和异步阶段安全等待。
+- [TurnBased 通用回合流程](turn-flow.md)：`GFTurnFlowSystem`、阶段 completion handle、Context operation claim、行动队列、排序和异步阶段安全等待。
 
 ## 使用边界
 

--- a/docs/zh/extensions/network-turnbased/turn-flow.md
+++ b/docs/zh/extensions/network-turnbased/turn-flow.md
@@ -73,6 +73,8 @@ func _execute(
 
 可变 `GFTurnContext` 由 operation-scoped claim 保护。不同 `GFTurnFlowSystem` 对同一 Context 的 `start()`、阶段推进或行动解析会在 round、phase、actor、队列和信号变化前失败关闭；最后一张 claim 释放后，另一个 system 可以顺序接管。相同 system 与相同 flow serial 可以同时持有精确 phase/action claim，因此阶段 `_execute()` 内调用同一 system 的 `resolve_actions()` 仍是受支持路径，且必须等两条 operation 都收尾后才释放 Context。不同 Context 可并行使用。这个合同只约束 GF Flow operation，不是线程锁，也不会拦截项目直接调用 Context 的公开 mutation API。
 
+如果本 system 的 `flow_started` 同步观察者调用 `stop()`，随后的 `flow_stopped` 观察者又调用 `start(reset_indices)`，系统会保留首个重启请求，等外层 `flow_started` 通知展开完成且旧 claim 释放后同步重放；请求中的 `reset_indices` 会原样保留。重放前再次调用 `stop()` 或 `dispose()` 会取消它。这个特例只服务于同一 system 的该次通知链；foreign system 和普通在途 operation 不会被自动排队。
+
 参与者对象可能在流程中被释放。`GFTurnContext.cleanup_invalid_actors()` 可显式移除失效参与者并清空失效的 `current_actor`，`GFTurnFlowSystem` 在推进和解析边界也会同步清理当前上下文。Context 对 RefCounted participant 采用强所有权，项目必须调用 `remove_actor()` 或释放 Context 才会释放该引用；Node 被 `free()` 后仍可由 cleanup 移除。`get_actor_value()` 只调用参数数量与类型兼容的 `get_turn_value(key, fallback)`，不兼容的同名方法会回退到属性读取；GDScript 无法捕获项目方法内部错误，项目实现仍须保证该回调安全返回。项目也应在行动效果层处理目标失效、死亡、离场或替换这类业务语义；TurnBased 只负责不让无效 Object 引用继续驱动通用流程。
 
 ## 与权威状态和表现队列的组合边界

--- a/docs/zh/extensions/network-turnbased/turn-flow.md
+++ b/docs/zh/extensions/network-turnbased/turn-flow.md
@@ -13,7 +13,10 @@ class_name ResolvePhase
 extends GFTurnPhase
 
 
-func _execute(context: GFTurnContext) -> Variant:
+func _execute(
+	context: GFTurnContext,
+	_completion: GFTurnPhaseCompletionHandle
+) -> Variant:
 	var flow := Gf.get_system(GFTurnFlowSystem) as GFTurnFlowSystem
 	flow.resolve_actions()
 	return null
@@ -34,7 +37,41 @@ flow.advance_phase()
 
 阶段和行动如果返回 Signal，系统会通过 `signal_timeout_seconds` 和当前流程 serial 做安全等待；`stop()` 或超时后不会继续调用旧阶段的 `_exit()`，也不会把旧行动标记为 resolved。`resolve_actions()` 在上一批行动仍等待时会拒绝同类重入，避免同一批行动被重复解析。`stop(true)` 的清理策略与停止通知分离：流程已经 stopped 时仍会幂等清空并封存队列，`stop(false)` 保留的在途行动也可由后续 `stop(true)` 升级为丢弃；重复调用不会重复发送 `flow_stopped`。
 
-当前 `finish(context)` 只按 Context 身份解析活动 phase runtime，不携带运行代际。因此项目在 timer、动画、网络或自定义 Signal 回调中调用它时，必须在 stop/timeout 时对称断开旧回调，并且不能让旧回调跨同一 Context 的 restart 存活；否则旧回调可能完成新 runtime。当前版本也没有跨 `GFTurnFlowSystem` 的 Context owner lease：一个可变 `GFTurnContext` 不得被两个 system 同时推进或解析。generation-scoped completion 与共享/嵌套 Context 所有权仍是待定的后续架构选择。
+`auto_finish=false` 的手工阶段必须保存本次 `_execute()` 收到的精确 completion handle；timer、动画、网络或自定义 Signal 回调只调用这个句柄：
+
+```gdscript
+class_name AnimationPhase
+extends GFTurnPhase
+
+
+@export var animation_player: AnimationPlayer
+
+
+func _init() -> void:
+	auto_finish = false
+
+
+func _execute(
+	_context: GFTurnContext,
+	completion: GFTurnPhaseCompletionHandle
+) -> Variant:
+	var connection_error: Error = animation_player.animation_finished.connect(
+		func(_animation_name: StringName) -> void:
+			if completion.try_complete():
+				print("本次阶段已提交完成")
+		,
+		CONNECT_ONE_SHOT
+	)
+	if connection_error != OK:
+		var _completed_after_connection_failure: bool = completion.try_complete()
+		return null
+	animation_player.play(&"resolve")
+	return null
+```
+
+`GFTurnPhaseCompletionHandle.try_complete()` 只有在句柄仍对应当前精确 phase operation、且是首次提交时才返回 `true`。`stop()`、timeout、`dispose()`、正常收尾或同一 Context 上的后续 restart 都会让旧句柄返回 `false`，旧回调不会完成新代次。项目仍应断开不再需要的回调以释放自身资源，但正确性不再依赖按 Context 查找当前 runtime。
+
+可变 `GFTurnContext` 由 operation-scoped claim 保护。不同 `GFTurnFlowSystem` 对同一 Context 的 `start()`、阶段推进或行动解析会在 round、phase、actor、队列和信号变化前失败关闭；最后一张 claim 释放后，另一个 system 可以顺序接管。相同 system 与相同 flow serial 可以同时持有精确 phase/action claim，因此阶段 `_execute()` 内调用同一 system 的 `resolve_actions()` 仍是受支持路径，且必须等两条 operation 都收尾后才释放 Context。不同 Context 可并行使用。这个合同只约束 GF Flow operation，不是线程锁，也不会拦截项目直接调用 Context 的公开 mutation API。
 
 参与者对象可能在流程中被释放。`GFTurnContext.cleanup_invalid_actors()` 可显式移除失效参与者并清空失效的 `current_actor`，`GFTurnFlowSystem` 在推进和解析边界也会同步清理当前上下文。Context 对 RefCounted participant 采用强所有权，项目必须调用 `remove_actor()` 或释放 Context 才会释放该引用；Node 被 `free()` 后仍可由 cleanup 移除。`get_actor_value()` 只调用参数数量与类型兼容的 `get_turn_value(key, fallback)`，不兼容的同名方法会回退到属性读取；GDScript 无法捕获项目方法内部错误，项目实现仍须保证该回调安全返回。项目也应在行动效果层处理目标失效、死亡、离场或替换这类业务语义；TurnBased 只负责不让无效 Object 引用继续驱动通用流程。
 

--- a/docs/zh/reference/api/classes/GFTurnFlowSystem.md
+++ b/docs/zh/reference/api/classes/GFTurnFlowSystem.md
@@ -272,7 +272,7 @@ func set_phases(p_phases: Array[GFTurnPhase]) -> void:
 func start(reset_indices: bool = true) -> void:
 ```
 
-开始流程。 若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
+开始流程。 若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。 若本 system 在自身 [signal flow_started] 通知中完成 [method stop]，并在由此发出的 [signal flow_stopped] 回调中再次调用本方法，首个重启请求会等旧 claim 释放后同步重放；重放前的后续 [method stop] 或 [method dispose] 会取消该请求。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFTurnFlowSystem.md
+++ b/docs/zh/reference/api/classes/GFTurnFlowSystem.md
@@ -31,6 +31,7 @@
 | 方法 | [`set_phases`](#member-gfturnflowsystem-methods-set_phases) | `func set_phases(p_phases: Array[GFTurnPhase]) -> void:` |
 | 方法 | [`start`](#member-gfturnflowsystem-methods-start) | `func start(reset_indices: bool = true) -> void:` |
 | 方法 | [`stop`](#member-gfturnflowsystem-methods-stop) | `func stop(should_clear_actions: bool = true) -> void:` |
+| 方法 | [`dispose`](#member-gfturnflowsystem-methods-dispose) | `func dispose() -> void:` |
 | 方法 | [`advance_phase`](#member-gfturnflowsystem-methods-advance_phase) | `func advance_phase() -> void:` |
 | 方法 | [`get_actions`](#member-gfturnflowsystem-methods-get_actions) | `func get_actions() -> Array[GFTurnAction]:` |
 | 方法 | [`get_action_count`](#member-gfturnflowsystem-methods-get_action_count) | `func get_action_count() -> int:` |
@@ -228,12 +229,13 @@ Signal 超时计时是否跟随 GFTimeUtility 的暂停与 time_scale。
 ### `set_context`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func set_context(p_context: GFTurnContext) -> void:
 ```
 
-设置上下文。
+设置上下文。 存在活动 Context operation claim 时会拒绝修改；operation 安全收尾并释放最后一张 claim 后可顺序重试。
 
 参数：
 
@@ -264,12 +266,13 @@ func set_phases(p_phases: Array[GFTurnPhase]) -> void:
 ### `start`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func start(reset_indices: bool = true) -> void:
 ```
 
-开始流程。
+开始流程。 若同一 Context 正由其他 Flow generation 持有，本次调用会在重置索引、轮次或发出信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
 
 参数：
 
@@ -296,17 +299,31 @@ func stop(should_clear_actions: bool = true) -> void:
 |---|---|
 | `should_clear_actions` | 是否清空待处理行动。即使流程已经 stopped，true 仍会幂等清理并封存队列；此前的保留策略也会升级为清理。 |
 
+<a id="member-gfturnflowsystem-methods-dispose"></a>
+
+### `dispose`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func dispose() -> void:
+```
+
+销毁系统，撤销所有在途 operation，并拒绝后续启动、阶段推进、行动入队与行动解析。 在途 continuation 会先完成精确清理，再释放 Context claim。
+
 <a id="member-gfturnflowsystem-methods-advance_phase"></a>
 
 ### `advance_phase`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func advance_phase() -> void:
 ```
 
-推进到下一个阶段。
+推进到下一个阶段。 若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、修改阶段/轮次或发出阶段信号前失败关闭；最后一张 operation claim 释放后可顺序重试。
 
 <a id="member-gfturnflowsystem-methods-get_actions"></a>
 
@@ -380,7 +397,7 @@ func enqueue_action(action: GFTurnAction) -> void:
 func resolve_actions(order_resolver: Callable = Callable()) -> void:
 ```
 
-解析当前上下文中的所有行动。
+解析当前上下文中的所有行动。 若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、取走队列、写入 current_actor 或调用 action 前失败关闭；最后一张 operation claim 释放后可顺序重试。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFTurnPhase.md
+++ b/docs/zh/reference/api/classes/GFTurnPhase.md
@@ -18,10 +18,9 @@
 | 信号 | [`finished`](#member-gfturnphase-signals-finished) | `signal finished` |
 | 属性 | [`phase_id`](#member-gfturnphase-properties-phase_id) | `var phase_id: StringName = &""` |
 | 属性 | [`auto_finish`](#member-gfturnphase-properties-auto_finish) | `var auto_finish: bool = true` |
-| 方法 | [`finish`](#member-gfturnphase-methods-finish) | `func finish(context: GFTurnContext = null) -> void:` |
 | 方法 | [`is_finished_for`](#member-gfturnphase-methods-is_finished_for) | `func is_finished_for(context: GFTurnContext) -> bool:` |
 | 方法 | [`_enter`](#member-gfturnphase-methods-_enter) | `func _enter(_context: GFTurnContext) -> void:` |
-| 方法 | [`_execute`](#member-gfturnphase-methods-_execute) | `func _execute(_context: GFTurnContext) -> Variant:` |
+| 方法 | [`_execute`](#member-gfturnphase-methods-_execute) | `func _execute( _context: GFTurnContext, _completion: GFTurnPhaseCompletionHandle ) -> Variant:` |
 | 方法 | [`_exit`](#member-gfturnphase-methods-_exit) | `func _exit(_context: GFTurnContext) -> void:` |
 
 ## 信号
@@ -65,25 +64,6 @@ var auto_finish: bool = true
 `_execute()` 返回后是否自动完成阶段。
 
 ## 方法
-
-<a id="member-gfturnphase-methods-finish"></a>
-
-### `finish`
-
-- API：`public`
-- 首次版本：`8.0.0`
-
-```gdscript
-func finish(context: GFTurnContext = null) -> void:
-```
-
-标记指定上下文的阶段运行完成。
-
-参数：
-
-| 名称 | 说明 |
-|---|---|
-| `context` | 活动 Flow 的上下文；只有一个运行态时可省略。 |
 
 <a id="member-gfturnphase-methods-is_finished_for"></a>
 
@@ -132,7 +112,7 @@ func _enter(_context: GFTurnContext) -> void:
 - 首次版本：`3.17.0`
 
 ```gdscript
-func _execute(_context: GFTurnContext) -> Variant:
+func _execute( _context: GFTurnContext, _completion: GFTurnPhaseCompletionHandle ) -> Variant:
 ```
 
 执行阶段逻辑时由 GFTurnFlowSystem 调用。
@@ -142,6 +122,7 @@ func _execute(_context: GFTurnContext) -> Variant:
 | 名称 | 说明 |
 |---|---|
 | `_context` | 回合上下文。 |
+| `_completion` | 仅能完成本次阶段运行的一次性句柄；异步回调必须捕获该句柄，而不是稍后按 Context 查找运行态。 |
 
 返回：可等待结果。
 

--- a/docs/zh/reference/api/classes/GFTurnPhaseCompletionHandle.md
+++ b/docs/zh/reference/api/classes/GFTurnPhaseCompletionHandle.md
@@ -1,0 +1,35 @@
+# GFTurnPhaseCompletionHandle
+
+[API Reference](../index.md) / [Turn Based](../extensions-turn-based.md) / [类索引](index.md)
+
+- 路径：`addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd`
+- 模块：`Turn Based`
+- 继承：`RefCounted`
+- API：`public`
+- 类别：运行时句柄 (`runtime_handle`)
+- 首次版本：`unreleased`
+
+单次阶段运行的完成能力句柄。 有效句柄只会由 GFTurnFlowSystem 传给当前 GFTurnPhase._execute() 调用；项目手工 new() 的实例没有完成权限。 首次对有效运行调用 try_complete() 会完成该阶段；停止、超时、释放、dispose、重启后的旧句柄及重复调用都返回 false，不影响其他代际。
+
+## 成员概览
+
+| 类型 | 名称 | 签名 |
+|---|---|---|
+| 方法 | [`try_complete`](#member-gfturnphasecompletionhandle-methods-try_complete) | `func try_complete() -> bool:` |
+
+## 方法
+
+<a id="member-gfturnphasecompletionhandle-methods-try_complete"></a>
+
+### `try_complete`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func try_complete() -> bool:
+```
+
+尝试完成创建此句柄的精确阶段运行。
+
+返回：当前主线程首次完成仍有效的精确运行时返回 true；失效、重复或非主线程调用返回 false。

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -25,7 +25,7 @@
 | Network | 38 | 602 | [Network](#module-extensions-network) |
 | Physics | 4 | 50 | [Physics](#module-extensions-physics) |
 | Save | 52 | 651 | [Save](#module-extensions-save) |
-| Turn Based | 4 | 49 | [Turn Based](#module-extensions-turn_based) |
+| Turn Based | 5 | 50 | [Turn Based](#module-extensions-turn_based) |
 | Tool Packages | 20 | 165 | [Tool Packages](#module-tools) |
 
 ## 模块索引
@@ -988,9 +988,10 @@
 
 | 类 | 类别 | 继承 | 成员 | 源文件 |
 |---|---|---|---:|---|
-| [`GFTurnFlowSystem`](GFTurnFlowSystem.md#gfturnflowsystem) | 运行时服务 (`runtime_service`) | `GFSystem` | 22 | `addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd` |
+| [`GFTurnFlowSystem`](GFTurnFlowSystem.md#gfturnflowsystem) | 运行时服务 (`runtime_service`) | `GFSystem` | 23 | `addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd` |
 | [`GFTurnAction`](GFTurnAction.md#gfturnaction) | 协议与扩展点 (`protocol`) | `RefCounted` | 11 | `addons/gf/extensions/turn_based/runtime/gf_turn_action.gd` |
-| [`GFTurnPhase`](GFTurnPhase.md#gfturnphase) | 协议与扩展点 (`protocol`) | `Resource` | 8 | `addons/gf/extensions/turn_based/resources/gf_turn_phase.gd` |
+| [`GFTurnPhase`](GFTurnPhase.md#gfturnphase) | 协议与扩展点 (`protocol`) | `Resource` | 7 | `addons/gf/extensions/turn_based/resources/gf_turn_phase.gd` |
+| [`GFTurnPhaseCompletionHandle`](GFTurnPhaseCompletionHandle.md#gfturnphasecompletionhandle) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 1 | `addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd` |
 | [`GFTurnContext`](GFTurnContext.md#gfturncontext) | 领域模型 (`domain_model`) | `RefCounted` | 8 | `addons/gf/extensions/turn_based/runtime/gf_turn_context.gd` |
 
 <a id="module-tools"></a>

--- a/docs/zh/reference/api/extensions-turn-based.md
+++ b/docs/zh/reference/api/extensions-turn-based.md
@@ -6,8 +6,9 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 1 | 22 | 10 |
-| [协议与扩展点](#category-protocol) | 2 | 19 | 9 |
+| [运行时服务](#category-runtime_service) | 1 | 23 | 11 |
+| [协议与扩展点](#category-protocol) | 2 | 18 | 8 |
+| [运行时句柄](#category-runtime_handle) | 1 | 1 | 1 |
 | [领域模型](#category-domain_model) | 1 | 8 | 5 |
 
 ## 类
@@ -28,6 +29,14 @@
 |---|---|---|
 | [`GFTurnAction`](classes/GFTurnAction.md#gfturnaction) | `RefCounted` | `addons/gf/extensions/turn_based/runtime/gf_turn_action.gd` |
 | [`GFTurnPhase`](classes/GFTurnPhase.md#gfturnphase) | `Resource` | `addons/gf/extensions/turn_based/resources/gf_turn_phase.gd` |
+
+<a id="category-runtime_handle"></a>
+
+### 运行时句柄
+
+| 类 | 继承 | 源文件 |
+|---|---|---|
+| [`GFTurnPhaseCompletionHandle`](classes/GFTurnPhaseCompletionHandle.md#gfturnphasecompletionhandle) | `RefCounted` | `addons/gf/extensions/turn_based/runtime/gf_turn_phase_completion_handle.gd` |
 
 <a id="category-domain_model"></a>
 

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -5,10 +5,10 @@
 ## 范围
 
 - 源码根目录：`addons/gf`
-- 公开类：`843`
+- 公开类：`844`
 - 公开 AutoLoad：`1`
-- 公开成员：`12481`
-- 公开方法：`7679`
+- 公开成员：`12482`
+- 公开方法：`7680`
 - AutoLoad 公开方法：`65`
 
 ## 模块
@@ -34,7 +34,7 @@
 | Network | 38 | 0 | 602 | 323 | [extensions-network.md](extensions-network.md) |
 | Physics | 4 | 0 | 50 | 23 | [extensions-physics.md](extensions-physics.md) |
 | Save | 52 | 0 | 651 | 414 | [extensions-save.md](extensions-save.md) |
-| Turn Based | 4 | 0 | 49 | 24 | [extensions-turn-based.md](extensions-turn-based.md) |
+| Turn Based | 5 | 0 | 50 | 25 | [extensions-turn-based.md](extensions-turn-based.md) |
 | Tool Packages | 20 | 0 | 165 | 106 | [tools.md](tools.md) |
 
 ## Owner 索引

--- a/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
+++ b/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
@@ -14,7 +14,10 @@ class RecordingPhase extends GFTurnPhase:
 	func _enter(_context: GFTurnContext) -> void:
 		order.append("enter:%s" % phase_id)
 
-	func _execute(_context: GFTurnContext) -> Variant:
+	func _execute(
+		_context: GFTurnContext,
+		_completion: GFTurnPhaseCompletionHandle
+	) -> Variant:
 		order.append("execute:%s" % phase_id)
 		return null
 
@@ -26,6 +29,7 @@ class ManualPhase extends GFTurnPhase:
 	signal completed
 
 	var order: Array[String] = []
+	var completion_handle: GFTurnPhaseCompletionHandle = null
 
 	func _init(p_order: Array[String]) -> void:
 		order = p_order
@@ -34,7 +38,11 @@ class ManualPhase extends GFTurnPhase:
 	func _enter(_context: GFTurnContext) -> void:
 		order.append("enter")
 
-	func _execute(_context: GFTurnContext) -> Variant:
+	func _execute(
+		_context: GFTurnContext,
+		completion: GFTurnPhaseCompletionHandle
+	) -> Variant:
+		completion_handle = completion
 		order.append("execute")
 		return completed
 
@@ -50,7 +58,10 @@ class StoppingPhase extends GFTurnPhase:
 		system = p_system
 		order = p_order
 
-	func _execute(_context: GFTurnContext) -> Variant:
+	func _execute(
+		_context: GFTurnContext,
+		_completion: GFTurnPhaseCompletionHandle
+	) -> Variant:
 		order.append("execute")
 		if system != null:
 			system.stop()
@@ -132,9 +143,47 @@ class ActorCountPhase extends GFTurnPhase:
 
 class SharedManualFinishPhase extends GFTurnPhase:
 	var exited_contexts: Array[GFTurnContext] = []
+	var completions_by_context_id: Dictionary = {}
 
 	func _init() -> void:
 		auto_finish = false
+
+	func _execute(
+		context: GFTurnContext,
+		completion: GFTurnPhaseCompletionHandle
+	) -> Variant:
+		completions_by_context_id[context.get_instance_id()] = completion
+		return null
+
+	func _exit(context: GFTurnContext) -> void:
+		exited_contexts.append(context)
+
+	func get_completion(context: GFTurnContext) -> GFTurnPhaseCompletionHandle:
+		if context == null:
+			return null
+		var completion_value: Variant = GFVariantData.get_option_value(
+			completions_by_context_id,
+			context.get_instance_id()
+		)
+		if completion_value is GFTurnPhaseCompletionHandle:
+			var completion: GFTurnPhaseCompletionHandle = completion_value
+			return completion
+		return null
+
+
+class CapturingManualPhase extends GFTurnPhase:
+	var completions: Array[GFTurnPhaseCompletionHandle] = []
+	var exited_contexts: Array[GFTurnContext] = []
+
+	func _init() -> void:
+		auto_finish = false
+
+	func _execute(
+		_context: GFTurnContext,
+		completion: GFTurnPhaseCompletionHandle
+	) -> Variant:
+		completions.append(completion)
+		return null
 
 	func _exit(context: GFTurnContext) -> void:
 		exited_contexts.append(context)
@@ -148,7 +197,10 @@ class ConcurrentResolutionPhase extends GFTurnPhase:
 	func _init(p_system: GFTurnFlowSystem) -> void:
 		system = p_system
 
-	func _execute(_context: GFTurnContext) -> Variant:
+	func _execute(
+		_context: GFTurnContext,
+		_completion: GFTurnPhaseCompletionHandle
+	) -> Variant:
 		@warning_ignore("missing_await")
 		system.resolve_actions()
 		return completed
@@ -178,6 +230,22 @@ class ExplicitInjectionAction extends GFTurnAction:
 		return null
 
 
+class StopDuringInjectionAction extends GFTurnAction:
+	var system: GFTurnFlowSystem = null
+	var resolved: bool = false
+
+	func _init(p_system: GFTurnFlowSystem) -> void:
+		system = p_system
+
+	func _inject_dependencies(_architecture: GFArchitecture) -> void:
+		if system != null:
+			system.stop(false)
+
+	func _resolve(_context: GFTurnContext) -> Variant:
+		resolved = true
+		return null
+
+
 class CompatibleTurnValueActor extends Object:
 	func get_turn_value(key: StringName, fallback: Variant) -> Variant:
 		return 9 if key == &"initiative" else fallback
@@ -189,6 +257,12 @@ class WrongArityTurnValueActor extends Object:
 
 
 # --- 测试方法 ---
+
+func test_unconfigured_phase_completion_handle_is_inert() -> void:
+	var completion: GFTurnPhaseCompletionHandle = GFTurnPhaseCompletionHandle.new()
+
+	assert_false(completion.try_complete(), "项目手工构造的未配置 handle 不得拥有完成权限。")
+
 
 ## 验证阶段推进会调用 enter/execute/exit 生命周期。
 func test_advance_phase_runs_phase_lifecycle() -> void:
@@ -236,6 +310,12 @@ func test_stop_prevents_awaited_phase_from_resuming() -> void:
 	await get_tree().process_frame
 
 	system.stop()
+	assert_not_null(phase.completion_handle)
+	if phase.completion_handle != null:
+		assert_false(
+			phase.completion_handle.try_complete(),
+			"stop 返回时必须立即撤销等待中 phase 的 completion authority。"
+		)
 	phase.completed.emit()
 	await get_tree().process_frame
 
@@ -275,6 +355,31 @@ func test_turn_flow_start_and_stop_are_idempotent_under_signal_reentry() -> void
 	assert_false(system.is_running, "幂等 stop 后状态必须稳定为 stopped。")
 
 
+func test_flow_started_holds_context_authority_until_observers_finish() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var replacement_context: GFTurnContext = GFTurnContext.new()
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	owner_system.set_context(context)
+	foreign_system.set_context(context)
+	var started_callback: Callable = func(_context: GFTurnContext) -> void:
+		foreign_system.start()
+		owner_system.set_context(replacement_context)
+	var _started_connection: Error = owner_system.flow_started.connect(started_callback) as Error
+
+	owner_system.start()
+	owner_system.flow_started.disconnect(started_callback)
+
+	assert_push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+	assert_push_warning("[GFTurnFlowSystem] set_context 失败：存在活动 Context operation。")
+	assert_same(owner_system.context, context, "start 通知期间不得替换仍被事务持有的 Context。")
+	assert_false(foreign_system.is_running, "flow_started 观察者不得穿插 foreign Context mutation。")
+	foreign_system.start()
+	assert_true(foreign_system.is_running, "start 事务结束后空闲 Context 仍允许另一 system 顺序使用。")
+	owner_system.stop()
+	foreign_system.stop()
+
+
 func test_turn_flow_can_restart_from_completed_stop_notification() -> void:
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
 	var restarted: Array[bool] = [false]
@@ -308,6 +413,21 @@ func test_stop_true_clears_actions_even_when_already_stopped() -> void:
 	assert_true(action.is_sealed(), "被 stopped cleanup 丢弃的 action 必须永久封存。")
 
 
+func test_disposed_flow_rejects_new_action_without_claiming_it() -> void:
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var fresh_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var action: GFTurnAction = GFTurnAction.new()
+	system.dispose()
+
+	system.enqueue_action(action)
+
+	assert_eq(system.get_action_count(), 0, "disposed system 不得接纳新 action。")
+	assert_false(action.is_sealed(), "未被接纳的 action 不得被 claim 或封存。")
+	fresh_system.enqueue_action(action)
+	assert_eq(fresh_system.get_action_count(), 1, "disposed guard 必须位于 one-shot claim 之前。")
+	fresh_system.stop(true)
+
+
 func test_stop_true_upgrades_completed_stop_false_restore() -> void:
 	var order: Array[String] = []
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
@@ -338,6 +458,33 @@ func test_phase_signal_timeout_aborts_without_exit() -> void:
 
 	assert_push_warning("[GFTurnFlowSystem] 等待阶段 Signal 超时，阶段推进已中止。")
 	assert_eq(order, ["enter", "execute"], "阶段 Signal 超时后不应继续 finish/exit。")
+	assert_not_null(phase.completion_handle)
+	if phase.completion_handle != null:
+		assert_false(phase.completion_handle.try_complete(), "Signal timeout 后 handle 必须失效。")
+
+
+func test_phase_completion_wait_timeout_invalidates_handle_without_exit() -> void:
+	var phase: CapturingManualPhase = CapturingManualPhase.new()
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	system.signal_timeout_seconds = 0.001
+	system.set_phases([phase])
+	foreign_system.set_context(system.context)
+
+	system.start()
+	@warning_ignore("missing_await")
+	system.advance_phase()
+	await get_tree().create_timer(0.05).timeout
+	await get_tree().process_frame
+
+	assert_push_warning("[GFTurnFlowSystem] 等待阶段完成超时，阶段推进已中止。")
+	assert_eq(phase.completions.size(), 1)
+	assert_true(phase.exited_contexts.is_empty(), "completion timeout 不得调用 phase exit。")
+	if not phase.completions.is_empty():
+		assert_false(phase.completions[0].try_complete(), "completion timeout 后 handle 必须失效。")
+	foreign_system.start()
+	assert_true(foreign_system.is_running, "completion timeout 清理后必须释放 Context claim。")
+	foreign_system.stop()
 
 
 func test_advance_phase_reentry_is_rejected_while_waiting() -> void:
@@ -453,7 +600,7 @@ func test_context_replacement_is_rejected_during_awaited_action() -> void:
 	assert_same(system.context, old_context, "in-flight 解析必须持有启动时 context lease。")
 	assert_null(old_context.current_actor, "解析结束必须清理启动时 context 的 current_actor。")
 	assert_eq(_get_queued_actions(system).size(), 2, "stop(false) 应把未解析行动恢复到原 flow 队列。")
-	assert_push_warning("[GFTurnFlowSystem] set_context 失败：流程正在推进或解析中。")
+	assert_push_warning("[GFTurnFlowSystem] set_context 失败：存在活动 Context operation。")
 	system.stop(true)
 	actor.free()
 
@@ -678,18 +825,256 @@ func test_shared_phase_completion_is_scoped_to_one_context() -> void:
 	@warning_ignore("missing_await")
 	system_b.advance_phase()
 	await get_tree().process_frame
-	phase.finish()
+	var completion_a: GFTurnPhaseCompletionHandle = phase.get_completion(system_a.context)
+	var completion_b: GFTurnPhaseCompletionHandle = phase.get_completion(system_b.context)
+
+	assert_not_null(completion_a, "每个 phase runtime 必须收到自己的 completion handle。")
+	assert_not_null(completion_b, "共享 phase 的不同 Context 必须收到不同 completion handle。")
+	if completion_a == null or completion_b == null:
+		system_a.stop()
+		system_b.stop()
+		return
+	assert_ne(completion_a, completion_b, "共享 phase 的 completion handle 不得跨 Context 复用。")
+	assert_true(completion_b.try_complete(), "精确 handle 应完成自己的 runtime。")
+	assert_false(completion_b.try_complete(), "completion handle 必须一次性提交。")
 	await get_tree().process_frame
 
-	assert_true(phase.exited_contexts.is_empty(), "共享 phase 的无作用域 finish 不得同时完成多个 flow。")
-	assert_push_error("[GFTurnPhase] finish 失败：存在多个活动运行态，必须提供 context。")
-	if phase.has_method("is_finished_for"):
-		phase.call("finish", system_b.context)
-		await get_tree().process_frame
-		assert_eq(phase.exited_contexts, [system_b.context], "显式 context 只能完成对应 phase 运行态。")
+	assert_eq(phase.exited_contexts, [system_b.context], "完成 Context B 不得结算 Context A。")
 	system_a.stop()
 	system_b.stop()
 	await get_tree().process_frame
+	assert_false(
+		completion_a.try_complete(),
+		"stop 后未完成 handle 必须失效。"
+	)
+
+
+func test_stale_phase_completion_cannot_settle_restarted_generation() -> void:
+	var phase: CapturingManualPhase = CapturingManualPhase.new()
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	system.set_phases([phase])
+	system.start()
+	@warning_ignore("missing_await")
+	system.advance_phase()
+	await get_tree().process_frame
+
+	assert_eq(phase.completions.size(), 1, "首个 generation 必须收到 completion handle。")
+	if phase.completions.is_empty() or phase.completions[0] == null:
+		system.stop()
+		return
+	var stale_completion: GFTurnPhaseCompletionHandle = phase.completions[0]
+	system.stop()
+	assert_false(
+		stale_completion.try_complete(),
+		"stop 必须立即撤销旧 generation 的 settlement authority。"
+	)
+	await get_tree().process_frame
+
+	system.start(false)
+	@warning_ignore("missing_await")
+	system.advance_phase()
+	await get_tree().process_frame
+	assert_eq(phase.completions.size(), 2, "重启后必须创建新的 completion handle。")
+	if phase.completions.size() < 2 or phase.completions[1] == null:
+		system.stop()
+		return
+	var current_completion: GFTurnPhaseCompletionHandle = phase.completions[1]
+
+	assert_false(
+		stale_completion.try_complete(),
+		"旧 callback 不得结算同一 Context 的新 generation。"
+	)
+	assert_true(
+		current_completion.try_complete(),
+		"当前 generation 的精确 handle 应可完成。"
+	)
+	assert_false(
+		current_completion.try_complete(),
+		"当前 handle 完成后必须拒绝重复提交。"
+	)
+	await get_tree().process_frame
+	assert_eq(phase.exited_contexts, [system.context], "只有重启后的 generation 应正常 exit。")
+
+
+func test_dispose_invalidates_completion_and_releases_context_after_unwind() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var phase: CapturingManualPhase = CapturingManualPhase.new()
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	owner_system.set_context(context)
+	foreign_system.set_context(context)
+	owner_system.set_phases([phase])
+	owner_system.start()
+	@warning_ignore("missing_await")
+	owner_system.advance_phase()
+	await get_tree().process_frame
+
+	assert_eq(phase.completions.size(), 1)
+	if phase.completions.is_empty():
+		owner_system.dispose()
+		return
+	var completion: GFTurnPhaseCompletionHandle = phase.completions[0]
+	owner_system.dispose()
+	assert_false(completion.try_complete(), "dispose 返回时必须立即撤销 phase completion。")
+	owner_system.dispose()
+	owner_system.start()
+	assert_false(owner_system.is_running, "disposed Flow System 不得重新启动。")
+
+	foreign_system.start()
+	assert_push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+	assert_false(foreign_system.is_running, "旧 continuation 清理前不得提前转交 Context。")
+	await get_tree().process_frame
+	foreign_system.start()
+	assert_true(foreign_system.is_running, "旧 continuation 收敛后必须允许另一 system 顺序接管。")
+	foreign_system.stop()
+
+
+func test_context_claims_release_only_after_last_exact_lease() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var third_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var first_lease: GFTurnContext.FlowOperationLease = (
+		context.try_acquire_flow_operation_lease(owner_system, 1)
+	)
+	var second_lease: GFTurnContext.FlowOperationLease = (
+		context.try_acquire_flow_operation_lease(owner_system, 1)
+	)
+
+	assert_not_null(first_lease)
+	assert_not_null(second_lease)
+	assert_true(context.release_flow_operation_lease(first_lease, owner_system))
+	assert_null(
+		context.try_acquire_flow_operation_lease(foreign_system, 1),
+		"同 owner 的第二张 exact claim 未释放前不得转交 Context。"
+	)
+	assert_true(context.cancel_flow_operation_lease(second_lease, owner_system))
+	assert_null(
+		context.try_acquire_flow_operation_lease(foreign_system, 1),
+		"取消只撤销写权限，不得提前释放旧 continuation 的 claim。"
+	)
+	assert_true(context.release_flow_operation_lease(second_lease, owner_system))
+	var foreign_lease: GFTurnContext.FlowOperationLease = (
+		context.try_acquire_flow_operation_lease(foreign_system, 1)
+	)
+	assert_not_null(foreign_lease)
+	assert_false(
+		context.release_flow_operation_lease(second_lease, owner_system),
+		"旧 lease 的重复释放不得清除新 owner。"
+	)
+	assert_null(
+		context.try_acquire_flow_operation_lease(third_system, 1),
+		"stale release 后新 owner 的 claim 必须继续有效。"
+	)
+	assert_true(context.release_flow_operation_lease(foreign_lease, foreign_system))
+
+
+func test_shared_context_rejects_foreign_flow_before_phase_mutation() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var owner_phase: CapturingManualPhase = CapturingManualPhase.new()
+	var foreign_order: Array[String] = []
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_start_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	owner_system.set_context(context)
+	foreign_system.set_context(context)
+	foreign_start_system.set_context(context)
+	owner_system.set_phases([owner_phase])
+	foreign_system.set_phases([RecordingPhase.new(&"foreign", foreign_order)])
+	owner_system.start()
+	foreign_system.start()
+	@warning_ignore("missing_await")
+	owner_system.advance_phase()
+	await get_tree().process_frame
+	var owned_round: int = context.round_index
+
+	foreign_start_system.start()
+	assert_push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+	assert_false(foreign_start_system.is_running, "foreign start 失败后不得提交 lifecycle 状态。")
+	assert_eq(context.round_index, owned_round, "foreign start 不得提前重置 Context 轮次。")
+	@warning_ignore("missing_await")
+	foreign_system.advance_phase()
+	assert_push_warning("[GFTurnFlowSystem] advance_phase 失败：context 正由另一个 flow generation 持有。")
+	assert_eq(foreign_system.current_phase_index, -1, "foreign advance 不得提前切换 phase index。")
+	assert_eq(context.round_index, owned_round, "foreign advance 不得提前推进 Context 轮次。")
+	assert_true(foreign_order.is_empty(), "foreign phase 不得 enter/execute/exit。")
+
+	owner_system.stop()
+	await get_tree().process_frame
+	await foreign_system.advance_phase()
+	assert_eq(foreign_order, ["enter:foreign", "execute:foreign", "exit:foreign"])
+	foreign_system.stop()
+
+
+func test_shared_context_rejects_foreign_action_before_queue_mutation() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var owner_phase: CapturingManualPhase = CapturingManualPhase.new()
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_order: Array[String] = []
+	var foreign_action: RecordingAction = RecordingAction.new("foreign", 0, 0.0, foreign_order)
+	owner_system.set_context(context)
+	foreign_system.set_context(context)
+	owner_system.set_phases([owner_phase])
+	owner_system.start()
+	@warning_ignore("missing_await")
+	owner_system.advance_phase()
+	await get_tree().process_frame
+	foreign_system.enqueue_action(foreign_action)
+
+	await foreign_system.resolve_actions()
+	assert_push_warning("[GFTurnFlowSystem] resolve_actions 失败：context 正由另一个 flow generation 持有。")
+	assert_eq(foreign_order, [], "foreign action 不得开始 resolve。")
+	assert_eq(foreign_system.get_action_count(), 1, "foreign rejection 不得清空或封存队列。")
+	assert_false(foreign_action.is_sealed(), "未接纳的 foreign action 必须保持待处理状态。")
+	assert_null(context.current_actor, "foreign rejection 不得写入 current_actor。")
+
+	owner_system.stop()
+	await get_tree().process_frame
+	await foreign_system.resolve_actions()
+	assert_eq(foreign_order, ["foreign"], "owner release 后另一 system 应可解析自己的队列。")
+	assert_true(foreign_action.is_sealed())
+
+
+func test_same_owner_phase_and_action_claims_block_foreign_until_both_finish() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var actor: Node = Node.new()
+	var action_order: Array[String] = []
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var phase: ConcurrentResolutionPhase = ConcurrentResolutionPhase.new(owner_system)
+	var action: ManualAction = ManualAction.new(action_order)
+	action.actor = actor
+	owner_system.set_context(context)
+	foreign_system.set_context(context)
+	owner_system.set_phases([phase])
+	owner_system.enqueue_action(action)
+	owner_system.start()
+	@warning_ignore("missing_await")
+	owner_system.advance_phase()
+	await get_tree().process_frame
+
+	assert_eq(action_order, ["resolve"], "phase 内启动的同 owner action 必须真实进入 resolve。")
+	assert_same(context.current_actor, actor)
+	foreign_system.start()
+	assert_push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+
+	phase.completed.emit()
+	await get_tree().process_frame
+	assert_same(context.current_actor, actor, "phase claim 释放后 action claim 仍应独占 Context。")
+	foreign_system.start()
+	assert_push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+	assert_false(foreign_system.is_running)
+
+	action.completed.emit()
+	await get_tree().process_frame
+	assert_null(context.current_actor)
+	foreign_system.start()
+	assert_true(foreign_system.is_running, "phase/action 两张 claim 都释放后必须允许顺序接管。")
+	foreign_system.stop()
+	owner_system.stop()
+	phase.system = null
+	actor.free()
 
 
 func test_action_injection_uses_framework_internal_dispatch_to_explicit_protected_hook() -> void:
@@ -707,6 +1092,26 @@ func test_action_injection_uses_framework_internal_dispatch_to_explicit_protecte
 	assert_same(explicit_action.injected_architecture, architecture, "framework_internal 边界应调度显式 protected 注入 hook。")
 	assert_true(collision_action.resolved)
 	assert_true(explicit_action.resolved)
+	system.release_dependencies()
+	architecture.dispose()
+
+
+func test_action_injection_stop_is_rechecked_before_context_write_or_resolve() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var stopping_action: StopDuringInjectionAction = StopDuringInjectionAction.new(system)
+	var next_action: GFTurnAction = GFTurnAction.new()
+	system.inject_dependencies(architecture)
+	system.enqueue_action(stopping_action)
+	system.enqueue_action(next_action)
+
+	await system.resolve_actions()
+
+	assert_false(stopping_action.resolved, "injection hook stop 后不得继续调用 action resolve。")
+	assert_eq(system.get_action_count(), 2, "stop(false) 应保留 current 与后续 action。")
+	assert_null(system.context.current_actor, "injection stop 后不得写入 current_actor。")
+	system.stop(true)
+	stopping_action.system = null
 	system.release_dependencies()
 	architecture.dispose()
 
@@ -778,8 +1183,10 @@ func test_turn_context_preflights_get_turn_value_signature() -> void:
 func test_turn_context_cleanup_invalid_actors() -> void:
 	var actor: Node = Node.new()
 	var context: GFTurnContext = GFTurnContext.new()
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var lease: GFTurnContext.FlowOperationLease = context.try_acquire_flow_operation_lease(system, 1)
 	context.add_actor(actor)
-	context.set_current_actor_from_flow(actor)
+	context.set_current_actor_from_flow(actor, lease, system, 1)
 
 	actor.free()
 	var removed_count: int = context.cleanup_invalid_actors()
@@ -787,6 +1194,7 @@ func test_turn_context_cleanup_invalid_actors() -> void:
 	assert_eq(removed_count, 1, "cleanup_invalid_actors 应移除失效 actor。")
 	assert_true(context.get_actors().is_empty(), "失效 actor 不应留在 actors 中。")
 	assert_null(context.current_actor, "失效 current_actor 应被复位。")
+	assert_true(context.release_flow_operation_lease(lease, system))
 
 
 # --- 辅助方法 ---

--- a/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
+++ b/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
@@ -402,6 +402,101 @@ func test_turn_flow_can_restart_from_completed_stop_notification() -> void:
 	assert_true(system.is_running, "旧 stop 调用链不得在通知返回后覆盖重入启动的新周期。")
 
 
+func test_turn_flow_honors_restart_requested_from_nested_start_stop_notifications() -> void:
+	var context: GFTurnContext = GFTurnContext.new()
+	var owner_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var foreign_system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	owner_system.set_context(context)
+	foreign_system.set_context(context)
+	var seed_order: Array[String] = []
+	owner_system.set_phases([RecordingPhase.new(&"seed", seed_order)])
+	owner_system.start()
+	await owner_system.advance_phase()
+	owner_system.stop()
+	var preserved_phase_index: int = owner_system.current_phase_index
+	var preserved_round_index: int = context.round_index
+	assert_eq(preserved_phase_index, 0, "回归夹具必须先建立可观察的非默认 phase index。")
+	assert_eq(preserved_round_index, 1, "回归夹具必须先建立可观察的非默认轮次。")
+	var events: Array[String] = []
+	var started_count: Array[int] = [0]
+	var stopped_count: Array[int] = [0]
+	var started_callback: Callable = func(_context: GFTurnContext) -> void:
+		started_count[0] += 1
+		events.append("owner_started:%d" % started_count[0])
+		if started_count[0] == 1:
+			owner_system.stop()
+	var stopped_callback: Callable = func(_context: GFTurnContext) -> void:
+		stopped_count[0] += 1
+		events.append("owner_stopped:%d" % stopped_count[0])
+		if stopped_count[0] == 1:
+			events.append("restart_requested")
+			owner_system.start(false)
+			events.append("foreign_attempted")
+			foreign_system.start(false)
+	var _started_connection: Error = owner_system.flow_started.connect(started_callback) as Error
+	var _stopped_connection: Error = owner_system.flow_stopped.connect(stopped_callback) as Error
+
+	owner_system.start(false)
+	owner_system.flow_started.disconnect(started_callback)
+	owner_system.flow_stopped.disconnect(stopped_callback)
+
+	assert_push_warning("[GFTurnFlowSystem] start 失败：context 正由另一个 flow generation 持有。")
+	assert_eq(
+		events,
+		[
+			"owner_started:1",
+			"owner_stopped:1",
+			"restart_requested",
+			"foreign_attempted",
+			"owner_started:2",
+		],
+		"新 generation 必须等外层 start 通知展开完成后再同步启动。"
+	)
+	assert_eq(started_count[0], 2, "完成嵌套 stop 通知后应启动一次新 generation。")
+	assert_eq(stopped_count[0], 1, "嵌套重启不得重复发出 stop 通知。")
+	assert_true(owner_system.is_running, "flow_stopped 中请求的重启应在外层 start 事务释放后生效。")
+	assert_false(foreign_system.is_running, "外层 start 通知仍在展开时不得穿插 foreign Context mutation。")
+	assert_eq(
+		owner_system.current_phase_index,
+		preserved_phase_index,
+		"start(false) 的嵌套重启不得丢失 reset_indices 载荷。"
+	)
+	assert_eq(
+		context.round_index,
+		preserved_round_index,
+		"start(false) 的嵌套重启不得重置 Context 轮次。"
+	)
+
+	owner_system.stop()
+	foreign_system.start(false)
+	assert_true(foreign_system.is_running, "重启事务收敛后不得泄漏 Context claim。")
+	foreign_system.stop()
+
+
+func test_later_stop_cancels_restart_queued_during_start_notification() -> void:
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var started_count: Array[int] = [0]
+	var started_callback: Callable = func(_context: GFTurnContext) -> void:
+		started_count[0] += 1
+		if started_count[0] == 1:
+			system.stop()
+	var restart_callback: Callable = func(_context: GFTurnContext) -> void:
+		system.start(false)
+	var final_stop_callback: Callable = func(_context: GFTurnContext) -> void:
+		system.stop()
+	var _started_connection: Error = system.flow_started.connect(started_callback) as Error
+	var _restart_connection: Error = system.flow_stopped.connect(restart_callback) as Error
+	var _final_stop_connection: Error = system.flow_stopped.connect(final_stop_callback) as Error
+
+	system.start()
+	system.flow_started.disconnect(started_callback)
+	system.flow_stopped.disconnect(restart_callback)
+	system.flow_stopped.disconnect(final_stop_callback)
+
+	assert_eq(started_count[0], 1, "后续 stop 应取消尚未执行的嵌套重启请求。")
+	assert_false(system.is_running, "延迟重启不得反转后续 stop 的最终状态。")
+
+
 func test_stop_true_clears_actions_even_when_already_stopped() -> void:
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
 	var action: GFTurnAction = GFTurnAction.new()


### PR DESCRIPTION
## Summary

Fixes phase completion and shared Context ownership in the TurnBased extension. Manual phases now receive an exact completion handle, and Context operations use owner-scoped exact claims so stale callbacks cannot settle a later phase and foreign flow systems cannot mutate shared state before conflict detection.

Closes #138

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: foreign Flow Systems fail closed before round, phase, actor, queue, or signal side effects; stale, repeated, stopped, timed-out, disposed, and released phase handles return false.
- API or extension contract: removes GFTurnPhase.finish() and finish(context), changes protected _execute(context) to _execute(context, completion), adds GFTurnPhaseCompletionHandle.try_complete(), and raises gf.turn_based extension_version from 2.0.1 to 3.0.0.
- Persisted data, package, protocol, or ProjectSettings impact: no persisted-data, protocol, or ProjectSettings change; the existing TurnBased package glob includes the new handle script and UID.
- Failure, cancellation, rollback, concurrency, and ownership impact: stop, timeout, and dispose revoke completion immediately while exact cleanup claims remain until continuations unwind. Same-owner phase and action operations may overlap; a foreign owner is admitted only after the final claim releases.
- Compatibility and migration: this is an intentional 11.0 breaking change. Custom manual phases must accept and retain the supplied completion handle and call try_complete(); the guide, API reference, changelog, and migration item 62 are updated.

## Verification

- [x] Focused tests cover the changed behavior and failure path: TurnBased 46/46 in the full GUT run.
- [x] API and documentation suites passed; generated Catalog, Reference, and AI knowledge are current.
- [x] GDScript warning and LSP gates are clean: 1341 files, zero diagnostics and zero timeouts.
- [x] Package boundaries and focused mapping passed; isolated gf.extension.turn_based Godot smoke installed 531 closure files, preloaded 261 scripts, and reported zero leaks.
- [x] Full GUT completed 6889/6890 with a clean lifecycle gate. The sole failure is the unchanged Windows direct-file-symlink fixture, also reproduced on prior clean-main runs; TurnBased itself is 46/46.
- [x] Independent runtime, API/docs, tests/package, and post-rebase audits reported CLEAN.
- [x] Draft PR feedback is not applicable because this PR is opened ready for review.
- [x] Ready PR CI completed through GF repository policy and GF merge gate.

## Documentation and Release

- [x] The TurnBased guide, API reference, AI knowledge, and 未发布 changelog/migration entry are updated.
- [x] Root remains 11.0.0-dev.0; gf.turn_based uses extension_version 3.0.0 for the breaking contract.
- [x] This PR does not create a tag or publish a release.

