### PR TITLE
fix(save): recover missing switch targets atomically

### DIFF
--- a/addons/gf/extensions/save/gf_extension.json
+++ b/addons/gf/extensions/save/gf_extension.json
@@ -2,7 +2,7 @@
   "id": "gf.save",
   "display_name": "GF Save",
   "version": "11.0.0-dev.0",
-  "extension_version": "6.2.1",
+  "extension_version": "6.3.0",
   "kind": "extension",
   "description": "Save profiles, versioned section orchestration, save graph composition, serializers, pipelines, scopes, sources, and slot workflows.",
   "dependencies": ["gf.kernel", "gf.standard"],

--- a/addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd
@@ -1,8 +1,8 @@
 ## GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。
 ##
-## Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider
-## domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease；
-## domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。
+## Lease 由失败的 activate 或 switch 操作创建，并绑定创建时的事务、来源与目标
+## Profile、Provider domain generation 与 lifecycle epoch。恢复入口必须原样提交同一
+## Lease；domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。
 ## [br]
 ## @api public
 ## [br]
@@ -15,14 +15,14 @@ extends RefCounted
 
 # --- 常量 ---
 
-## 激活目标没有持久化文档。
+## activate 或 switch 目标没有持久化文档。
 ## [br]
 ## @api public
 ## [br]
 ## @since unreleased
 const REASON_MISSING: StringName = &"missing"
 
-## 激活目标文档损坏或完整性无效。
+## activate 或 switch 目标文档损坏、完整性无效或 Storage family 结构损坏。
 ## [br]
 ## @api public
 ## [br]
@@ -56,6 +56,7 @@ const STATE_STALE: StringName = &"stale"
 var _configured: bool = false
 var _lease_id: int = 0
 var _transaction_id: int = 0
+var _source_profile_id: StringName = &""
 var _profile_id: StringName = &""
 var _reason: StringName = &""
 var _domain_id: int = 0
@@ -86,6 +87,19 @@ func get_lease_id() -> int:
 ## @return 正整数事务 ID；未配置时为 0。
 func get_transaction_id() -> int:
 	return _transaction_id
+
+
+## 获取恢复事务绑定的来源 Profile ID。
+##
+## 首次 activate 恢复没有来源；switch 恢复始终绑定创建 Lease 时仍然活动的来源。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return switch 恢复的来源 Profile ID；首次 activate 恢复时为空。
+func get_source_profile_id() -> StringName:
+	return _source_profile_id
 
 
 ## 获取待恢复 Profile ID。
@@ -199,6 +213,8 @@ func is_stale() -> bool:
 ## [br]
 ## @param transaction_id: 产生该 Lease 的正整数事务 ID。
 ## [br]
+## @param source_profile_id: switch 恢复的来源 Profile ID；首次 activate 恢复时为空。
+## [br]
 ## @param profile_id: 待恢复 Profile ID。
 ## [br]
 ## @param reason: `REASON_MISSING` 或 `REASON_CORRUPT`。
@@ -213,6 +229,7 @@ func is_stale() -> bool:
 func configure_for_framework(
 	lease_id: int,
 	transaction_id: int,
+	source_profile_id: StringName,
 	profile_id: StringName,
 	reason: StringName,
 	domain_id: int,
@@ -225,6 +242,7 @@ func configure_for_framework(
 		lease_id <= 0
 		or transaction_id <= 0
 		or profile_id == &""
+		or (source_profile_id != &"" and source_profile_id == profile_id)
 		or reason not in [REASON_MISSING, REASON_CORRUPT]
 		or domain_id <= 0
 		or domain_generation <= 0
@@ -234,6 +252,7 @@ func configure_for_framework(
 	_configured = true
 	_lease_id = lease_id
 	_transaction_id = transaction_id
+	_source_profile_id = source_profile_id
 	_profile_id = profile_id
 	_reason = reason
 	_domain_id = domain_id
@@ -251,11 +270,12 @@ func configure_for_framework(
 ## [br]
 ## @return Lease 身份、绑定 generation/epoch 与当前状态。
 ## [br]
-## @schema return: Payload-free Dictionary with lease_id, transaction_id, profile_id, reason, domain_id, domain_generation, epoch, state, and available.
+## @schema return: Payload-free Dictionary with lease_id, transaction_id, source_profile_id, profile_id, reason, domain_id, domain_generation, epoch, state, and available.
 func inspect_for_framework() -> Dictionary:
 	return {
 		"lease_id": _lease_id,
 		"transaction_id": _transaction_id,
+		"source_profile_id": _source_profile_id,
 		"profile_id": _profile_id,
 		"reason": _reason,
 		"domain_id": _domain_id,
@@ -275,6 +295,8 @@ func inspect_for_framework() -> Dictionary:
 ## [br]
 ## @since unreleased
 ## [br]
+## @param expected_source_profile_id: 当前恢复操作的来源 Profile ID。
+## [br]
 ## @param expected_profile_id: 当前恢复操作的目标 Profile ID。
 ## [br]
 ## @param expected_domain_id: 当前 Provider domain ID。
@@ -285,8 +307,9 @@ func inspect_for_framework() -> Dictionary:
 ## [br]
 ## @return 匹配时返回 Lease 身份记录并转为 claimed；否则返回空字典。
 ## [br]
-## @schema return: Payload-free Dictionary with lease_id, transaction_id, profile_id, reason, domain_id, domain_generation, and epoch.
+## @schema return: Payload-free Dictionary with lease_id, transaction_id, source_profile_id, profile_id, reason, domain_id, domain_generation, and epoch.
 func claim_for_framework(
+	expected_source_profile_id: StringName,
 	expected_profile_id: StringName,
 	expected_domain_id: int,
 	expected_domain_generation: int,
@@ -295,7 +318,8 @@ func claim_for_framework(
 	if not is_available():
 		return {}
 	if (
-		expected_profile_id != _profile_id
+		expected_source_profile_id != _source_profile_id
+		or expected_profile_id != _profile_id
 		or expected_domain_id != _domain_id
 		or expected_domain_generation != _domain_generation
 		or expected_epoch != _epoch
@@ -306,6 +330,7 @@ func claim_for_framework(
 	return {
 		"lease_id": _lease_id,
 		"transaction_id": _transaction_id,
+		"source_profile_id": _source_profile_id,
 		"profile_id": _profile_id,
 		"reason": _reason,
 		"domain_id": _domain_id,

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
@@ -80,6 +80,9 @@ const _STAGE_ACTIVATE_LOAD: StringName = &"activate_load"
 const _STAGE_SOURCE_FLUSH: StringName = &"source_flush"
 const _STAGE_TARGET_LOAD: StringName = &"target_load"
 const _STAGE_RECOVERY_SAVE: StringName = &"recovery_save"
+const _STAGE_RECOVERY_SOURCE_FLUSH: StringName = &"recovery_source_flush"
+const _STAGE_RECOVERY_RESET: StringName = &"recovery_reset"
+const _STAGE_RECOVERY_TARGET_SAVE: StringName = &"recovery_target_save"
 const _STAGE_MUTATION_FLUSH: StringName = &"mutation_flush"
 const _STAGE_MUTATION_QUEUED: StringName = &"mutation_queued"
 const _STAGE_MUTATION_APPLY: StringName = &"mutation_apply"
@@ -542,7 +545,7 @@ func activate_profile(
 ## [br]
 ## @schema metadata: Dictionary with caller-defined result metadata.
 ## [br]
-## @return 类型化 switch 操作。
+## @return 类型化 switch 操作；目标缺失或可恢复损坏时返回绑定活动来源的 Recovery Lease。
 func switch_profile(
 	target_profile_id: StringName,
 	context: Dictionary = {},
@@ -659,6 +662,60 @@ func adopt_profile(
 ) -> GFSaveProfileTransactionOperation:
 	return _start_recovery_save(
 		GFSaveProfileTransactionOperation.OPERATION_ADOPT,
+		GFSaveProfileRecoveryLease.REASON_CORRUPT,
+		lease,
+		request
+	)
+
+
+## 使用 switch 返回的 missing lease 创建目标并原子切换活动身份。
+##
+## 接纳后会重新 flush Lease 绑定的当前来源，再把最新 Provider 状态保存到目标；
+## 目标持久化确认前来源始终保持权威。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 尚未过期且绑定活动来源的 missing Recovery Lease。
+## [br]
+## @param request: 目标保存的一次性请求；null 表示空元数据。
+## [br]
+## @return 类型化 bootstrap-and-switch 操作；边界拒绝不会 claim lease 或 request。
+func bootstrap_and_switch_profile(
+	lease: GFSaveProfileRecoveryLease,
+	request: GFSaveProfileRequest = null
+) -> GFSaveProfileTransactionOperation:
+	return _start_switch_recovery(
+		GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP_AND_SWITCH,
+		GFSaveProfileRecoveryLease.REASON_MISSING,
+		lease,
+		request
+	)
+
+
+## 使用 switch 返回的 corrupt lease 恢复目标并原子切换活动身份。
+##
+## 接纳后会重新 flush Lease 绑定的当前来源。Storage family 结构损坏必须先凭
+## 同一读取来源的授权完成 reset；高层 Save 文档损坏则直接保存最新 Provider 状态。
+## reset 或目标保存确定失败时来源身份保持不变，无法签发结构 reset 授权时 switch
+## 会 fail closed 且不会返回可执行的 Recovery Lease。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param lease: 尚未过期且绑定活动来源的 corrupt Recovery Lease。
+## [br]
+## @param request: 目标保存的一次性请求；null 表示空元数据。
+## [br]
+## @return 类型化 adopt-and-switch 操作；边界拒绝不会 claim lease 或 request。
+func adopt_and_switch_profile(
+	lease: GFSaveProfileRecoveryLease,
+	request: GFSaveProfileRequest = null
+) -> GFSaveProfileTransactionOperation:
+	return _start_switch_recovery(
+		GFSaveProfileTransactionOperation.OPERATION_ADOPT_AND_SWITCH,
 		GFSaveProfileRecoveryLease.REASON_CORRUPT,
 		lease,
 		request
@@ -1047,7 +1104,8 @@ func _handle_activate_load_result(
 		var lease: GFSaveProfileRecoveryLease = _create_recovery_lease(
 			domain,
 			transaction,
-			reason
+			reason,
+			result.get_storage_result()
 		)
 		_finish_domain_transaction(
 			domain,
@@ -1160,6 +1218,45 @@ func _handle_switch_target_result(
 			evidence
 		)
 		return
+	if result.get_status() in [
+		GFSaveProfileResult.STATUS_MISSING,
+		GFSaveProfileResult.STATUS_CORRUPT,
+	]:
+		var reason: StringName = (
+			GFSaveProfileRecoveryLease.REASON_MISSING
+			if result.get_status() == GFSaveProfileResult.STATUS_MISSING
+			else GFSaveProfileRecoveryLease.REASON_CORRUPT
+		)
+		var recovery_lease: GFSaveProfileRecoveryLease = _create_recovery_lease(
+			domain,
+			transaction,
+			reason,
+			result.get_storage_result()
+		)
+		if recovery_lease == null:
+			_finish_domain_transaction(
+				domain,
+				transaction,
+				GFSaveProfileTransactionResult.STATUS_TARGET_LOAD_FAILED,
+				result.get_error_code(),
+				"Structural target corruption could not be authorized for reset.",
+				_STAGE_TARGET_LOAD,
+				evidence,
+				result.get_rollback_errors()
+			)
+			return
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED,
+			result.get_error_code(),
+			"Explicit bootstrap-and-switch or adopt-and-switch is required.",
+			_STAGE_TARGET_LOAD,
+			evidence,
+			result.get_rollback_errors(),
+			recovery_lease
+		)
+		return
 	if result.get_status() == GFSaveProfileResult.STATUS_ROLLBACK_FAILED:
 		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
 			domain,
@@ -1245,6 +1342,247 @@ func _handle_recovery_save_result(
 		result.get_error_code(),
 		result.get_error(),
 		_STAGE_RECOVERY_SAVE,
+		evidence
+	)
+
+
+func _handle_switch_recovery_flush_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	var evidence: Dictionary = _make_profile_result_evidence(result)
+	if result.is_successful():
+		transaction.stage_evidence["source_flush"] = evidence
+		if (
+			transaction.operation.get_operation()
+				== GFSaveProfileTransactionOperation.OPERATION_ADOPT_AND_SWITCH
+			and transaction.requires_family_reset
+		):
+			if transaction.reset_authorization != null:
+				_start_switch_recovery_reset(domain, transaction)
+			else:
+				_finish_domain_transaction(
+					domain,
+					transaction,
+					GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+					ERR_UNAVAILABLE,
+					"Structural target corruption requires an authorized family reset.",
+					_STAGE_RECOVERY_RESET,
+					transaction.stage_evidence
+				)
+		else:
+			_start_switch_recovery_target_save(domain, transaction)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN:
+		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.source_profile_id,
+			result
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_RECOVERY_SOURCE_FLUSH,
+			evidence,
+			[],
+			null,
+			lease
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_SOURCE_FLUSH_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_RECOVERY_SOURCE_FLUSH,
+		evidence
+	)
+
+
+func _start_switch_recovery_reset(
+	domain: DomainState,
+	transaction: TransactionState
+) -> void:
+	var target: ManagedProfile = _get_profile(transaction.target_profile_id)
+	if target == null or _profile_utility == null:
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+			ERR_DOES_NOT_EXIST,
+			"Managed reset target is unavailable.",
+			_STAGE_RECOVERY_RESET,
+			transaction.stage_evidence
+		)
+		return
+	transaction.stage = _STAGE_RECOVERY_RESET
+	var operation: GFStorageAsyncOperation = (
+		_profile_utility.reset_profile_family_for_manager_for_framework(
+			transaction.target_profile_id,
+			transaction.reset_authorization,
+			target.permit
+		)
+	)
+	transaction.write_admitted = (
+		operation != null
+		and transaction.reset_authorization != null
+		and transaction.reset_authorization.is_claimed()
+	)
+	transaction.reset_authorization = null
+	_observe_storage_reset_operation(domain, transaction, operation)
+
+
+func _observe_storage_reset_operation(
+	domain: DomainState,
+	transaction: TransactionState,
+	operation: GFStorageAsyncOperation
+) -> void:
+	if operation == null:
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+			ERR_CANT_CREATE,
+			"GFStorageUtility did not admit the target family reset.",
+			_STAGE_RECOVERY_RESET,
+			transaction.stage_evidence
+		)
+		return
+	transaction.storage_operation = operation
+	if operation.is_completed():
+		_on_storage_reset_operation_completed(
+			operation.get_result(),
+			domain.domain_id,
+			transaction.operation.get_transaction_id()
+		)
+		return
+	var callback: Callable = Callable(
+		self,
+		"_on_storage_reset_operation_completed"
+	).bind(
+		domain.domain_id,
+		transaction.operation.get_transaction_id()
+	)
+	transaction.storage_callback = callback
+	var _connected: Error = operation.completed.connect(
+		callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+
+
+func _handle_switch_recovery_reset_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFStorageAsyncResult
+) -> void:
+	var reset_result: GFStorageFamilyResetResult = (
+		result.get_reset_result() if result != null else null
+	)
+	var reset_evidence: Dictionary = (
+		reset_result.to_dict() if reset_result != null else {}
+	)
+	if result != null:
+		reset_evidence["request_id"] = result.get_request_id()
+	transaction.stage_evidence["reset"] = reset_evidence
+	if (
+		result != null
+		and result.get_operation() == GFStorageAsyncOperation.OPERATION_RESET
+		and reset_result != null
+		and reset_result.is_successful()
+	):
+		_start_switch_recovery_target_save(domain, transaction)
+		return
+	var error_code: Error = (
+		reset_result.get_error_code()
+		if reset_result != null
+		else ERR_INVALID_DATA
+	)
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+		error_code,
+		"Storage family reset failed before target persistence.",
+		_STAGE_RECOVERY_RESET,
+		transaction.stage_evidence
+	)
+
+
+func _start_switch_recovery_target_save(
+	domain: DomainState,
+	transaction: TransactionState
+) -> void:
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		transaction.document_metadata,
+		transaction.context,
+		transaction.result_metadata
+	)
+	transaction.document_metadata = {}
+	transaction.context = {}
+	transaction.result_metadata = {}
+	transaction.stage = _STAGE_RECOVERY_TARGET_SAVE
+	_start_save(domain, transaction, transaction.target_profile_id, request)
+
+
+func _handle_switch_recovery_target_save_result(
+	domain: DomainState,
+	transaction: TransactionState,
+	result: GFSaveProfileResult
+) -> void:
+	transaction.result_metadata = result.get_metadata()
+	var evidence: Dictionary = transaction.stage_evidence.duplicate(true)
+	evidence["target_save"] = _make_profile_result_evidence(result)
+	if result.is_successful():
+		_commit_active_profile(domain, transaction.target_profile_id)
+		var status: StringName = (
+			GFSaveProfileTransactionResult.STATUS_BOOTSTRAPPED_AND_SWITCHED
+			if transaction.operation.get_operation()
+				== GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP_AND_SWITCH
+			else GFSaveProfileTransactionResult.STATUS_ADOPTED_AND_SWITCHED
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			status,
+			OK,
+			"",
+			_STAGE_RECOVERY_TARGET_SAVE,
+			evidence
+		)
+		return
+	if result.get_status() == GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN:
+		var lease: GFSaveProfileReconcileLease = _create_reconcile_fence(
+			domain,
+			transaction,
+			transaction.target_profile_id,
+			result
+		)
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN,
+			result.get_error_code(),
+			result.get_error(),
+			_STAGE_RECOVERY_TARGET_SAVE,
+			evidence,
+			[],
+			null,
+			lease
+		)
+		return
+	_finish_domain_transaction(
+		domain,
+		transaction,
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+		result.get_error_code(),
+		result.get_error(),
+		_STAGE_RECOVERY_TARGET_SAVE,
 		evidence
 	)
 
@@ -1583,6 +1921,7 @@ func _start_recovery_save(
 		or record.is_empty()
 		or profile == null
 		or domain == null
+		or lease.get_source_profile_id() != &""
 		or lease.get_reason() != expected_reason
 		or not lease.is_available()
 	):
@@ -1663,6 +2002,7 @@ func _start_recovery_save(
 		_end_processing()
 		return rejected_operation
 	var lease_claim: Dictionary = lease.claim_for_framework(
+		&"",
 		profile_id,
 		domain.domain_id,
 		domain.domain_generation,
@@ -1685,6 +2025,229 @@ func _start_recovery_save(
 	transaction.stage = _STAGE_RECOVERY_SAVE
 	transaction.write_admitted = true
 	_observe_profile_operation(domain, transaction, profile_operation)
+	_end_processing()
+	return transaction.operation
+
+
+func _start_switch_recovery(
+	operation_kind: StringName,
+	expected_reason: StringName,
+	lease: GFSaveProfileRecoveryLease,
+	request: GFSaveProfileRequest
+) -> GFSaveProfileTransactionOperation:
+	var target_profile_id: StringName = lease.get_profile_id() if lease != null else &""
+	var source_profile_id: StringName = (
+		lease.get_source_profile_id() if lease != null else &""
+	)
+	var target: ManagedProfile = _get_profile(target_profile_id)
+	var source: ManagedProfile = _get_profile(source_profile_id)
+	var domain: DomainState = _get_domain_for_profile(target_profile_id)
+	var record: Dictionary = _get_recovery_record(lease)
+	if (
+		lease == null
+		or record.is_empty()
+		or source_profile_id == &""
+		or source == null
+		or target == null
+		or domain == null
+		or source.domain_id != domain.domain_id
+		or lease.get_reason() != expected_reason
+		or not lease.is_available()
+		or GFVariantData.get_option_string_name(record, "source_profile_id")
+			!= source_profile_id
+	):
+		return _reject_transaction(
+			operation_kind,
+			source_profile_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Switch Recovery Lease is invalid, stale, or has the wrong identity.",
+			_STAGE_RECOVERY_SOURCE_FLUSH
+		)
+	var admission: Dictionary = _get_domain_admission_failure(domain)
+	if not admission.is_empty():
+		return _reject_from_admission(
+			operation_kind,
+			source_profile_id,
+			target_profile_id,
+			admission,
+			_STAGE_RECOVERY_SOURCE_FLUSH
+		)
+	if domain.active_profile_id != source_profile_id:
+		return _reject_transaction(
+			operation_kind,
+			source_profile_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Switch recovery source is no longer the active Profile.",
+			_STAGE_RECOVERY_SOURCE_FLUSH
+		)
+	if not source.save_enabled or not target.save_enabled:
+		return _reject_transaction(
+			operation_kind,
+			source_profile_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION,
+			ERR_UNAVAILABLE,
+			"Switch recovery requires source flush and target save capabilities.",
+			_STAGE_RECOVERY_SOURCE_FLUSH
+		)
+	if request != null and not request.is_available_for_framework():
+		return _reject_transaction(
+			operation_kind,
+			source_profile_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+			ERR_INVALID_PARAMETER,
+			"Switch recovery save request is uninitialized or already claimed.",
+			_STAGE_RECOVERY_SOURCE_FLUSH
+		)
+	var owned_request: GFSaveProfileRequest = request
+	if owned_request == null:
+		owned_request = GFSaveProfileRequest.take_ownership({}, {}, {})
+	domain.admission_reserved = true
+	_update_domain_managed_access(domain)
+	_begin_processing()
+	var flush_operation: GFSaveProfileOperation = (
+		_profile_utility.flush_profile_for_manager_for_framework(
+			source_profile_id,
+			{},
+			source.permit
+		)
+		if _profile_utility != null
+		else null
+	)
+	domain.admission_reserved = false
+	var flush_admitted: bool = (
+		flush_operation != null
+		and (
+			flush_operation.get_requested_generation() > 0
+			or (
+				flush_operation.is_completed()
+				and flush_operation.get_result() != null
+				and flush_operation.get_result().is_successful()
+			)
+		)
+	)
+	if not flush_admitted:
+		var rejected_operation: GFSaveProfileTransactionOperation = (
+			_reject_switch_recovery_flush_admission(
+				operation_kind,
+				source_profile_id,
+				target_profile_id,
+				flush_operation
+			)
+		)
+		_update_domain_managed_access(domain)
+		_end_processing()
+		return rejected_operation
+	var current_domain: DomainState = _get_domain_for_profile(target_profile_id)
+	record = _get_recovery_record(lease)
+	if (
+		current_domain != domain
+		or record.is_empty()
+		or _get_profile(source_profile_id) != source
+		or _get_profile(target_profile_id) != target
+		or source.domain_id != domain.domain_id
+		or domain.active_profile_id != source_profile_id
+		or lease.get_source_profile_id() != source_profile_id
+		or lease.get_profile_id() != target_profile_id
+		or lease.get_reason() != expected_reason
+		or lease.get_domain_id() != domain.domain_id
+		or lease.get_domain_generation() != domain.domain_generation
+		or lease.get_epoch() != domain.transaction_epoch
+		or not lease.is_available()
+		or GFVariantData.get_option_string_name(record, "source_profile_id")
+			!= source_profile_id
+	):
+		var stale_operation: GFSaveProfileTransactionOperation = _reject_transaction(
+			operation_kind,
+			source_profile_id,
+			target_profile_id,
+			GFSaveProfileTransactionResult.STATUS_INVALID_LEASE,
+			ERR_INVALID_PARAMETER,
+			"Switch recovery boundary changed during source flush admission.",
+			_STAGE_RECOVERY_SOURCE_FLUSH
+		)
+		_update_domain_managed_access(domain)
+		_end_processing()
+		return stale_operation
+	admission = _get_domain_admission_failure(domain)
+	if not admission.is_empty():
+		var unavailable_operation: GFSaveProfileTransactionOperation = (
+			_reject_from_admission(
+				operation_kind,
+				source_profile_id,
+				target_profile_id,
+				admission,
+				_STAGE_RECOVERY_SOURCE_FLUSH
+			)
+		)
+		_update_domain_managed_access(domain)
+		_end_processing()
+		return unavailable_operation
+	if not owned_request.is_available_for_framework():
+		var invalid_request_operation: GFSaveProfileTransactionOperation = (
+			_reject_transaction(
+				operation_kind,
+				source_profile_id,
+				target_profile_id,
+				GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST,
+				ERR_INVALID_PARAMETER,
+				"Switch recovery save request changed during source flush admission.",
+				_STAGE_RECOVERY_SOURCE_FLUSH
+			)
+		)
+		_update_domain_managed_access(domain)
+		_end_processing()
+		return invalid_request_operation
+	var request_claim: Dictionary = owned_request.claim_for_framework()
+	var lease_claim: Dictionary = lease.claim_for_framework(
+		source_profile_id,
+		target_profile_id,
+		domain.domain_id,
+		domain.domain_generation,
+		domain.transaction_epoch
+	)
+	if request_claim.is_empty() or lease_claim.is_empty():
+		push_error(
+			"[GFSaveProfileTransactionCoordinator] Admitted switch recovery could not claim ownership."
+		)
+	var reset_authorization: GFStorageFamilyResetAuthorization = null
+	var reset_authorization_value: Variant = GFVariantData.get_option_value(
+		record,
+		"reset_authorization"
+	)
+	if reset_authorization_value is GFStorageFamilyResetAuthorization:
+		reset_authorization = reset_authorization_value
+	var requires_family_reset: bool = GFVariantData.get_option_bool(
+		record,
+		"requires_family_reset"
+	)
+	var _record_erased: bool = _recovery_records.erase(lease.get_lease_id())
+	var transaction: TransactionState = _begin_domain_transaction(
+		domain,
+		operation_kind,
+		source_profile_id,
+		target_profile_id,
+		{}
+	)
+	transaction.document_metadata = _get_dictionary_claim(
+		request_claim,
+		"document_metadata"
+	)
+	transaction.context = _get_dictionary_claim(request_claim, "context")
+	transaction.result_metadata = _get_dictionary_claim(
+		request_claim,
+		"result_metadata"
+	)
+	transaction.reset_authorization = reset_authorization
+	transaction.requires_family_reset = requires_family_reset
+	transaction.stage = _STAGE_RECOVERY_SOURCE_FLUSH
+	transaction.write_admitted = true
+	_observe_profile_operation(domain, transaction, flush_operation)
 	_end_processing()
 	return transaction.operation
 
@@ -1724,6 +2287,45 @@ func _reject_recovery_save_admission(
 		error_code,
 		error,
 		_STAGE_RECOVERY_SAVE
+	)
+
+
+func _reject_switch_recovery_flush_admission(
+	operation_kind: StringName,
+	source_profile_id: StringName,
+	target_profile_id: StringName,
+	profile_operation: GFSaveProfileOperation
+) -> GFSaveProfileTransactionOperation:
+	var status: StringName = GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST
+	var error_code: Error = ERR_CANT_CREATE
+	var error: String = "GFSaveProfileUtility did not admit the source reflush."
+	var result: GFSaveProfileResult = (
+		profile_operation.get_result()
+		if profile_operation != null and profile_operation.is_completed()
+		else null
+	)
+	if result != null:
+		error_code = result.get_error_code()
+		error = result.get_error()
+		match result.get_status():
+			GFSaveProfileResult.STATUS_BUSY:
+				status = GFSaveProfileTransactionResult.STATUS_BUSY
+			GFSaveProfileResult.STATUS_INVALID_PROFILE:
+				status = GFSaveProfileTransactionResult.STATUS_INVALID_PROFILE
+			GFSaveProfileResult.STATUS_UNSUPPORTED_OPERATION:
+				status = GFSaveProfileTransactionResult.STATUS_UNSUPPORTED_OPERATION
+			GFSaveProfileResult.STATUS_DISPOSED:
+				status = GFSaveProfileTransactionResult.STATUS_DISPOSED
+			_:
+				status = GFSaveProfileTransactionResult.STATUS_INVALID_REQUEST
+	return _reject_transaction(
+		operation_kind,
+		source_profile_id,
+		target_profile_id,
+		status,
+		error_code,
+		error,
+		_STAGE_RECOVERY_SOURCE_FLUSH
 	)
 
 
@@ -1886,6 +2488,7 @@ func _finish_domain_transaction(
 		)
 		_update_domain_managed_access(domain)
 	_disconnect_transaction_profile_operation(transaction)
+	_disconnect_transaction_storage_operation(transaction)
 	transaction.clear_payload_for_framework()
 	var completed: bool = transaction.operation.complete_for_framework(result)
 	if completed:
@@ -1989,12 +2592,34 @@ func _emit_active_profile_changed(
 func _create_recovery_lease(
 	domain: DomainState,
 	transaction: TransactionState,
-	reason: StringName
+	reason: StringName,
+	storage_result: GFStorageReadResult = null
 ) -> GFSaveProfileRecoveryLease:
+	var requires_family_reset: bool = (
+		reason == GFSaveProfileRecoveryLease.REASON_CORRUPT
+		and transaction.source_profile_id != &""
+		and storage_result != null
+		and not storage_result.ok
+		and storage_result.failure_kind == GFStorageReadResult.FailureKind.CORRUPT
+	)
+	var reset_authorization: GFStorageFamilyResetAuthorization = null
+	var target_profile: ManagedProfile = _get_profile(transaction.target_profile_id)
+	if requires_family_reset and target_profile != null and _profile_utility != null:
+		reset_authorization = (
+			_profile_utility
+			.create_profile_family_reset_authorization_for_manager_for_framework(
+				transaction.target_profile_id,
+				storage_result,
+				target_profile.permit
+			)
+		)
+	if requires_family_reset and reset_authorization == null:
+		return null
 	var lease: GFSaveProfileRecoveryLease = GFSaveProfileRecoveryLease.new()
 	var configured: bool = lease.configure_for_framework(
 		_next_lease_id,
 		transaction.operation.get_transaction_id(),
+		transaction.source_profile_id,
 		transaction.target_profile_id,
 		reason,
 		domain.domain_id,
@@ -2008,6 +2633,9 @@ func _create_recovery_lease(
 		"lease": lease,
 		"domain_id": domain.domain_id,
 		"reason": reason,
+		"source_profile_id": transaction.source_profile_id,
+		"requires_family_reset": requires_family_reset,
+		"reset_authorization": reset_authorization,
 	}
 	return lease
 
@@ -2028,6 +2656,12 @@ func _create_reconcile_fence(
 		generation = profile_result.get_requested_generation()
 	elif transaction.profile_operation != null:
 		generation = transaction.profile_operation.get_requested_generation()
+	if transaction.storage_operation != null:
+		var storage_request_id: int = transaction.storage_operation.get_request_id()
+		if storage_request_id > 0 and not request_ids.has(storage_request_id):
+			var _appended_storage_request_id: bool = request_ids.append(
+				storage_request_id
+			)
 	var initial_evidence: Dictionary = {}
 	if _profile_utility != null and generation > 0:
 		initial_evidence = _profile_utility.get_generation_evidence_for_framework(
@@ -2199,6 +2833,12 @@ func _get_domain_admission_failure(domain: DomainState) -> Dictionary:
 			"error_code": int(ERR_BUSY),
 			"error": "Reentrant transaction admission is not allowed from a callback.",
 		}
+	if domain.admission_reserved:
+		return {
+			"status": GFSaveProfileTransactionResult.STATUS_BUSY,
+			"error_code": int(ERR_BUSY),
+			"error": "Provider domain has a synchronous admission reservation.",
+		}
 	if domain.current_transaction != null:
 		return {
 			"status": GFSaveProfileTransactionResult.STATUS_BUSY,
@@ -2362,6 +3002,7 @@ func _update_domain_managed_access(domain: DomainState) -> void:
 		_admission_open
 		and not _disposed
 		and not _dispose_requested
+		and not domain.admission_reserved
 		and domain.state == DOMAIN_STATE_ACTIVE
 		and domain.current_transaction == null
 		and domain.reconcile_lease == null
@@ -2438,6 +3079,18 @@ func _make_profile_result_evidence(result: GFSaveProfileResult) -> Dictionary:
 		"preparation_work_units": result.get_preparation_work_units(),
 		"storage_request_ids": result.get_storage_request_ids(),
 	}
+
+
+func _make_dispose_stage_evidence(transaction: TransactionState) -> Dictionary:
+	if transaction == null:
+		return {}
+	var evidence: Dictionary = transaction.stage_evidence.duplicate(true)
+	if transaction.storage_operation != null:
+		evidence["reset_in_flight"] = {
+			"request_id": transaction.storage_operation.get_request_id(),
+			"operation": transaction.storage_operation.get_operation(),
+		}
+	return evidence
 
 
 func _enqueue_domain_tick(domain: DomainState) -> void:
@@ -2518,6 +3171,25 @@ func _disconnect_transaction_profile_operation(
 	transaction.profile_operation = null
 
 
+func _disconnect_transaction_storage_operation(
+	transaction: TransactionState
+) -> void:
+	if transaction == null:
+		return
+	if (
+		transaction.storage_operation != null
+		and transaction.storage_callback.is_valid()
+		and transaction.storage_operation.completed.is_connected(
+			transaction.storage_callback
+		)
+	):
+		transaction.storage_operation.completed.disconnect(
+			transaction.storage_callback
+		)
+	transaction.storage_callback = Callable()
+	transaction.storage_operation = null
+
+
 func _dispose_domain(domain: DomainState) -> void:
 	if domain == null or domain.state == DOMAIN_STATE_DISPOSED:
 		return
@@ -2527,7 +3199,12 @@ func _dispose_domain(domain: DomainState) -> void:
 		var lease: GFSaveProfileReconcileLease = transaction.reconcile_lease
 		if write_outcome_uncertain and lease == null:
 			var reconcile_profile_id: StringName = transaction.source_profile_id
-			if transaction.stage in [_STAGE_RECOVERY_SAVE, _STAGE_MUTATION_SAVE]:
+			if transaction.stage in [
+				_STAGE_RECOVERY_SAVE,
+				_STAGE_RECOVERY_RESET,
+				_STAGE_RECOVERY_TARGET_SAVE,
+				_STAGE_MUTATION_SAVE,
+			]:
 				reconcile_profile_id = transaction.target_profile_id
 			lease = _create_reconcile_fence(
 				domain,
@@ -2572,7 +3249,7 @@ func _dispose_domain(domain: DomainState) -> void:
 			ERR_UNAVAILABLE,
 			"Save Profile transaction coordinator was disposed.",
 			transaction.stage,
-			{},
+			_make_dispose_stage_evidence(transaction),
 			transaction.forced_rollback_errors,
 			null,
 			lease
@@ -2854,6 +3531,10 @@ func _on_profile_operation_completed(
 			_handle_switch_target_result(domain, transaction, result)
 		_STAGE_RECOVERY_SAVE:
 			_handle_recovery_save_result(domain, transaction, result)
+		_STAGE_RECOVERY_SOURCE_FLUSH:
+			_handle_switch_recovery_flush_result(domain, transaction, result)
+		_STAGE_RECOVERY_TARGET_SAVE:
+			_handle_switch_recovery_target_save_result(domain, transaction, result)
 		_STAGE_MUTATION_FLUSH:
 			_handle_mutation_flush_result(domain, transaction, result)
 		_STAGE_MUTATION_SAVE:
@@ -2869,6 +3550,32 @@ func _on_profile_operation_completed(
 				"Transaction entered an invalid Profile operation stage.",
 				transaction.stage
 			)
+
+
+func _on_storage_reset_operation_completed(
+	result: GFStorageAsyncResult,
+	domain_id: int,
+	transaction_id: int
+) -> void:
+	if _disposed:
+		return
+	var domain: DomainState = _get_domain(domain_id)
+	var transaction: TransactionState = (
+		domain.current_transaction
+		if domain != null
+		else null
+	)
+	if (
+		domain == null
+		or transaction == null
+		or transaction.operation.get_transaction_id() != transaction_id
+		or transaction.stage != _STAGE_RECOVERY_RESET
+		or result == null
+	):
+		return
+	_disconnect_transaction_storage_operation(transaction)
+	transaction.write_admitted = false
+	_handle_switch_recovery_reset_result(domain, transaction, result)
 
 
 func _on_profile_generation_evidence_changed(
@@ -2990,6 +3697,11 @@ class DomainState extends RefCounted:
 	## @api framework_internal
 	var transaction_epoch: int = 0
 
+	## 同步底层准入期间阻止同一 domain 的可重入事务抢占。
+	## [br]
+	## @api framework_internal
+	var admission_reserved: bool = false
+
 	## 当前独占 domain 的事务状态。
 	## [br]
 	## @api framework_internal
@@ -3070,6 +3782,26 @@ class TransactionState extends RefCounted:
 	## @api framework_internal
 	var profile_callback: Callable = Callable()
 
+	## 当前由 Storage Utility 执行的 family reset 物理操作。
+	## [br]
+	## @api framework_internal
+	var storage_operation: GFStorageAsyncOperation = null
+
+	## 当前 Storage reset 操作的一次性完成回调。
+	## [br]
+	## @api framework_internal
+	var storage_callback: Callable = Callable()
+
+	## corrupt switch recovery 在严格读取终态签发的一次性 Storage reset 授权。
+	## [br]
+	## @api framework_internal
+	var reset_authorization: GFStorageFamilyResetAuthorization = null
+
+	## corrupt target 是否必须先完成已授权的 Storage family reset。
+	## [br]
+	## @api framework_internal
+	var requires_family_reset: bool = false
+
 	## 从 mutation 请求转移的 section 全量替换描述。
 	## [br]
 	## @api framework_internal
@@ -3129,3 +3861,5 @@ class TransactionState extends RefCounted:
 		mutation_candidates.clear()
 		mutation_provider_ids = PackedStringArray()
 		mutation_snapshots.clear()
+		reset_authorization = null
+		requires_family_reset = false

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd
@@ -54,6 +54,20 @@ const OPERATION_BOOTSTRAP: StringName = &"bootstrap"
 ## @since unreleased
 const OPERATION_ADOPT: StringName = &"adopt"
 
+## 从活动来源重新 flush 后，以当前 Provider 状态创建缺失目标并原子切换。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_BOOTSTRAP_AND_SWITCH: StringName = &"bootstrap_and_switch"
+
+## 从活动来源重新 flush 后，以当前 Provider 状态覆盖损坏目标并原子切换。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const OPERATION_ADOPT_AND_SWITCH: StringName = &"adopt_and_switch"
+
 ## 应用完整候选 section 并持久化。
 ## [br]
 ## @api public
@@ -107,8 +121,8 @@ func get_transaction_id() -> int:
 
 ## 获取事务来源 Profile ID。
 ##
-## activate、bootstrap 与 adopt 没有来源身份；mutate-and-persist 和 reconcile
-## 使用当前受管 Profile 作为来源。
+## activate、bootstrap 与 adopt 没有来源身份；switch、bootstrap/adopt-and-switch、
+## mutate-and-persist 和 reconcile 使用当前受管 Profile 作为来源。
 ## [br]
 ## @api public
 ## [br]
@@ -286,6 +300,8 @@ static func _get_valid_operations() -> Array[StringName]:
 		OPERATION_SWITCH,
 		OPERATION_BOOTSTRAP,
 		OPERATION_ADOPT,
+		OPERATION_BOOTSTRAP_AND_SWITCH,
+		OPERATION_ADOPT_AND_SWITCH,
 		OPERATION_MUTATE_AND_PERSIST,
 		OPERATION_RECONCILE,
 	]

--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd
@@ -43,6 +43,20 @@ const STATUS_BOOTSTRAPPED: StringName = &"bootstrapped"
 ## @since unreleased
 const STATUS_ADOPTED: StringName = &"adopted"
 
+## 缺失目标已持久化，活动身份随后从来源原子切换到目标。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_BOOTSTRAPPED_AND_SWITCHED: StringName = &"bootstrapped_and_switched"
+
+## 损坏目标已显式恢复并持久化，活动身份随后从来源原子切换到目标。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+const STATUS_ADOPTED_AND_SWITCHED: StringName = &"adopted_and_switched"
+
 ## 候选 sections 已应用并持久化。
 ## [br]
 ## @api public
@@ -106,7 +120,7 @@ const STATUS_BUSY: StringName = &"busy"
 ## @since unreleased
 const STATUS_UNSUPPORTED_OPERATION: StringName = &"unsupported_operation"
 
-## activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。
+## activate 或 switch 检测到可恢复的缺失/损坏目标，必须显式选择对应恢复入口。
 ## [br]
 ## @api public
 ## [br]
@@ -370,7 +384,7 @@ func get_stage_evidence() -> Dictionary:
 	return _stage_evidence.duplicate(true)
 
 
-## 获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。
+## 获取显式 bootstrap/adopt 或 bootstrap/adopt-and-switch 所需的同一身份 Recovery Lease。
 ## [br]
 ## @api public
 ## [br]
@@ -556,6 +570,7 @@ func configure_for_framework(options: Dictionary) -> bool:
 		status,
 		operation,
 		transaction_id,
+		GFVariantData.get_option_string_name(options, "source_profile_id"),
 		GFVariantData.get_option_string_name(options, "target_profile_id"),
 		recovery_lease,
 		reconcile_lease
@@ -611,6 +626,8 @@ static func _get_success_statuses() -> Array[StringName]:
 		STATUS_SWITCHED,
 		STATUS_BOOTSTRAPPED,
 		STATUS_ADOPTED,
+		STATUS_BOOTSTRAPPED_AND_SWITCHED,
+		STATUS_ADOPTED_AND_SWITCHED,
 		STATUS_MUTATED,
 		STATUS_RECONCILED,
 	]
@@ -645,6 +662,8 @@ static func _get_valid_operations() -> Array[StringName]:
 		GFSaveProfileTransactionOperation.OPERATION_SWITCH,
 		GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP,
 		GFSaveProfileTransactionOperation.OPERATION_ADOPT,
+		GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP_AND_SWITCH,
+		GFSaveProfileTransactionOperation.OPERATION_ADOPT_AND_SWITCH,
 		GFSaveProfileTransactionOperation.OPERATION_MUTATE_AND_PERSIST,
 		GFSaveProfileTransactionOperation.OPERATION_RECONCILE,
 	]
@@ -685,6 +704,7 @@ static func _leases_match_status(
 	status: StringName,
 	operation: StringName,
 	transaction_id: int,
+	source_profile_id: StringName,
 	target_profile_id: StringName,
 	recovery_lease: GFSaveProfileRecoveryLease,
 	reconcile_lease: GFSaveProfileReconcileLease
@@ -692,11 +712,15 @@ static func _leases_match_status(
 	if status == STATUS_RECOVERY_REQUIRED:
 		if (
 			recovery_lease == null
-			or operation != GFSaveProfileTransactionOperation.OPERATION_ACTIVATE
+			or operation not in [
+				GFSaveProfileTransactionOperation.OPERATION_ACTIVATE,
+				GFSaveProfileTransactionOperation.OPERATION_SWITCH,
+			]
 		):
 			return false
 		if (
 			recovery_lease.get_transaction_id() != transaction_id
+			or recovery_lease.get_source_profile_id() != source_profile_id
 			or recovery_lease.get_profile_id() != target_profile_id
 			or recovery_lease.get_reason() not in [
 				GFSaveProfileRecoveryLease.REASON_MISSING,
@@ -753,6 +777,7 @@ func _get_recovery_lease_summary() -> Dictionary:
 	return {
 		"lease_id": _recovery_lease.get_lease_id(),
 		"transaction_id": _recovery_lease.get_transaction_id(),
+		"source_profile_id": _recovery_lease.get_source_profile_id(),
 		"profile_id": _recovery_lease.get_profile_id(),
 		"reason": _recovery_lease.get_reason(),
 		"state": _recovery_lease.get_state(),

--- a/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
@@ -298,6 +298,11 @@ func tick(_delta: float) -> void:
 		var state: ProfileState = _get_state_value(state_value)
 		if state == null:
 			continue
+		if (
+			state.manager_reset_operation != null
+			and state.manager_reset_operation.is_completed()
+		):
+			_clear_manager_reset_operation(state)
 		_reap_expired_managed_permit_if_safe(state)
 		if state.mode == STATE_RETRY_WAIT and now_msec >= state.retry_due_msec:
 			_retry_current_io(state)
@@ -325,7 +330,7 @@ func dispose() -> void:
 		return
 	_admission_open = false
 	_block_all_managed_access_for_shutdown()
-	if _processing_depth > 0:
+	if _processing_depth > 0 or _has_active_manager_reset_work():
 		_dispose_requested = true
 		return
 	_dispose_now()
@@ -602,6 +607,7 @@ func claim_profile_management_for_framework(
 		or state.managed_permit != null
 		or state.mode != STATE_IDLE
 		or _has_pending_operations(state)
+		or state.manager_reset_operation != null
 		or not state.detached_write_operations.is_empty()
 	):
 		return null
@@ -649,6 +655,7 @@ func set_profile_managed_access_for_framework(
 		or _dispose_requested
 		or _unsafe_callback_depth > 0
 		or state.memory_transaction_active
+		or state.manager_reset_operation != null
 	):
 		return false
 	state.managed_access = access
@@ -682,6 +689,7 @@ func release_profile_management_for_framework(
 		or not _is_valid_managed_permit(state, permit)
 		or state.mode != STATE_IDLE
 		or _has_pending_operations(state)
+		or state.manager_reset_operation != null
 		or not state.detached_write_operations.is_empty()
 	):
 		return false
@@ -774,6 +782,104 @@ func load_profile_strict_for_manager_for_framework(
 	permit: RefCounted
 ) -> GFSaveProfileOperation:
 	return _request_load_profile(profile_id, context, metadata, permit, true)
+
+
+## 为受管 Profile 的精确 Storage 读取结果创建一次性 family reset 授权。
+##
+## 仅在 observed_result 仍携带同一 Storage Utility、同一冻结 file_name 的 opaque
+## CORRUPT 来源绑定时返回可用授权；高层文档损坏或来源不匹配返回 null。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param observed_result: 严格读取保留的底层 Storage 结果。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @return 可用于同一 Profile logical family 的一次性授权；不可授权时为 null。
+func create_profile_family_reset_authorization_for_manager_for_framework(
+	profile_id: StringName,
+	observed_result: GFStorageReadResult,
+	permit: RefCounted
+) -> GFStorageFamilyResetAuthorization:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or state == null
+		or _storage == null
+		or observed_result == null
+		or not _is_valid_managed_permit(state, permit)
+		or state.memory_transaction_active
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or state.current_storage_operation != null
+		or state.manager_reset_operation != null
+		or not state.detached_write_operations.is_empty()
+		or state.pending_schedule_enqueued
+		or state.active_preparation_enqueued
+	):
+		return null
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_storage.create_family_reset_authorization(state.file_name, observed_result)
+	)
+	return authorization if authorization != null and authorization.is_available() else null
+
+
+## 以 manager capability 对受管 Profile 的 frozen Storage family 发起 reset/recreate。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param authorization: 同一 Utility 为该 Profile 创建的可用一次性授权。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @return 低层 reset 物理操作；身份、准入或授权无效时返回 null 且不 claim 授权。
+func reset_profile_family_for_manager_for_framework(
+	profile_id: StringName,
+	authorization: GFStorageFamilyResetAuthorization,
+	permit: RefCounted
+) -> GFStorageAsyncOperation:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or state == null
+		or _storage == null
+		or authorization == null
+		or not authorization.is_available()
+		or not _is_valid_managed_permit(state, permit)
+		or state.memory_transaction_active
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or state.current_storage_operation != null
+		or state.manager_reset_operation != null
+		or not state.detached_write_operations.is_empty()
+		or state.pending_schedule_enqueued
+		or state.active_preparation_enqueued
+	):
+		return null
+	_begin_processing()
+	var operation: GFStorageAsyncOperation = _storage.reset_file_family_request_async(
+		state.file_name,
+		authorization
+	)
+	_observe_manager_reset_operation(state, operation)
+	_end_processing()
+	return operation
 
 
 ## 以 manager capability 请求 flush。
@@ -2676,7 +2782,7 @@ func _end_processing() -> void:
 	_processing_depth = maxi(_processing_depth - 1, 0)
 	if _processing_depth > 0:
 		return
-	if _dispose_requested:
+	if _dispose_requested and not _has_active_manager_reset_work():
 		_dispose_now()
 	_drain_completion_events()
 	_try_complete_quiesce()
@@ -2693,6 +2799,9 @@ func _exit_unsafe_callback() -> void:
 func _dispose_now() -> void:
 	if _disposed:
 		return
+	if _has_active_manager_reset_work():
+		_dispose_requested = true
+		return
 	_disposed = true
 	_dispose_requested = false
 	for state_value: Variant in _states.values():
@@ -2704,6 +2813,7 @@ func _dispose_now() -> void:
 		if state.managed_permit != null:
 			state.managed_permit.invalidate_for_framework()
 			state.managed_permit = null
+		_clear_manager_reset_operation(state)
 	_states.clear()
 	_pending_schedule_head = null
 	_pending_schedule_tail = null
@@ -2772,6 +2882,7 @@ func _reap_expired_managed_permit_if_safe(state: ProfileState) -> void:
 		or state.mode != STATE_IDLE
 		or _has_pending_operations(state)
 		or state.current_storage_operation != null
+		or state.manager_reset_operation != null
 		or not state.detached_write_operations.is_empty()
 		or state.pending_schedule_enqueued
 		or state.active_preparation_enqueued
@@ -2795,6 +2906,14 @@ func _is_valid_managed_permit(
 	if state == null or state.managed_permit == null or permit_value == null:
 		return false
 	return state.managed_permit == permit_value and state.managed_permit.is_active_for_framework()
+
+
+func _has_active_manager_reset_work() -> bool:
+	for state_value: Variant in _states.values():
+		var state: ProfileState = _get_state_value(state_value)
+		if state != null and state.manager_reset_operation != null:
+			return true
+	return false
 
 
 func _is_direct_managed_operation_allowed(
@@ -2858,6 +2977,49 @@ func _observe_storage_operation(
 			callback,
 			CONNECT_ONE_SHOT as Object.ConnectFlags
 		) as Error
+
+
+func _observe_manager_reset_operation(
+	state: ProfileState,
+	operation: GFStorageAsyncOperation
+) -> void:
+	if state == null or operation == null:
+		return
+	state.manager_reset_operation = operation
+	if operation.is_completed():
+		_clear_manager_reset_operation(state)
+		return
+	var callback: Callable = Callable(
+		self,
+		"_on_manager_reset_operation_completed"
+	).bind(
+		state.profile_id,
+		operation.get_request_id()
+	)
+	state.manager_reset_callback = callback
+	var connected: Error = operation.completed.connect(
+		callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	if connected != OK:
+		state.manager_reset_callback = Callable()
+
+
+func _clear_manager_reset_operation(state: ProfileState) -> void:
+	if state == null:
+		return
+	if (
+		state.manager_reset_operation != null
+		and state.manager_reset_callback.is_valid()
+		and state.manager_reset_operation.completed.is_connected(
+			state.manager_reset_callback
+		)
+	):
+		state.manager_reset_operation.completed.disconnect(
+			state.manager_reset_callback
+		)
+	state.manager_reset_operation = null
+	state.manager_reset_callback = Callable()
 
 
 func _clear_current_storage_operation(state: ProfileState) -> void:
@@ -3494,6 +3656,7 @@ func _try_complete_quiesce() -> void:
 				or state.mode != STATE_IDLE
 				or _has_pending_operations(state)
 				or state.current_storage_operation != null
+				or state.manager_reset_operation != null
 				or not state.detached_write_operations.is_empty()
 				or state.pending_schedule_enqueued
 				or state.active_preparation_enqueued
@@ -3674,6 +3837,29 @@ func _on_storage_operation_completed(
 			_handle_load_failure(state, read_result)
 		else:
 			_process_loaded_document(state, read_result)
+	_end_processing()
+
+
+func _on_manager_reset_operation_completed(
+	result: GFStorageAsyncResult,
+	profile_id: StringName,
+	request_id: int
+) -> void:
+	if _disposed:
+		return
+	_begin_processing()
+	var state: ProfileState = _get_state(profile_id)
+	if (
+		state == null
+		or state.manager_reset_operation == null
+		or state.manager_reset_operation.get_request_id() != request_id
+		or result == null
+		or result.get_request_id() != request_id
+	):
+		_end_processing()
+		return
+	_clear_manager_reset_operation(state)
+	_reap_expired_managed_permit_if_safe(state)
 	_end_processing()
 
 
@@ -4048,6 +4234,16 @@ class ProfileState extends RefCounted:
 	## [br]
 	## @api framework_internal
 	var current_storage_callback: Callable = Callable()
+
+	## manager 接纳并等待物理终态的 Storage family reset。
+	## [br]
+	## @api framework_internal
+	var manager_reset_operation: GFStorageAsyncOperation = null
+
+	## manager reset 的内部生命周期回调。
+	## [br]
+	## @api framework_internal
+	var manager_reset_callback: Callable = Callable()
 
 	## 当前底层 IO 单调超时截止时间。
 	## [br]

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "catalog_version": "2.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "9a089d46962c238747b03892d9e4e057bf7eb99c808b1b3dac28f44fa4f2dce3",
+  "source_digest": "a602f3a0a753dd778c558883750bfe38638bf5bd025572e29aa0757445c6c5d5",
   "class_count": 824,
   "autoload_count": 1,
   "package_count": 56,
@@ -71482,7 +71482,7 @@
       "module": "extensions/save",
       "package_id": "gf.extension.save",
       "path": "addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd",
-      "summary": "GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。 Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease；",
+      "summary": "GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。 Lease 由失败的 activate 或 switch 操作创建，并绑定创建时的事务、来源与目标 Profile、Provider domain generation 与 lifecycle epoch。恢复入口必须原样提交同一",
       "visibility": "public",
       "category": "runtime_handle",
       "since": "unreleased",
@@ -71491,14 +71491,14 @@
           "kind": "const",
           "name": "REASON_MISSING",
           "signature": "const REASON_MISSING: StringName = &\"missing\"",
-          "summary": "激活目标没有持久化文档。",
+          "summary": "activate 或 switch 目标没有持久化文档。",
           "visibility": "public"
         },
         {
           "kind": "const",
           "name": "REASON_CORRUPT",
           "signature": "const REASON_CORRUPT: StringName = &\"corrupt\"",
-          "summary": "激活目标文档损坏或完整性无效。",
+          "summary": "activate 或 switch 目标文档损坏、完整性无效或 Storage family 结构损坏。",
           "visibility": "public"
         },
         {
@@ -71534,6 +71534,13 @@
           "name": "get_transaction_id",
           "signature": "func get_transaction_id() -> int",
           "summary": "获取产生当前 Lease 的事务 ID。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "get_source_profile_id",
+          "signature": "func get_source_profile_id() -> StringName",
+          "summary": "获取恢复事务绑定的来源 Profile ID。",
           "visibility": "public"
         },
         {
@@ -72144,6 +72151,20 @@
         },
         {
           "kind": "func",
+          "name": "bootstrap_and_switch_profile",
+          "signature": "func bootstrap_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation",
+          "summary": "使用 switch 返回的 missing lease 创建目标并原子切换活动身份。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "adopt_and_switch_profile",
+          "signature": "func adopt_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation",
+          "summary": "使用 switch 返回的 corrupt lease 恢复目标并原子切换活动身份。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
           "name": "mutate_and_persist",
           "signature": "func mutate_and_persist( profile_id: StringName, request: GFSaveProfileMutationRequest ) -> GFSaveProfileTransactionOperation",
           "summary": "事务化应用一个或多个完整 section replacement 并持久化活动 Profile。",
@@ -72202,6 +72223,20 @@
           "name": "OPERATION_ADOPT",
           "signature": "const OPERATION_ADOPT: StringName = &\"adopt\"",
           "summary": "显式采用当前 Provider 状态作为恢复后的活跃 Profile。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_BOOTSTRAP_AND_SWITCH",
+          "signature": "const OPERATION_BOOTSTRAP_AND_SWITCH: StringName = &\"bootstrap_and_switch\"",
+          "summary": "从活动来源重新 flush 后，以当前 Provider 状态创建缺失目标并原子切换。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "OPERATION_ADOPT_AND_SWITCH",
+          "signature": "const OPERATION_ADOPT_AND_SWITCH: StringName = &\"adopt_and_switch\"",
+          "summary": "从活动来源重新 flush 后，以当前 Provider 状态覆盖损坏目标并原子切换。",
           "visibility": "public"
         },
         {
@@ -72317,6 +72352,20 @@
         },
         {
           "kind": "const",
+          "name": "STATUS_BOOTSTRAPPED_AND_SWITCHED",
+          "signature": "const STATUS_BOOTSTRAPPED_AND_SWITCHED: StringName = &\"bootstrapped_and_switched\"",
+          "summary": "缺失目标已持久化，活动身份随后从来源原子切换到目标。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
+          "name": "STATUS_ADOPTED_AND_SWITCHED",
+          "signature": "const STATUS_ADOPTED_AND_SWITCHED: StringName = &\"adopted_and_switched\"",
+          "summary": "损坏目标已显式恢复并持久化，活动身份随后从来源原子切换到目标。",
+          "visibility": "public"
+        },
+        {
+          "kind": "const",
           "name": "STATUS_MUTATED",
           "signature": "const STATUS_MUTATED: StringName = &\"mutated\"",
           "summary": "候选 sections 已应用并持久化。",
@@ -72382,7 +72431,7 @@
           "kind": "const",
           "name": "STATUS_RECOVERY_REQUIRED",
           "signature": "const STATUS_RECOVERY_REQUIRED: StringName = &\"recovery_required\"",
-          "summary": "activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。",
+          "summary": "activate 或 switch 检测到可恢复的缺失/损坏目标，必须显式选择对应恢复入口。",
           "visibility": "public"
         },
         {
@@ -72557,7 +72606,7 @@
           "kind": "func",
           "name": "get_recovery_lease",
           "signature": "func get_recovery_lease() -> GFSaveProfileRecoveryLease",
-          "summary": "获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。",
+          "summary": "获取显式 bootstrap/adopt 或 bootstrap/adopt-and-switch 所需的同一身份 Recovery Lease。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFSaveProfileRecoveryLease.xml
+++ b/docs/api_catalog/classes/GFSaveProfileRecoveryLease.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveProfileRecoveryLease" path="addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd" module="extensions/save" extends="RefCounted" classDigest="d389e2a11ad3ed277cde8cc69819c28f56e512cac0574b406b6fc5d5d6cb117c">
+<class name="GFSaveProfileRecoveryLease" path="addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd" module="extensions/save" extends="RefCounted" classDigest="5dd4d0b9b00b7ca86b92f9cbd48426da2106ea21e06f887939914d854e1197bd">
 	<description>GFSaveProfileRecoveryLease: 缺失或损坏 Profile 的一次性恢复授权。
-Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider
-domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease；
-domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。</description>
+Lease 由失败的 activate 或 switch 操作创建，并绑定创建时的事务、来源与目标
+Profile、Provider domain generation 与 lifecycle epoch。恢复入口必须原样提交同一
+Lease；domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_handle</tag>
@@ -14,7 +14,7 @@ domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定�
 	<constants>
 		<member kind="const" name="REASON_MISSING">
 			<signature>const REASON_MISSING: StringName = &amp;"missing"</signature>
-			<description>激活目标没有持久化文档。</description>
+			<description>activate 或 switch 目标没有持久化文档。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">unreleased</tag>
@@ -22,7 +22,7 @@ domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定�
 		</member>
 		<member kind="const" name="REASON_CORRUPT">
 			<signature>const REASON_CORRUPT: StringName = &amp;"corrupt"</signature>
-			<description>激活目标文档损坏或完整性无效。</description>
+			<description>activate 或 switch 目标文档损坏、完整性无效或 Storage family 结构损坏。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">unreleased</tag>
@@ -70,6 +70,16 @@ domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定�
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">正整数事务 ID；未配置时为 0。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="get_source_profile_id">
+			<signature>func get_source_profile_id() -&gt; StringName:</signature>
+			<description>获取恢复事务绑定的来源 Profile ID。
+首次 activate 恢复没有来源；switch 恢复始终绑定创建 Lease 时仍然活动的来源。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">switch 恢复的来源 Profile ID；首次 activate 恢复时为空。</tag>
 				<tag name="since">unreleased</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFSaveProfileTransactionCoordinator.xml
+++ b/docs/api_catalog/classes/GFSaveProfileTransactionCoordinator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveProfileTransactionCoordinator" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd" module="extensions/save" extends="GFUtility" classDigest="6bb17be159ff057aeb195290bf07aa9912c7a8d4d5a4d22e63eb1de5139f93bc">
+<class name="GFSaveProfileTransactionCoordinator" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd" module="extensions/save" extends="GFUtility" classDigest="7867186e8010c4d76060f8b1302e42b8eed40eeb64fa2498dadd13d20f13207c">
 	<description>GFSaveProfileTransactionCoordinator: 活动 Profile 身份与跨 Profile 事务协调器。
 Coordinator 在完全相同且同序的 Provider 实例拓扑上建立独立 domain，委托
 `GFSaveProfileUtility` 完成 generation、Storage IO、重试与 detached settlement。
@@ -216,7 +216,7 @@ missing/corrupt 不会应用低层 `ACTION_USE_CURRENT_STATE`；结果分别返�
 				<tag name="param">target_profile_id: 同一 domain 内的目标 Profile ID。</tag>
 				<tag name="param">context: 目标读取的迁移与 Provider 临时上下文。</tag>
 				<tag name="param">metadata: 仅写入外层事务结果的调用方元数据。</tag>
-				<tag name="return">类型化 switch 操作。</tag>
+				<tag name="return">类型化 switch 操作；目标缺失或可恢复损坏时返回绑定活动来源的 Recovery Lease。</tag>
 				<tag name="schema">context: Dictionary with caller-defined ephemeral operation data.</tag>
 				<tag name="schema">metadata: Dictionary with caller-defined result metadata.</tag>
 				<tag name="since">unreleased</tag>
@@ -241,6 +241,34 @@ missing/corrupt 不会应用低层 `ACTION_USE_CURRENT_STATE`；结果分别返�
 				<tag name="param">lease: 尚未过期的 corrupt Recovery Lease。</tag>
 				<tag name="param">request: 当前 Provider 状态的保存请求；null 表示空元数据。</tag>
 				<tag name="return">类型化 adopt 操作；拒绝不会 claim lease 或 request。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="bootstrap_and_switch_profile">
+			<signature>func bootstrap_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>使用 switch 返回的 missing lease 创建目标并原子切换活动身份。
+接纳后会重新 flush Lease 绑定的当前来源，再把最新 Provider 状态保存到目标；
+目标持久化确认前来源始终保持权威。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">lease: 尚未过期且绑定活动来源的 missing Recovery Lease。</tag>
+				<tag name="param">request: 目标保存的一次性请求；null 表示空元数据。</tag>
+				<tag name="return">类型化 bootstrap-and-switch 操作；边界拒绝不会 claim lease 或 request。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="adopt_and_switch_profile">
+			<signature>func adopt_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -&gt; GFSaveProfileTransactionOperation:</signature>
+			<description>使用 switch 返回的 corrupt lease 恢复目标并原子切换活动身份。
+接纳后会重新 flush Lease 绑定的当前来源。Storage family 结构损坏必须先凭
+同一读取来源的授权完成 reset；高层 Save 文档损坏则直接保存最新 Provider 状态。
+reset 或目标保存确定失败时来源身份保持不变，无法签发结构 reset 授权时 switch
+会 fail closed 且不会返回可执行的 Recovery Lease。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">lease: 尚未过期且绑定活动来源的 corrupt Recovery Lease。</tag>
+				<tag name="param">request: 目标保存的一次性请求；null 表示空元数据。</tag>
+				<tag name="return">类型化 adopt-and-switch 操作；边界拒绝不会 claim lease 或 request。</tag>
 				<tag name="since">unreleased</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFSaveProfileTransactionOperation.xml
+++ b/docs/api_catalog/classes/GFSaveProfileTransactionOperation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveProfileTransactionOperation" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd" module="extensions/save" extends="RefCounted" classDigest="099afddec6e78fd3624ef311c449ab3613ef2b52256467b51fd4ab9e8e332103">
+<class name="GFSaveProfileTransactionOperation" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd" module="extensions/save" extends="RefCounted" classDigest="fc1ed2c7a52e22a8e942ebd4cd2a5866c303bd2f712bd21f8aa4b9a377c4a64c">
 	<description>GFSaveProfileTransactionOperation: Profile 身份与持久化事务的异步句柄。
 句柄由 Save Profile 事务协调器完成一次且只完成一次。调用方可在连接信号前
 检查 `is_completed()`，避免同步拒绝或立即终态造成竞态。</description>
@@ -53,6 +53,22 @@
 				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
+		<member kind="const" name="OPERATION_BOOTSTRAP_AND_SWITCH">
+			<signature>const OPERATION_BOOTSTRAP_AND_SWITCH: StringName = &amp;"bootstrap_and_switch"</signature>
+			<description>从活动来源重新 flush 后，以当前 Provider 状态创建缺失目标并原子切换。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="OPERATION_ADOPT_AND_SWITCH">
+			<signature>const OPERATION_ADOPT_AND_SWITCH: StringName = &amp;"adopt_and_switch"</signature>
+			<description>从活动来源重新 flush 后，以当前 Provider 状态覆盖损坏目标并原子切换。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="const" name="OPERATION_MUTATE_AND_PERSIST">
 			<signature>const OPERATION_MUTATE_AND_PERSIST: StringName = &amp;"mutate_and_persist"</signature>
 			<description>应用完整候选 section 并持久化。</description>
@@ -93,8 +109,8 @@
 		<member kind="method" name="get_source_profile_id">
 			<signature>func get_source_profile_id() -&gt; StringName:</signature>
 			<description>获取事务来源 Profile ID。
-activate、bootstrap 与 adopt 没有来源身份；mutate-and-persist 和 reconcile
-使用当前受管 Profile 作为来源。</description>
+activate、bootstrap 与 adopt 没有来源身份；switch、bootstrap/adopt-and-switch、
+mutate-and-persist 和 reconcile 使用当前受管 Profile 作为来源。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">来源 Profile ID；不适用时为空。</tag>

--- a/docs/api_catalog/classes/GFSaveProfileTransactionResult.xml
+++ b/docs/api_catalog/classes/GFSaveProfileTransactionResult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFSaveProfileTransactionResult" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd" module="extensions/save" extends="RefCounted" classDigest="a649282a39a46c716c7a76a66b4613d301d42cc3416c29e677b4eaae0277c64c">
+<class name="GFSaveProfileTransactionResult" path="addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd" module="extensions/save" extends="RefCounted" classDigest="dde1684aa2f01600e0f893a62626e5f87496821e29644c7efd62080ff2c99d0c">
 	<description>GFSaveProfileTransactionResult: Profile 事务的不可变终态快照。
 结果不保留文档、section、Provider snapshot 或候选 payload，只保留有界阶段
 证据、类型化回滚失败、调用方元数据和必要的 Lease。`duplicate_result()` 会
@@ -39,6 +39,22 @@
 		<member kind="const" name="STATUS_ADOPTED">
 			<signature>const STATUS_ADOPTED: StringName = &amp;"adopted"</signature>
 			<description>当前状态已被显式采用为恢复后的活跃 Profile。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_BOOTSTRAPPED_AND_SWITCHED">
+			<signature>const STATUS_BOOTSTRAPPED_AND_SWITCHED: StringName = &amp;"bootstrapped_and_switched"</signature>
+			<description>缺失目标已持久化，活动身份随后从来源原子切换到目标。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="const" name="STATUS_ADOPTED_AND_SWITCHED">
+			<signature>const STATUS_ADOPTED_AND_SWITCHED: StringName = &amp;"adopted_and_switched"</signature>
+			<description>损坏目标已显式恢复并持久化，活动身份随后从来源原子切换到目标。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">unreleased</tag>
@@ -118,7 +134,7 @@
 		</member>
 		<member kind="const" name="STATUS_RECOVERY_REQUIRED">
 			<signature>const STATUS_RECOVERY_REQUIRED: StringName = &amp;"recovery_required"</signature>
-			<description>activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。</description>
+			<description>activate 或 switch 检测到可恢复的缺失/损坏目标，必须显式选择对应恢复入口。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="since">unreleased</tag>
@@ -336,7 +352,7 @@
 		</member>
 		<member kind="method" name="get_recovery_lease">
 			<signature>func get_recovery_lease() -&gt; GFSaveProfileRecoveryLease:</signature>
-			<description>获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。</description>
+			<description>获取显式 bootstrap/adopt 或 bootstrap/adopt-and-switch 所需的同一身份 Recovery Lease。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">recovery_required 结果中的 Lease；其他结果通常为 null。</tag>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="42c892cbadc666fef13f294c40dfd03d9928105b0bda84a9c2d6be1f850ef2cc" classCount="848" methodCount="7714" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="6b7ddd47f6a866942dd0cb856a93391a92f0e36889249c43f9e960ea202b0cba" classCount="848" methodCount="7717" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="75" methodCount="801" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -806,7 +806,7 @@
 		<class name="GFGravityField3D" path="classes/GFGravityField3D.xml" sourcePath="addons/gf/extensions/physics/nodes/gf_gravity_field_3d.gd" extends="Node3D" />
 		<class name="GFGravityProbe3D" path="classes/GFGravityProbe3D.xml" sourcePath="addons/gf/extensions/physics/nodes/gf_gravity_probe_3d.gd" extends="Node3D" />
 	</module>
-	<module id="extensions/save" label="Save" classCount="52" methodCount="414" autoloadCount="0" autoloadMethodCount="0">
+	<module id="extensions/save" label="Save" classCount="52" methodCount="417" autoloadCount="0" autoloadMethodCount="0">
 		<class name="GFNodeAnimationPlayerSerializer" path="classes/GFNodeAnimationPlayerSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_animation_player_serializer.gd" extends="GFNodeSerializer" />
 		<class name="GFNodeAudioStreamPlayerSerializer" path="classes/GFNodeAudioStreamPlayerSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_audio_stream_player_serializer.gd" extends="GFNodeSerializer" />
 		<class name="GFNodeCanvasItemSerializer" path="classes/GFNodeCanvasItemSerializer.xml" sourcePath="addons/gf/extensions/save/serializers/gf_node_canvas_item_serializer.gd" extends="GFNodeSerializer" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -51,11 +51,12 @@
 - `GFSaveProfileUtility` 新增全局准备 work budget、单 profile slice budget 和软时间 budget；`GFSaveProfileResult` 新增准备耗时、Storage attempt 累计耗时与准备 work units 诊断。
 - 新增 `GFSaveProfileTransactionCoordinator`、`GFSaveProfileTransactionOperation` 与
   `GFSaveProfileTransactionResult`：在单 Profile 原语之上按精确有序 Provider 身份管理
-  domain、活动 Profile、严格 activate/switch、显式 bootstrap/adopt、类型化 mutation
-  和 reconcile，并以独立不可变终态报告跨 Profile 事务。
+  domain、活动 Profile、严格 activate/switch、显式 bootstrap/adopt 及其 source-bound
+  and-switch continuation、类型化 mutation 和 reconcile，并以独立不可变终态报告跨 Profile 事务。
 - 新增 `GFSaveProfileRecoveryLease`、`GFSaveProfileReconcileLease` 与
-  `GFSaveProfileReconcileRequest`：missing/corrupt 只能通过匹配的一次性恢复能力继续，
-  写入结果未知时冻结 domain，等待底层证据 settled 后通过显式严格重读收敛。
+  `GFSaveProfileReconcileRequest`：missing/corrupt 只能通过匹配的一次性恢复能力继续；
+  switch Lease 额外绑定仍活动的来源，写入结果未知时冻结 domain，等待底层证据 settled
+  后通过显式严格重读收敛。
 - 新增 `GFSaveSectionMutation` 与 `GFSaveProfileMutationRequest`：用 move-only 候选 section
   清单替代事务内任意回调，固定 Provider 顺序并在确定失败时逆序恢复。
 - `GFSaveSlotStorageAdapter` 新增 `build_slot_file_plan()`：无需配置 Storage 即可返回已校验的数据/元数据文件名和 portable logical target，供同步入口在访问 backend 前复用同一模板安全规则。
@@ -275,6 +276,11 @@
   保存实际 claim Request 后消费 Recovery Lease 并推进 domain epoch，瞬时准入拒绝可用
   同一 Lease/Request 重试；底层超长错误进入事务 stage evidence 前限制为 2048 字符，
   missing/corrupt 激活仍可靠返回 `recovery_required` 与可用恢复能力。
+- 修复 `switch_profile()` 的 missing/corrupt 目标只能以 `target_load_failed` 结束、迫使项目
+  在 Coordinator 外拼接恢复的问题：新的一次性 source-bound Lease 允许显式
+  bootstrap/adopt-and-switch，并在 continuation 接纳后重新 flush 最新来源。Storage family
+  结构损坏必须先凭同一 Utility、同一目标读取签发的 opaque 授权完成 reset；无法授权时
+  失败关闭。reset、来源 flush 或目标保存的确定失败保留来源身份，未知结果只 fence 对应来源或目标。
 - 修复 SaveGraph 在 Source/Scope/Pipeline 已记录采集错误后仍生成并覆盖健康存档、内层格式版本接受缺失/旧版/字符串值、调用方 context 可伪造事务根、同步 apply 重入无界递归，以及 participant 或 Source snapshot 回滚失败只存在于可选 trace 的问题；默认 apply 结果现在始终公开 `rollback_failures` 与 `atomicity_restored`。
 - 修复 Graph 与 Slot 读取入口接受 `ok=true` 但 integrity 为 `INVALID` 的内容、PersistProperties 的 local/registry 同 ID Serializer 发生编码/解码实现漂移、Slot Sync 绕过 Adapter 模板与规范路径碰撞检查、Document parser 静默丢弃空白/非字符串/trim alias section key，以及 Section/Document 在有界持久化验收前深复制循环或超深容器的问题。
 - 修复 `GFSignalSubscriptionToken` 会隐式接管既有同一 `Signal + Callable` 连接、并在取消时断开其他创建方资源的问题；重复连接现在返回非活动 token，原连接继续由原创建方持有。
@@ -388,6 +394,15 @@
   `GFSaveProfileReconcileRequest`、`GFSaveSectionMutation` 与
   `GFSaveProfileMutationRequest` 是新的公开 operation、result、lease 和 move-only request
   类型；它们不与普通 `GFSaveProfileOperation` / `GFSaveProfileResult` 混用。`gf.save` 因新增可选活动身份事务层并收紧受管 Profile 准入，`extension_version` 从 `6.0.0` 提升到 `6.1.0`。
+- `GFSaveProfileTransactionCoordinator` 新增 `bootstrap_and_switch_profile()` 与
+  `adopt_and_switch_profile()`；`GFSaveProfileRecoveryLease` 新增 `get_source_profile_id()`；
+  Transaction Operation 新增 `OPERATION_BOOTSTRAP_AND_SWITCH` / `OPERATION_ADOPT_AND_SWITCH`，
+  Result 新增 `STATUS_BOOTSTRAPPED_AND_SWITCHED` / `STATUS_ADOPTED_AND_SWITCHED`；
+  `GFSaveProfileTransactionResult.to_dict().recovery_lease` 摘要新增 `source_profile_id`。
+  `switch_profile()` 的 missing/corrupt 目标现在可返回 source-bound
+  `STATUS_RECOVERY_REQUIRED`，结构损坏无法取得
+  Storage reset 授权时仍以 `STATUS_TARGET_LOAD_FAILED` 失败关闭。`gf.save` 因此以向后兼容
+  minor 能力把 `extension_version` 从 `6.2.1` 提升到 `6.3.0`；框架版本保持不变。
 - Save 扩展 Installer 现在先确保 `GFStorageUtility` 存在，再装配 Save Graph、Profile 与 Profile Transaction Coordinator；项目 Installer 不再重复拥有 Storage 注册。
 - `GFSaveGraphUtility.apply_scope()`、`apply_section()`、`apply_document()` 与 `load_scope()` 的结果 schema 新增稳定字段 `rollback_failures` 与 `atomicity_restored`；`GFSaveSlotStorageAdapter.build_slot_file_plan()` 是新的公开预检 API。SaveGraph 内层版本、读取完整性、Serializer ID 与 Slot 模板的准入语义同步收紧，`gf.save` 的 `extension_version` 从 `6.1.0` 提升到 `6.2.0`。
 - `GFModel`、`GFSystem`、`GFUtility` 新增 `begin_activation(GFAsyncScope) -> GFAsyncCompletion` 与 `begin_quiesce(GFAsyncScope) -> GFAsyncCompletion`。
@@ -458,6 +473,12 @@
     项目备份/确认政策，再调用 `adopt_profile()`。不要用 `ACTION_USE_CURRENT_STATE` 发布身份。
 23. 把项目手写的 flush-source/load-target 切换改为 `switch_profile()`，并以
     `GFSaveProfileTransactionResult` 判断 source flush、target load、rollback 和活动身份终态。
+    过去把目标 missing/corrupt 一律视为 `STATUS_TARGET_LOAD_FAILED` 的代码应处理
+    `STATUS_RECOVERY_REQUIRED`：确认 source-bound Lease 后分别调用
+    `bootstrap_and_switch_profile()` / `adopt_and_switch_profile()`。Continuation 会重新 flush
+    最新来源，目标保存确认前来源保持活动；switch Lease 不能交给 activation-only 的
+    `bootstrap_profile()` / `adopt_profile()`。Corrupt continuation 仍应先执行项目确认和备份
+    政策；不要绕过 Coordinator 直接覆盖或自行解析 Storage 私有布局。
 24. 需要“修改后必须持久化”的 section 流程改为构造 `GFSaveSectionMutation` 清单，通过
     `GFSaveProfileMutationRequest` 提交 `mutate_and_persist()`；成功 claim 后放弃请求与候选
     payload 的全部 alias，不再在写失败后自行追加补偿保存。

--- a/docs/zh/extensions/save-graph/save-profile-adr.md
+++ b/docs/zh/extensions/save-graph/save-profile-adr.md
@@ -43,7 +43,8 @@ GF 已经具备版本化 `GFSaveDocument`、独立 section、迁移注册表、�
 - `GFSaveRecoveryPolicy` 只允许显式、可审计的恢复和有界重试。
 - `GFStorageAsyncOperation` 为每次底层 IO 提供独立 request ID 和类型化终态。
 - `GFSaveProfileTransactionCoordinator` 在上述原语之上编译精确 provider domain，管理
-  活动 Profile 身份，并串行推进 activate、switch、bootstrap、adopt、mutation 和 reconcile。
+  活动 Profile 身份，并串行推进 activate、switch、bootstrap、adopt、对应的 and-switch
+  continuation、mutation 和 reconcile。
 - `GFSaveProfileTransactionOperation` / `GFSaveProfileTransactionResult` 为跨 Profile 流程
   提供独立类型化句柄与不可变终态，不扩张普通 `GFSaveProfileResult` 的单 Profile 语义。
 - `GFSaveProfileRecoveryLease` 把已知 missing/corrupt 恢复选择变成一次性显式能力；
@@ -86,8 +87,8 @@ Profile 层不引入第二套文件格式，不解释业务字段，不绑定槽
 29. 每个 domain 最多有一个活动 Profile；只有严格加载或显式恢复写入获得确定成功后才可原子发布或切换活动身份。
 30. Coordinator 管理的 Profile 只允许稳定活动身份执行直接 save/flush；直接 load、非活动 Profile 操作和事务/fence 期间的全部直接操作必须失败关闭。
 31. Switch 必须先 flush 调用时源 generation，再采集完整 Provider 快照并严格加载目标；已知失败按逆序恢复且不改变源活动身份。
-32. 首次 activate 的 missing 只能产生 Bootstrap Recovery Lease，corrupt 只能产生 Adopt Recovery Lease；两类一次性能力不得互换、复用或跨 domain generation 使用；switch 目标的同类失败保留源身份并以 target load failure 结束。
-33. Bootstrap 与 Adopt 只有在候选写入确定成功后才激活目标；普通恢复政策不得隐式发布活动身份。
+32. 首次 activate 与 switch 的 missing 只能产生 Bootstrap Recovery Lease，corrupt 只能产生 Adopt Recovery Lease；switch Lease 还必须绑定仍活动的来源。两类一次性能力不得互换、复用或跨 domain generation 使用；无法为 Storage family 结构损坏签发精确 reset 授权时失败关闭。
+33. Bootstrap/Adopt 与对应的 and-switch continuation 只有在候选写入确定成功后才发布目标；switch continuation 必须重新 flush 调用时来源，按需先完成来源绑定的 family reset，普通恢复政策不得隐式发布或切换活动身份。
 34. Mutation 必须先固定 Provider 顺序并采集回滚快照，再应用类型化候选并等待保存终态；已知 Storage 失败证明未提交，因此逆序恢复内存且不得自动补偿写入。
 35. 任何无法证明提交与否的写入都必须冻结整个 domain 并返回 Reconcile Lease；不得自动回滚、补偿、重试、激活或接受冲突工作。
 36. Reconcile Lease 在底层 generation 证据 settled 前保持 waiting，pending 调用不 claim Request；ready 后只能严格重读 lease 指定 Profile，完整应用成功才解锁并重建活动身份。
@@ -121,7 +122,7 @@ Coordinator 在 primitive 状态机之外为每个 provider domain 维护以下�
 | Domain 状态 | 含义 | 公开准入 |
 | --- | --- | --- |
 | `inactive` | 尚无活动 Profile | activate；匹配 lease 的 bootstrap/adopt |
-| `active` | 一个 Profile 拥有当前 Provider 状态 | switch、mutation；活动 Profile save/flush |
+| `active` | 一个 Profile 拥有当前 Provider 状态 | switch、mutation；匹配 source-bound lease 的 `bootstrap_and_switch_profile()` / `adopt_and_switch_profile()`；活动 Profile save/flush |
 | `transacting` | 已接纳事务正在推进 | 拒绝并发 domain 操作与直接原语 |
 | `reconciliation_required` | 写入结果未知并持有 fence | 仅匹配 lease 的 reconcile 与诊断查询 |
 | `disposed` | 强制释放终态 | 无 |
@@ -148,10 +149,12 @@ Quiesce 是 Coordinator 的全局准入阶段，不伪装成额外 domain 状态
 | 非 managed 普通读取文档损坏 | `corrupt` | 显式 `use_current_state`，不立即覆盖原文件 | 原始读取结果、恢复动作 |
 | Managed activate 文件不存在 | `recovery_required` | 只签发 Bootstrap Recovery Lease | profile/domain/generation、读取结果 |
 | Managed activate 文档损坏 | `recovery_required` | 只签发 Adopt Recovery Lease | profile/domain/generation、读取结果 |
-| Switch 目标文件缺失或损坏 | `target_load_failed` | 恢复 Provider 并保留源身份 | 目标读取结果、回滚错误 |
+| Switch 目标文件缺失或可恢复损坏 | `recovery_required` | 只签发绑定来源的 Bootstrap/Adopt Recovery Lease；保留源身份 | 来源/目标、domain generation、目标读取结果 |
+| Switch 目标 Storage 结构损坏但无法授权 reset | `target_load_failed` | 失败关闭，不允许普通覆盖 | 目标读取结果、授权失败原因 |
 | Managed Profile 直接 load 或非活动 save/flush | `busy` | 改用 Coordinator，或等待活动稳定 | profile/domain/活动身份 |
 | Switch 的源 flush 失败 | `source_flush_failed` | 保留源活动身份 | 源 generation 与底层终态 |
 | Switch 目标已知失败 | `target_load_failed` / 应用失败 | 逆序恢复并保留源身份 | 目标读取结果、回滚错误 |
+| Switch 恢复 reset 或目标保存已知失败 | `persist_failed` | 保留源身份；reset 成功证据不得伪装成回滚 | reset 类型化证据、目标保存终态 |
 | Mutation 已知持久化失败 | `persist_failed` | 逆序恢复；不发补偿写 | generation、底层确定失败 |
 | 事务写入结果未知 | `outcome_unknown` | 冻结 domain，签发 Reconcile Lease | domain generation、request IDs |
 | Lease 无效、过期或重复消费 | `invalid_lease` | 重新取得当前状态证据 | lease kind、domain generation |
@@ -174,7 +177,8 @@ Quiesce 是 Coordinator 的全局准入阶段，不伪装成额外 domain 状态
 - `use_current_state` 只适用于非 managed 普通读取，表示保留内存中的当前/default 状态并
   返回显式 recovered 终态；读取本身不写盘，也不删除、替换或修补原文件。
 - Coordinator 的 strict load 忽略 `use_current_state`：missing/corrupt 必须分别经过
-  Bootstrap/Adopt Recovery Lease，写确认后才能发布活动身份。
+  Bootstrap/Adopt Recovery Lease；switch continuation 重新 flush 来源，并在 Storage
+  结构损坏时凭来源绑定授权先 reset family，写确认后才能发布或切换活动身份。
 - 未来 schema、schema id 不匹配和迁移失败不属于损坏恢复。
 - 重试延迟是有限的毫秒序列；序列耗尽后必须返回失败，禁止无限循环。
 - 时间判断只使用注入的 `GFClock` 单调时间，测试使用 `GFManualClock`。
@@ -220,8 +224,10 @@ Quiesce 是 Coordinator 的全局准入阶段，不伪装成额外 domain 状态
   activation，不只依赖测试替身；Save Profile 不为执行模式增加第二套公开 API。
 - 精确相同的有序 Provider 身份共享 domain，重排和部分重叠注册失败关闭；不相交 domain
   可独立推进；
-- activate/switch 只在严格成功后发布活动身份；首次 activate 的 missing/corrupt 分别
-  只能由匹配的 bootstrap/adopt lease 继续，switch 目标失败则保留源身份；
+- activate/switch 只在严格成功后发布活动身份；missing/corrupt 分别只能由匹配的
+  bootstrap/adopt continuation 继续，switch Lease 绑定来源且在目标保存确认前保留源身份；
+- source-bound switch recovery 覆盖调用时最新来源 flush、结构损坏 reset、目标保存、
+  已知失败与 source/target outcome-unknown fence，活动身份只在最终确认后发布一次；
 - 活动 managed Profile 只开放稳定期 save/flush，直接 load、非活动写入和事务期重入均被拒绝；
 - switch 源 flush、目标读取、应用和逆序恢复的每个故障点都保持可证明身份；
 - typed mutation 的无效请求不被消费，已知持久化失败逆序恢复且不产生补偿写；

--- a/docs/zh/extensions/save-graph/save-profile-runtime.md
+++ b/docs/zh/extensions/save-graph/save-profile-runtime.md
@@ -238,8 +238,11 @@ schema ID 不匹配、迁移失败和 provider 应用失败不进入损坏恢复
 
 Coordinator 管理的 Profile 不把 `ACTION_USE_CURRENT_STATE` 当成激活授权：严格 activate
 会把 missing/corrupt 分别转换为受约束的 Recovery Lease，项目必须显式调用
-bootstrap/adopt，且只有写确认后才发布活动身份。Switch 的目标缺失或损坏会恢复并保留
-源活动身份，不会隐式创建或覆盖目标存档。
+bootstrap/adopt，且只有写确认后才发布活动身份。Switch 的目标缺失或可恢复损坏会返回
+绑定当前来源的 Lease；项目显式调用 `bootstrap_and_switch_profile()` 或
+`adopt_and_switch_profile()` 后，Coordinator 会重新 flush 来源，再按需执行来源绑定的
+Storage family reset，最后保存目标。目标保存确认前
+来源始终保持活动；结构损坏无法获得精确 reset 授权时失败关闭。
 
 未知 section 默认采用 `GFSaveProfile.UNKNOWN_SECTION_REJECT`，避免旧客户端读取后保存时
 静默删除新客户端数据。只有明确拥有向前兼容要求时才选择 `UNKNOWN_SECTION_PRESERVE`；

--- a/docs/zh/extensions/save-graph/save-profile-transactions.md
+++ b/docs/zh/extensions/save-graph/save-profile-transactions.md
@@ -58,13 +58,18 @@ reconcile fence 仍拒绝注销，成功注销会使该 domain 的 recovery leas
 
 严格 activate 遇到缺失文件时返回 `recovery_required` 与一次性的
 `GFSaveProfileRecoveryLease`；遇到已知损坏文件时也返回 recovery lease，但两种原因
-不能互换。Switch 的目标缺失或损坏属于已知 target load failure，会恢复 Provider 并
-保留源活动身份，不会把源内存状态隐式写成目标存档：
+不能互换。Switch 的目标缺失或可恢复损坏也会返回绑定当前活动来源的 Lease，并在整个
+恢复流程中保留源活动身份：
 
 - `bootstrap_profile()` 只消费由 `missing` 产生且仍属于当前 domain generation 的 lease。
 - `adopt_profile()` 只消费由 `corrupt` 产生且仍属于当前 domain generation 的 lease。
+- `bootstrap_and_switch_profile()` 消费 source-bound `missing` lease，重新 flush 调用时来源
+  generation，再保存目标并在确认成功后切换身份。
+- `adopt_and_switch_profile()` 消费 source-bound `corrupt` lease；Storage family 结构损坏
+  必须先使用同一 Utility、同一目标读取签发的 opaque 授权完成 family reset，无法授权时
+  失败关闭。Save 文档或完整性损坏不需要破坏性 reset。
 
-两者都把当前内存状态作为候选，只有 Storage 写入获得确定成功后才激活目标 Profile。
+四个入口都把当前内存状态作为候选，只有 Storage 写入获得确定成功后才激活或切换目标。
 无效、过期、重复消费或原因不匹配的 lease 会失败关闭。框架不会因为 Profile 的普通
 读取恢复政策而替项目自动创建、覆盖或接管一个活动身份；是否向用户展示“新建”或
 “接管损坏存档”，以及是否先备份损坏文件，均由项目决定。
@@ -90,8 +95,8 @@ Mutation Request 是 move-only 边界。成功提交后，调用方必须放弃�
 写入超时、释放中仍有物理写入等无法证明是否提交的情况返回 `outcome_unknown`，并交付
 一次性的 `GFSaveProfileReconcileLease`。Coordinator 此时冻结整个 provider domain：
 不发布新的活动身份，不执行反向回滚、自动重试或补偿写，也拒绝新的 activate、switch、
-bootstrap、adopt、mutation 和直接原语。否则磁盘可能已经保存候选状态，而内存又被静默
-改回旧状态。
+bootstrap、adopt、bootstrap/adopt-and-switch、mutation 和直接原语。否则磁盘可能已经
+保存候选状态，而内存又被静默改回旧状态。
 
 `GFSaveProfileReconcileLease` 初始为 waiting。此时调用 `reconcile_profile()` 只返回
 `reconcile_pending`，不会 claim `GFSaveProfileReconcileRequest`。底层 Utility 的
@@ -110,7 +115,7 @@ reconcile Profile 固定为源 Profile，原目标不会在迟到成功后自动
 
 需要在首个运行场景开放前恢复存档的项目 System，应声明
 `GFSaveProfileTransactionCoordinator` 为必需 Utility，并在 `begin_activation(scope)`
-中把 activate/switch/bootstrap/adopt Operation 的唯一终态桥接到
+中把 activate/switch/bootstrap/adopt 及 bootstrap/adopt-and-switch Operation 的唯一终态桥接到
 `GFAsyncCompletion`。不要手动轮询 `architecture.tick()`；依赖 DAG 会继续推进
 Coordinator、Save Profile 与 Storage 的本地依赖闭包。
 

--- a/docs/zh/reference/api/classes/GFSaveProfileRecoveryLease.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileRecoveryLease.md
@@ -9,7 +9,7 @@
 - 类别：运行时句柄 (`runtime_handle`)
 - 首次版本：`unreleased`
 
-缺失或损坏 Profile 的一次性恢复授权。 Lease 由失败的 activate 操作创建，并绑定创建时的事务、Profile、Provider domain generation 与 lifecycle epoch。bootstrap/adopt 必须原样提交同一 Lease； domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。
+缺失或损坏 Profile 的一次性恢复授权。 Lease 由失败的 activate 或 switch 操作创建，并绑定创建时的事务、来源与目标 Profile、Provider domain generation 与 lifecycle epoch。恢复入口必须原样提交同一 Lease；domain 或 epoch 前进后，旧 Lease 会失效，不能把陈旧恢复决定应用到新状态。
 
 ## 成员概览
 
@@ -22,6 +22,7 @@
 | 常量 | [`STATE_STALE`](#member-gfsaveprofilerecoverylease-constants-state_stale) | `const STATE_STALE: StringName = &"stale"` |
 | 方法 | [`get_lease_id`](#member-gfsaveprofilerecoverylease-methods-get_lease_id) | `func get_lease_id() -> int:` |
 | 方法 | [`get_transaction_id`](#member-gfsaveprofilerecoverylease-methods-get_transaction_id) | `func get_transaction_id() -> int:` |
+| 方法 | [`get_source_profile_id`](#member-gfsaveprofilerecoverylease-methods-get_source_profile_id) | `func get_source_profile_id() -> StringName:` |
 | 方法 | [`get_profile_id`](#member-gfsaveprofilerecoverylease-methods-get_profile_id) | `func get_profile_id() -> StringName:` |
 | 方法 | [`get_reason`](#member-gfsaveprofilerecoverylease-methods-get_reason) | `func get_reason() -> StringName:` |
 | 方法 | [`get_domain_id`](#member-gfsaveprofilerecoverylease-methods-get_domain_id) | `func get_domain_id() -> int:` |
@@ -45,7 +46,7 @@
 const REASON_MISSING: StringName = &"missing"
 ```
 
-激活目标没有持久化文档。
+activate 或 switch 目标没有持久化文档。
 
 <a id="member-gfsaveprofilerecoverylease-constants-reason_corrupt"></a>
 
@@ -58,7 +59,7 @@ const REASON_MISSING: StringName = &"missing"
 const REASON_CORRUPT: StringName = &"corrupt"
 ```
 
-激活目标文档损坏或完整性无效。
+activate 或 switch 目标文档损坏、完整性无效或 Storage family 结构损坏。
 
 <a id="member-gfsaveprofilerecoverylease-constants-state_available"></a>
 
@@ -130,6 +131,21 @@ func get_transaction_id() -> int:
 获取产生当前 Lease 的事务 ID。
 
 返回：正整数事务 ID；未配置时为 0。
+
+<a id="member-gfsaveprofilerecoverylease-methods-get_source_profile_id"></a>
+
+### `get_source_profile_id`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func get_source_profile_id() -> StringName:
+```
+
+获取恢复事务绑定的来源 Profile ID。 首次 activate 恢复没有来源；switch 恢复始终绑定创建 Lease 时仍然活动的来源。
+
+返回：switch 恢复的来源 Profile ID；首次 activate 恢复时为空。
 
 <a id="member-gfsaveprofilerecoverylease-methods-get_profile_id"></a>
 

--- a/docs/zh/reference/api/classes/GFSaveProfileTransactionCoordinator.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileTransactionCoordinator.md
@@ -38,6 +38,8 @@
 | 方法 | [`switch_profile`](#member-gfsaveprofiletransactioncoordinator-methods-switch_profile) | `func switch_profile( target_profile_id: StringName, context: Dictionary = {}, metadata: Dictionary = {} ) -> GFSaveProfileTransactionOperation:` |
 | 方法 | [`bootstrap_profile`](#member-gfsaveprofiletransactioncoordinator-methods-bootstrap_profile) | `func bootstrap_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:` |
 | 方法 | [`adopt_profile`](#member-gfsaveprofiletransactioncoordinator-methods-adopt_profile) | `func adopt_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`bootstrap_and_switch_profile`](#member-gfsaveprofiletransactioncoordinator-methods-bootstrap_and_switch_profile) | `func bootstrap_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:` |
+| 方法 | [`adopt_and_switch_profile`](#member-gfsaveprofiletransactioncoordinator-methods-adopt_and_switch_profile) | `func adopt_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:` |
 | 方法 | [`mutate_and_persist`](#member-gfsaveprofiletransactioncoordinator-methods-mutate_and_persist) | `func mutate_and_persist( profile_id: StringName, request: GFSaveProfileMutationRequest ) -> GFSaveProfileTransactionOperation:` |
 | 方法 | [`reconcile_profile`](#member-gfsaveprofiletransactioncoordinator-methods-reconcile_profile) | `func reconcile_profile( lease: GFSaveProfileReconcileLease, request: GFSaveProfileReconcileRequest = null ) -> GFSaveProfileTransactionOperation:` |
 
@@ -429,7 +431,7 @@ func switch_profile( target_profile_id: StringName, context: Dictionary = {}, me
 | `context` | 目标读取的迁移与 Provider 临时上下文。 |
 | `metadata` | 仅写入外层事务结果的调用方元数据。 |
 
-返回：类型化 switch 操作。
+返回：类型化 switch 操作；目标缺失或可恢复损坏时返回绑定活动来源的 Recovery Lease。
 
 结构：
 
@@ -479,6 +481,50 @@ func adopt_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileReq
 | `request` | 当前 Provider 状态的保存请求；null 表示空元数据。 |
 
 返回：类型化 adopt 操作；拒绝不会 claim lease 或 request。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-bootstrap_and_switch_profile"></a>
+
+### `bootstrap_and_switch_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func bootstrap_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:
+```
+
+使用 switch 返回的 missing lease 创建目标并原子切换活动身份。 接纳后会重新 flush Lease 绑定的当前来源，再把最新 Provider 状态保存到目标； 目标持久化确认前来源始终保持权威。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `lease` | 尚未过期且绑定活动来源的 missing Recovery Lease。 |
+| `request` | 目标保存的一次性请求；null 表示空元数据。 |
+
+返回：类型化 bootstrap-and-switch 操作；边界拒绝不会 claim lease 或 request。
+
+<a id="member-gfsaveprofiletransactioncoordinator-methods-adopt_and_switch_profile"></a>
+
+### `adopt_and_switch_profile`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func adopt_and_switch_profile( lease: GFSaveProfileRecoveryLease, request: GFSaveProfileRequest = null ) -> GFSaveProfileTransactionOperation:
+```
+
+使用 switch 返回的 corrupt lease 恢复目标并原子切换活动身份。 接纳后会重新 flush Lease 绑定的当前来源。Storage family 结构损坏必须先凭 同一读取来源的授权完成 reset；高层 Save 文档损坏则直接保存最新 Provider 状态。 reset 或目标保存确定失败时来源身份保持不变，无法签发结构 reset 授权时 switch 会 fail closed 且不会返回可执行的 Recovery Lease。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `lease` | 尚未过期且绑定活动来源的 corrupt Recovery Lease。 |
+| `request` | 目标保存的一次性请求；null 表示空元数据。 |
+
+返回：类型化 adopt-and-switch 操作；边界拒绝不会 claim lease 或 request。
 
 <a id="member-gfsaveprofiletransactioncoordinator-methods-mutate_and_persist"></a>
 

--- a/docs/zh/reference/api/classes/GFSaveProfileTransactionOperation.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileTransactionOperation.md
@@ -20,6 +20,8 @@ Profile 身份与持久化事务的异步句柄。 句柄由 Save Profile 事务
 | 常量 | [`OPERATION_SWITCH`](#member-gfsaveprofiletransactionoperation-constants-operation_switch) | `const OPERATION_SWITCH: StringName = &"switch"` |
 | 常量 | [`OPERATION_BOOTSTRAP`](#member-gfsaveprofiletransactionoperation-constants-operation_bootstrap) | `const OPERATION_BOOTSTRAP: StringName = &"bootstrap"` |
 | 常量 | [`OPERATION_ADOPT`](#member-gfsaveprofiletransactionoperation-constants-operation_adopt) | `const OPERATION_ADOPT: StringName = &"adopt"` |
+| 常量 | [`OPERATION_BOOTSTRAP_AND_SWITCH`](#member-gfsaveprofiletransactionoperation-constants-operation_bootstrap_and_switch) | `const OPERATION_BOOTSTRAP_AND_SWITCH: StringName = &"bootstrap_and_switch"` |
+| 常量 | [`OPERATION_ADOPT_AND_SWITCH`](#member-gfsaveprofiletransactionoperation-constants-operation_adopt_and_switch) | `const OPERATION_ADOPT_AND_SWITCH: StringName = &"adopt_and_switch"` |
 | 常量 | [`OPERATION_MUTATE_AND_PERSIST`](#member-gfsaveprofiletransactionoperation-constants-operation_mutate_and_persist) | `const OPERATION_MUTATE_AND_PERSIST: StringName = &"mutate_and_persist"` |
 | 常量 | [`OPERATION_RECONCILE`](#member-gfsaveprofiletransactionoperation-constants-operation_reconcile) | `const OPERATION_RECONCILE: StringName = &"reconcile"` |
 | 方法 | [`get_operation`](#member-gfsaveprofiletransactionoperation-methods-get_operation) | `func get_operation() -> StringName:` |
@@ -106,6 +108,32 @@ const OPERATION_ADOPT: StringName = &"adopt"
 
 显式采用当前 Provider 状态作为恢复后的活跃 Profile。
 
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_bootstrap_and_switch"></a>
+
+### `OPERATION_BOOTSTRAP_AND_SWITCH`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_BOOTSTRAP_AND_SWITCH: StringName = &"bootstrap_and_switch"
+```
+
+从活动来源重新 flush 后，以当前 Provider 状态创建缺失目标并原子切换。
+
+<a id="member-gfsaveprofiletransactionoperation-constants-operation_adopt_and_switch"></a>
+
+### `OPERATION_ADOPT_AND_SWITCH`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const OPERATION_ADOPT_AND_SWITCH: StringName = &"adopt_and_switch"
+```
+
+从活动来源重新 flush 后，以当前 Provider 状态覆盖损坏目标并原子切换。
+
 <a id="member-gfsaveprofiletransactionoperation-constants-operation_mutate_and_persist"></a>
 
 ### `OPERATION_MUTATE_AND_PERSIST`
@@ -175,7 +203,7 @@ func get_transaction_id() -> int:
 func get_source_profile_id() -> StringName:
 ```
 
-获取事务来源 Profile ID。 activate、bootstrap 与 adopt 没有来源身份；mutate-and-persist 和 reconcile 使用当前受管 Profile 作为来源。
+获取事务来源 Profile ID。 activate、bootstrap 与 adopt 没有来源身份；switch、bootstrap/adopt-and-switch、 mutate-and-persist 和 reconcile 使用当前受管 Profile 作为来源。
 
 返回：来源 Profile ID；不适用时为空。
 

--- a/docs/zh/reference/api/classes/GFSaveProfileTransactionResult.md
+++ b/docs/zh/reference/api/classes/GFSaveProfileTransactionResult.md
@@ -19,6 +19,8 @@ Profile 事务的不可变终态快照。 结果不保留文档、section、Prov
 | 常量 | [`STATUS_SWITCHED`](#member-gfsaveprofiletransactionresult-constants-status_switched) | `const STATUS_SWITCHED: StringName = &"switched"` |
 | 常量 | [`STATUS_BOOTSTRAPPED`](#member-gfsaveprofiletransactionresult-constants-status_bootstrapped) | `const STATUS_BOOTSTRAPPED: StringName = &"bootstrapped"` |
 | 常量 | [`STATUS_ADOPTED`](#member-gfsaveprofiletransactionresult-constants-status_adopted) | `const STATUS_ADOPTED: StringName = &"adopted"` |
+| 常量 | [`STATUS_BOOTSTRAPPED_AND_SWITCHED`](#member-gfsaveprofiletransactionresult-constants-status_bootstrapped_and_switched) | `const STATUS_BOOTSTRAPPED_AND_SWITCHED: StringName = &"bootstrapped_and_switched"` |
+| 常量 | [`STATUS_ADOPTED_AND_SWITCHED`](#member-gfsaveprofiletransactionresult-constants-status_adopted_and_switched) | `const STATUS_ADOPTED_AND_SWITCHED: StringName = &"adopted_and_switched"` |
 | 常量 | [`STATUS_MUTATED`](#member-gfsaveprofiletransactionresult-constants-status_mutated) | `const STATUS_MUTATED: StringName = &"mutated"` |
 | 常量 | [`STATUS_RECONCILED`](#member-gfsaveprofiletransactionresult-constants-status_reconciled) | `const STATUS_RECONCILED: StringName = &"reconciled"` |
 | 常量 | [`STATUS_INVALID_PROFILE`](#member-gfsaveprofiletransactionresult-constants-status_invalid_profile) | `const STATUS_INVALID_PROFILE: StringName = &"invalid_profile"` |
@@ -115,6 +117,32 @@ const STATUS_ADOPTED: StringName = &"adopted"
 ```
 
 当前状态已被显式采用为恢复后的活跃 Profile。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_bootstrapped_and_switched"></a>
+
+### `STATUS_BOOTSTRAPPED_AND_SWITCHED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_BOOTSTRAPPED_AND_SWITCHED: StringName = &"bootstrapped_and_switched"
+```
+
+缺失目标已持久化，活动身份随后从来源原子切换到目标。
+
+<a id="member-gfsaveprofiletransactionresult-constants-status_adopted_and_switched"></a>
+
+### `STATUS_ADOPTED_AND_SWITCHED`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+const STATUS_ADOPTED_AND_SWITCHED: StringName = &"adopted_and_switched"
+```
+
+损坏目标已显式恢复并持久化，活动身份随后从来源原子切换到目标。
 
 <a id="member-gfsaveprofiletransactionresult-constants-status_mutated"></a>
 
@@ -244,7 +272,7 @@ Profile 配置不支持请求的读取或写入阶段。
 const STATUS_RECOVERY_REQUIRED: StringName = &"recovery_required"
 ```
 
-activate 检测到缺失或损坏文档，必须显式选择 bootstrap 或 adopt。
+activate 或 switch 检测到可恢复的缺失/损坏目标，必须显式选择对应恢复入口。
 
 <a id="member-gfsaveprofiletransactionresult-constants-status_source_flush_failed"></a>
 
@@ -603,7 +631,7 @@ func get_stage_evidence() -> Dictionary:
 func get_recovery_lease() -> GFSaveProfileRecoveryLease:
 ```
 
-获取显式 bootstrap/adopt 所需的同一身份 Recovery Lease。
+获取显式 bootstrap/adopt 或 bootstrap/adopt-and-switch 所需的同一身份 Recovery Lease。
 
 返回：recovery_required 结果中的 Lease；其他结果通常为 null。
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -24,7 +24,7 @@
 | Extensions / Layered Sprite | 4 | 46 | [Extensions / Layered Sprite](#module-extensions-layered_sprite) |
 | Network | 38 | 602 | [Network](#module-extensions-network) |
 | Physics | 4 | 50 | [Physics](#module-extensions-physics) |
-| Save | 52 | 651 | [Save](#module-extensions-save) |
+| Save | 52 | 658 | [Save](#module-extensions-save) |
 | Turn Based | 5 | 50 | [Turn Based](#module-extensions-turn_based) |
 | Tool Packages | 22 | 185 | [Tool Packages](#module-tools) |
 
@@ -934,7 +934,7 @@
 | [`GFNodeSerializerRegistry`](GFNodeSerializerRegistry.md#gfnodeserializerregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/extensions/save/serializers/gf_node_serializer_registry.gd` |
 | [`GFSaveGraphUtility`](GFSaveGraphUtility.md#gfsavegraphutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 30 | `addons/gf/extensions/save/graph/gf_save_graph_utility.gd` |
 | [`GFSaveMigrationRegistry`](GFSaveMigrationRegistry.md#gfsavemigrationregistry) | 运行时服务 (`runtime_service`) | `RefCounted` | 7 | `addons/gf/extensions/save/document/gf_save_migration_registry.gd` |
-| [`GFSaveProfileTransactionCoordinator`](GFSaveProfileTransactionCoordinator.md#gfsaveprofiletransactioncoordinator) | 运行时服务 (`runtime_service`) | `GFUtility` | 25 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd` |
+| [`GFSaveProfileTransactionCoordinator`](GFSaveProfileTransactionCoordinator.md#gfsaveprofiletransactioncoordinator) | 运行时服务 (`runtime_service`) | `GFUtility` | 27 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd` |
 | [`GFSaveProfileUtility`](GFSaveProfileUtility.md#gfsaveprofileutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 26 | `addons/gf/extensions/save/profile/gf_save_profile_utility.gd` |
 | [`GFSaveSlotStorageAdapter`](GFSaveSlotStorageAdapter.md#gfsaveslotstorageadapter) | 运行时服务 (`runtime_service`) | `Resource` | 17 | `addons/gf/extensions/save/slots/gf_save_slot_storage_adapter.gd` |
 | [`GFSaveSlotSyncBridge`](GFSaveSlotSyncBridge.md#gfsaveslotsyncbridge) | 运行时服务 (`runtime_service`) | `RefCounted` | 6 | `addons/gf/extensions/save/slots/gf_save_slot_sync_bridge.gd` |
@@ -965,9 +965,9 @@
 | [`GFSaveProfileOperation`](GFSaveProfileOperation.md#gfsaveprofileoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 11 | `addons/gf/extensions/save/profile/gf_save_profile_operation.gd` |
 | [`GFSaveProfileReconcileLease`](GFSaveProfileReconcileLease.md#gfsaveprofilereconcilelease) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 22 | `addons/gf/extensions/save/profile/gf_save_profile_reconcile_lease.gd` |
 | [`GFSaveProfileReconcileRequest`](GFSaveProfileReconcileRequest.md#gfsaveprofilereconcilerequest) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 3 | `addons/gf/extensions/save/profile/gf_save_profile_reconcile_request.gd` |
-| [`GFSaveProfileRecoveryLease`](GFSaveProfileRecoveryLease.md#gfsaveprofilerecoverylease) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 16 | `addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd` |
+| [`GFSaveProfileRecoveryLease`](GFSaveProfileRecoveryLease.md#gfsaveprofilerecoverylease) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 17 | `addons/gf/extensions/save/profile/gf_save_profile_recovery_lease.gd` |
 | [`GFSaveProfileRequest`](GFSaveProfileRequest.md#gfsaveprofilerequest) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 2 | `addons/gf/extensions/save/profile/gf_save_profile_request.gd` |
-| [`GFSaveProfileTransactionOperation`](GFSaveProfileTransactionOperation.md#gfsaveprofiletransactionoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 15 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd` |
+| [`GFSaveProfileTransactionOperation`](GFSaveProfileTransactionOperation.md#gfsaveprofiletransactionoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 17 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_operation.gd` |
 | [`GFSaveSectionMutation`](GFSaveSectionMutation.md#gfsavesectionmutation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 8 | `addons/gf/extensions/save/profile/gf_save_section_mutation.gd` |
 | [`GFSaveSectionSnapshot`](GFSaveSectionSnapshot.md#gfsavesectionsnapshot) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 8 | `addons/gf/extensions/save/profile/gf_save_section_snapshot.gd` |
 | [`GFSaveSectionSnapshotOperation`](GFSaveSectionSnapshotOperation.md#gfsavesectionsnapshotoperation) | 运行时句柄 (`runtime_handle`) | `RefCounted` | 20 | `addons/gf/extensions/save/profile/gf_save_section_snapshot_operation.gd` |
@@ -976,7 +976,7 @@
 | [`GFSaveMigrationResult`](GFSaveMigrationResult.md#gfsavemigrationresult) | 值对象 (`value_object`) | `RefCounted` | 9 | `addons/gf/extensions/save/document/gf_save_migration_result.gd` |
 | [`GFSavePipelineContext`](GFSavePipelineContext.md#gfsavepipelinecontext) | 值对象 (`value_object`) | `RefCounted` | 21 | `addons/gf/extensions/save/pipeline/gf_save_pipeline_context.gd` |
 | [`GFSaveProfileResult`](GFSaveProfileResult.md#gfsaveprofileresult) | 值对象 (`value_object`) | `RefCounted` | 47 | `addons/gf/extensions/save/profile/gf_save_profile_result.gd` |
-| [`GFSaveProfileTransactionResult`](GFSaveProfileTransactionResult.md#gfsaveprofiletransactionresult) | 值对象 (`value_object`) | `RefCounted` | 46 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd` |
+| [`GFSaveProfileTransactionResult`](GFSaveProfileTransactionResult.md#gfsaveprofiletransactionresult) | 值对象 (`value_object`) | `RefCounted` | 48 | `addons/gf/extensions/save/profile/gf_save_profile_transaction_result.gd` |
 | [`GFSaveRollbackFailure`](GFSaveRollbackFailure.md#gfsaverollbackfailure) | 值对象 (`value_object`) | `RefCounted` | 4 | `addons/gf/extensions/save/profile/gf_save_rollback_failure.gd` |
 | [`GFSaveSection`](GFSaveSection.md#gfsavesection) | 值对象 (`value_object`) | `RefCounted` | 9 | `addons/gf/extensions/save/document/gf_save_section.gd` |
 | [`GFSaveSlotCard`](GFSaveSlotCard.md#gfsaveslotcard) | 值对象 (`value_object`) | `Resource` | 14 | `addons/gf/extensions/save/slots/gf_save_slot_card.gd` |

--- a/docs/zh/reference/api/extensions-save.md
+++ b/docs/zh/reference/api/extensions-save.md
@@ -6,11 +6,11 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 7 | 118 | 85 |
+| [运行时服务](#category-runtime_service) | 7 | 120 | 87 |
 | [协议与扩展点](#category-protocol) | 10 | 114 | 69 |
 | [资源定义](#category-resource_definition) | 13 | 92 | 58 |
-| [运行时句柄](#category-runtime_handle) | 10 | 110 | 76 |
-| [值对象](#category-value_object) | 10 | 200 | 120 |
+| [运行时句柄](#category-runtime_handle) | 10 | 113 | 77 |
+| [值对象](#category-value_object) | 10 | 202 | 120 |
 | [领域模型](#category-domain_model) | 1 | 6 | 3 |
 | [事件契约](#category-event_contract) | 1 | 11 | 3 |
 

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -7,8 +7,8 @@
 - 源码根目录：`addons/gf`
 - 公开类：`848`
 - 公开 AutoLoad：`1`
-- 公开成员：`12535`
-- 公开方法：`7714`
+- 公开成员：`12542`
+- 公开方法：`7717`
 - AutoLoad 公开方法：`65`
 
 ## 模块
@@ -33,7 +33,7 @@
 | Extensions / Layered Sprite | 4 | 0 | 46 | 21 | [extensions-layered-sprite.md](extensions-layered-sprite.md) |
 | Network | 38 | 0 | 602 | 323 | [extensions-network.md](extensions-network.md) |
 | Physics | 4 | 0 | 50 | 23 | [extensions-physics.md](extensions-physics.md) |
-| Save | 52 | 0 | 651 | 414 | [extensions-save.md](extensions-save.md) |
+| Save | 52 | 0 | 658 | 417 | [extensions-save.md](extensions-save.md) |
 | Turn Based | 5 | 0 | 50 | 25 | [extensions-turn-based.md](extensions-turn-based.md) |
 | Tool Packages | 22 | 0 | 185 | 118 | [tools.md](tools.md) |
 

--- a/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd
+++ b/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd
@@ -91,9 +91,13 @@ class ControlledStorage extends GFStorageUtility:
 	var active_io_count: int = 0
 	var max_active_io_count: int = 0
 	var driver: GFSaveProfileUtility = null
+	var enable_family_reset_authorization: bool = false
+	var reset_call_count: int = 0
 	var _next_request_id: int = 1
+	var _next_authorization_id: int = 1
 	var _pending_save_operations: Array[GFStorageAsyncOperation] = []
 	var _pending_load_operations: Array[GFStorageAsyncOperation] = []
+	var _pending_reset_operations: Array[GFStorageAsyncOperation] = []
 
 	func save_data_request_async(
 		file_name: String,
@@ -167,6 +171,78 @@ class ControlledStorage extends GFStorageUtility:
 		_begin_io()
 		return operation
 
+	func create_family_reset_authorization(
+		file_name: String,
+		observed_result: GFStorageReadResult
+	) -> GFStorageFamilyResetAuthorization:
+		if (
+			not enable_family_reset_authorization
+			or observed_result == null
+			or observed_result.ok
+			or observed_result.failure_kind != GFStorageReadResult.FailureKind.CORRUPT
+		):
+			return super.create_family_reset_authorization(file_name, observed_result)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			GFStorageFamilyResetAuthorization.new()
+		)
+		var configured: bool = authorization.configure_for_framework(
+			_next_authorization_id,
+			get_instance_id(),
+			file_name,
+			_get_async_file_key(file_name),
+			GFStorageFamilyResetAuthorization.REASON_CORRUPT
+		)
+		if not configured:
+			return null
+		_next_authorization_id += 1
+		return authorization
+
+	func reset_file_family_request_async(
+		file_name: String,
+		authorization: GFStorageFamilyResetAuthorization,
+		options: GFStorageAsyncRequestOptions = null
+	) -> GFStorageAsyncOperation:
+		var _ignored_options: GFStorageAsyncRequestOptions = options
+		var operation: GFStorageAsyncOperation = _make_operation(
+			GFStorageAsyncOperation.OPERATION_RESET,
+			file_name
+		)
+		var claimed: bool = (
+			authorization != null
+			and authorization.claim_for_framework(
+				get_instance_id(),
+				file_name,
+				_get_async_file_key(file_name)
+			)
+		)
+		if not claimed:
+			var unauthorized: GFStorageFamilyResetResult = (
+				GFStorageFamilyResetResult.new()
+			)
+			var _configured_unauthorized: bool = unauthorized.configure_for_framework(
+				ERR_UNAUTHORIZED,
+				GFStorageFamilyResetResult.FailureKind.UNAUTHORIZED,
+				GFStorageFamilyResetResult.SourceKind.UNKNOWN,
+				GFStorageFamilyResetResult.Phase.PREFLIGHT,
+				0,
+				0,
+				0,
+				GFStorageFamilyResetResult.FamilyMember.NONE
+			)
+			_complete_operation(
+				operation,
+				ERR_UNAUTHORIZED,
+				null,
+				GFStorageAsyncResult.WriteFailureKind.NONE,
+				unauthorized
+			)
+			return operation
+		reset_call_count += 1
+		events.append("reset:%s" % file_name)
+		_pending_reset_operations.append(operation)
+		_begin_io()
+		return operation
+
 	func complete_next_save(error_code: Error = OK) -> void:
 		complete_save_at(0, error_code)
 
@@ -181,6 +257,35 @@ class ControlledStorage extends GFStorageUtility:
 
 	func complete_next_load(result: GFStorageReadResult) -> void:
 		complete_load_at(0, result)
+
+	func complete_next_reset(
+		reset_result: GFStorageFamilyResetResult = null
+	) -> void:
+		if _pending_reset_operations.is_empty():
+			return
+		var operation: GFStorageAsyncOperation = _pending_reset_operations.pop_front()
+		var resolved_result: GFStorageFamilyResetResult = reset_result
+		if resolved_result == null:
+			resolved_result = GFStorageFamilyResetResult.new()
+			var _configured_success: bool = resolved_result.configure_for_framework(
+				OK,
+				GFStorageFamilyResetResult.FailureKind.NONE,
+				GFStorageFamilyResetResult.SourceKind.STRUCTURAL_IDENTITY,
+				GFStorageFamilyResetResult.Phase.NONE,
+				2,
+				3,
+				0,
+				GFStorageFamilyResetResult.FamilyMember.NONE
+			)
+		_end_io()
+		_complete_operation(
+			operation,
+			resolved_result.get_error_code(),
+			null,
+			GFStorageAsyncResult.WriteFailureKind.NONE,
+			resolved_result
+		)
+		_tick_driver()
 
 	func complete_load_at(index: int, result: GFStorageReadResult) -> void:
 		if index < 0 or index >= _pending_load_operations.size() or result == null:
@@ -203,6 +308,14 @@ class ControlledStorage extends GFStorageUtility:
 
 	func get_pending_load_count() -> int:
 		return _pending_load_operations.size()
+
+	func get_pending_reset_count() -> int:
+		return _pending_reset_operations.size()
+
+	func get_pending_reset_request_id(index: int = 0) -> int:
+		if index < 0 or index >= _pending_reset_operations.size():
+			return 0
+		return _pending_reset_operations[index].get_request_id()
 
 	func get_pending_save_file_name(index: int = 0) -> String:
 		if index < 0 or index >= _pending_save_operations.size():
@@ -252,7 +365,8 @@ class ControlledStorage extends GFStorageUtility:
 		read_result: GFStorageReadResult,
 		write_failure_kind: GFStorageAsyncResult.WriteFailureKind = (
 			GFStorageAsyncResult.WriteFailureKind.NONE
-		)
+		),
+		reset_result: GFStorageFamilyResetResult = null
 	) -> void:
 		var _finished_transfer: bool = operation.finish_payload_attempt_for_framework()
 		var successful: bool = error_code == OK
@@ -274,7 +388,10 @@ class ControlledStorage extends GFStorageUtility:
 			error_code,
 			read_result,
 			resolved_write_failure_kind,
-			{}
+			{},
+			null,
+			GFStorageAsyncResult.SettlementKind.DOMAIN_RESULT,
+			reset_result
 		)
 		var _completed: bool = operation.complete_for_framework(async_result)
 

--- a/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
@@ -655,6 +655,848 @@ func test_corrupt_activate_requires_lease_before_adopt_can_activate() -> void:
 	assert_eq(_coordinator.get_active_profile_id(profile.profile_id), profile.profile_id)
 
 
+func test_switch_recovery_leases_bind_source_and_reject_legacy_or_wrong_reason_apis() -> void:
+	var missing_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"missing", 10)
+	)
+	var corrupt_provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"corrupt", 20)
+	)
+	var missing_providers: Array[GFSaveSectionProvider] = [missing_provider]
+	var corrupt_providers: Array[GFSaveSectionProvider] = [corrupt_provider]
+	var missing_source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_recovery.missing_source",
+		missing_providers
+	)
+	var missing_target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_recovery.missing_target",
+		missing_providers
+	)
+	var corrupt_source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_recovery.corrupt_source",
+		corrupt_providers
+	)
+	var corrupt_target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_recovery.corrupt_target",
+		corrupt_providers
+	)
+	assert_true(_register(missing_source))
+	assert_true(_register(missing_target))
+	assert_true(_register(corrupt_source))
+	assert_true(_register(corrupt_target))
+	_activate_existing(missing_source, { &"missing": { "value": 10 } })
+	_activate_existing(corrupt_source, { &"corrupt": { "value": 20 } })
+
+	var missing_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		missing_target.profile_id
+	)
+	var missing_lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		missing_switch,
+		missing_target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	assert_not_null(missing_lease)
+	if missing_lease == null:
+		return
+	assert_eq(missing_lease.get_source_profile_id(), missing_source.profile_id)
+	assert_eq(missing_lease.get_profile_id(), missing_target.profile_id)
+	assert_eq(missing_lease.get_transaction_id(), missing_switch.get_transaction_id())
+	assert_eq(missing_lease.get_reason(), GFSaveProfileRecoveryLease.REASON_MISSING)
+	var missing_report: Dictionary = missing_switch.get_result().to_dict()
+	var missing_lease_summary: Dictionary = GFVariantData.get_option_dictionary(
+		missing_report,
+		"recovery_lease"
+	)
+	assert_eq(
+		GFVariantData.get_option_string_name(missing_lease_summary, "source_profile_id"),
+		missing_source.profile_id
+	)
+	assert_eq(
+		_coordinator.get_active_profile_id(missing_target.profile_id),
+		missing_source.profile_id
+	)
+
+	var corrupt_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		corrupt_target.profile_id
+	)
+	var corrupt_lease: GFSaveProfileRecoveryLease = _complete_switch_document_corruption(
+		corrupt_switch,
+		corrupt_target
+	)
+	assert_not_null(corrupt_lease)
+	if corrupt_lease == null:
+		return
+	assert_eq(corrupt_lease.get_source_profile_id(), corrupt_source.profile_id)
+	assert_eq(corrupt_lease.get_profile_id(), corrupt_target.profile_id)
+	assert_eq(corrupt_lease.get_transaction_id(), corrupt_switch.get_transaction_id())
+	assert_eq(corrupt_lease.get_reason(), GFSaveProfileRecoveryLease.REASON_CORRUPT)
+	assert_eq(
+		_coordinator.get_active_profile_id(corrupt_target.profile_id),
+		corrupt_source.profile_id
+	)
+
+	var legacy_missing_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "api": "legacy_bootstrap" }
+	)
+	var legacy_missing: GFSaveProfileTransactionOperation = _coordinator.bootstrap_profile(
+		missing_lease,
+		legacy_missing_request
+	)
+	assert_eq(
+		legacy_missing.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_LEASE
+	)
+	assert_false(legacy_missing_request.is_claimed())
+	assert_true(missing_lease.is_available())
+	var wrong_missing_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "api": "wrong_adopt_and_switch" }
+	)
+	var wrong_missing: GFSaveProfileTransactionOperation = (
+		_coordinator.adopt_and_switch_profile(missing_lease, wrong_missing_request)
+	)
+	assert_eq(
+		wrong_missing.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_LEASE
+	)
+	assert_false(wrong_missing_request.is_claimed())
+	assert_true(missing_lease.is_available())
+
+	var legacy_corrupt_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "api": "legacy_adopt" }
+	)
+	var legacy_corrupt: GFSaveProfileTransactionOperation = _coordinator.adopt_profile(
+		corrupt_lease,
+		legacy_corrupt_request
+	)
+	assert_eq(
+		legacy_corrupt.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_LEASE
+	)
+	assert_false(legacy_corrupt_request.is_claimed())
+	assert_true(corrupt_lease.is_available())
+	var wrong_corrupt_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "api": "wrong_bootstrap_and_switch" }
+	)
+	var wrong_corrupt: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(
+			corrupt_lease,
+			wrong_corrupt_request
+		)
+	)
+	assert_eq(
+		wrong_corrupt.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_LEASE
+	)
+	assert_false(wrong_corrupt_request.is_claimed())
+	assert_true(corrupt_lease.is_available())
+
+
+func test_switch_unbound_structural_corruption_fails_closed() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 33)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_unbound_corrupt.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_unbound_corrupt.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 33 } })
+
+	var operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	_profile_utility.tick(0.0)
+	_storage.complete_load_for_file(
+		target.file_name,
+		GFSaveProfileTransactionTestSupport.read_failure(
+			ERR_FILE_CORRUPT,
+			"Injected unbound structural corruption.",
+			GFStorageReadResult.FailureKind.CORRUPT
+		)
+	)
+
+	assert_true(operation.is_completed())
+	assert_eq(
+		operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_TARGET_LOAD_FAILED
+	)
+	assert_null(operation.get_result().get_recovery_lease())
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	assert_eq(_storage.get_pending_save_count(), 0)
+
+
+func test_adopt_and_switch_resets_structural_family_before_target_save() -> void:
+	var fixture: Dictionary = _prepare_structural_switch_recovery(
+		"session.adopt_switch_reset.success"
+	)
+	var source: GFSaveProfile = _fixture_profile(fixture, "source")
+	var target: GFSaveProfile = _fixture_profile(fixture, "target")
+	var lease: GFSaveProfileRecoveryLease = _fixture_recovery_lease(fixture)
+	var request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "recovery": "structural" }
+	)
+
+	var operation: GFSaveProfileTransactionOperation = (
+		_coordinator.adopt_and_switch_profile(lease, request)
+	)
+	assert_true(request.is_claimed())
+	assert_true(lease.is_claimed())
+	assert_eq(_storage.get_pending_reset_count(), 1)
+	assert_eq(_storage.reset_call_count, 1)
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+
+	_storage.complete_next_reset()
+	assert_eq(_storage.get_pending_reset_count(), 0)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	_storage.complete_next_save(OK)
+
+	assert_true(operation.is_completed())
+	assert_eq(
+		operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_ADOPTED_AND_SWITCHED
+	)
+	assert_eq(
+		operation.get_result().get_operation(),
+		GFSaveProfileTransactionOperation.OPERATION_ADOPT_AND_SWITCH
+	)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), target.profile_id)
+	assert_lt(
+		_storage.events.find("reset:%s" % target.file_name),
+		_storage.events.find("save:%s" % target.file_name)
+	)
+
+
+func test_adopt_and_switch_reset_failure_preserves_source_without_target_save() -> void:
+	var fixture: Dictionary = _prepare_structural_switch_recovery(
+		"session.adopt_switch_reset.failure"
+	)
+	var source: GFSaveProfile = _fixture_profile(fixture, "source")
+	var target: GFSaveProfile = _fixture_profile(fixture, "target")
+	var lease: GFSaveProfileRecoveryLease = _fixture_recovery_lease(fixture)
+	var operation: GFSaveProfileTransactionOperation = (
+		_coordinator.adopt_and_switch_profile(lease)
+	)
+	var reset_failure: GFStorageFamilyResetResult = GFStorageFamilyResetResult.new()
+	var _configured_failure: bool = reset_failure.configure_for_framework(
+		ERR_FILE_CANT_WRITE,
+		GFStorageFamilyResetResult.FailureKind.IO_FAILED,
+		GFStorageFamilyResetResult.SourceKind.STRUCTURAL_IDENTITY,
+		GFStorageFamilyResetResult.Phase.CLEANUP,
+		2,
+		3,
+		1,
+		GFStorageFamilyResetResult.FamilyMember.FAMILY_CONTAINER
+	)
+
+	_storage.complete_next_reset(reset_failure)
+
+	assert_true(operation.is_completed())
+	assert_eq(
+		operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED
+	)
+	assert_eq(operation.get_result().get_phase(), &"recovery_reset")
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	var reset_evidence: Dictionary = GFVariantData.get_option_dictionary(
+		operation.get_result().get_stage_evidence(),
+		"reset"
+	)
+	assert_eq(
+		GFVariantData.get_option_int(reset_evidence, "failure_kind"),
+		int(GFStorageFamilyResetResult.FailureKind.IO_FAILED)
+	)
+
+
+func test_adopt_and_switch_reset_success_then_target_save_failure_preserves_source() -> void:
+	var fixture: Dictionary = _prepare_structural_switch_recovery(
+		"session.adopt_switch_reset.target_save_failure"
+	)
+	var source: GFSaveProfile = _fixture_profile(fixture, "source")
+	var target: GFSaveProfile = _fixture_profile(fixture, "target")
+	var lease: GFSaveProfileRecoveryLease = _fixture_recovery_lease(fixture)
+	var operation: GFSaveProfileTransactionOperation = (
+		_coordinator.adopt_and_switch_profile(lease)
+	)
+	assert_eq(_storage.get_pending_reset_count(), 1)
+	assert_eq(_storage.get_pending_save_count(), 0)
+
+	_storage.complete_next_reset()
+	assert_false(operation.is_completed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	_storage.complete_next_save(ERR_FILE_CANT_WRITE)
+
+	assert_true(operation.is_completed())
+	assert_eq(
+		operation.get_result().get_operation(),
+		GFSaveProfileTransactionOperation.OPERATION_ADOPT_AND_SWITCH
+	)
+	assert_eq(
+		operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED
+	)
+	assert_eq(operation.get_result().get_phase(), &"recovery_target_save")
+	assert_eq(operation.get_result().get_active_profile_after(), source.profile_id)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	var reset_evidence: Dictionary = GFVariantData.get_option_dictionary(
+		operation.get_result().get_stage_evidence(),
+		"reset"
+	)
+	assert_true(GFVariantData.get_option_bool(reset_evidence, "ok"))
+	assert_eq(
+		GFVariantData.get_option_int(reset_evidence, "failure_kind"),
+		int(GFStorageFamilyResetResult.FailureKind.NONE)
+	)
+	assert_lt(
+		_storage.events.find("reset:%s" % target.file_name),
+		_storage.events.find("save:%s" % target.file_name)
+	)
+
+
+func test_dispose_during_switch_reset_fences_request_and_waits_for_physical_tail() -> void:
+	var fixture: Dictionary = _prepare_structural_switch_recovery(
+		"session.adopt_switch_reset.dispose"
+	)
+	var target: GFSaveProfile = _fixture_profile(fixture, "target")
+	var lease: GFSaveProfileRecoveryLease = _fixture_recovery_lease(fixture)
+	var operation: GFSaveProfileTransactionOperation = (
+		_coordinator.adopt_and_switch_profile(lease)
+	)
+	var request_id: int = _storage.get_pending_reset_request_id()
+	var _connected: Error = operation.completed.connect(_on_transaction_completed) as Error
+	assert_gt(request_id, 0)
+
+	_coordinator.dispose()
+	assert_true(operation.is_completed())
+	assert_eq(
+		operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN
+	)
+	var reconcile_lease: GFSaveProfileReconcileLease = (
+		operation.get_result().get_reconcile_lease()
+	)
+	assert_not_null(reconcile_lease)
+	if reconcile_lease != null:
+		assert_true(reconcile_lease.get_storage_request_ids().has(request_id))
+	var quiesce: GFAsyncCompletion = _profile_utility.begin_quiesce(GFAsyncScope.new())
+	assert_false(quiesce.is_completed())
+
+	_storage.complete_next_reset()
+	assert_true(quiesce.is_successful())
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_terminal_count, 1)
+	assert_eq(operation.get_result().get_target_profile_id(), target.profile_id)
+
+
+func test_switch_recovery_reservation_blocks_synchronous_flush_callback_save() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 41)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_reservation.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_reservation.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 41 } })
+	var switch_operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		switch_operation,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	var reentrant_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "source": "flush_callback" }
+	)
+	var callback_state: Dictionary = {}
+	var callback: Callable = func(_result: GFSaveProfileResult) -> void:
+		if not callback_state.is_empty():
+			return
+		callback_state["operation"] = _profile_utility.save_profile(
+			source.profile_id,
+			reentrant_request
+		)
+	var connected: Error = _profile_utility.profile_operation_completed.connect(
+		callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	assert_eq(connected, OK)
+
+	var recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(lease)
+	)
+	assert_false(
+		recovery.is_completed(),
+		"同步 flush callback 后 recovery 不得在 target save 前失败：%s" % [
+			recovery.get_result().to_dict() if recovery.get_result() != null else {}
+		]
+	)
+	assert_false(reentrant_request.is_claimed())
+	var reentrant_value: Variant = GFVariantData.get_option_value(
+		callback_state,
+		"operation"
+	)
+	assert_true(reentrant_value is GFSaveProfileOperation)
+	if reentrant_value is GFSaveProfileOperation:
+		var reentrant_operation: GFSaveProfileOperation = reentrant_value
+		assert_true(reentrant_operation.is_completed())
+		assert_eq(reentrant_operation.get_result().get_status(), GFSaveProfileResult.STATUS_BUSY)
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	_storage.complete_next_save(OK)
+	assert_true(recovery.get_result().is_successful())
+
+
+func test_switch_recovery_source_flush_unknown_fences_source() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 61)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_unknown.source",
+		providers,
+		10
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_unknown.target",
+		providers,
+		10
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 61 } })
+	var switch_operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		switch_operation,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	provider.value = 62
+	var source_save: GFSaveProfileOperation = _profile_utility.save_profile(
+		source.profile_id
+	)
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	var recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(lease)
+	)
+	assert_false(recovery.is_completed())
+	var _advanced: bool = _clock.advance_msec(11)
+	_profile_utility.tick(0.0)
+
+	assert_eq(source_save.get_result().get_status(), GFSaveProfileResult.STATUS_OUTCOME_UNKNOWN)
+	assert_true(recovery.is_completed())
+	assert_eq(
+		recovery.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN
+	)
+	var reconcile_lease: GFSaveProfileReconcileLease = (
+		recovery.get_result().get_reconcile_lease()
+	)
+	assert_not_null(reconcile_lease)
+	if reconcile_lease != null:
+		assert_eq(reconcile_lease.get_reconcile_profile_id(), source.profile_id)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), source.file_name)
+	_storage.complete_next_save(OK)
+	assert_eq(_storage.get_pending_save_count(), 0)
+
+
+func test_switch_recovery_target_save_unknown_fences_target_without_identity_commit() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 71)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_target_unknown.source",
+		providers,
+		10
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_target_unknown.target",
+		providers,
+		10
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 71 } })
+	var switch_operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		switch_operation,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	var identity_changes: Dictionary = { "count": 0 }
+	var callback: Callable = func(
+		_previous_profile_id: StringName,
+		_current_profile_id: StringName
+	) -> void:
+		identity_changes["count"] = GFVariantData.get_option_int(
+			identity_changes,
+			"count"
+		) + 1
+	var connected: Error = _coordinator.active_profile_changed.connect(callback) as Error
+	assert_eq(connected, OK)
+	var recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(lease)
+	)
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	var _advanced: bool = _clock.advance_msec(11)
+	_profile_utility.tick(0.0)
+
+	assert_true(recovery.is_completed())
+	assert_eq(
+		recovery.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_OUTCOME_UNKNOWN
+	)
+	var reconcile_lease: GFSaveProfileReconcileLease = (
+		recovery.get_result().get_reconcile_lease()
+	)
+	assert_not_null(reconcile_lease)
+	if reconcile_lease != null:
+		assert_eq(reconcile_lease.get_reconcile_profile_id(), target.profile_id)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	assert_eq(GFVariantData.get_option_int(identity_changes, "count"), 0)
+	_storage.complete_next_save(OK)
+	assert_eq(GFVariantData.get_option_int(identity_changes, "count"), 0)
+	if _coordinator.active_profile_changed.is_connected(callback):
+		_coordinator.active_profile_changed.disconnect(callback)
+
+
+func test_bootstrap_and_switch_reflushes_latest_source_before_atomic_commit() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 5)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap_switch.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap_switch.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 5 } })
+	var failed_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		failed_switch,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	assert_not_null(lease)
+	if lease == null:
+		return
+
+	provider.value = 31
+	var source_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "generation": "latest_source" }
+	)
+	var source_save: GFSaveProfileOperation = _profile_utility.save_profile(
+		source.profile_id,
+		source_request
+	)
+	var recovery_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{ "recovery": "missing_switch" },
+		{},
+		{ "trace": 89 }
+	)
+	var recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(lease, recovery_request)
+	)
+	assert_true(recovery_request.is_claimed(), "已接纳事务必须同步接管一次性 request。")
+	assert_true(lease.is_claimed(), "已接纳事务必须同步消费 switch Recovery Lease。")
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+
+	_profile_utility.tick(0.0)
+	assert_true(source_request.is_claimed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), source.file_name)
+	assert_eq(_storage.save_calls.size(), 1, "target save 必须等待 recovery-time source flush。")
+	_storage.complete_next_save(OK)
+	_profile_utility.tick(0.0)
+	assert_true(source_save.is_completed())
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	assert_eq(_storage.save_calls.size(), 2)
+	assert_eq(
+		GFSaveProfileTransactionTestSupport.get_saved_value(
+			_storage.save_calls[1],
+			&"state"
+		),
+		31,
+		"target 必须持久化 recovery 调用时重新 flush 的最新 source 状态。"
+	)
+	assert_eq(
+		_coordinator.get_active_profile_id(target.profile_id),
+		source.profile_id,
+		"target save 获得确定成功前不得提交活动身份。"
+	)
+	_storage.complete_next_save(OK)
+
+	assert_true(recovery.get_result().is_successful())
+	assert_eq(
+		recovery.get_operation(),
+		GFSaveProfileTransactionOperation.OPERATION_BOOTSTRAP_AND_SWITCH
+	)
+	assert_eq(
+		recovery.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BOOTSTRAPPED_AND_SWITCHED
+	)
+	assert_eq(recovery.get_result().get_source_profile_id(), source.profile_id)
+	assert_eq(recovery.get_result().get_target_profile_id(), target.profile_id)
+	assert_eq(recovery.get_result().get_active_profile_before(), source.profile_id)
+	assert_eq(recovery.get_result().get_active_profile_after(), target.profile_id)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), target.profile_id)
+
+
+func test_switch_recovery_stale_and_replayed_leases_do_not_claim_requests() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 7)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_recovery_lease.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.switch_recovery_lease.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 7 } })
+	var first_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var stale_lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		first_switch,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	assert_not_null(stale_lease)
+	if stale_lease == null:
+		return
+
+	var second_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var current_lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		second_switch,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	assert_true(stale_lease.is_stale())
+	assert_not_null(current_lease)
+	if current_lease == null:
+		return
+	var stale_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "lease": "stale" }
+	)
+	var stale_recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(stale_lease, stale_request)
+	)
+	assert_eq(
+		stale_recovery.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_LEASE
+	)
+	assert_false(stale_request.is_claimed())
+
+	var accepted_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "lease": "accepted" }
+	)
+	var accepted: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(current_lease, accepted_request)
+	)
+	assert_true(current_lease.is_claimed())
+	assert_true(accepted_request.is_claimed())
+	var replay_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "lease": "replay" }
+	)
+	var replay: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(current_lease, replay_request)
+	)
+	assert_eq(
+		replay.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_INVALID_LEASE
+	)
+	assert_false(replay_request.is_claimed())
+
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	_storage.complete_next_save(OK)
+	assert_true(accepted.get_result().is_successful())
+	assert_eq(
+		accepted.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_BOOTSTRAPPED_AND_SWITCHED
+	)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), target.profile_id)
+
+
+func test_bootstrap_and_switch_source_flush_failure_preserves_source() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 11)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap_switch_flush_failure.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap_switch_flush_failure.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 11 } })
+	var failed_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		failed_switch,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	assert_not_null(lease)
+	if lease == null:
+		return
+
+	provider.value = 12
+	var source_save: GFSaveProfileOperation = _profile_utility.save_profile(source.profile_id)
+	var recovery_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "failure": "source_flush" }
+	)
+	var recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(lease, recovery_request)
+	)
+	assert_true(recovery_request.is_claimed())
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_file_name(), source.file_name)
+	_storage.complete_next_save(ERR_FILE_CANT_WRITE)
+
+	assert_true(source_save.is_completed())
+	assert_true(recovery.is_completed())
+	assert_eq(
+		recovery.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_SOURCE_FLUSH_FAILED
+	)
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_storage.save_calls.size(), 1, "source flush 失败后不得触碰 target 持久化。")
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	assert_eq(recovery.get_result().get_active_profile_after(), source.profile_id)
+
+
+func test_bootstrap_and_switch_target_save_failure_preserves_source() -> void:
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 13)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap_switch_save_failure.source",
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		&"session.bootstrap_switch_save_failure.target",
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 13 } })
+	var failed_switch: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		failed_switch,
+		target,
+		ERR_FILE_NOT_FOUND,
+		GFStorageReadResult.FailureKind.NOT_FOUND
+	)
+	assert_not_null(lease)
+	if lease == null:
+		return
+	var recovery_request: GFSaveProfileRequest = GFSaveProfileRequest.take_ownership(
+		{},
+		{},
+		{ "failure": "target_save" }
+	)
+	var recovery: GFSaveProfileTransactionOperation = (
+		_coordinator.bootstrap_and_switch_profile(lease, recovery_request)
+	)
+	assert_true(recovery_request.is_claimed())
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_save_count(), 1)
+	assert_eq(_storage.get_pending_save_file_name(), target.file_name)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	_storage.complete_next_save(ERR_FILE_CANT_WRITE)
+
+	assert_true(recovery.is_completed())
+	assert_eq(
+		recovery.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED
+	)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	assert_eq(recovery.get_result().get_active_profile_after(), source.profile_id)
+
+
 func test_switch_waits_for_source_generation_before_loading_target() -> void:
 	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
 		GFSaveProfileTransactionTestSupport.make_provider(&"state", 0)
@@ -1169,6 +2011,98 @@ func _activate_existing(profile: GFSaveProfile, payloads: Dictionary) -> void:
 	)
 	assert_true(operation.is_completed())
 	assert_true(operation.get_result().is_successful())
+
+
+func _prepare_structural_switch_recovery(prefix: String) -> Dictionary:
+	_storage.enable_family_reset_authorization = true
+	var provider: GFSaveProfileTransactionTestSupport.MemorySectionProvider = (
+		GFSaveProfileTransactionTestSupport.make_provider(&"state", 55)
+	)
+	var providers: Array[GFSaveSectionProvider] = [provider]
+	var source: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		StringName("%s.source" % prefix),
+		providers
+	)
+	var target: GFSaveProfile = GFSaveProfileTransactionTestSupport.make_profile(
+		StringName("%s.target" % prefix),
+		providers
+	)
+	assert_true(_register(source))
+	assert_true(_register(target))
+	_activate_existing(source, { &"state": { "value": 55 } })
+	var switch_operation: GFSaveProfileTransactionOperation = _coordinator.switch_profile(
+		target.profile_id
+	)
+	var lease: GFSaveProfileRecoveryLease = _complete_switch_recovery_failure(
+		switch_operation,
+		target,
+		ERR_FILE_CORRUPT,
+		GFStorageReadResult.FailureKind.CORRUPT
+	)
+	assert_not_null(lease)
+	return {
+		"source": source,
+		"target": target,
+		"lease": lease,
+	}
+
+
+func _fixture_profile(fixture: Dictionary, key: String) -> GFSaveProfile:
+	var value: Variant = fixture.get(key)
+	assert_true(value is GFSaveProfile, "结构恢复夹具必须提供强类型 Profile。")
+	if value is GFSaveProfile:
+		var profile: GFSaveProfile = value
+		return profile
+	return null
+
+
+func _fixture_recovery_lease(fixture: Dictionary) -> GFSaveProfileRecoveryLease:
+	var value: Variant = fixture.get("lease")
+	assert_true(value is GFSaveProfileRecoveryLease, "结构恢复夹具必须提供强类型 Lease。")
+	if value is GFSaveProfileRecoveryLease:
+		var lease: GFSaveProfileRecoveryLease = value
+		return lease
+	return null
+
+
+func _complete_switch_recovery_failure(
+	operation: GFSaveProfileTransactionOperation,
+	target: GFSaveProfile,
+	error_code: Error,
+	failure_kind: GFStorageReadResult.FailureKind
+) -> GFSaveProfileRecoveryLease:
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_file_name(), target.file_name)
+	_storage.complete_load_for_file(
+		target.file_name,
+		GFSaveProfileTransactionTestSupport.read_failure(
+			error_code,
+			"Injected switch recovery target failure.",
+			failure_kind
+		)
+	)
+	assert_true(operation.is_completed())
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED)
+	return result.get_recovery_lease()
+
+
+func _complete_switch_document_corruption(
+	operation: GFSaveProfileTransactionOperation,
+	target: GFSaveProfile
+) -> GFSaveProfileRecoveryLease:
+	_profile_utility.tick(0.0)
+	assert_eq(_storage.get_pending_load_file_name(), target.file_name)
+	_storage.complete_load_for_file(
+		target.file_name,
+		GFStorageReadResult.new().configure_success({
+			"malformed_save_document": true,
+		})
+	)
+	assert_true(operation.is_completed())
+	var result: GFSaveProfileTransactionResult = operation.get_result()
+	assert_eq(result.get_status(), GFSaveProfileTransactionResult.STATUS_RECOVERY_REQUIRED)
+	return result.get_recovery_lease()
 
 
 # --- 信号处理函数 ---


### PR DESCRIPTION
## Summary

- return a typed, source-bound recovery lease when `switch_profile()` reaches a missing or corrupt target while keeping the active source authoritative
- add explicit `bootstrap_and_switch_profile()` and `adopt_and_switch_profile()` continuations that reflush the latest source before target recovery and publish the new identity only after target persistence succeeds
- require exact origin-bound Storage family reset authorization for structural corruption, fail closed when it is unavailable, and fence the affected profile when source flush or target persistence has an unknown outcome
- update `gf.save` to extension version `6.3.0`, generated API/AI references, Save Profile guidance, changelog migration notes, and transaction regression coverage

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: a missing/corrupt switch target can now return `STATUS_RECOVERY_REQUIRED` with a source-bound lease instead of always ending as `STATUS_TARGET_LOAD_FAILED`.
- API or extension contract: adds `bootstrap_and_switch_profile()`, `adopt_and_switch_profile()`, `GFSaveProfileRecoveryLease.get_source_profile_id()`, two operation constants, two success statuses, and `source_profile_id` in the recovery-lease result summary; `gf.save` moves from `6.2.1` to `6.3.0`.
- Persisted data, package, protocol, or ProjectSettings impact: existing Save documents and ProjectSettings remain compatible; structural Storage corruption can reset only the exact authorized target family before the replacement save.
- Failure, cancellation, rollback, concurrency, and ownership impact: the source remains active until target save confirmation; known source/reset/target failures preserve the source identity, synchronous reentry is rejected, unknown writes fence only the affected profile, and disposal waits for manager-owned reset settlement while reporting typed outcome-unknown evidence.
- Compatibility and migration: the API additions are backward compatible. Consumers that treated missing/corrupt switch targets only as `STATUS_TARGET_LOAD_FAILED` should handle `STATUS_RECOVERY_REQUIRED` and explicitly choose bootstrap-and-switch or adopt-and-switch; activation-only recovery APIs remain unchanged.

## Verification

- [x] Focused session-transaction coverage: 31/31 tests, 503 assertions, lifecycle gate clean.
- [x] Related Save coverage: utility 49/49, scheduler 9/9, preparation 8/8, mutation transactions 11/11.
- [x] Final authoritative Full on `5bc8f93b`: 46/46 canonical checks, 8/8 valid shards, GUT 7038/7038 with 80709 assertions, LSP 1354 files with 0 diagnostics and 0 timeouts.
- [x] Full workspace/artifact fingerprint: `87bcd2ac1c81158439ef7cde13827a9d19a9bbeb77fc7b86342d10359cfbd5e4`; report SHA-256: `7a79a838b549f23f744f4ede09f651562f878fc1e7ded1f2ade13682512f0dce`.
- [x] Generated API Catalog, Reference, and AI knowledge output are fresh for the new public surface.
- [x] Draft PR feedback completed through `GF draft gate`.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

## Documentation and Release

- [x] Save Profile guides and `[未发布]` changelog/API migration entries are updated.
- [x] `gf.save` uses the additive minor extension version `6.3.0`; the GF root development version remains unchanged.
- [x] This PR does not create a tag or publish a release.

Closes #89


