### PR TITLE
Centralize validation timeout policy

### DIFF
--- a/docs/adr/0003-validation-authority.md
+++ b/docs/adr/0003-validation-authority.md
@@ -31,4 +31,6 @@ Threat handling is layered:
 
 ## Migration sequence
 
-This decision is implemented incrementally. The first slice centralizes action identifiers, statically available command arguments, dependency declarations, existing check groups and suites, and ordered Full lanes without changing execution behavior. A missing static command means only that the runner materializes it later from live inputs; it does not select an executor. Executor selection, timeouts, inputs, artifacts, partitioning, and reuse remain runner-owned until a real consumer is migrated with focused tests. This temporary representation is not the final Action specification.
+This decision is implemented incrementally. The first slice centralizes action identifiers, statically available command arguments, dependency declarations, existing check groups and suites, and ordered Full lanes without changing execution behavior. A missing static command means only that the runner materializes it later from live inputs; it does not select an executor. Executor selection, inputs, artifacts, partitioning, and reuse remain runner-owned until a real consumer is migrated with focused tests. This temporary representation is not the final Action specification.
+
+The next consumer slice moved the default and per-action timeout floors into the Catalog. The runner still owns caller-requested timeout increases, suite-deadline clipping, and aggregate parallel-lane envelopes; those are distinct policies and are not folded into the action floor.

--- a/tests/gf_core/tools/test_gf_maintenance_execution.py
+++ b/tests/gf_core/tools/test_gf_maintenance_execution.py
@@ -283,6 +283,31 @@ class ValidationCatalogContractTests(unittest.TestCase):
 		self.assertEqual(first_before["examples_boot"][-1], "<boot-first>")
 		self.assertEqual(first_before["examples_smoke"][-1], "<smoke-first>")
 
+	def test_catalog_timeout_policy_matches_pre_migration_runner_values(self) -> None:
+		catalog = gf_validation_catalog.build_validation_catalog(
+			self._snapshot_context()
+		)
+		expected_overrides = {
+			"gut": 1200,
+			"gut_lifecycle_smoke": 360,
+			"ai_developer_adapter_acceptance": 900,
+			"package_editor_wizard_smoke": 1200,
+			"package_godot_cli_smoke": 2400,
+			"package_godot_cli_local_smoke": 1200,
+			"package_godot_cli_network_smoke": 1200,
+			"package_godot_matrix_smoke": 2400,
+		}
+
+		self.assertEqual(catalog.default_timeout_seconds, 600)
+		self.assertEqual(catalog.timeout_overrides(), expected_overrides)
+		self.assertEqual(catalog.timeout_floor_seconds("api"), 600)
+		for action_name, timeout_seconds in expected_overrides.items():
+			with self.subTest(action=action_name):
+				self.assertEqual(
+					catalog.timeout_floor_seconds(action_name),
+					timeout_seconds,
+				)
+
 	def test_runner_legacy_projections_come_from_catalog(self) -> None:
 		catalog = gf_maintenance._VALIDATION_CATALOG
 		legacy_groups = {
@@ -501,6 +526,62 @@ class ValidationCatalogContractTests(unittest.TestCase):
 					{"examples_sync_write"},
 				)
 
+	def test_serial_runner_consumes_the_catalog_timeout_floor(self) -> None:
+		plan = gf_maintenance._VALIDATION_CATALOG.plan("api", ["api"])
+		workspace_state = {
+			"schema_version": 1,
+			"head": "a" * 40,
+			"dirty": False,
+			"untracked_file_count": 0,
+			"fingerprint": "b" * 64,
+		}
+		timeout_catalog = mock.Mock()
+		timeout_catalog.timeout_floor_seconds.return_value = 321
+
+		def succeed(
+			name: str,
+			command: list[str],
+			timeout_seconds: float,
+			_output_callback: object,
+		) -> gf_maintenance.CommandResult:
+			return gf_maintenance.CommandResult(
+				name=name,
+				command=command,
+				exit_code=0,
+				stdout="",
+				stderr="",
+				timeout_seconds=timeout_seconds,
+			)
+
+		with mock.patch.object(
+			gf_maintenance,
+			"_VALIDATION_CATALOG",
+			timeout_catalog,
+		), mock.patch.object(
+			gf_maintenance,
+			"maintenance_in_process_check_runners",
+			return_value={},
+		), mock.patch.object(
+			gf_maintenance,
+			"run_command",
+			side_effect=succeed,
+		):
+			report = gf_maintenance.run_checks_with_active_snapshot(
+				plan,
+				workspace_state=workspace_state,
+			)
+
+		timeout_catalog.timeout_floor_seconds.assert_called_once_with("api")
+		self.assertEqual(
+			report["results"][0]["timeout_budget"],
+			{
+				"policy_seconds": 321.0,
+				"requested_minimum_seconds": None,
+				"suite_remaining_seconds": None,
+				"effective_seconds": 321.0,
+			},
+		)
+
 	def test_invalid_parallel_jobs_return_a_structured_plan_setup_failure(self) -> None:
 		plan = gf_maintenance._VALIDATION_CATALOG.plan("quick")
 		for suite_timeout_seconds in (None, 0):
@@ -560,6 +641,9 @@ class ValidationCatalogContractTests(unittest.TestCase):
 			"lane": {
 				"parallel_full_shard_suites": ("suite", "suite"),
 			},
+			"timeout override": {
+				"timeout_overrides": (("alpha", 1), ("alpha", 2)),
+			},
 		}
 		for label, overrides in invalid_overrides.items():
 			with self.subTest(label=label), self.assertRaises(
@@ -574,6 +658,7 @@ class ValidationCatalogContractTests(unittest.TestCase):
 			"group action": {"check_groups": (("group", ("unknown",)),)},
 			"suite action": {"suites": (("suite", ("unknown",)),)},
 			"lane suite": {"parallel_full_shard_suites": ("unknown",)},
+			"timeout action": {"timeout_overrides": (("unknown", 1),)},
 		}
 		for label, overrides in invalid_overrides.items():
 			with self.subTest(label=label), self.assertRaises(
@@ -582,6 +667,30 @@ class ValidationCatalogContractTests(unittest.TestCase):
 				self._minimal_catalog(**overrides)
 		with self.assertRaises(gf_validation_catalog.ValidationCatalogError):
 			self._minimal_catalog().check_group("unknown")
+		with self.assertRaises(gf_validation_catalog.ValidationCatalogError):
+			self._minimal_catalog().timeout_floor_seconds("unknown")
+
+	def test_timeout_policy_rejects_non_positive_or_non_integer_seconds(self) -> None:
+		for value in (True, 0, -1, 1.0, "1"):
+			with self.subTest(default=value), self.assertRaises(
+				gf_validation_catalog.ValidationCatalogError
+			):
+				self._minimal_catalog(default_timeout_seconds=value)
+			with self.subTest(override=value), self.assertRaises(
+				gf_validation_catalog.ValidationCatalogError
+			):
+				self._minimal_catalog(timeout_overrides=(("alpha", value),))
+
+	def test_timeout_policy_rejects_malformed_override_declarations(self) -> None:
+		for declarations in (
+			(["alpha", 15],),
+			(("alpha",),),
+			(("alpha", 15, "extra"),),
+		):
+			with self.subTest(declarations=declarations), self.assertRaises(
+				gf_validation_catalog.ValidationCatalogError
+			):
+				self._minimal_catalog(timeout_overrides=declarations)
 
 	def test_dependency_topology_is_validated_during_catalog_construction(self) -> None:
 		invalid_dependencies = {
@@ -615,27 +724,32 @@ class ValidationCatalogContractTests(unittest.TestCase):
 		group = ["alpha", "beta"]
 		suite = ["alpha", "beta"]
 		lanes = ["suite"]
+		timeout_overrides = [("alpha", 15)]
 		catalog = self._minimal_catalog(
 			actions=(("alpha", command), ("beta", None)),
 			dependencies=(("beta", dependencies),),
 			check_groups=(("group", group),),
 			suites=(("suite", suite),),
 			parallel_full_shard_suites=lanes,
+			timeout_overrides=timeout_overrides,
 		)
 		command.append("mutated")
 		dependencies.append("beta")
 		group.append("alpha")
 		suite.append("alpha")
 		lanes.append("suite")
+		timeout_overrides.append(("beta", 30))
 
 		command_copy = catalog.command_definitions()
 		dependency_copy = catalog.dependencies()
 		group_copy = catalog.check_groups()
 		suite_copy = catalog.suites()
+		timeout_copy = catalog.timeout_overrides()
 		command_copy["alpha"].append("mutated")
 		dependency_copy["beta"].append("beta")
 		group_copy["group"].append("alpha")
 		suite_copy["suite"].append("alpha")
+		timeout_copy["alpha"] = 99
 
 		self.assertEqual(catalog.action_names, ("alpha", "beta"))
 		self.assertEqual(catalog.command_definitions(), {"alpha": ["python"]})
@@ -643,6 +757,10 @@ class ValidationCatalogContractTests(unittest.TestCase):
 		self.assertEqual(catalog.check_groups(), {"group": ["alpha", "beta"]})
 		self.assertEqual(catalog.suites(), {"suite": ["alpha", "beta"]})
 		self.assertEqual(catalog.parallel_full_shard_suites, ("suite",))
+		self.assertEqual(catalog.default_timeout_seconds, 10)
+		self.assertEqual(catalog.timeout_overrides(), {"alpha": 15})
+		self.assertEqual(catalog.timeout_floor_seconds("alpha"), 15)
+		self.assertEqual(catalog.timeout_floor_seconds("beta"), 10)
 
 	@staticmethod
 	def _snapshot_context() -> gf_validation_catalog.ValidationCatalogContext:
@@ -685,6 +803,8 @@ class ValidationCatalogContractTests(unittest.TestCase):
 			"check_groups": (("group", ("alpha", "beta")),),
 			"suites": (("suite", ("alpha", "beta")),),
 			"parallel_full_shard_suites": ("suite",),
+			"default_timeout_seconds": 10,
+			"timeout_overrides": (("alpha", 15),),
 		}
 		arguments.update(overrides)
 		return gf_validation_catalog.ValidationCatalog(**arguments)
@@ -3515,7 +3635,10 @@ class GutShardPlanIntegrationTests(unittest.TestCase):
 			gf_maintenance.resolve_gut_shard_observation_timeout_seconds(1500),
 			1500,
 		)
-		self.assertEqual(gf_maintenance.CHECK_TIMEOUT_SECONDS["gut"], 1200)
+		self.assertEqual(
+			gf_maintenance._VALIDATION_CATALOG.timeout_floor_seconds("gut"),
+			1200,
+		)
 		self.assertEqual(
 			gf_maintenance.resolve_check_timeout_seconds("gut", None),
 			1200,
@@ -3539,6 +3662,61 @@ class GutShardPlanIntegrationTests(unittest.TestCase):
 			gf_maintenance.parallel_shard_timeout_seconds(framework_gut, None),
 			2820,
 		)
+
+	def test_gut_observation_timeout_consumes_the_catalog_floor(self) -> None:
+		timeout_catalog = mock.Mock()
+		timeout_catalog.timeout_floor_seconds.return_value = 1301
+
+		with mock.patch.object(
+			gf_maintenance,
+			"_VALIDATION_CATALOG",
+			timeout_catalog,
+		):
+			self.assertEqual(
+				gf_maintenance.resolve_gut_shard_observation_timeout_seconds(None),
+				1301,
+			)
+			self.assertEqual(
+				gf_maintenance.resolve_gut_shard_observation_timeout_seconds(1500),
+				1500,
+			)
+
+		timeout_catalog.timeout_floor_seconds.assert_has_calls([
+			mock.call("gut"),
+			mock.call("gut"),
+		])
+
+	def test_parallel_shard_timeout_consumes_each_catalog_floor(self) -> None:
+		floor_by_action = {
+			"godot_import": 501,
+			"gut_lifecycle_smoke": 502,
+			"gut": 503,
+			"gdscript_warnings": 504,
+		}
+		timeout_catalog = mock.Mock()
+		timeout_catalog.timeout_floor_seconds.side_effect = floor_by_action.__getitem__
+		shard = gf_maintenance.ParallelCheckShardPlan(
+			name="framework-gut",
+			checks=("gut", "gut_lifecycle_smoke", "gdscript_warnings"),
+			execution_checks=tuple(floor_by_action),
+		)
+
+		with mock.patch.object(
+			gf_maintenance,
+			"_VALIDATION_CATALOG",
+			timeout_catalog,
+		):
+			resolved = gf_maintenance.parallel_shard_timeout_seconds(shard, None)
+
+		self.assertEqual(
+			resolved,
+			sum(floor_by_action.values())
+			+ gf_maintenance.PARALLEL_SHARD_STARTUP_ALLOWANCE_SECONDS,
+		)
+		timeout_catalog.timeout_floor_seconds.assert_has_calls([
+			mock.call(action_name)
+			for action_name in floor_by_action
+		])
 
 	def test_renderer_exposes_diagnostic_completeness_and_duration_scope(self) -> None:
 		text = gf_maintenance_rendering.render_gut_shard_plan_text({

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -1183,35 +1183,6 @@ def check_command(
 		package_artifact_manifest_sha256,
 	]
 
-DEFAULT_CHECK_TIMEOUT_SECONDS: int = 600
-CHECK_TIMEOUT_SECONDS: dict[str, int] = {
-	# The unfiltered authoritative suite now exceeds the generic ten-minute
-	# budget on clean Windows runs. Keep the same measured floor as the explicit
-	# full-suite observation and qualification control instead of relying on a
-	# caller-specific override.
-	"gut": 1200,
-	# Runs six focused process-level lifecycle scenarios after a shared import.
-	"gut_lifecycle_smoke": 360,
-	# The executable Adapter contract performs one isolated import and one GUT
-	# run. A measured Windows run takes about 5.5 minutes, so retain a bounded
-	# 15-minute outer budget while each supervised Godot phase stays capped.
-	"ai_developer_adapter_acceptance": 900,
-	# The editor wizard smoke launches and tears down isolated editor projects;
-	# a clean Windows run is routinely longer than the generic ten-minute budget.
-	"package_editor_wizard_smoke": 1200,
-	# This check runs 24 isolated Godot CLI scenarios. A measured Windows release
-	# run reaches its late failure-path scenarios after 20 minutes, so keep a
-	# dedicated 40-minute outer budget while each Godot command remains capped.
-	"package_godot_cli_smoke": 2400,
-	# The split profiles measure around ten minutes on Windows. Keep a 2x
-	# scenario-level margin while failing materially earlier than the aggregate.
-	"package_godot_cli_local_smoke": 1200,
-	"package_godot_cli_network_smoke": 1200,
-	# The release matrix installs and parses every registry package in an isolated
-	# project. At 52 packages it exceeds the generic ten-minute budget on Windows.
-	"package_godot_matrix_smoke": 2400,
-}
-
 _API_CACHE: list[ApiScript] | None = None
 _ACTIVE_WORKSPACE_SNAPSHOT: WorkspaceSnapshot | None = None
 _ACTIVE_SUITE_DEADLINE: float | None = None
@@ -23883,7 +23854,7 @@ def run_checks_with_active_snapshot(
 			if suite_deadline is not None
 			else None
 		)
-		policy_timeout_seconds = float(CHECK_TIMEOUT_SECONDS.get(name, DEFAULT_CHECK_TIMEOUT_SECONDS))
+		policy_timeout_seconds = float(resolve_check_timeout_seconds(name, None))
 		timeout_budget = resolve_timeout_budget(
 			policy_timeout_seconds,
 			float(timeout_seconds) if timeout_seconds is not None else None,
@@ -24042,7 +24013,7 @@ def run_checks_with_log_hygiene(
 
 
 def resolve_check_timeout_seconds(name: str, override_seconds: int | None) -> int:
-	policy_seconds = CHECK_TIMEOUT_SECONDS.get(name, DEFAULT_CHECK_TIMEOUT_SECONDS)
+	policy_seconds = _VALIDATION_CATALOG.timeout_floor_seconds(name)
 	if override_seconds is None:
 		return policy_seconds
 	return max(policy_seconds, override_seconds)

--- a/tools/gf_maintenance_self_test.py
+++ b/tools/gf_maintenance_self_test.py
@@ -5295,7 +5295,7 @@ def _maintenance_self_test_body() -> dict[str, Any]:
 		and GUT_SHARD_OBSERVATION_TIMEOUT_SECONDS == 1200
 		and resolve_gut_shard_observation_timeout_seconds(None) == 1200
 		and resolve_gut_shard_observation_timeout_seconds(1500) == 1500
-		and CHECK_TIMEOUT_SECONDS.get("gut") == 1200
+		and _VALIDATION_CATALOG.timeout_floor_seconds("gut") == 1200
 		and resolve_check_timeout_seconds("gut", None) == 1200
 		and resolve_check_timeout_seconds("gut", 600) == 1200
 		and resolve_check_timeout_seconds("gut", 1500) == 1500,
@@ -6276,7 +6276,8 @@ def _maintenance_self_test_body() -> dict[str, Any]:
 		and resolve_check_timeout_seconds("package_godot_cli_network_smoke", None) == 1200
 		and resolve_check_timeout_seconds("package_godot_matrix_smoke", None) == 2400
 		and resolve_check_timeout_seconds("package_godot_matrix_smoke", 45) == 2400
-		and resolve_check_timeout_seconds("api", None) == DEFAULT_CHECK_TIMEOUT_SECONDS
+		and resolve_check_timeout_seconds("api", None)
+		== _VALIDATION_CATALOG.default_timeout_seconds
 		and resolve_check_timeout_seconds("api", 900) == 900,
 		"generic timeout settings may raise budgets but must not erase measured longer check policies.",
 	)

--- a/tools/gf_validation_catalog.py
+++ b/tools/gf_validation_catalog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Canonical action, dependency, group, and suite catalog for GF validation."""
+"""Canonical action, timeout, dependency, group, and suite catalog for GF validation."""
 
 from __future__ import annotations
 
@@ -73,10 +73,20 @@ class ValidationCatalog:
 		check_groups: Iterable[tuple[str, Sequence[str]]],
 		suites: Iterable[tuple[str, Sequence[str]]],
 		parallel_full_shard_suites: Sequence[str],
+		default_timeout_seconds: int,
+		timeout_overrides: Iterable[tuple[str, int]],
 	) -> None:
 		validated_actions = _validate_actions(actions)
 		action_names = tuple(validated_actions)
 		known_actions = frozenset(action_names)
+		validated_default_timeout_seconds = _validated_positive_timeout_seconds(
+			"Default validation action timeout",
+			default_timeout_seconds,
+		)
+		validated_timeout_overrides = _validate_timeout_overrides(
+			timeout_overrides,
+			known_actions,
+		)
 		validated_dependencies = _validate_dependencies(
 			dependencies,
 		)
@@ -102,6 +112,10 @@ class ValidationCatalog:
 			validated_actions
 		)
 		self._action_names = action_names
+		self._default_timeout_seconds = validated_default_timeout_seconds
+		self._timeout_overrides: Mapping[str, int] = MappingProxyType(
+			validated_timeout_overrides
+		)
 		self._dependencies: Mapping[str, tuple[str, ...]] = MappingProxyType(
 			validated_dependencies
 		)
@@ -126,6 +140,27 @@ class ValidationCatalog:
 			for name, command in self._actions.items()
 			if command is not None
 		}
+
+	@property
+	def default_timeout_seconds(self) -> int:
+		"""Return the default action timeout floor in seconds."""
+		return self._default_timeout_seconds
+
+	def timeout_overrides(self) -> dict[str, int]:
+		"""Return explicit per-action timeout floors as a detached mapping."""
+		return dict(self._timeout_overrides)
+
+	def timeout_floor_seconds(self, action_name: str) -> int:
+		"""Return the declared timeout floor for one known validation action."""
+		_validate_action_name(action_name)
+		if action_name not in self._actions:
+			raise ValidationCatalogError(
+				f"Unknown validation action timeout: {action_name}"
+			)
+		return self._timeout_overrides.get(
+			action_name,
+			self._default_timeout_seconds,
+		)
 
 	def dependencies(self) -> dict[str, list[str]]:
 		"""Return direct action dependencies in canonical declaration order."""
@@ -567,6 +602,33 @@ def build_validation_catalog(context: ValidationCatalogContext) -> ValidationCat
 		),
 		("release_metadata", None),
 	)
+	default_timeout_seconds = 600
+	timeout_overrides = (
+		# The unfiltered authoritative suite exceeds the generic ten-minute
+		# budget on clean Windows runs. Keep the same measured floor as the explicit
+		# full-suite observation and qualification control.
+		("gut", 1200),
+		# Runs six focused process-level lifecycle scenarios after a shared import.
+		("gut_lifecycle_smoke", 360),
+		# The executable Adapter contract performs one isolated import and one GUT
+		# run. A measured Windows run takes about 5.5 minutes, so retain a bounded
+		# 15-minute outer budget while each supervised Godot phase stays capped.
+		("ai_developer_adapter_acceptance", 900),
+		# The editor wizard smoke launches and tears down isolated editor projects;
+		# a clean Windows run is routinely longer than the generic ten-minute budget.
+		("package_editor_wizard_smoke", 1200),
+		# This check runs 24 isolated Godot CLI scenarios. A measured Windows release
+		# run reaches its late failure-path scenarios after 20 minutes, so keep a
+		# dedicated 40-minute outer budget while each Godot command remains capped.
+		("package_godot_cli_smoke", 2400),
+		# The split profiles measure around ten minutes on Windows. Keep a 2x
+		# scenario-level margin while failing materially earlier than the aggregate.
+		("package_godot_cli_local_smoke", 1200),
+		("package_godot_cli_network_smoke", 1200),
+		# The release matrix installs and parses every registry package in an isolated
+		# project. At 52 packages it exceeds the generic ten-minute budget on Windows.
+		("package_godot_matrix_smoke", 2400),
+	)
 
 	dependencies: tuple[tuple[str, tuple[str, ...]], ...] = (
 		("gut_lifecycle_smoke", ("godot_import",)),
@@ -855,6 +917,8 @@ def build_validation_catalog(context: ValidationCatalogContext) -> ValidationCat
 		check_groups=check_groups,
 		suites=suites,
 		parallel_full_shard_suites=parallel_full_shard_suites,
+		default_timeout_seconds=default_timeout_seconds,
+		timeout_overrides=timeout_overrides,
 	)
 
 
@@ -883,6 +947,39 @@ def _validate_actions(
 
 def _replace_sync_examples_action(name: str) -> str:
 	return "examples_sync_write" if name == "examples_sync" else name
+
+
+def _validate_timeout_overrides(
+	declarations: Iterable[tuple[str, int]],
+	known_actions: frozenset[str],
+) -> dict[str, int]:
+	validated: dict[str, int] = {}
+	for declaration in declarations:
+		if type(declaration) is not tuple or len(declaration) != 2:
+			raise ValidationCatalogError(
+				"Validation timeout override declarations must be pairs."
+			)
+		action_name, timeout_seconds = declaration
+		_validate_action_name(action_name)
+		if action_name not in known_actions:
+			raise ValidationCatalogError(
+				f"Validation timeout override references an unknown action: {action_name}"
+			)
+		if action_name in validated:
+			raise ValidationCatalogError(
+				f"Duplicate validation timeout override: {action_name}"
+			)
+		validated[action_name] = _validated_positive_timeout_seconds(
+			f"Validation timeout override for {action_name}",
+			timeout_seconds,
+		)
+	return validated
+
+
+def _validated_positive_timeout_seconds(label: str, value: Any) -> int:
+	if type(value) is not int or value <= 0:
+		raise ValidationCatalogError(f"{label} must be a positive integer.")
+	return value
 
 
 def _validate_dependencies(


### PR DESCRIPTION
## Summary

- move the 600-second default and all eight per-action timeout floors into the Validation Catalog
- remove the duplicate runner-owned timeout tables and route serial, parallel, and GUT consumers through the Catalog-backed resolver
- preserve caller minimums, suite-deadline clipping, parallel lane envelopes, commands, suites, report schemas, and CI topology
- add fail-closed declaration validation, injected consumer-binding regressions, and update ADR-0003

## Verification

- focused catalog and GUT timeout tests: 52/52 passed
- maintenance execution test file: 234/234 passed
- canonical maintenance self-test: 411/411 passed; output SHA-256 remained 4273cb7cb099f2ffa53510175002428ac4cf108b9c0bb15d583a5a4113789b07
- mapped maintenance execution and self-test checks: 2/2 passed
- Quick: 30/30 passed
- docs quality: 449 pages; public docs boundary: 458 files; strict MkDocs: passed
- frozen three-track audit: 0 blocker, 0 warning; staged candidate matched the reviewed source byte-for-byte
- Full with jobs=3: 46/46 canonical checks and 8/8 lane reports passed in 2404.028 seconds
- GUT: 6979/6979 tests, 71671 assertions, clean lifecycle gate
- LSP: 1351 files, 0 diagnostics
- post-Full source/audit verification: 169/169 comparisons; workspace fingerprint unchanged

No runtime/public API, version, release metadata, tag, or CI topology change is included.