### PR TITLE
fix(kernel): reject conflicting required plan aliases

### DIFF
--- a/addons/gf/kernel/core/gf_architecture.gd
+++ b/addons/gf/kernel/core/gf_architecture.gd
@@ -6961,6 +6961,13 @@ func _register_required_plan_alias(
 		return false
 	if not GFScriptTypeInspector.script_extends_or_equals(target_cls, alias_cls):
 		return false
+	if module_registry._has_direct(alias_cls):
+		return alias_cls == target_cls
+	if module_registry.aliases.has(alias_cls):
+		return (
+			_get_dictionary_script(module_registry.aliases, alias_cls)
+			== target_cls
+		)
 	return _register_module_alias(module_registry, alias_cls, target_cls)
 
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -200,6 +200,7 @@
 ### 🐛 Bug 修复 (Fixed)
 
 - 修复类型化场景请求的四个终端边界：非主线程配置失败不再返回无法终结的半配置 Operation 或派发 Broker Lease；preload 在调用 Broker poll 前进入 settlement fence，终态回调中的同路径重入以 busy 失败关闭，不再递归轮询旧 aggregate；同步自定义切场的显式确认与同步 `scene_changed` 只记录 current-generation 回执，并在 override 返回 true 及 owner/token 复核后结算；同路径异步 override 用 `_defer_target_scene_commit()` 区分合法等待与 same-root no-op，不同路径 legacy async observer 保持兼容；基础 pathless commit 预实例化并只接受精确 root，自定义 pathless commit 则必须显式确认精确回执，不再把任意新空路径或同路径旧 root 误认成冻结目标。
+- 修复 required Binding Plan 把与直接注册键冲突的 alias、或同一 alias 指向不同 target 的覆盖写入误报为成功的问题；required 路径现在拒绝会被直接键遮蔽或改写既有目标的 alias，同时保留指向同一 target 的幂等映射。
 - 修复 Settings 把损坏数据恢复为默认值后仍无法覆盖 structural-corrupt Storage family，以及 catalog、owner 或事务 identity 损坏只能永久失败、无法由明确授权重建的问题。reset 现在在任何退休副作用前冻结证据并发布可恢复 intent，崩溃后优先于普通同 family I/O 幂等收敛；未知/future layout、多重有效 identity、来源不匹配、私有 ancestry link/wrong-type 与扫描预算耗尽都会零写失败关闭，未发布的截断 pending staging 可有界清理，已发布的损坏记录仍保留为冲突证据。
 - 修复 `GFStorageUtility` 异步保存、读取和删除在单线程 Web 导出中仍尝试 `Thread.start()`，导致请求启动失败并使依赖真实 Storage 的 Save Profile 无法完成 activation 的问题；默认 `AUTOMATIC` 现在在 `nothreads` 运行时选择 cooperative executor。请求调用栈只入队，正常调度由 `tick N` 接纳、`tick N+1` 执行此前已接纳任务，每个 tick 最多完成一个完整任务，同时保留请求身份、同 family FIFO、取消/deadline、物理终态、事务恢复和 quiesce 语义。
 

--- a/tests/gf_core/kernel/core/test_gf_binding_plan.gd
+++ b/tests/gf_core/kernel/core/test_gf_binding_plan.gd
@@ -544,6 +544,128 @@ func test_alias_rejection_reports_alias_phase_and_rolls_back_module() -> void:
 	architecture.dispose()
 
 
+func test_required_alias_rejects_existing_direct_registration() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	assert_true(
+		await architecture.register_utility_instance(PlanSnapshotAliasBase.new())
+	)
+	var binder: GFBinder = architecture.create_binder()
+	var plan: GFBindingPlan = binder.create_required_plan()
+	var _entry: GFBindingPlan = plan.require_singleton(
+		&"alias.direct_conflict",
+		binder.bind_utility(PlanSnapshotUtility).with_alias(
+			PlanSnapshotAliasBase
+		)
+	)
+	var scope: GFAsyncScope = GFAsyncScope.new()
+
+	var result: GFBindingPlanResult = plan.execute(scope)
+
+	_assert_result(
+		result,
+		GFBindingPlanResult.Status.FAILED,
+		GFBindingPlanResult.BindingKind.UTILITY,
+		GFBindingPlanResult.Phase.ALIAS,
+		GFBindingPlanResult.Reason.ALIAS_REJECTED,
+		0,
+		&"alias.direct_conflict",
+		_script_path(PlanSnapshotUtility),
+		GFBindingLifetimes.Lifetime.SINGLETON,
+		1,
+		false
+	)
+	assert_true(scope.is_cancel_requested())
+	assert_true(architecture.has_initialization_failed())
+	assert_null(architecture.get_local_utility(PlanSnapshotAliasBase))
+	assert_null(architecture.get_local_utility(PlanSnapshotUtility))
+	assert_push_error(result.get_detail())
+	architecture.dispose()
+
+
+func test_required_alias_rejects_reuse_for_different_targets() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	var binder: GFBinder = architecture.create_binder()
+	var plan: GFBindingPlan = binder.create_required_plan()
+	var _first_entry: GFBindingPlan = plan.require_singleton(
+		&"alias.first_target",
+		binder.bind_utility(PlanSnapshotUtility).with_alias(
+			PlanSnapshotAliasBase
+		)
+	)
+	var _second_entry: GFBindingPlan = plan.require_singleton(
+		&"alias.second_target",
+		binder.bind_utility(PlanSnapshotSecondUtility).with_alias(
+			PlanSnapshotAliasBase
+		)
+	)
+	var scope: GFAsyncScope = GFAsyncScope.new()
+
+	var result: GFBindingPlanResult = plan.execute(scope)
+
+	_assert_result(
+		result,
+		GFBindingPlanResult.Status.FAILED,
+		GFBindingPlanResult.BindingKind.UTILITY,
+		GFBindingPlanResult.Phase.ALIAS,
+		GFBindingPlanResult.Reason.ALIAS_REJECTED,
+		1,
+		&"alias.second_target",
+		_script_path(PlanSnapshotSecondUtility),
+		GFBindingLifetimes.Lifetime.SINGLETON,
+		2,
+		false
+	)
+	assert_true(scope.is_cancel_requested())
+	assert_true(architecture.has_initialization_failed())
+	assert_null(architecture.get_local_utility(PlanSnapshotAliasBase))
+	assert_null(architecture.get_local_utility(PlanSnapshotUtility))
+	assert_null(architecture.get_local_utility(PlanSnapshotSecondUtility))
+	assert_push_error(result.get_detail())
+	architecture.dispose()
+
+
+func test_required_alias_accepts_existing_idempotent_mapping() -> void:
+	var architecture: GFArchitecture = GFArchitecture.new()
+	architecture.register_utility_alias(
+		PlanSnapshotAliasBase,
+		PlanSnapshotUtility
+	)
+	assert_push_warning(
+		"[GFArchitecture] register_utility_alias：目标类型尚未注册，仍会记录别名。"
+	)
+	var binder: GFBinder = architecture.create_binder()
+	var plan: GFBindingPlan = binder.create_required_plan()
+	var _entry: GFBindingPlan = plan.require_singleton(
+		&"alias.idempotent",
+		binder.bind_utility(PlanSnapshotUtility).with_alias(
+			PlanSnapshotAliasBase
+		)
+	)
+	var scope: GFAsyncScope = GFAsyncScope.new()
+
+	var result: GFBindingPlanResult = plan.execute(scope)
+
+	_assert_result(
+		result,
+		GFBindingPlanResult.Status.SUCCESS,
+		GFBindingPlanResult.BindingKind.NONE,
+		GFBindingPlanResult.Phase.NONE,
+		GFBindingPlanResult.Reason.NONE,
+		-1,
+		&"",
+		"",
+		-1,
+		1,
+		true
+	)
+	assert_true(scope.is_active())
+	var utility: Object = architecture.get_local_utility(PlanSnapshotUtility)
+	assert_not_null(utility)
+	assert_same(architecture.get_local_utility(PlanSnapshotAliasBase), utility)
+	assert_true(await architecture.init())
+	architecture.dispose()
+
+
 func test_instance_creation_failure_reports_exact_first_entry() -> void:
 	var architecture: GFArchitecture = GFArchitecture.new()
 	var binder: GFBinder = architecture.create_binder()
@@ -2678,6 +2800,10 @@ class PlanSnapshotAliasBase extends GFUtility:
 
 
 class PlanSnapshotUtility extends PlanSnapshotAliasBase:
+	pass
+
+
+class PlanSnapshotSecondUtility extends PlanSnapshotAliasBase:
 	pass
 
 


### PR DESCRIPTION
## Summary

Reject conflicting required-plan aliases before they can be shadowed by a direct registration or overwrite a different required target. Preserve idempotent reuse when the existing alias already maps to the exact same target.

This is the focused follow-up for the unresolved review on merged PR #162.

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: required binding plans now return `ALIAS_REJECTED` for ineffective or conflicting aliases instead of reporting a false success.
- API or extension contract: no public API additions or removals; this tightens required-plan validation.
- Persisted data, package, protocol, or ProjectSettings impact: none.
- Failure, cancellation, rollback, concurrency, and ownership impact: conflicts fail before alias mutation; existing failed-initialization rollback behavior is preserved.
- Compatibility and migration: exact same-target alias mappings remain idempotent; invalid conflicting plans must be corrected.

## Verification

- [x] Focused tests cover the changed behavior and failure path.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only`
- [x] GDScript warning and LSP gates are clean when `.gd` files changed.
- [x] Generated API or knowledge output is fresh when its source changed.
- [x] Draft PR feedback completed through `GF draft gate` when applicable.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

Exact rebased-byte validation:

- import and GDScript warnings: PASS
- Binding Plan focused GUT: 53/53 tests, 2,518 assertions, lifecycle/orphan/exit-leak gates all zero
- strict LSP: 1,365 files, 0 diagnostics, 0 timeouts
- API/AI: 853 classes, 1 autoload, 12,615 members current; AI Kit 237 tests passed (1 skipped)
- docs/public boundaries: PASS; 451 pages
- `gf.kernel` package smoke: 277 installed files, 134 preloads, 0 issues, 0 exit leaks

## Documentation and Release

- [x] Relevant guide and `[未发布]` changelog entries are updated, or the change is not user-visible.
- [x] Development version impact is correct, or the change does not alter the intended SemVer line.
- [x] This PR does not create a tag or publish a release.
