### PR TITLE
Harden turn action callback invalidation

### DIFF
--- a/addons/gf/extensions/turn_based/gf_extension.json
+++ b/addons/gf/extensions/turn_based/gf_extension.json
@@ -2,7 +2,7 @@
   "id": "gf.turn_based",
   "display_name": "GF Turn Based",
   "version": "11.0.0-dev.0",
-  "extension_version": "3.0.0",
+  "extension_version": "3.0.1",
   "kind": "extension",
   "description": "Turn phases, turn actions, contexts, and turn flow system primitives.",
   "dependencies": ["gf.kernel", "gf.standard"],

--- a/addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd
+++ b/addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd
@@ -467,7 +467,7 @@ func enqueue_action(action: GFTurnAction) -> void:
 ## [br]
 ## @since 3.17.0
 ## [br]
-## @param order_resolver: 可选排序回调，签名为 func(a, b) -> bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则。
+## @param order_resolver: 可选排序回调，签名为 func(a, b) -> bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则；若回调使当前 operation 失效，框架会停止后续调用，并按排序前快照恢复或封存队列。
 func resolve_actions(order_resolver: Callable = Callable()) -> void:
 	if _is_disposed:
 		return
@@ -485,6 +485,7 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 		push_warning("[GFTurnFlowSystem] resolve_actions 失败：context 正由另一个 flow generation 持有。")
 		return
 	var pending_actions: Array[GFTurnAction] = _actions.duplicate()
+	var original_pending_actions: Array[GFTurnAction] = pending_actions.duplicate()
 	_actions.clear()
 	_is_resolving_actions = true
 	_active_operation_stop_requested = false
@@ -498,11 +499,20 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 
 	if sort_actions_before_resolve:
 		if order_resolver.is_valid():
-			pending_actions.sort_custom(order_resolver)
+			var comparator_state: Dictionary = {"is_active": true}
+			pending_actions.sort_custom(
+				Callable(self, "_sort_action_with_operation_guard").bind(
+					order_resolver,
+					comparator_state,
+					action_lease,
+					flow_serial,
+					active_context
+				)
+			)
 		else:
 			pending_actions.sort_custom(_sort_action_desc)
 	if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
-		_restore_unresolved_actions(pending_actions, 0)
+		_restore_unresolved_actions(original_pending_actions, 0)
 		_finish_action_resolution(active_context, action_lease)
 		return
 
@@ -520,6 +530,10 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
 			_restore_unresolved_actions(pending_actions, action_index)
 			break
+		if action == null or action.is_cancelled or _action_has_invalid_actor(action):
+			_consume_action(action)
+			action_index += 1
+			continue
 		action.replace_runtime_targets(action.targets)
 		if not _is_context_operation_lease_current(action_lease, flow_serial, active_context):
 			_restore_unresolved_actions(pending_actions, action_index)
@@ -577,6 +591,28 @@ func _sort_action_desc(a: GFTurnAction, b: GFTurnAction) -> bool:
 	if a_sort_value != b_sort_value:
 		return a_sort_value > b_sort_value
 	return _get_action_order(a) < _get_action_order(b)
+
+
+func _sort_action_with_operation_guard(
+	a: GFTurnAction,
+	b: GFTurnAction,
+	order_resolver: Callable,
+	comparator_state: Dictionary,
+	lease: GFTurnContext.FlowOperationLease,
+	flow_serial: int,
+	active_context: GFTurnContext
+) -> bool:
+	if (
+		not GFVariantData.get_option_bool(comparator_state, "is_active")
+		or not _is_context_operation_lease_current(lease, flow_serial, active_context)
+	):
+		comparator_state["is_active"] = false
+		return false
+	var result: Variant = order_resolver.call(a, b)
+	if not _is_context_operation_lease_current(lease, flow_serial, active_context):
+		comparator_state["is_active"] = false
+		return false
+	return result is bool and result
 
 
 func _next_valid_phase() -> Dictionary:

--- a/docs/api_catalog/classes/GFTurnFlowSystem.xml
+++ b/docs/api_catalog/classes/GFTurnFlowSystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTurnFlowSystem" path="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" module="extensions/turn_based" extends="GFSystem" classDigest="1dd11fd080bcc829b36d079e2ff915f644db84ff6e7be07912200f44021ccf7e">
+<class name="GFTurnFlowSystem" path="addons/gf/extensions/turn_based/runtime/gf_turn_flow_system.gd" module="extensions/turn_based" extends="GFSystem" classDigest="d0f50369e69dda73a290eea1a92a5c5bb09563bc0bbe86f69bde8d6d012a6118">
 	<description>GFTurnFlowSystem: 通用回合流程系统。
 提供阶段推进、行动排队和按优先级解析能力。
 它不关心战斗、卡牌、棋盘等具体业务，只调度抽象行动。</description>
@@ -205,7 +205,7 @@
 若同一 Context 正由其他 Flow generation 持有，本次调用会在清理 actor、取走队列、写入 current_actor 或调用 action 前失败关闭；最后一张 operation claim 释放后可顺序重试。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="param">order_resolver: 可选排序回调，签名为 func(a, b) -&gt; bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则。</tag>
+				<tag name="param">order_resolver: 可选排序回调，签名为 func(a, b) -&gt; bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则；若回调使当前 operation 失效，框架会停止后续调用，并按排序前快照恢复或封存队列。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="fa2c38136c5772302e812f59012d07079f00614775bddd10119a2cd6dc59b391" classCount="844" methodCount="7680" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="8d967683d2c9812cbd1f6c9ca8f12bc1728e4a4ae101806279ded6be44678241" classCount="844" methodCount="7680" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="75" methodCount="801" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -313,7 +313,7 @@
 - 修复 Interaction 的 Pointer 与 Receiver-to-Receiver 转发对已编码报告再次编码、Area2D/3D 自定义 sender 的空或非 Dictionary 结果产生残缺报告或被静默丢弃、候选回调释放后续 receiver 后访问 previously freed Object、失效 `validation_callback` 静默恢复默认允许，以及同名不兼容项目方法触发脚本错误的问题；每次实际 Area 分发现在都返回并发布完整 JSON-safe 报告。
 - 修复 Network snapshot 生成 `ok=true` 但同版本 applicator 因深度、操作数或非法内容静默拒绝，service discovery 的自定义 `now_seconds` 与内部 elapsed clock 混用而延长 TTL，以及 fixed-tick signal 回调递归推进导致 stack overflow 的问题。
 - 修复 Physics 同路径 field 替换命中陈旧缓存、最高优先级的 32 位哨兵丢弃合法 int64、Vector3 聚合与平方范数溢出、浮力总力携带 Infinity、平方反比与超大浸没半径发生可避免中间溢出，以及 field 回调改写 Probe 后形成混合时点或错误缓存的问题。
-- 修复 TurnBased 旧异步回调只凭 Context 完成后来 phase runtime，以及不同 Flow System 在发现共享 Context 冲突前已修改 round、phase、actor 或行动队列的问题。精确 completion handle 在 stop、timeout、dispose、正常收尾或 restart 后立即失效；Context claim 只在最后一个同 owner operation 安全收尾后释放。另修复 lifecycle 已 stopped 时让 `stop(true)` 静默跳过清理、`stop(false)` 的在途 restore policy 无法升级、phase/action 双通道先结束者过早清除 stop 证据，以及 `get_actor_value()` 对同名错误 arity/type 方法直接产生脚本错误的问题；action target 的重复 O(n²) 清洗收敛为单次 O(n)。
+- 修复 TurnBased 旧异步回调只凭 Context 完成后来 phase runtime，以及不同 Flow System 在发现共享 Context 冲突前已修改 round、phase、actor 或行动队列的问题。精确 completion handle 在 stop、timeout、dispose、正常收尾或 restart 后立即失效；Context claim 只在最后一个同 owner operation 安全收尾后释放。另修复 lifecycle 已 stopped 时让 `stop(true)` 静默跳过清理、`stop(false)` 的在途 restore policy 无法升级、phase/action 双通道先结束者过早清除 stop 证据，以及 `get_actor_value()` 对同名错误 arity/type 方法直接产生脚本错误的问题；action target 的重复 O(n²) 清洗收敛为单次 O(n)。自定义 action comparator 使 operation 失效后不再继续调用项目回调，并按排序前快照恢复原始入队顺序；依赖注入 hook 取消当前 action 后也会在 `_resolve()` 前消费它并继续解析队列。
 
 ### ⚠️ 废弃与移除 (Deprecated/Removed)
 
@@ -415,7 +415,7 @@
 - `GFInteractions.is_method_call_compatible_for_framework()` 是新的框架内部动态协议预检入口。Interaction 的公开方法和信号签名不变，但失效 validator、非法 sender/provider/receiver 协议、Area 非法返回和 Pointer 多按钮的运行时语义均已收紧；`gf.interaction` 的 `extension_version` 因此提升到 `3.0.0`。
 - `GFNetworkSnapshot.make_patch_to()` 会把 `max_depth` 限制到 8，并以 `patch_operation_budget_exceeded` / `generated_patch_not_applicable` 显式拒绝 applicator 无法接受的成功候选。`GFNetworkServiceDiscovery.now_seconds` 只影响记录时间；`GFFixedTickClock.advance()` / `step_once()` 在同实例 signal 重入时无副作用返回。公开签名不变，`gf.network` 的 `extension_version` 提升到 `7.0.0`。
 - Physics 公开签名不变；`GFGravityProbe3D.sample()` / `sample_fields()` / `sample_field_provider()` 现在冻结入口查询状态并在同实例同步重入时返回零，全部重力/浮力公开向量保持有限。该运行语义收紧使 `gf.physics` 的 `extension_version` 提升到 `2.0.0`。
-- TurnBased 移除基于 Context 查找当前运行态的 `GFTurnPhase.finish()` / `finish(context)`，protected 扩展点从 `_execute(context)` 改为 `_execute(context, completion)`，并新增 `GFTurnPhaseCompletionHandle.try_complete()`。`GFTurnFlowSystem.dispose()` 现在显式终止接纳新 operation；`stop(true)` 继续对 stopped/恢复中队列执行幂等且可升级的清理，`GFTurnContext.get_actor_value()` 只调用接受两个兼容实参的 duck method。默认 non-finite 排序与自定义 comparator 的合同已写明，`gf.turn_based` 的 `extension_version` 从 `2.0.1` 提升到 `3.0.0`。
+- TurnBased 移除基于 Context 查找当前运行态的 `GFTurnPhase.finish()` / `finish(context)`，protected 扩展点从 `_execute(context)` 改为 `_execute(context, completion)`，并新增 `GFTurnPhaseCompletionHandle.try_complete()`。`GFTurnFlowSystem.dispose()` 现在显式终止接纳新 operation；`stop(true)` 继续对 stopped/恢复中队列执行幂等且可升级的清理，`GFTurnContext.get_actor_value()` 只调用接受两个兼容实参的 duck method。默认 non-finite 排序与自定义 comparator 的合同已写明，`gf.turn_based` 的 `extension_version` 从 `2.0.1` 提升到 `3.0.1`。
 
 ### 📘 升级指南 (Migration Guide)
 

--- a/docs/zh/extensions/network-turnbased/turn-flow.md
+++ b/docs/zh/extensions/network-turnbased/turn-flow.md
@@ -33,7 +33,7 @@ flow.enqueue_action(GFTurnAction.new(actor_a, [target_b], { "value": 10 }, 1, 20
 flow.advance_phase()
 ```
 
-默认排序规则是 `priority` 降序，然后按有限 `sort_value` 降序；NaN 与正负 Infinity 统一排在有限值之后，并按入队顺序保持稳定。自定义 `order_resolver` 必须是无副作用、确定且满足严格弱序的 `func(a, b) -> bool`，并自行定义 non-finite 与平局规则。框架会在比较器使当前 lease 失效时恢复或封存快照，但不会把非传递比较器改造成可重放顺序。
+默认排序规则是 `priority` 降序，然后按有限 `sort_value` 降序；NaN 与正负 Infinity 统一排在有限值之后，并按入队顺序保持稳定。自定义 `order_resolver` 必须是无副作用、确定且满足严格弱序的 `func(a, b) -> bool`，并自行定义 non-finite 与平局规则。若比较器使当前 lease 失效，框架会停止后续比较器调用，并按排序前快照恢复或封存原始入队顺序；框架不会把非传递比较器改造成可重放顺序。
 
 阶段和行动如果返回 Signal，系统会通过 `signal_timeout_seconds` 和当前流程 serial 做安全等待；`stop()` 或超时后不会继续调用旧阶段的 `_exit()`，也不会把旧行动标记为 resolved。`resolve_actions()` 在上一批行动仍等待时会拒绝同类重入，避免同一批行动被重复解析。`stop(true)` 的清理策略与停止通知分离：流程已经 stopped 时仍会幂等清空并封存队列，`stop(false)` 保留的在途行动也可由后续 `stop(true)` 升级为丢弃；重复调用不会重复发送 `flow_stopped`。
 

--- a/docs/zh/reference/api/classes/GFTurnFlowSystem.md
+++ b/docs/zh/reference/api/classes/GFTurnFlowSystem.md
@@ -403,4 +403,4 @@ func resolve_actions(order_resolver: Callable = Callable()) -> void:
 
 | 名称 | 说明 |
 |---|---|
-| `order_resolver` | 可选排序回调，签名为 func(a, b) -> bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则。 |
+| `order_resolver` | 可选排序回调，签名为 func(a, b) -> bool；调用方必须提供无副作用、确定且满足严格弱序的比较器。自定义比较器不继承默认 non-finite 与入队顺序规则；若回调使当前 operation 失效，框架会停止后续调用，并按排序前快照恢复或封存队列。 |

--- a/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
+++ b/tests/gf_core/extensions/turn_based/test_gf_turn_flow_system.gd
@@ -246,6 +246,19 @@ class StopDuringInjectionAction extends GFTurnAction:
 		return null
 
 
+class CancelDuringInjectionAction extends GFTurnAction:
+	var injection_called: bool = false
+	var resolved: bool = false
+
+	func _inject_dependencies(_architecture: GFArchitecture) -> void:
+		injection_called = true
+		cancel()
+
+	func _resolve(_context: GFTurnContext) -> Variant:
+		resolved = true
+		return null
+
+
 class CompatibleTurnValueActor extends Object:
 	func get_turn_value(key: StringName, fallback: Variant) -> Variant:
 		return 9 if key == &"initiative" else fallback
@@ -846,23 +859,101 @@ func test_equal_priority_actions_resolve_in_enqueue_order() -> void:
 	assert_eq(order, ["first", "second", "third"], "priority 与 sort_value 相同时应按入队顺序解析。")
 
 
-func test_comparator_stop_restores_snapshot_without_resolving() -> void:
+func test_custom_comparator_applies_requested_order_while_operation_is_current() -> void:
 	var order: Array[String] = []
 	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
-	var stopped: Array[bool] = [false]
-	system.enqueue_action(RecordingAction.new("first", 0, 0.0, order))
-	system.enqueue_action(RecordingAction.new("second", 0, 0.0, order))
-	var comparator: Callable = func(_a: GFTurnAction, _b: GFTurnAction) -> bool:
-		if not stopped[0]:
-			stopped[0] = true
+	var comparator_calls: Array[int] = [0]
+	system.enqueue_action(RecordingAction.new("first", 1, 0.0, order))
+	system.enqueue_action(RecordingAction.new("second", 3, 0.0, order))
+	system.enqueue_action(RecordingAction.new("third", 2, 0.0, order))
+	var comparator: Callable = func(a: GFTurnAction, b: GFTurnAction) -> bool:
+		comparator_calls[0] += 1
+		return a.priority < b.priority
+
+	await system.resolve_actions(comparator)
+
+	assert_gt(comparator_calls[0], 0, "有效 operation 应调用项目 comparator。")
+	assert_eq(order, ["first", "third", "second"], "有效 comparator 应决定 action 解析顺序。")
+	assert_eq(system.get_action_count(), 0, "自定义排序完成后不应遗留 action。")
+
+
+func test_comparator_stop_restores_original_enqueue_order() -> void:
+	var order: Array[String] = []
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var comparator_calls: Array[int] = [0]
+	var first_action: RecordingAction = RecordingAction.new("first", 1, 0.0, order)
+	var second_action: RecordingAction = RecordingAction.new("second", 3, 0.0, order)
+	var third_action: RecordingAction = RecordingAction.new("third", 2, 0.0, order)
+	system.enqueue_action(first_action)
+	system.enqueue_action(second_action)
+	system.enqueue_action(third_action)
+	var comparator: Callable = func(a: GFTurnAction, b: GFTurnAction) -> bool:
+		comparator_calls[0] += 1
+		if comparator_calls[0] == 1:
 			system.stop(false)
-		return false
+		return a.priority > b.priority
 
 	await system.resolve_actions(comparator)
 
 	assert_eq(order, [], "比较器使 transaction 失效后不得开始解析行动。")
-	assert_eq(_get_queued_actions(system).size(), 2, "比较器 stop(false) 后应完整恢复排序快照。")
-	system.stop(true)
+	assert_eq(comparator_calls[0], 1, "比较器使 operation 失效后不得继续调用项目回调。")
+	var queued_actions: Array = _get_queued_actions(system)
+	assert_eq(queued_actions.size(), 3, "比较器 stop(false) 后应完整恢复排序前快照。")
+	if queued_actions.size() == 3:
+		var restored_first_value: Variant = queued_actions[0]
+		var restored_second_value: Variant = queued_actions[1]
+		var restored_third_value: Variant = queued_actions[2]
+		assert_true(restored_first_value is GFTurnAction, "恢复队列的第一项应保持 action 类型。")
+		assert_true(restored_second_value is GFTurnAction, "恢复队列的第二项应保持 action 类型。")
+		assert_true(restored_third_value is GFTurnAction, "恢复队列的第三项应保持 action 类型。")
+		if (
+			restored_first_value is GFTurnAction
+			and restored_second_value is GFTurnAction
+			and restored_third_value is GFTurnAction
+		):
+			var restored_first: GFTurnAction = restored_first_value
+			var restored_second: GFTurnAction = restored_second_value
+			var restored_third: GFTurnAction = restored_third_value
+			assert_same(restored_first, first_action, "恢复队列应保留第一个 action 的入队位置。")
+			assert_same(restored_second, second_action, "恢复队列应保留第二个 action 的入队位置。")
+			assert_same(restored_third, third_action, "恢复队列应保留第三个 action 的入队位置。")
+	assert_false(first_action.is_sealed(), "stop(false) 恢复的第一个 action 应仍可再次解析。")
+	assert_false(second_action.is_sealed(), "stop(false) 恢复的第二个 action 应仍可再次解析。")
+	assert_false(third_action.is_sealed(), "stop(false) 恢复的第三个 action 应仍可再次解析。")
+
+	await system.resolve_actions()
+
+	assert_eq(order, ["second", "third", "first"], "恢复后的 action 应能在下一次调用中正常解析。")
+	assert_true(first_action.is_sealed(), "再次解析后第一个 action 应被封存。")
+	assert_true(second_action.is_sealed(), "再次解析后第二个 action 应被封存。")
+	assert_true(third_action.is_sealed(), "再次解析后第三个 action 应被封存。")
+	assert_eq(system.get_action_count(), 0, "再次解析后不应遗留恢复 action。")
+
+
+func test_comparator_clear_stop_seals_original_snapshot() -> void:
+	var order: Array[String] = []
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var comparator_calls: Array[int] = [0]
+	var first_action: RecordingAction = RecordingAction.new("first", 1, 0.0, order)
+	var second_action: RecordingAction = RecordingAction.new("second", 3, 0.0, order)
+	var third_action: RecordingAction = RecordingAction.new("third", 2, 0.0, order)
+	system.enqueue_action(first_action)
+	system.enqueue_action(second_action)
+	system.enqueue_action(third_action)
+	var comparator: Callable = func(a: GFTurnAction, b: GFTurnAction) -> bool:
+		comparator_calls[0] += 1
+		if comparator_calls[0] == 1:
+			system.stop(true)
+		return a.priority > b.priority
+
+	await system.resolve_actions(comparator)
+
+	assert_eq(order, [], "比较器 stop(true) 后不得解析 action。")
+	assert_eq(comparator_calls[0], 1, "clear stop 失效后不得继续调用项目 comparator。")
+	assert_eq(system.get_action_count(), 0, "stop(true) 应清空排序前 action 快照。")
+	assert_true(first_action.is_sealed(), "stop(true) 应封存第一个 action。")
+	assert_true(second_action.is_sealed(), "stop(true) 应封存第二个 action。")
+	assert_true(third_action.is_sealed(), "stop(true) 应封存第三个 action。")
 
 
 func test_non_finite_sort_values_are_stable_and_last() -> void:
@@ -1207,6 +1298,28 @@ func test_action_injection_stop_is_rechecked_before_context_write_or_resolve() -
 	assert_null(system.context.current_actor, "injection stop 后不得写入 current_actor。")
 	system.stop(true)
 	stopping_action.system = null
+	system.release_dependencies()
+	architecture.dispose()
+
+
+func test_action_injection_cancel_skips_resolve_and_continues_queue() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var system: GFTurnFlowSystem = GFTurnFlowSystem.new()
+	var order: Array[String] = []
+	var cancelling_action: CancelDuringInjectionAction = CancelDuringInjectionAction.new()
+	var next_action: RecordingAction = RecordingAction.new("next", 0, 0.0, order)
+	system.inject_dependencies(architecture)
+	system.enqueue_action(cancelling_action)
+	system.enqueue_action(next_action)
+
+	await system.resolve_actions()
+
+	assert_true(cancelling_action.injection_called, "action 应先经过显式依赖注入 hook。")
+	assert_true(cancelling_action.is_cancelled, "注入 hook 的取消请求应保留。")
+	assert_false(cancelling_action.resolved, "注入期间取消的 action 不得继续执行 resolve hook。")
+	assert_true(cancelling_action.is_sealed(), "注入期间取消的 action 应离开队列并封存。")
+	assert_eq(order, ["next"], "取消当前 action 后应继续解析后续有效 action。")
+	assert_eq(system.get_action_count(), 0, "完成解析后不应遗留已消费 action。")
 	system.release_dependencies()
 	architecture.dispose()
 


### PR DESCRIPTION
## Summary

- stop invoking a project action comparator after it invalidates the exact active Context operation claim
- restore or seal actions from the original enqueue snapshot when comparator invalidation happens before resolution
- consume actions cancelled during dependency injection without calling `_resolve()`, while allowing the remaining queue to continue
- bump `gf.turn_based` extension version to `3.0.1` and synchronize the guide, changelog, and generated API reference

## Context

This is a narrow hardening follow-up after #138 was resolved by #150. It keeps the existing `GFTurnPhaseCompletionHandle`, queued restart, and multi-claim Context lease contracts unchanged. Abandoned-owner lease reclamation remains a separate follow-up.

## Verification

- Full maintenance suite: 46/46 checks passed
- Focused TurnBased GUT: 51/51 tests, 204 assertions, 0 lifecycle warnings, 0 orphans
- Target GDScript LSP: 0 diagnostics
- API Reference and AI Developer Kit generated-source checks passed
- `gf.extension.turn_based` package Godot smoke passed
- Final immutable three-track audit: Blocker 0 / Should-fix 0
