### PR TITLE
fix(storage): harden family reset authorization

### DIFF
--- a/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_transaction_coordinator.gd
@@ -1421,6 +1421,22 @@ func _start_switch_recovery_reset(
 			transaction.stage_evidence
 		)
 		return
+	if not _profile_utility.validate_profile_family_reset_authorization_for_manager_for_framework(
+		transaction.target_profile_id,
+		transaction.reset_authorization,
+		target.permit
+	):
+		transaction.reset_authorization = null
+		_finish_domain_transaction(
+			domain,
+			transaction,
+			GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED,
+			ERR_UNAUTHORIZED,
+			"Storage family reset authorization is stale after target revalidation.",
+			_STAGE_RECOVERY_RESET,
+			transaction.stage_evidence
+		)
+		return
 	transaction.stage = _STAGE_RECOVERY_RESET
 	var operation: GFStorageAsyncOperation = (
 		_profile_utility.reset_profile_family_for_manager_for_framework(

--- a/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
+++ b/addons/gf/extensions/save/profile/gf_save_profile_utility.gd
@@ -832,6 +832,52 @@ func create_profile_family_reset_authorization_for_manager_for_framework(
 	return authorization if authorization != null and authorization.is_available() else null
 
 
+## 在 coordinator 消费 reset 授权前复核目标 Storage family 仍是原 corrupt 观察快照。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param profile_id: 受管 Profile ID。
+## [br]
+## @param authorization: 待复核且尚未消费的 family reset 授权。
+## [br]
+## @param permit: claim 时返回的 opaque capability。
+## [br]
+## @return Profile、permit 与当前 Storage family 快照都匹配时返回 true。
+func validate_profile_family_reset_authorization_for_manager_for_framework(
+	profile_id: StringName,
+	authorization: GFStorageFamilyResetAuthorization,
+	permit: RefCounted
+) -> bool:
+	var state: ProfileState = _get_state(profile_id)
+	_reap_expired_managed_permit_if_safe(state)
+	if (
+		not _admission_open
+		or _disposed
+		or _dispose_requested
+		or _unsafe_callback_depth > 0
+		or state == null
+		or _storage == null
+		or authorization == null
+		or not authorization.is_available()
+		or not _is_valid_managed_permit(state, permit)
+		or state.memory_transaction_active
+		or state.mode != STATE_IDLE
+		or _has_pending_operations(state)
+		or state.current_storage_operation != null
+		or state.manager_reset_operation != null
+		or not state.detached_write_operations.is_empty()
+		or state.pending_schedule_enqueued
+		or state.active_preparation_enqueued
+	):
+		return false
+	return _storage.validate_family_reset_authorization_for_framework(
+		state.file_name,
+		authorization
+	)
+
+
 ## 以 manager capability 对受管 Profile 的 frozen Storage family 发起 reset/recreate。
 ## [br]
 ## @api framework_internal

--- a/addons/gf/standard/utilities/storage/gf_storage_family_reset_authorization.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_family_reset_authorization.gd
@@ -2,6 +2,7 @@
 ##
 ## 授权只能由 GFStorageUtility 为当前实例、冻结 root 与 canonical logical identity 创建。
 ## reset 必须原样提交同一对象；跨 Utility、跨 root/file 或重复提交都会失败关闭。
+## 授权冻结签发时的 family 观察；较新写入或修复会在签发、claim 或 worker 复核时使其 stale。
 ## [br]
 ## @api public
 ## [br]
@@ -50,6 +51,7 @@ var _authorization_id: int = 0
 var _utility_id: int = 0
 var _logical_path: String = ""
 var _file_key: String = ""
+var _observation_token: String = ""
 var _reason: StringName = &""
 var _state: StringName = STATE_STALE
 
@@ -106,7 +108,7 @@ func get_state() -> StringName:
 ## [br]
 ## @since unreleased
 ## [br]
-## @return 已配置且尚未消费时返回 true。
+## @return 本地句柄已配置且尚未消费时返回 true；实际提交仍会复核冻结的 family 观察。
 func is_available() -> bool:
 	return _configured and _state == STATE_AVAILABLE
 
@@ -151,6 +153,8 @@ func is_stale() -> bool:
 ## [br]
 ## @param file_key: 冻结 root 与 family identity 的私有绑定键。
 ## [br]
+## @param observation_token: 触发授权的 corrupt read 所绑定的 family 观察快照。
+## [br]
 ## @param reason: 调用方确认的破坏性恢复原因。
 ## [br]
 ## @return 首次合法配置成功时返回 true。
@@ -159,6 +163,7 @@ func configure_for_framework(
 	utility_id: int,
 	logical_path: String,
 	file_key: String,
+	observation_token: String,
 	reason: StringName
 ) -> bool:
 	if (
@@ -167,6 +172,7 @@ func configure_for_framework(
 		or utility_id == 0
 		or not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(logical_path)
 		or file_key.is_empty()
+		or observation_token.is_empty()
 		or reason != REASON_CORRUPT
 	):
 		return false
@@ -175,6 +181,7 @@ func configure_for_framework(
 	_utility_id = utility_id
 	_logical_path = logical_path
 	_file_key = file_key
+	_observation_token = observation_token
 	_reason = reason
 	_state = STATE_AVAILABLE
 	return true
@@ -196,11 +203,14 @@ func configure_for_framework(
 ## [br]
 ## @param expected_file_key: 当前冻结 root 与 family 的私有绑定键。
 ## [br]
+## @param expected_observation_token: 当前 serialization boundary 内重新观察的 family 快照。
+## [br]
 ## @return 精确匹配且首次消费时返回 true。
 func claim_for_framework(
 	expected_utility_id: int,
 	expected_logical_path: String,
-	expected_file_key: String
+	expected_file_key: String,
+	expected_observation_token: String
 ) -> bool:
 	if not is_available():
 		return false
@@ -208,11 +218,64 @@ func claim_for_framework(
 		expected_utility_id != _utility_id
 		or expected_logical_path != _logical_path
 		or expected_file_key != _file_key
+		or expected_observation_token != _observation_token
 	):
 		_state = STATE_STALE
 		return false
 	_state = STATE_CLAIMED
 	return true
+
+
+## 在不消费授权的情况下复核 Utility、identity 与 family 观察快照。
+##
+## 任一绑定不匹配都会把尚可用授权标记 stale，确保高层协调器可以在 reset
+## admission 前拒绝已经被新写入修复的目标。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @since unreleased
+## [br]
+## @param expected_utility_id: 当前 GFStorageUtility 实例 ID。
+## [br]
+## @param expected_logical_path: 当前请求的 canonical logical identity。
+## [br]
+## @param expected_file_key: 当前冻结 root 与 family 的私有绑定键。
+## [br]
+## @param expected_observation_token: 当前 serialization boundary 内的 family 快照。
+## [br]
+## @return 所有绑定仍精确匹配时返回 true；不匹配会使授权 stale。
+func validate_for_framework(
+	expected_utility_id: int,
+	expected_logical_path: String,
+	expected_file_key: String,
+	expected_observation_token: String
+) -> bool:
+	if not is_available():
+		return false
+	if (
+		expected_utility_id != _utility_id
+		or expected_logical_path != _logical_path
+		or expected_file_key != _file_key
+		or expected_observation_token != _observation_token
+	):
+		_state = STATE_STALE
+		return false
+	return true
+
+
+## 获取 worker 二次复核所需的 opaque family 观察快照。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @since unreleased
+## [br]
+## @return 已配置授权冻结的 opaque family 观察快照；未配置时为空字符串。
+func get_observation_token_for_framework() -> String:
+	return _observation_token if _configured else ""
 
 
 ## 显式使尚可用授权过期。

--- a/addons/gf/standard/utilities/storage/gf_storage_read_result.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_read_result.gd
@@ -148,6 +148,7 @@ var _origin_utility_id: int = 0
 var _origin_logical_path: String = ""
 var _origin_file_key: String = ""
 var _origin_token: String = ""
+var _origin_observation_token: String = ""
 var _origin_ok: bool = false
 var _origin_error_code: Error = FAILED
 var _origin_failure_kind: FailureKind = FailureKind.NONE
@@ -267,7 +268,8 @@ func duplicate_result() -> GFStorageReadResult:
 			_origin_utility_id,
 			_origin_logical_path,
 			_origin_file_key,
-			_origin_token
+			_origin_token,
+			_origin_observation_token
 		)
 	return copy
 
@@ -365,12 +367,15 @@ static func from_dict(data: Dictionary) -> GFStorageReadResult:
 ## [br]
 ## @param origin_token: Utility 生命周期内不可序列化的来源 token。
 ## [br]
+## @param observation_token: 读取终态绑定的不可序列化 family 观察快照。
+## [br]
 ## @return 首次绑定合法来源时返回 true。
 func bind_origin_for_framework(
 	utility_id: int,
 	logical_path: String,
 	file_key: String,
-	origin_token: String
+	origin_token: String,
+	observation_token: String
 ) -> bool:
 	if (
 		_origin_bound
@@ -378,6 +383,7 @@ func bind_origin_for_framework(
 		or not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(logical_path)
 		or file_key.is_empty()
 		or origin_token.is_empty()
+		or observation_token.is_empty()
 	):
 		return false
 	_origin_bound = true
@@ -385,6 +391,7 @@ func bind_origin_for_framework(
 	_origin_logical_path = logical_path
 	_origin_file_key = file_key
 	_origin_token = origin_token
+	_origin_observation_token = observation_token
 	_origin_ok = ok
 	_origin_error_code = error_code
 	_origin_failure_kind = failure_kind
@@ -424,6 +431,39 @@ func matches_origin_for_framework(
 	)
 
 
+## 获取精确来源绑定携带的不可序列化 family 观察快照。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @since unreleased
+## [br]
+## @param utility_id: 当前 GFStorageUtility 实例 ID。
+## [br]
+## @param logical_path: 当前请求的 canonical logical identity。
+## [br]
+## @param file_key: 当前冻结 Storage root 与 family 的私有绑定键。
+## [br]
+## @param origin_token: 当前 Utility 生命周期的来源 token。
+## [br]
+## @return 来源身份仍精确匹配时返回非空 opaque token，否则返回空字符串。
+func get_origin_observation_token_for_framework(
+	utility_id: int,
+	logical_path: String,
+	file_key: String,
+	origin_token: String
+) -> String:
+	if not matches_origin_for_framework(
+		utility_id,
+		logical_path,
+		file_key,
+		origin_token
+	):
+		return ""
+	return _origin_observation_token
+
+
 # --- 私有/辅助方法 ---
 
 func _clear_origin_binding() -> void:
@@ -432,6 +472,7 @@ func _clear_origin_binding() -> void:
 	_origin_logical_path = ""
 	_origin_file_key = ""
 	_origin_token = ""
+	_origin_observation_token = ""
 	_origin_ok = false
 	_origin_error_code = FAILED
 	_origin_failure_kind = FailureKind.NONE

--- a/addons/gf/standard/utilities/storage/gf_storage_utility.gd
+++ b/addons/gf/standard/utilities/storage/gf_storage_utility.gd
@@ -115,6 +115,7 @@ const _RESET_INTENT_SUFFIX: String = ".intent.json"
 const _RESET_MAX_INTENT_BYTES: int = 16 * 1024
 const _RESET_MAX_TREE_DEPTH: int = 16
 const _RESET_MAX_TREE_ENTRIES: int = 1024
+const _RESET_MAX_REVERSE_SCAN_ENTRIES: int = 16 * 1024
 const _RESET_MAX_SHARD_ENTRIES: int = 256
 const _RESET_MAX_PENDING_INTENTS: int = 1024
 
@@ -739,7 +740,8 @@ func delete_file_request_async(
 ## 为一次显式的破坏性 family reset 创建绑定授权。
 ##
 ## 只有当前 GFStorageUtility 对同一 logical identity 返回的 CORRUPT 读取结果才可
-## 创建授权。授权冻结 Utility、Storage root 与 canonical logical identity，且只能消费一次。
+## 创建授权。授权冻结 Utility、Storage root、canonical logical identity 与当前 family 观察，
+## 且只能消费一次；签发前或后发生的较新同 family 写入/修复会使旧观察失效。
 ## [br]
 ## @api public
 ## [br]
@@ -780,8 +782,21 @@ func create_family_reset_authorization(
 		)
 	):
 		return authorization
+	var observation_token: String = (
+		observed_result.get_origin_observation_token_for_framework(
+			get_instance_id(),
+			canonical_file_name,
+			GFVariantData.get_option_string(target_family, "file_key"),
+			_read_result_origin_token
+		)
+	)
+	if observation_token.is_empty():
+		return authorization
 	target_family = _freeze_async_target_family(canonical_file_name)
-	if target_family.is_empty():
+	if (
+		target_family.is_empty()
+		or observation_token != _make_family_observation_token(canonical_file_name)
+	):
 		return authorization
 	var authorization_id: int = _next_family_reset_authorization_id
 	_next_family_reset_authorization_id += 1
@@ -792,6 +807,7 @@ func create_family_reset_authorization(
 		get_instance_id(),
 		canonical_file_name,
 		GFVariantData.get_option_string(target_family, "file_key"),
+		observation_token,
 		GFStorageFamilyResetAuthorization.REASON_CORRUPT
 	)
 	return authorization
@@ -866,7 +882,8 @@ func reset_file_family(
 	return _make_reset_result_from_worker(
 		_reset_file_family_thread(
 			GFVariantData.get_option_string(target_family, "storage_root_path"),
-			canonical_file_name
+			canonical_file_name,
+			authorization.get_observation_token_for_framework()
 		)
 	)
 
@@ -1060,10 +1077,9 @@ func load_data(file_name: String) -> GFStorageReadResult:
 	ignore_pause = true
 	var readiness_error: Error = _ensure_storage_ready()
 	if readiness_error != OK:
-		last_load_result = _make_load_failure(
-			"Storage recovery is unavailable",
-			readiness_error,
-			_classify_readiness_load_failure(readiness_error)
+		last_load_result = _make_readiness_load_failure_for_target(
+			file_name,
+			readiness_error
 		)
 		return last_load_result.duplicate_result()
 	if not _wait_for_async_tasks_for_file(file_name):
@@ -1082,10 +1098,9 @@ func load_data(file_name: String) -> GFStorageReadResult:
 		return last_load_result.duplicate_result()
 	readiness_error = _ensure_storage_ready()
 	if readiness_error != OK:
-		last_load_result = _make_load_failure(
-			"Storage recovery is unavailable",
-			readiness_error,
-			_classify_readiness_load_failure(readiness_error)
+		last_load_result = _make_readiness_load_failure_for_target(
+			file_name,
+			readiness_error
 		)
 		return last_load_result.duplicate_result()
 	var prepare_error: Error = _prepare_family_for_read_after_readiness(file_name)
@@ -1403,6 +1418,44 @@ func get_registered_migrations() -> Array[Dictionary]:
 
 
 # --- 框架内部方法 ---
+
+## 在不消费授权的情况下复核当前 family 是否仍等于签发 corrupt read 时的观察快照。
+## [br]
+## @api framework_internal
+## [br]
+## @layer standard/utilities/storage
+## [br]
+## @since unreleased
+## [br]
+## @param file_name: 必须与 authorization 绑定一致的 canonical logical identity。
+## [br]
+## @param authorization: 待复核的一次性 reset 授权。
+## [br]
+## @return 快照、Utility 与 logical identity 都仍精确匹配时返回 true。
+func validate_family_reset_authorization_for_framework(
+	file_name: String,
+	authorization: GFStorageFamilyResetAuthorization
+) -> bool:
+	if (
+		not _io_admission_open
+		or authorization == null
+		or not authorization.is_available()
+		or not _validate_public_file_name(
+			file_name,
+			"validate_family_reset_authorization_for_framework"
+		)
+	):
+		return false
+	var canonical_file_name: String = _canonicalize_storage_file_name(file_name)
+	var target_family: Dictionary = _freeze_async_target_family(canonical_file_name)
+	if target_family.is_empty():
+		return false
+	return authorization.validate_for_framework(
+		get_instance_id(),
+		canonical_file_name,
+		GFVariantData.get_option_string(target_family, "file_key"),
+		_make_family_observation_token(canonical_file_name)
+	)
 
 ## 在首个异步请求前替换异步生命周期使用的单调时钟。
 ## [br]
@@ -2094,19 +2147,20 @@ func _enqueue_async_load(
 	ignore_pause = true
 	var readiness_error: Error = _ensure_storage_ready()
 	if readiness_error != OK:
-		var readiness_result: GFStorageReadResult = _make_load_failure(
-			"Storage readiness failed: %s" % error_string(readiness_error),
-			readiness_error,
-			_classify_readiness_load_failure(readiness_error)
+		var readiness_result: GFStorageReadResult = (
+			_make_readiness_load_failure_for_target(
+				canonical_file_name,
+				readiness_error
+			)
 		)
 		last_load_result = readiness_result.duplicate_result()
 		_complete_async_operation(
 			operation,
-			readiness_error,
+			readiness_result.error_code,
 			readiness_result
 		)
 		load_completed.emit(file_name, readiness_result.duplicate_result())
-		return readiness_error
+		return readiness_result.error_code
 	var target_family: Dictionary = _make_async_target_family(canonical_file_name)
 	_queue_async_task({
 		"type": &"load",
@@ -2378,6 +2432,7 @@ func _enqueue_async_reset(
 		"transaction_commit_path": GFVariantData.get_option_string(target_family, "transaction_commit_path"),
 		"transaction_commit_pending_path": GFVariantData.get_option_string(target_family, "transaction_commit_pending_path"),
 		"resource_stage_path": GFVariantData.get_option_string(target_family, "resource_stage_path"),
+		"reset_observation_token": authorization.get_observation_token_for_framework(),
 		"operation": operation,
 	})
 	_request_async_start_only()
@@ -2790,7 +2845,10 @@ func _discover_pending_reset_logical_names(families_root: String) -> Dictionary:
 	}
 
 
-func _list_reset_recovery_shards(path: String) -> Dictionary:
+func _list_reset_recovery_shards(
+	path: String,
+	entry_budget: Array[int] = []
+) -> Dictionary:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return {"error": int(ERR_FILE_CANT_OPEN), "entries": []}
@@ -2801,6 +2859,12 @@ func _list_reset_recovery_shards(path: String) -> Dictionary:
 	var entry: String = directory.get_next()
 	while not entry.is_empty():
 		if entries.size() >= _RESET_MAX_SHARD_ENTRIES:
+			directory.list_dir_end()
+			return {"error": int(ERR_OUT_OF_MEMORY), "entries": []}
+		if (
+			not entry_budget.is_empty()
+			and not _consume_reset_scan_budget(entry_budget)
+		):
 			directory.list_dir_end()
 			return {"error": int(ERR_OUT_OF_MEMORY), "entries": []}
 		entries.append({
@@ -2875,6 +2939,10 @@ func _discover_reset_intents_in_family_parent(
 			!= family_parent
 			or not _reset_intent_matches_descriptor(intent, descriptor, reset_id)
 		):
+			if _is_reset_intent_pending_leaf_shape(entry):
+				malformed_pending_paths.append(intent_path)
+				entry = directory.get_next()
+				continue
 			directory.list_dir_end()
 			return ERR_FILE_CORRUPT
 		logical_names[logical_name] = true
@@ -2967,6 +3035,50 @@ func _classify_readiness_load_failure(
 			return GFStorageReadResult.FailureKind.UNAVAILABLE
 		_:
 			return GFStorageReadResult.FailureKind.IO_FAILED
+
+
+func _make_readiness_load_failure_for_target(
+	canonical_file_name: String,
+	readiness_error: Error
+) -> GFStorageReadResult:
+	var target_preparation: Dictionary = _prepare_family_for_read_after_readiness_result(
+		canonical_file_name
+	)
+	var target_error: Error = GFVariantData.get_option_int(
+		target_preparation,
+		"error",
+		ERR_BUG
+	) as Error
+	var target_descriptor: Dictionary = (
+		GFStorageFamilyStore.make_family_descriptor_for_framework(
+			_get_save_base_path(),
+			canonical_file_name
+		)
+	)
+	if (
+		target_error == ERR_FILE_CORRUPT
+		and GFVariantData.get_option_bool(
+			target_preparation,
+			"target_provenance"
+		)
+		and not target_descriptor.is_empty()
+		and _validate_reset_mutation_ancestry(
+			_get_save_base_path(),
+			target_descriptor
+		) == OK
+	):
+		var target_result: GFStorageReadResult = _make_load_failure(
+			"Storage family unavailable",
+			ERR_FILE_CORRUPT,
+			GFStorageReadResult.FailureKind.CORRUPT
+		)
+		_bind_read_result_origin(target_result, canonical_file_name)
+		return target_result
+	return _make_load_failure(
+		"Storage recovery is unavailable",
+		readiness_error,
+		_classify_readiness_load_failure(readiness_error)
+	)
 
 
 func _classify_readiness_write_failure(
@@ -3366,7 +3478,8 @@ func _start_async_task(task: Dictionary) -> void:
 	elif task_type == &"reset":
 		callback = Callable(self, "_reset_file_family_thread").bind(
 			_get_task_storage_root_path(task),
-			storage_file_name
+			storage_file_name,
+			GFVariantData.get_option_string(task, "reset_observation_token")
 		)
 	if not callback.is_valid():
 		_settle_async_task_start_failure(
@@ -3738,19 +3851,31 @@ func _recover_frozen_async_transaction(task: Dictionary) -> Dictionary:
 	var layout_error: Error = frozen_family_store.ensure_layout_for_framework()
 	if layout_error != OK:
 		return {"error": int(layout_error), "target_provenance": false}
-	var reset_recovery_error: Error = _resume_pending_reset_for_file(
+	var reset_recovery_result: Dictionary = _resume_pending_reset_for_file_result(
 		storage_root_path,
 		storage_file_name
 	)
+	var reset_recovery_error: Error = GFVariantData.get_option_int(
+		reset_recovery_result,
+		"error",
+		ERR_BUG
+	) as Error
+	var target_provenance: bool = GFVariantData.get_option_bool(
+		reset_recovery_result,
+		"target_provenance"
+	)
 	if reset_recovery_error != OK:
-		return {"error": int(reset_recovery_error), "target_provenance": true}
+		return reset_recovery_result
 	var family_error: Error
 	if _get_task_type(task) == &"save":
 		family_error = frozen_family_store.claim_family_for_framework(expected)
 	else:
 		family_error = frozen_family_store.validate_family_for_framework(expected)
 	if family_error != OK:
-		return {"error": int(family_error), "target_provenance": true}
+		return {
+			"error": int(family_error),
+			"target_provenance": target_provenance,
+		}
 	var frozen_transaction_manager: _StorageTransactionManager = _StorageTransactionManager.new(
 		self,
 		_FrozenStoragePathPolicy.new(storage_root_path),
@@ -3766,7 +3891,10 @@ func _recover_frozen_async_transaction(task: Dictionary) -> Dictionary:
 		_get_task_transaction_commit_path(task)
 	)
 	frozen_transaction_manager._dispose()
-	return {"error": int(recovery_error), "target_provenance": true}
+	return {
+		"error": int(recovery_error),
+		"target_provenance": target_provenance,
+	}
 
 
 func _emit_async_start_failed(
@@ -4178,7 +4306,8 @@ func _claim_family_reset_authorization(
 		and authorization.claim_for_framework(
 			get_instance_id(),
 			canonical_file_name,
-			GFVariantData.get_option_string(target_family, "file_key")
+			GFVariantData.get_option_string(target_family, "file_key"),
+			_make_family_observation_token(canonical_file_name)
 		)
 	)
 
@@ -4187,18 +4316,74 @@ func _bind_read_result_origin(
 	result: GFStorageReadResult,
 	canonical_file_name: String
 ) -> void:
-	if result == null or canonical_file_name.is_empty():
+	if (
+		result == null
+		or result.ok
+		or result.error_code == OK
+		or result.failure_kind != GFStorageReadResult.FailureKind.CORRUPT
+		or canonical_file_name.is_empty()
+	):
 		return
 	var target_family: Dictionary = _make_async_target_family(canonical_file_name)
 	var file_key: String = GFVariantData.get_option_string(target_family, "file_key")
-	if file_key.is_empty():
+	var observation_token: String = _make_family_observation_token(
+		canonical_file_name
+	)
+	if file_key.is_empty() or observation_token.is_empty():
 		return
 	var _bound: bool = result.bind_origin_for_framework(
 		get_instance_id(),
 		canonical_file_name,
 		file_key,
-		_read_result_origin_token
+		_read_result_origin_token,
+		observation_token
 	)
+
+
+func _make_family_observation_token(
+	canonical_file_name: String,
+	storage_root_path: String = ""
+) -> String:
+	var resolved_storage_root_path: String = (
+		_get_save_base_path()
+		if storage_root_path.is_empty()
+		else storage_root_path
+	)
+	var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
+		resolved_storage_root_path,
+		canonical_file_name
+	)
+	if descriptor.is_empty():
+		return ""
+	var records: Array[String] = []
+	for path_key: String in [
+		"catalog_path",
+		"family_path",
+		"owner_path",
+		"payload_path",
+		"candidate_path",
+		"backup_path",
+		"transaction_path",
+		"transaction_pending_path",
+		"transaction_commit_path",
+		"transaction_commit_pending_path",
+		"resource_stage_path",
+	]:
+		var path: String = GFVariantData.get_option_string(descriptor, path_key)
+		if path.is_empty():
+			return ""
+		if _absolute_storage_path_is_link(path):
+			records.append(path_key + ":link")
+		elif FileAccess.file_exists(path):
+			var digest: String = FileAccess.get_sha256(path)
+			if digest.is_empty():
+				return ""
+			records.append(path_key + ":file:" + digest)
+		elif DirAccess.dir_exists_absolute(path):
+			records.append(path_key + ":directory")
+		else:
+			records.append(path_key + ":missing")
+	return JSON.stringify(records).sha256_text()
 
 
 func _complete_async_load(
@@ -4716,38 +4901,50 @@ func _resume_pending_reset_for_file(
 	storage_root_path: String,
 	logical_name: String
 ) -> Error:
+	var result: Dictionary = _resume_pending_reset_for_file_result(
+		storage_root_path,
+		logical_name
+	)
+	return GFVariantData.get_option_int(result, "error", ERR_BUG) as Error
+
+
+func _resume_pending_reset_for_file_result(
+	storage_root_path: String,
+	logical_name: String
+) -> Dictionary:
 	var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
 		storage_root_path,
 		logical_name
 	)
 	if descriptor.is_empty():
-		return ERR_INVALID_PARAMETER
+		return {"error": int(ERR_INVALID_PARAMETER), "target_provenance": false}
 	var family_store: GFStorageFamilyStore = _GF_STORAGE_FAMILY_STORE_SCRIPT.new()
 	if not family_store.configure_for_framework(storage_root_path):
-		return ERR_INVALID_PARAMETER
+		return {"error": int(ERR_INVALID_PARAMETER), "target_provenance": false}
 	var ancestry_error: Error = _validate_reset_mutation_ancestry(
 		storage_root_path,
 		descriptor
 	)
 	if ancestry_error != OK:
-		return ancestry_error
+		return {"error": int(ancestry_error), "target_provenance": false}
 	var layout_inspection: Dictionary = family_store.inspect_layout_for_reset_for_framework()
 	var layout_status: StringName = GFVariantData.get_option_string_name(
 		layout_inspection,
 		"status"
 	)
 	if layout_status == &"missing":
-		return OK
+		return {"error": int(OK), "target_provenance": false}
 	if layout_status == &"future":
-		return ERR_UNAVAILABLE
+		return {"error": int(ERR_UNAVAILABLE), "target_provenance": false}
 	if layout_status == &"corrupt":
-		return ERR_FILE_CORRUPT
+		return {"error": int(ERR_FILE_CORRUPT), "target_provenance": false}
 	if layout_status != &"current":
-		return GFVariantData.get_option_int(
+		var layout_error: Error = GFVariantData.get_option_int(
 			layout_inspection,
 			"error",
 			ERR_FILE_CANT_READ
 		) as Error
+		return {"error": int(layout_error), "target_provenance": false}
 	var intent_lookup: Dictionary = _find_reset_intent(descriptor)
 	var lookup_error: Error = GFVariantData.get_option_int(
 		intent_lookup,
@@ -4755,19 +4952,32 @@ func _resume_pending_reset_for_file(
 		ERR_FILE_CORRUPT
 	) as Error
 	if lookup_error != OK:
-		return lookup_error
+		return {"error": int(lookup_error), "target_provenance": true}
 	if not GFVariantData.get_option_bool(intent_lookup, "exists"):
-		return OK
+		return {"error": int(OK), "target_provenance": true}
 	var worker_result: Dictionary = _reset_file_family_thread(
 		storage_root_path,
 		logical_name
 	)
-	return _make_reset_result_from_worker(worker_result).get_error_code()
+	var worker_reset_result: GFStorageFamilyResetResult = (
+		_make_reset_result_from_worker(worker_result)
+	)
+	return {
+		"error": int(worker_reset_result.get_error_code()),
+		"target_provenance": (
+			worker_reset_result.get_error_code() == OK
+			or (
+				worker_reset_result.get_failed_member()
+				!= GFStorageFamilyResetResult.FamilyMember.LAYOUT
+			)
+		),
+	}
 
 
 func _reset_file_family_thread(
 	storage_root_path: String,
-	logical_name: String
+	logical_name: String,
+	expected_observation_token: String = ""
 ) -> Dictionary:
 	var descriptor: Dictionary = GFStorageFamilyStore.make_family_descriptor_for_framework(
 		storage_root_path,
@@ -4777,6 +4987,21 @@ func _reset_file_family_thread(
 		return _make_reset_worker_result(
 			ERR_INVALID_PARAMETER,
 			GFStorageFamilyResetResult.FailureKind.INVALID_REQUEST,
+			GFStorageFamilyResetResult.SourceKind.UNKNOWN,
+			GFStorageFamilyResetResult.Phase.PREFLIGHT,
+			0,
+			0,
+			0,
+			GFStorageFamilyResetResult.FamilyMember.NONE
+		)
+	if (
+		not expected_observation_token.is_empty()
+		and _make_family_observation_token(logical_name, storage_root_path)
+		!= expected_observation_token
+	):
+		return _make_reset_worker_result(
+			ERR_UNAUTHORIZED,
+			GFStorageFamilyResetResult.FailureKind.UNAUTHORIZED,
 			GFStorageFamilyResetResult.SourceKind.UNKNOWN,
 			GFStorageFamilyResetResult.Phase.PREFLIGHT,
 			0,
@@ -4942,6 +5167,24 @@ func _reset_file_family_thread(
 			logical_name,
 			descriptor
 		)
+		if (
+			GFVariantData.get_option_int(
+				multi_member_evidence,
+				"error",
+				ERR_FILE_CORRUPT
+			) == OK
+			and not GFVariantData.get_option_bool(
+				multi_member_evidence,
+				"is_valid_multi"
+			)
+		):
+			multi_member_evidence = (
+				_inspect_reverse_multi_member_reset_evidence(
+					storage_root_path,
+					logical_name,
+					descriptor
+				)
+			)
 		var multi_member_error: Error = GFVariantData.get_option_int(
 			multi_member_evidence,
 			"error",
@@ -5779,9 +6022,284 @@ func _inspect_multi_member_reset_evidence(
 	return {"error": int(OK), "is_valid_multi": false}
 
 
+func _get_reset_reverse_scan_entry_limit() -> int:
+	return _RESET_MAX_REVERSE_SCAN_ENTRIES
+
+
+func _inspect_reverse_multi_member_reset_evidence(
+	storage_root_path: String,
+	logical_name: String,
+	target_descriptor: Dictionary
+) -> Dictionary:
+	var families_root: String = storage_root_path.path_join(
+		".gf-storage/v1/families"
+	)
+	if not DirAccess.dir_exists_absolute(families_root):
+		return {"error": int(OK), "is_valid_multi": false}
+	var target_family_path: String = GFVariantData.get_option_string(
+		target_descriptor,
+		"family_path"
+	)
+	var entry_budget: Array[int] = [maxi(0, _get_reset_reverse_scan_entry_limit())]
+	var first_level: Dictionary = _list_reset_recovery_shards(
+		families_root,
+		entry_budget
+	)
+	var first_error: Error = GFVariantData.get_option_int(
+		first_level,
+		"error",
+		ERR_FILE_CANT_READ
+	) as Error
+	if first_error != OK:
+		return {"error": int(first_error), "is_valid_multi": false}
+	var first_entries: Array = GFVariantData.get_option_array(
+		first_level,
+		"entries"
+	)
+	var family_entry_count: int = 0
+	for first_entry_value: Variant in first_entries:
+		if not first_entry_value is Dictionary:
+			return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+		var first_entry: Dictionary = first_entry_value
+		var first_name: String = GFVariantData.get_option_string(first_entry, "name")
+		if (
+			not _is_reset_shard_name(first_name)
+			or not GFVariantData.get_option_bool(first_entry, "is_directory")
+			or GFVariantData.get_option_bool(first_entry, "is_link")
+		):
+			return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+		var second_root: String = families_root.path_join(first_name)
+		var second_level: Dictionary = _list_reset_recovery_shards(
+			second_root,
+			entry_budget
+		)
+		var second_error: Error = GFVariantData.get_option_int(
+			second_level,
+			"error",
+			ERR_FILE_CANT_READ
+		) as Error
+		if second_error != OK:
+			return {"error": int(second_error), "is_valid_multi": false}
+		var second_entries: Array = GFVariantData.get_option_array(
+			second_level,
+			"entries"
+		)
+		for second_entry_value: Variant in second_entries:
+			if not second_entry_value is Dictionary:
+				return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+			var second_entry: Dictionary = second_entry_value
+			var second_name: String = GFVariantData.get_option_string(
+				second_entry,
+				"name"
+			)
+			if (
+				not _is_reset_shard_name(second_name)
+				or not GFVariantData.get_option_bool(second_entry, "is_directory")
+				or GFVariantData.get_option_bool(second_entry, "is_link")
+			):
+				return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+			var family_parent: String = second_root.path_join(second_name)
+			var family_directory: DirAccess = DirAccess.open(family_parent)
+			if family_directory == null:
+				return {"error": int(ERR_FILE_CANT_OPEN), "is_valid_multi": false}
+			var begin_error: Error = family_directory.list_dir_begin()
+			if begin_error != OK:
+				return {"error": int(begin_error), "is_valid_multi": false}
+			var family_leaf: String = family_directory.get_next()
+			while not family_leaf.is_empty():
+				family_entry_count += 1
+				if family_entry_count > _RESET_MAX_TREE_ENTRIES:
+					family_directory.list_dir_end()
+					return {
+						"error": int(ERR_OUT_OF_MEMORY),
+						"is_valid_multi": false,
+					}
+				if not _consume_reset_scan_budget(entry_budget):
+					family_directory.list_dir_end()
+					return {
+						"error": int(ERR_OUT_OF_MEMORY),
+						"is_valid_multi": false,
+					}
+				var family_path: String = family_parent.path_join(family_leaf)
+				var is_family_identity: bool = GFUuid.is_valid(family_leaf, 8)
+				var compact_family_id: String = family_leaf.replace("-", "")
+				var is_surviving_family: bool = (
+					is_family_identity
+					and family_path != target_family_path
+				)
+				if is_surviving_family and (
+					compact_family_id.substr(0, 2) != first_name
+					or compact_family_id.substr(2, 2) != second_name
+				):
+					family_directory.list_dir_end()
+					return {
+						"error": int(ERR_FILE_CORRUPT),
+						"is_valid_multi": false,
+					}
+				if is_surviving_family and (
+					not family_directory.current_is_dir()
+					or family_directory.is_link(family_leaf)
+				):
+					family_directory.list_dir_end()
+					return {
+						"error": int(ERR_FILE_CORRUPT),
+						"is_valid_multi": false,
+					}
+				if is_surviving_family:
+					var surviving_evidence: Dictionary = (
+						_inspect_surviving_family_for_reset_target(
+							family_path,
+							family_leaf,
+							logical_name,
+							entry_budget
+						)
+					)
+					var surviving_error: Error = GFVariantData.get_option_int(
+						surviving_evidence,
+						"error",
+						ERR_FILE_CORRUPT
+					) as Error
+					if surviving_error != OK:
+						family_directory.list_dir_end()
+						return {
+							"error": int(surviving_error),
+							"is_valid_multi": false,
+						}
+					if GFVariantData.get_option_bool(
+						surviving_evidence,
+						"is_valid_multi"
+					):
+						family_directory.list_dir_end()
+						return {"error": int(OK), "is_valid_multi": true}
+				family_leaf = family_directory.get_next()
+			family_directory.list_dir_end()
+	return {"error": int(OK), "is_valid_multi": false}
+
+
+func _inspect_surviving_family_for_reset_target(
+	family_path: String,
+	owner_family_id: String,
+	target_logical_name: String,
+	entry_budget: Array[int]
+) -> Dictionary:
+	if entry_budget.is_empty():
+		return {"error": int(ERR_INVALID_PARAMETER), "is_valid_multi": false}
+	if (
+		_absolute_storage_path_is_link(family_path)
+		or not DirAccess.dir_exists_absolute(family_path)
+	):
+		return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+	var committed_by_leaf: Dictionary = {
+		"transaction.prepare.pending.json": false,
+		"transaction.prepare.json": false,
+		"transaction.commit.pending.json": true,
+		"transaction.commit.json": true,
+	}
+	var directory: DirAccess = DirAccess.open(family_path)
+	if directory == null:
+		return {"error": int(ERR_FILE_CANT_OPEN), "is_valid_multi": false}
+	var begin_error: Error = directory.list_dir_begin()
+	if begin_error != OK:
+		return {"error": int(begin_error), "is_valid_multi": false}
+	var marker_entries: Array[Dictionary] = []
+	var family_entry: String = directory.get_next()
+	while not family_entry.is_empty():
+		if not _consume_reset_scan_budget(entry_budget):
+			directory.list_dir_end()
+			return {"error": int(ERR_OUT_OF_MEMORY), "is_valid_multi": false}
+		if committed_by_leaf.has(family_entry):
+			if directory.current_is_dir() or directory.is_link(family_entry):
+				directory.list_dir_end()
+				return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+			marker_entries.append({
+				"leaf": family_entry,
+				"committed": GFVariantData.get_option_bool(
+					committed_by_leaf,
+					family_entry
+				),
+			})
+		family_entry = directory.get_next()
+	directory.list_dir_end()
+	marker_entries.sort_custom(func(left: Dictionary, right: Dictionary) -> bool:
+		return GFVariantData.get_option_string(left, "leaf") < GFVariantData.get_option_string(
+			right,
+			"leaf"
+		)
+	)
+	for marker_entry: Dictionary in marker_entries:
+		var marker_path: String = family_path.path_join(
+			GFVariantData.get_option_string(marker_entry, "leaf")
+		)
+		if _absolute_storage_path_is_link(marker_path):
+			return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+		var marker_read: Dictionary = _read_transaction_record_result_absolute(
+			marker_path
+		)
+		var marker_error: Error = GFVariantData.get_option_int(
+			marker_read,
+			"error",
+			ERR_FILE_CORRUPT
+		) as Error
+		if marker_error != OK:
+			return {"error": int(marker_error), "is_valid_multi": false}
+		var marker: Dictionary = GFVariantData.get_option_dictionary(
+			marker_read,
+			"record"
+		)
+		var owner: Dictionary = GFVariantData.get_option_dictionary(marker, "owner")
+		var owner_logical_path: String = GFVariantData.get_option_string(
+			owner,
+			"logical_path"
+		)
+		var expected_committed: bool = GFVariantData.get_option_bool(
+			marker_entry,
+			"committed"
+		)
+		var committed_value: Variant = marker.get("committed")
+		var valid_single: bool = (
+			committed_value is bool
+			and committed_value == expected_committed
+			and _is_valid_single_file_transaction_marker(
+				marker,
+				owner_logical_path
+			)
+		)
+		var valid_multi: bool = _is_valid_multi_member_transaction_marker(
+			marker,
+			expected_committed
+		)
+		if (
+			GFVariantData.get_option_string(owner, "family_id") != owner_family_id
+			or (not valid_single and not valid_multi)
+		):
+			return {"error": int(ERR_FILE_CORRUPT), "is_valid_multi": false}
+		if valid_multi and _is_valid_multi_member_reset_marker(
+			marker,
+			target_logical_name,
+			expected_committed
+		):
+			return {"error": int(OK), "is_valid_multi": true}
+	return {"error": int(OK), "is_valid_multi": false}
+
+
 static func _is_valid_multi_member_reset_marker(
 	marker: Dictionary,
 	logical_name: String,
+	expected_committed: bool
+) -> bool:
+	if not _is_valid_multi_member_transaction_marker(marker, expected_committed):
+		return false
+	for member_value: Variant in GFVariantData.get_option_array(marker, "members"):
+		if not member_value is Dictionary:
+			return false
+		var member: Dictionary = member_value
+		if GFVariantData.get_option_string(member, "logical_path") == logical_name:
+			return true
+	return false
+
+
+static func _is_valid_multi_member_transaction_marker(
+	marker: Dictionary,
 	expected_committed: bool
 ) -> bool:
 	if marker.size() != 6:
@@ -5806,7 +6324,7 @@ static func _is_valid_multi_member_reset_marker(
 	if members.size() <= 1 or members.size() > _MAX_TRANSACTION_FILES:
 		return false
 	var seen: Dictionary = {}
-	var contains_target: bool = false
+	var previous_member_path: String = ""
 	for member_value: Variant in members:
 		if not member_value is Dictionary:
 			return false
@@ -5816,13 +6334,14 @@ static func _is_valid_multi_member_reset_marker(
 			member.size() != 3
 			or not GFStorageFamilyStore.is_valid_logical_file_path_for_framework(member_path)
 			or seen.has(member_path)
+			or (not previous_member_path.is_empty() and member_path <= previous_member_path)
 			or GFVariantData.get_option_string(member, "family_id")
 			!= GFStorageFamilyStore.make_family_id_for_framework(member_path)
 			or not member.get("had_final") is bool
 		):
 			return false
 		seen[member_path] = true
-		contains_target = contains_target or member_path == logical_name
+		previous_member_path = member_path
 	var owner: Dictionary = GFVariantData.get_option_dictionary(marker, "owner")
 	var owner_path: String = GFVariantData.get_option_string(owner, "logical_path")
 	return (
@@ -5830,8 +6349,17 @@ static func _is_valid_multi_member_reset_marker(
 		and seen.has(owner_path)
 		and GFVariantData.get_option_string(owner, "family_id")
 		== GFStorageFamilyStore.make_family_id_for_framework(owner_path)
-		and contains_target
 	)
+
+
+static func _consume_reset_scan_budget(
+	entry_budget: Array[int],
+	amount: int = 1
+) -> bool:
+	if entry_budget.is_empty() or amount < 0 or entry_budget[0] < amount:
+		return false
+	entry_budget[0] -= amount
+	return true
 
 
 func _remove_reset_tree(path: String, depth: int, entry_budget: Array[int]) -> Error:
@@ -7105,24 +7633,48 @@ func _prepare_family_for_read(file_name: String) -> Error:
 
 
 func _prepare_family_for_read_after_readiness(file_name: String) -> Error:
-	var reset_recovery_error: Error = _resume_pending_reset_for_file(
+	var result: Dictionary = _prepare_family_for_read_after_readiness_result(file_name)
+	return GFVariantData.get_option_int(result, "error", ERR_BUG) as Error
+
+
+func _prepare_family_for_read_after_readiness_result(file_name: String) -> Dictionary:
+	var reset_recovery_result: Dictionary = _resume_pending_reset_for_file_result(
 		_get_save_base_path(),
 		file_name
 	)
+	var reset_recovery_error: Error = GFVariantData.get_option_int(
+		reset_recovery_result,
+		"error",
+		ERR_BUG
+	) as Error
+	var target_provenance: bool = GFVariantData.get_option_bool(
+		reset_recovery_result,
+		"target_provenance"
+	)
 	if reset_recovery_error != OK:
-		return reset_recovery_error
+		return reset_recovery_result
 	var descriptor: Dictionary = _make_family_descriptor(file_name)
 	if descriptor.is_empty():
-		return ERR_INVALID_PARAMETER
+		return {"error": int(ERR_INVALID_PARAMETER), "target_provenance": false}
 	var validate_error: Error = _family_store.validate_family_for_framework(descriptor)
 	if validate_error != OK:
-		return validate_error
+		return {
+			"error": int(validate_error),
+			"target_provenance": target_provenance,
+		}
 	var recovery_error: Error = _recover_transaction_files([file_name])
 	if recovery_error != OK:
-		return recovery_error
-	return OK if FileAccess.file_exists(
+		return {
+			"error": int(recovery_error),
+			"target_provenance": target_provenance,
+		}
+	var payload_exists: bool = FileAccess.file_exists(
 		GFVariantData.get_option_string(descriptor, "payload_path")
-	) else ERR_FILE_NOT_FOUND
+	)
+	return {
+		"error": int(OK if payload_exists else ERR_FILE_NOT_FOUND),
+		"target_provenance": target_provenance,
+	}
 
 
 func _resolve_internal_storage_path(file_name: String) -> String:

--- a/docs/api_catalog/classes/GFStorageFamilyResetAuthorization.xml
+++ b/docs/api_catalog/classes/GFStorageFamilyResetAuthorization.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageFamilyResetAuthorization" path="addons/gf/standard/utilities/storage/gf_storage_family_reset_authorization.gd" module="standard" extends="RefCounted" classDigest="cb39a5b52efc7cee1cee7ba1fa3b84034d7c1a7b85fefcf39a8f0def101a2117">
+<class name="GFStorageFamilyResetAuthorization" path="addons/gf/standard/utilities/storage/gf_storage_family_reset_authorization.gd" module="standard" extends="RefCounted" classDigest="8a197c2cafa08637d37a325b9a3c434558e8e9109c62c369262a5d26584cee64">
 	<description>GFStorageFamilyResetAuthorization: 单个 Storage logical family 的一次性破坏性恢复授权。
 授权只能由 GFStorageUtility 为当前实例、冻结 root 与 canonical logical identity 创建。
-reset 必须原样提交同一对象；跨 Utility、跨 root/file 或重复提交都会失败关闭。</description>
+reset 必须原样提交同一对象；跨 Utility、跨 root/file 或重复提交都会失败关闭。
+授权冻结签发时的 family 观察；较新写入或修复会在签发、claim 或 worker 复核时使其 stale。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_handle</tag>
@@ -87,7 +88,7 @@ reset 必须原样提交同一对象；跨 Utility、跨 root/file 或重复提�
 			<description>检查授权是否仍可提交一次。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">已配置且尚未消费时返回 true。</tag>
+				<tag name="return">本地句柄已配置且尚未消费时返回 true；实际提交仍会复核冻结的 family 观察。</tag>
 				<tag name="since">unreleased</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/classes/GFStorageUtility.xml
+++ b/docs/api_catalog/classes/GFStorageUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="5e1d516e6867a60c783d0f41b20abc2363b108b0e438e5f26c66e904775f16ee">
+<class name="GFStorageUtility" path="addons/gf/standard/utilities/storage/gf_storage_utility.gd" module="standard" extends="GFUtility" classDigest="b123840ce41983139f7709b47136f6ce41662494f5a8dbe78962d57b3006c49d">
 	<description>GFStorageUtility: 基于 `user://` 的轻量存档系统。
 支持槽位存档、元数据分离读取、`Resource` 存取，
 以及可配置 codec、完整性校验、版本迁移和简单混淆，适合通用本地持久化场景。
@@ -362,7 +362,8 @@ cooperative 模式固定每个 lifecycle tick 最多执行一个任务。</descr
 			<signature>func create_family_reset_authorization( file_name: String, observed_result: GFStorageReadResult ) -&gt; GFStorageFamilyResetAuthorization:</signature>
 			<description>为一次显式的破坏性 family reset 创建绑定授权。
 只有当前 GFStorageUtility 对同一 logical identity 返回的 CORRUPT 读取结果才可
-创建授权。授权冻结 Utility、Storage root 与 canonical logical identity，且只能消费一次。</description>
+创建授权。授权冻结 Utility、Storage root、canonical logical identity 与当前 family 观察，
+且只能消费一次；签发前或后发生的较新同 family 写入/修复会使旧观察失效。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">file_name: portable logical file identity。</tag>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="7d6c18addf74e3075b9ad3dd19a3e1ac712077c9047bbbbd4cd20da8bf43860a" classCount="853" methodCount="7763" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="af0dd6ef687917c88cdc72b38043e80a292797e45c817a1e5203ecb58d2c9158" classCount="853" methodCount="7763" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="77" methodCount="818" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -201,7 +201,7 @@
 
 - 修复类型化场景请求的四个终端边界：非主线程配置失败不再返回无法终结的半配置 Operation 或派发 Broker Lease；preload 在调用 Broker poll 前进入 settlement fence，终态回调中的同路径重入以 busy 失败关闭，不再递归轮询旧 aggregate；同步自定义切场的显式确认与同步 `scene_changed` 只记录 current-generation 回执，并在 override 返回 true 及 owner/token 复核后结算；同路径异步 override 用 `_defer_target_scene_commit()` 区分合法等待与 same-root no-op，不同路径 legacy async observer 保持兼容；基础 pathless commit 预实例化并只接受精确 root，自定义 pathless commit 则必须显式确认精确回执，不再把任意新空路径或同路径旧 root 误认成冻结目标。
 - 修复 required Binding Plan 把与直接注册键冲突的 alias、或同一 alias 指向不同 target 的覆盖写入误报为成功的问题；required 路径现在拒绝会被直接键遮蔽或改写既有目标的 alias，同时保留指向同一 target 的幂等映射。
-- 修复 Settings 把损坏数据恢复为默认值后仍无法覆盖 structural-corrupt Storage family，以及 catalog、owner 或事务 identity 损坏只能永久失败、无法由明确授权重建的问题。reset 现在在任何退休副作用前冻结证据并发布可恢复 intent，崩溃后优先于普通同 family I/O 幂等收敛；未知/future layout、多重有效 identity、来源不匹配、私有 ancestry link/wrong-type 与扫描预算耗尽都会零写失败关闭，未发布的截断 pending staging 可有界清理，已发布的损坏记录仍保留为冲突证据。
+- 修复 Settings 把损坏数据恢复为默认值后仍无法覆盖 structural-corrupt Storage family，以及 catalog、owner 或事务 identity 损坏只能永久失败、无法由明确授权重建的问题。reset 现在在任何退休副作用前冻结证据与 family 观察快照并发布可恢复 intent，崩溃后优先于普通同 family I/O 幂等收敛；冷启动目标损坏仍保留可授权来源，无关的全局 layout/恢复失败保持 unbound，授权后的较新写入会使旧决定失效，其他 family 的存活事务反向记录会阻止单 family 退休。未知/future layout、多重有效 identity、来源不匹配、私有 ancestry link/wrong-type 与扫描预算耗尽都会零写失败关闭；未发布且内容/文件名身份不匹配的 pending staging 可有界清理，已发布的损坏或不匹配记录仍保留为冲突证据。
 - 修复 `GFStorageUtility` 异步保存、读取和删除在单线程 Web 导出中仍尝试 `Thread.start()`，导致请求启动失败并使依赖真实 Storage 的 Save Profile 无法完成 activation 的问题；默认 `AUTOMATIC` 现在在 `nothreads` 运行时选择 cooperative executor。请求调用栈只入队，正常调度由 `tick N` 接纳、`tick N+1` 执行此前已接纳任务，每个 tick 最多完成一个完整任务，同时保留请求身份、同 family FIFO、取消/deadline、物理终态、事务恢复和 quiesce 语义。
 
 - 修复 AI Developer 只能把生成报告、审计、截图或导出物声明为必须存在的精确文件或普通来源模块、导致尚未生成的输出根使依赖快照不完整的问题；`architecture.modules[].ownership: generated` 现在表示有界、只作为依赖目标的所有权：根可缺失且不参与来源扫描，源码路径引用以 `generated_output` 形成有界依赖证据，既有规范路径、框架保留根、所有权重叠与允许/禁止依赖门禁保持不变。
@@ -292,7 +292,8 @@
   在 Coordinator 外拼接恢复的问题：新的一次性 source-bound Lease 允许显式
   bootstrap/adopt-and-switch，并在 continuation 接纳后重新 flush 最新来源。Storage family
   结构损坏必须先凭同一 Utility、同一目标读取签发的 opaque 授权完成 reset；无法授权时
-  失败关闭。reset、来源 flush 或目标保存的确定失败保留来源身份，未知结果只 fence 对应来源或目标。
+  失败关闭。Coordinator 在消费授权前重新验证目标，较新写入已经修复目标时不执行 reset。
+  reset、来源 flush 或目标保存的确定失败保留来源身份，未知结果只 fence 对应来源或目标。
 - 修复 SaveGraph 在 Source/Scope/Pipeline 已记录采集错误后仍生成并覆盖健康存档、内层格式版本接受缺失/旧版/字符串值、调用方 context 可伪造事务根、同步 apply 重入无界递归，以及 participant 或 Source snapshot 回滚失败只存在于可选 trace 的问题；默认 apply 结果现在始终公开 `rollback_failures` 与 `atomicity_restored`。
 - 修复 Graph 与 Slot 读取入口接受 `ok=true` 但 integrity 为 `INVALID` 的内容、PersistProperties 的 local/registry 同 ID Serializer 发生编码/解码实现漂移、Slot Sync 绕过 Adapter 模板与规范路径碰撞检查、Document parser 静默丢弃空白/非字符串/trim alias section key，以及 Section/Document 在有界持久化验收前深复制循环或超深容器的问题。
 - 修复 `GFSignalSubscriptionToken` 会隐式接管既有同一 `Signal + Callable` 连接、并在取消时断开其他创建方资源的问题；重复连接现在返回非活动 token，原连接继续由原创建方持有。

--- a/docs/zh/extensions/save-graph/save-profile-transactions.md
+++ b/docs/zh/extensions/save-graph/save-profile-transactions.md
@@ -67,7 +67,9 @@ reconcile fence 仍拒绝注销，成功注销会使该 domain 的 recovery leas
   generation，再保存目标并在确认成功后切换身份。
 - `adopt_and_switch_profile()` 消费 source-bound `corrupt` lease；Storage family 结构损坏
   必须先使用同一 Utility、同一目标读取签发的 opaque 授权完成 family reset，无法授权时
-  失败关闭。Save 文档或完整性损坏不需要破坏性 reset。
+  失败关闭。Coordinator 会在消费 reset 授权前重新验证目标 family 的观察快照；目标已经
+  被较新写入修复时会保留当前来源与修复后的目标，不执行破坏性 reset。Save 文档或完整性
+  损坏不需要破坏性 reset。
 
 四个入口都把当前内存状态作为候选，只有 Storage 写入获得确定成功后才激活或切换目标。
 无效、过期、重复消费或原因不匹配的 lease 会失败关闭。框架不会因为 Profile 的普通

--- a/docs/zh/reference/api/classes/GFStorageFamilyResetAuthorization.md
+++ b/docs/zh/reference/api/classes/GFStorageFamilyResetAuthorization.md
@@ -9,7 +9,7 @@
 - 类别：运行时句柄 (`runtime_handle`)
 - 首次版本：`unreleased`
 
-单个 Storage logical family 的一次性破坏性恢复授权。 授权只能由 GFStorageUtility 为当前实例、冻结 root 与 canonical logical identity 创建。 reset 必须原样提交同一对象；跨 Utility、跨 root/file 或重复提交都会失败关闭。
+单个 Storage logical family 的一次性破坏性恢复授权。 授权只能由 GFStorageUtility 为当前实例、冻结 root 与 canonical logical identity 创建。 reset 必须原样提交同一对象；跨 Utility、跨 root/file 或重复提交都会失败关闭。 授权冻结签发时的 family 观察；较新写入或修复会在签发、claim 或 worker 复核时使其 stale。
 
 ## 成员概览
 
@@ -156,7 +156,7 @@ func is_available() -> bool:
 
 检查授权是否仍可提交一次。
 
-返回：已配置且尚未消费时返回 true。
+返回：本地句柄已配置且尚未消费时返回 true；实际提交仍会复核冻结的 family 观察。
 
 <a id="member-gfstoragefamilyresetauthorization-methods-is_claimed"></a>
 

--- a/docs/zh/reference/api/classes/GFStorageUtility.md
+++ b/docs/zh/reference/api/classes/GFStorageUtility.md
@@ -690,7 +690,7 @@ func delete_file_request_async( file_name: String, options: GFStorageAsyncReques
 func create_family_reset_authorization( file_name: String, observed_result: GFStorageReadResult ) -> GFStorageFamilyResetAuthorization:
 ```
 
-为一次显式的破坏性 family reset 创建绑定授权。 只有当前 GFStorageUtility 对同一 logical identity 返回的 CORRUPT 读取结果才可 创建授权。授权冻结 Utility、Storage root 与 canonical logical identity，且只能消费一次。
+为一次显式的破坏性 family reset 创建绑定授权。 只有当前 GFStorageUtility 对同一 logical identity 返回的 CORRUPT 读取结果才可 创建授权。授权冻结 Utility、Storage root、canonical logical identity 与当前 family 观察， 且只能消费一次；签发前或后发生的较新同 family 写入/修复会使旧观察失效。
 
 参数：
 

--- a/docs/zh/standard/utilities/io/storage-snapshot/family-reset.md
+++ b/docs/zh/standard/utilities/io/storage-snapshot/family-reset.md
@@ -4,7 +4,7 @@ family reset 是 structural corruption 后的显式、破坏性恢复入口，�
 
 ## 来源绑定与调用流程
 
-Storage 返回的 `GFStorageReadResult` 可携带不透明、不可序列化的来源绑定，用于证明观察确实来自同一个 Utility、同一冻结 root 与同一 canonical logical identity。授权资格字段 `ok`、`error_code` 与 `failure_kind` 仍匹配签发快照时，`duplicate_result()` 会保留该绑定；`to_dict()` / `from_dict()`、`configure_success()`、`configure_failure()` 与 `apply_dict()` 都不会传播它。项目不能自行合成结果或改写授权资格字段来取得破坏性恢复权限。
+Storage 返回的 `GFStorageReadResult` 可携带不透明、不可序列化的来源绑定，用于证明观察确实来自同一个 Utility、同一冻结 root 与同一 canonical logical identity。只有已经确认当前 layout 后、由目标 family 的 intent、identity 或事务恢复产生的损坏才能取得该绑定；无关的全局 layout 或恢复失败保持 unbound。授权资格字段 `ok`、`error_code` 与 `failure_kind` 仍匹配签发快照时，`duplicate_result()` 会保留该绑定；`to_dict()` / `from_dict()`、`configure_success()`、`configure_failure()` 与 `apply_dict()` 都不会传播它。项目不能自行合成结果或改写授权资格字段来取得破坏性恢复权限。
 
 ```gdscript
 var observed: GFStorageReadResult = storage.load_data("profile.json")
@@ -19,13 +19,13 @@ if not observed.ok and observed.failure_kind == GFStorageReadResult.FailureKind.
 			_report_storage_error(save_error)
 ```
 
-`GFStorageFamilyResetAuthorization` 按 attempt 一次性消费，并冻结 Utility、root、canonical logical identity 与私有 family identity；失败后不能重放同一授权。需要重试时，只能从授权资格字段仍匹配签发快照的来源绑定 `CORRUPT` 结果重新签发。只有 `GFStorageFamilyResetResult.is_successful()` 为真时才能保存默认值；`recreated_member_count` 不是可提交成功的替代判断。
+`GFStorageFamilyResetAuthorization` 按 attempt 一次性消费，并冻结 Utility、root、canonical logical identity、私有 family identity 与产生该 `CORRUPT` 结果时的 family 观察快照。授权签发后，任何改变该快照的同 family 较新写入或修复都会让旧授权失效；同步 reset 在等待既有异步工作后重新验证，异步 reset 也会在轮到自己的 FIFO worker 时再次验证，不能用旧恢复决定退休新保存的健康数据。失败后不能重放同一授权。需要重试时，只能从当前来源绑定 `CORRUPT` 结果重新签发。只有 `GFStorageFamilyResetResult.is_successful()` 为真时才能保存默认值；`recreated_member_count` 不是可提交成功的替代判断。
 
 ## 收敛协议与结果
 
-执行器先拒绝未知或未来 layout、已存在多个有效 identity、授权不匹配、扫描预算耗尽与 private ancestry 的 link/wrong-type 重定向，再持久化 reset intent、把旧 catalog/family identity 移入 retirement staging、发布新的 owner/catalog claim，最后有界清理旧证据。reset 只根据 canonical logical identity 与已经验证的内部 descriptor 修改目标，不扫描或收养相邻 family。
+执行器先拒绝未知或未来 layout、已存在多个有效 identity、授权不匹配、扫描预算耗尽与 private ancestry 的 link/wrong-type 重定向，并检查其他 family 中仍存活、且声明目标为同一多成员事务成员的反向记录；存在这种记录时不能单独退休目标，反向记录无法读取、类型错误或语义形状不合法时也会零写失败关闭。通过后才持久化 reset intent、把旧 catalog/family identity 移入 retirement staging、发布新的 owner/catalog claim，最后有界清理旧证据。reset 只根据 canonical logical identity 与已经验证的内部 descriptor 修改目标，不收养相邻 family。
 
-intent 是已经提交的授权决定；崩溃或 IO 失败后，同一 family 的后续正常 I/O 会先幂等收敛该 intent，不能越过它写入随后又被旧恢复删除的数据。未发布且截断的 pending staging 可以有界清理；损坏的已发布 intent、未知 layout 或歧义 identity 始终失败关闭。`GFStorageFamilyResetResult` 只暴露有界的来源、阶段、成员与 retired/recreated/remaining 计数，不暴露 root、opaque family ID 或私有路径。
+intent 是已经提交的授权决定；崩溃或 IO 失败后，同一 family 的后续正常 I/O 会先幂等收敛该 intent，不能越过它写入随后又被旧恢复删除的数据。未发布的 pending staging 无论是截断内容，还是文件名中的 reset/family identity 与正文不匹配，都作为未提交残留有界清理；同样的 exact intent 已经发布，语义不匹配时必须保留证据并失败关闭。损坏的已发布 intent、未知 layout 或歧义 identity 始终失败关闭。`GFStorageFamilyResetResult` 只暴露有界的来源、阶段、成员与 retired/recreated/remaining 计数，不暴露 root、opaque family ID 或私有路径。
 
 ## 异步与生命周期
 

--- a/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd
+++ b/tests/gf_core/extensions/save/support/gf_save_profile_transaction_test_support.gd
@@ -92,6 +92,7 @@ class ControlledStorage extends GFStorageUtility:
 	var max_active_io_count: int = 0
 	var driver: GFSaveProfileUtility = null
 	var enable_family_reset_authorization: bool = false
+	var family_reset_authorization_current: bool = true
 	var reset_call_count: int = 0
 	var _next_request_id: int = 1
 	var _next_authorization_id: int = 1
@@ -190,12 +191,24 @@ class ControlledStorage extends GFStorageUtility:
 			get_instance_id(),
 			file_name,
 			_get_async_file_key(file_name),
+			"controlled-observation",
 			GFStorageFamilyResetAuthorization.REASON_CORRUPT
 		)
 		if not configured:
 			return null
 		_next_authorization_id += 1
 		return authorization
+
+	func validate_family_reset_authorization_for_framework(
+		file_name: String,
+		authorization: GFStorageFamilyResetAuthorization
+	) -> bool:
+		events.append("revalidate:%s" % file_name)
+		if not family_reset_authorization_current:
+			if authorization != null:
+				var _stale: bool = authorization.mark_stale_for_framework()
+			return false
+		return authorization != null and authorization.is_available()
 
 	func reset_file_family_request_async(
 		file_name: String,
@@ -212,7 +225,8 @@ class ControlledStorage extends GFStorageUtility:
 			and authorization.claim_for_framework(
 				get_instance_id(),
 				file_name,
-				_get_async_file_key(file_name)
+				_get_async_file_key(file_name),
+				"controlled-observation"
 			)
 		)
 		if not claimed:

--- a/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
+++ b/tests/gf_core/extensions/save/test_gf_save_profile_session_transactions.gd
@@ -886,6 +886,33 @@ func test_adopt_and_switch_resets_structural_family_before_target_save() -> void
 	)
 
 
+func test_adopt_and_switch_revalidates_repaired_target_before_reset() -> void:
+	var fixture: Dictionary = _prepare_structural_switch_recovery(
+		"session.adopt_switch_reset.repaired_target"
+	)
+	var source: GFSaveProfile = _fixture_profile(fixture, "source")
+	var target: GFSaveProfile = _fixture_profile(fixture, "target")
+	var lease: GFSaveProfileRecoveryLease = _fixture_recovery_lease(fixture)
+	_storage.family_reset_authorization_current = false
+
+	var operation: GFSaveProfileTransactionOperation = (
+		_coordinator.adopt_and_switch_profile(lease)
+	)
+
+	assert_true(operation.is_completed())
+	assert_eq(
+		operation.get_result().get_status(),
+		GFSaveProfileTransactionResult.STATUS_PERSIST_FAILED
+	)
+	assert_eq(operation.get_result().get_error_code(), ERR_UNAUTHORIZED)
+	assert_eq(operation.get_result().get_phase(), &"recovery_reset")
+	assert_eq(_storage.reset_call_count, 0)
+	assert_eq(_storage.get_pending_reset_count(), 0)
+	assert_eq(_storage.get_pending_save_count(), 0)
+	assert_eq(_coordinator.get_active_profile_id(target.profile_id), source.profile_id)
+	assert_true(_storage.events.has("revalidate:%s" % target.file_name))
+
+
 func test_adopt_and_switch_reset_failure_preserves_source_without_target_save() -> void:
 	var fixture: Dictionary = _prepare_structural_switch_recovery(
 		"session.adopt_switch_reset.failure"

--- a/tests/gf_core/standard/utilities/storage/test_gf_storage_family_reset.gd
+++ b/tests/gf_core/standard/utilities/storage/test_gf_storage_family_reset.gd
@@ -348,20 +348,211 @@ func test_malformed_transaction_identity_is_retired_and_recreated() -> void:
 	assert_false(_storage.has_file(file_name))
 
 
+func test_surviving_companion_transaction_blocks_corrupt_target_reset() -> void:
+	var marker_scenarios: Array[Dictionary] = [
+		{"path_key": "transaction_pending_path", "committed": false},
+		{"path_key": "transaction_path", "committed": false},
+		{"path_key": "transaction_commit_pending_path", "committed": true},
+		{"path_key": "transaction_commit_path", "committed": true},
+	]
+	for scenario_index: int in range(marker_scenarios.size()):
+		if scenario_index > 0:
+			_recreate_storage_fixture_root()
+		var file_name: String = "structural/reverse-target-%d.json" % scenario_index
+		var companion_file_name: String = (
+			"structural/reverse-companion-%d.json" % scenario_index
+		)
+		assert_eq(_storage.save_data(file_name, { "value": 1 }), OK)
+		assert_eq(_storage.save_data(companion_file_name, { "value": 2 }), OK)
+		var descriptor: Dictionary = _descriptor(file_name)
+		var companion_descriptor: Dictionary = _descriptor(companion_file_name)
+		var file_names: Array[String] = [file_name, companion_file_name]
+		file_names.sort()
+		var had_final_by_file: Dictionary = {}
+		had_final_by_file[file_name] = true
+		had_final_by_file[companion_file_name] = true
+		var scenario: Dictionary = marker_scenarios[scenario_index]
+		var marker: Dictionary = GFStorageUtility._make_transaction_marker(
+			file_names,
+			companion_file_name,
+			"reverse-reset-conflict-%d" % scenario_index,
+			GFVariantData.get_option_bool(scenario, "committed"),
+			had_final_by_file
+		)
+		assert_eq(
+			_write_json(
+				GFVariantData.get_option_string(
+					companion_descriptor,
+					GFVariantData.get_option_string(scenario, "path_key")
+				),
+				marker
+			),
+			OK
+		)
+		assert_eq(
+			_write_text(
+				GFVariantData.get_option_string(descriptor, "transaction_path"),
+				"{"
+			),
+			OK
+		)
+		var observed_result: GFStorageReadResult = _assert_corrupt_read(file_name)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_available_authorization(file_name, observed_result)
+		)
+		var before_digest: String = _snapshot_tree_digest(_storage_root_path)
+
+		var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
+			file_name,
+			authorization
+		)
+
+		_assert_reset_failure(
+			reset_result,
+			GFStorageFamilyResetResult.FailureKind.CONFLICT,
+			GFStorageFamilyResetResult.Phase.PREFLIGHT
+		)
+		assert_eq(reset_result.get_error_code(), ERR_BUSY)
+		assert_eq(
+			reset_result.get_failed_member(),
+			GFStorageFamilyResetResult.FamilyMember.MUTABLE_EVIDENCE
+		)
+		assert_eq(_snapshot_tree_digest(_storage_root_path), before_digest)
+
+
+func test_uncertain_companion_transaction_evidence_fails_closed() -> void:
+	var scenarios: Array[StringName] = [
+		&"malformed_record",
+		&"wrong_type_record",
+		&"unsorted_record",
+	]
+	for scenario_index: int in range(scenarios.size()):
+		if scenario_index > 0:
+			_recreate_storage_fixture_root()
+		var scenario: StringName = scenarios[scenario_index]
+		var file_name: String = "structural/uncertain-target-%s.json" % scenario
+		var companion_file_name: String = (
+			"structural/uncertain-companion-%s.json" % scenario
+		)
+		assert_eq(_storage.save_data(file_name, { "value": 1 }), OK)
+		assert_eq(_storage.save_data(companion_file_name, { "value": 2 }), OK)
+		var descriptor: Dictionary = _descriptor(file_name)
+		var companion_descriptor: Dictionary = _descriptor(companion_file_name)
+		assert_eq(
+			_write_text(
+				GFVariantData.get_option_string(descriptor, "transaction_path"),
+				"{"
+			),
+			OK
+		)
+		var companion_transaction_path: String = GFVariantData.get_option_string(
+			companion_descriptor,
+			"transaction_path"
+		)
+		if scenario == &"malformed_record":
+			assert_eq(_write_text(companion_transaction_path, "{"), OK)
+		elif scenario == &"wrong_type_record":
+			assert_eq(
+				DirAccess.make_dir_recursive_absolute(companion_transaction_path),
+				OK
+			)
+		else:
+			var other_file_name: String = (
+				"structural/uncertain-other-%s.json" % scenario
+			)
+			assert_eq(_storage.save_data(other_file_name, { "value": 3 }), OK)
+			var member_names: Array[String] = [
+				companion_file_name,
+				other_file_name,
+			]
+			member_names.sort()
+			var had_final_by_file: Dictionary = {}
+			had_final_by_file[companion_file_name] = true
+			had_final_by_file[other_file_name] = true
+			var marker: Dictionary = GFStorageUtility._make_transaction_marker(
+				member_names,
+				companion_file_name,
+				"uncertain-unsorted-record",
+				false,
+				had_final_by_file
+			)
+			var members: Array = GFVariantData.get_option_array(marker, "members")
+			members.reverse()
+			marker["members"] = members
+			assert_eq(_write_json(companion_transaction_path, marker), OK)
+		var observed_result: GFStorageReadResult = _assert_corrupt_read(file_name)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_available_authorization(file_name, observed_result)
+		)
+		var before_digest: String = _snapshot_tree_digest(_storage_root_path)
+
+		var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
+			file_name,
+			authorization
+		)
+
+		_assert_reset_failure(
+			reset_result,
+			GFStorageFamilyResetResult.FailureKind.IO_FAILED,
+			GFStorageFamilyResetResult.Phase.PREFLIGHT
+		)
+		assert_eq(reset_result.get_error_code(), ERR_FILE_CORRUPT)
+		assert_eq(
+			reset_result.get_failed_member(),
+			GFStorageFamilyResetResult.FamilyMember.MUTABLE_EVIDENCE
+		)
+		assert_eq(_snapshot_tree_digest(_storage_root_path), before_digest)
+
+
+func test_reverse_companion_scan_exhaustion_fails_closed_without_writing() -> void:
+	_replace_storage(BoundedReverseScanStorageUtility.new())
+	var file_name: String = "structural/reverse-budget-target.json"
+	var companion_file_name: String = "structural/reverse-budget-companion.json"
+	assert_eq(_storage.save_data(file_name, { "value": 1 }), OK)
+	assert_eq(_storage.save_data(companion_file_name, { "value": 2 }), OK)
+	var descriptor: Dictionary = _descriptor(file_name)
+	assert_eq(
+		_write_text(
+			GFVariantData.get_option_string(descriptor, "transaction_path"),
+			"{"
+		),
+		OK
+	)
+	var observed_result: GFStorageReadResult = _assert_corrupt_read(file_name)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_available_authorization(file_name, observed_result)
+	)
+	var before_digest: String = _snapshot_tree_digest(_storage_root_path)
+
+	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
+		file_name,
+		authorization
+	)
+
+	_assert_reset_failure(
+		reset_result,
+		GFStorageFamilyResetResult.FailureKind.IO_FAILED,
+		GFStorageFamilyResetResult.Phase.PREFLIGHT
+	)
+	assert_eq(reset_result.get_error_code(), ERR_OUT_OF_MEMORY)
+	assert_eq(
+		reset_result.get_failed_member(),
+		GFStorageFamilyResetResult.FamilyMember.MUTABLE_EVIDENCE
+	)
+	assert_eq(_snapshot_tree_digest(_storage_root_path), before_digest)
+
+
 func test_valid_multi_member_transactions_block_reset_without_writing() -> void:
 	for committed: bool in [false, true]:
 		var phase_name: String = "commit" if committed else "prepare"
 		var file_name: String = "conflict/%s-target.json" % phase_name
 		var companion_file_name: String = "conflict/%s-companion.json" % phase_name
-		var observed_result: GFStorageReadResult = _save_and_corrupt_payload(
+		var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(
 			file_name
 		)
 		assert_eq(
 			_storage.save_data(companion_file_name, { "preserved": phase_name }),
 			OK
-		)
-		var authorization: GFStorageFamilyResetAuthorization = (
-			_create_available_authorization(file_name, observed_result)
 		)
 		var descriptor: Dictionary = _descriptor(file_name)
 		var file_names: Array[String] = [file_name, companion_file_name]
@@ -380,6 +571,9 @@ func test_valid_multi_member_transactions_block_reset_without_writing() -> void:
 			"transaction_commit_path" if committed else "transaction_path"
 		)
 		assert_eq(_write_json(marker_path, marker), OK)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_fixture_authorization_for_current_family(file_name)
+		)
 		var before_digest: String = _snapshot_tree_digest(_storage_root_path)
 
 		var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
@@ -492,6 +686,91 @@ func test_malformed_pending_reset_intents_are_discarded_without_touching_family(
 		assert_true(authorization.is_available())
 
 
+func test_cold_recovery_discards_semantically_mismatched_pending_intents() -> void:
+	var mismatch_keys: Array[String] = [
+		"reset_id",
+		"logical_path",
+		"family_id",
+	]
+	for scenario_index: int in range(mismatch_keys.size()):
+		if scenario_index > 0:
+			_recreate_storage_fixture_root()
+		var file_name: String = "recovery/mismatched-pending-%d.json" % scenario_index
+		var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(
+			file_name
+		)
+		var descriptor: Dictionary = _descriptor(file_name)
+		var reset_id: String = GFUuid.generate_v4()
+		var pending_path: String = (
+			_reset_intent_path(descriptor, reset_id)
+			+ ".pending-"
+			+ GFUuid.generate_v4()
+		)
+		var intent: Dictionary = _make_reset_intent_fixture(
+			descriptor,
+			reset_id,
+			GFStorageFamilyResetResult.SourceKind.PAYLOAD_ONLY
+		)
+		match mismatch_keys[scenario_index]:
+			"reset_id":
+				intent["reset_id"] = GFUuid.generate_v4()
+			"logical_path":
+				intent["logical_path"] = "recovery/other-family.json"
+			"family_id":
+				intent["family_id"] = (
+					GFStorageFamilyStore.make_family_id_for_framework(
+						"recovery/other-family.json"
+					)
+				)
+		assert_eq(_write_json(pending_path, intent), OK)
+		var family_digest: String = _snapshot_tree_digest(
+			GFVariantData.get_option_string(descriptor, "family_path")
+		)
+		var catalog_bytes: PackedByteArray = FileAccess.get_file_as_bytes(
+			GFVariantData.get_option_string(descriptor, "catalog_path")
+		)
+
+		_replace_storage(_make_integrity_storage())
+
+		_assert_absolute_leaf_absent(pending_path)
+		assert_eq(
+			_snapshot_tree_digest(
+				GFVariantData.get_option_string(descriptor, "family_path")
+			),
+			family_digest
+		)
+		assert_eq(
+			FileAccess.get_file_as_bytes(
+				GFVariantData.get_option_string(descriptor, "catalog_path")
+			),
+			catalog_bytes
+		)
+
+
+func test_cold_recovery_fails_closed_for_semantically_mismatched_exact_intent() -> void:
+	var file_name: String = "recovery/mismatched-exact.json"
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
+	var descriptor: Dictionary = _descriptor(file_name)
+	var reset_id: String = GFUuid.generate_v4()
+	var intent_path: String = _reset_intent_path(descriptor, reset_id)
+	var intent: Dictionary = _make_reset_intent_fixture(
+		descriptor,
+		reset_id,
+		GFStorageFamilyResetResult.SourceKind.PAYLOAD_ONLY
+	)
+	intent["logical_path"] = "recovery/other-exact-family.json"
+	assert_eq(_write_json(intent_path, intent), OK)
+	var before_digest: String = _snapshot_tree_digest(_storage_root_path)
+
+	_replace_storage_without_init(GFStorageUtility.new())
+	var load_result: GFStorageReadResult = _storage.load_data(file_name)
+
+	assert_false(load_result.ok)
+	assert_eq(load_result.error_code, ERR_FILE_CORRUPT)
+	assert_true(FileAccess.file_exists(intent_path))
+	assert_eq(_snapshot_tree_digest(_storage_root_path), before_digest)
+
+
 func test_malformed_exact_reset_intent_fails_closed_without_writing() -> void:
 	var file_name: String = "recovery/malformed-exact.json"
 	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
@@ -585,10 +864,7 @@ func test_wrong_shape_pending_reset_intent_fails_closed_without_writing() -> voi
 
 func test_owner_only_recreate_state_resumes_without_losing_retired_evidence() -> void:
 	var file_name: String = "recovery/owner-only.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var reset_id: String = GFUuid.generate_v4()
 	var intent_path: String = _reset_intent_path(descriptor, reset_id)
@@ -637,6 +913,9 @@ func test_owner_only_recreate_state_resumes_without_losing_retired_evidence() ->
 			GFVariantData.get_option_string(descriptor, "catalog_path")
 		)
 	)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -653,10 +932,7 @@ func test_owner_only_recreate_state_resumes_without_losing_retired_evidence() ->
 
 func test_owner_only_recreate_discards_malformed_catalog_pending_and_resumes() -> void:
 	var file_name: String = "recovery/owner-only-catalog-pending.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var reset_id: String = GFUuid.generate_v4()
 	assert_eq(
@@ -704,6 +980,9 @@ func test_owner_only_recreate_discards_malformed_catalog_pending_and_resumes() -
 		+ GFUuid.generate_v4()
 	)
 	assert_eq(_write_text(catalog_pending_path, ""), OK)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -781,11 +1060,8 @@ func test_cleanup_resume_preserves_initial_retired_count() -> void:
 			"catalog-remains" if retired_catalog_remains else "intent-only"
 		)
 		var file_name: String = "recovery/cleanup-%s.json" % scenario_name
-		var observed_result: GFStorageReadResult = _save_and_corrupt_payload(
+		var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(
 			file_name
-		)
-		var authorization: GFStorageFamilyResetAuthorization = (
-			_create_available_authorization(file_name, observed_result)
 		)
 		var descriptor: Dictionary = _descriptor(file_name)
 		var reset_id: String = GFUuid.generate_v4()
@@ -831,6 +1107,9 @@ func test_cleanup_resume_preserves_initial_retired_count() -> void:
 		assert_eq(_remove_owned_test_tree(retired_family_path), OK)
 		if not retired_catalog_remains:
 			assert_eq(DirAccess.remove_absolute(retired_catalog_path), OK)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_fixture_authorization_for_current_family(file_name)
+		)
 
 		var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 			file_name,
@@ -847,10 +1126,7 @@ func test_cleanup_resume_preserves_initial_retired_count() -> void:
 
 func test_missing_family_race_returns_not_found_without_writing() -> void:
 	var file_name: String = "preflight/missing-race.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	assert_eq(
 		_remove_owned_test_tree(
@@ -863,6 +1139,9 @@ func test_missing_family_race_returns_not_found_without_writing() -> void:
 			GFVariantData.get_option_string(descriptor, "catalog_path")
 		),
 		OK
+	)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
 	)
 	var before_digest: String = _snapshot_tree_digest(_storage_root_path)
 
@@ -930,11 +1209,8 @@ func test_storage_ancestry_links_fail_closed_without_crossing_boundary() -> void
 			_recreate_storage_fixture_root()
 		var scenario: StringName = scenarios[scenario_index]
 		var file_name: String = "boundary/%s.json" % scenario
-		var observed_result: GFStorageReadResult = _save_and_corrupt_payload(
+		var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(
 			file_name
-		)
-		var authorization: GFStorageFamilyResetAuthorization = (
-			_create_available_authorization(file_name, observed_result)
 		)
 		var descriptor: Dictionary = _descriptor(file_name)
 		var link_path: String = ""
@@ -974,6 +1250,9 @@ func test_storage_ancestry_links_fail_closed_without_crossing_boundary() -> void
 		)
 		if link_error != OK:
 			continue
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_fixture_authorization_for_current_family(file_name)
+		)
 
 		var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 			file_name,
@@ -1018,13 +1297,10 @@ func test_storage_ancestry_links_fail_closed_without_crossing_boundary() -> void
 func test_exact_family_directory_link_is_structural_and_reset_never_crosses_boundary() -> void:
 	var file_name: String = "boundary/exact-family-link.json"
 	var companion_file_name: String = "boundary/exact-family-link-companion.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	assert_eq(
 		_storage.save_data(companion_file_name, { "preserved": true }),
 		OK
-	)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
 	)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var family_path: String = GFVariantData.get_option_string(
@@ -1064,6 +1340,9 @@ func test_exact_family_directory_link_is_structural_and_reset_never_crosses_boun
 	if link_error != OK:
 		return
 	assert_true(_absolute_path_is_link(family_path))
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -1082,10 +1361,7 @@ func test_exact_family_directory_link_is_structural_and_reset_never_crosses_boun
 
 func test_allowed_payload_file_link_is_structural_and_reset_never_crosses_boundary() -> void:
 	var file_name: String = "boundary/payload-file-link.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var payload_path: String = GFVariantData.get_option_string(
 		descriptor,
@@ -1104,6 +1380,9 @@ func test_allowed_payload_file_link_is_structural_and_reset_never_crosses_bounda
 	if link_error != OK:
 		return
 	assert_true(_absolute_path_is_link(payload_path))
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -1169,10 +1448,7 @@ func test_mismatched_layout_publish_pending_fails_before_reset_mutation() -> voi
 
 func test_existing_intent_rejects_conflicting_fresh_claim_and_preserves_evidence() -> void:
 	var file_name: String = "recovery/conflicting-fresh-claim.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var reset_id: String = GFUuid.generate_v4()
 	var retired_paths: Dictionary = _install_reset_intent_and_retire_exact(
@@ -1219,6 +1495,9 @@ func test_existing_intent_rejects_conflicting_fresh_claim_and_preserves_evidence
 		retired_catalog_path
 	)
 	var exact_claim_digest: String = _snapshot_tree_digest(family_path)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -1253,10 +1532,7 @@ func test_existing_intent_rejects_conflicting_fresh_claim_and_preserves_evidence
 
 func test_existing_intent_caps_overfull_exact_claim_without_mutating_evidence() -> void:
 	var file_name: String = "capacity/overfull-exact-claim.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var reset_id: String = GFUuid.generate_v4()
 	var retired_paths: Dictionary = _install_reset_intent_and_retire_exact(
@@ -1306,6 +1582,9 @@ func test_existing_intent_caps_overfull_exact_claim_without_mutating_evidence() 
 		retired_catalog_path
 	)
 	var exact_claim_digest: String = _snapshot_tree_digest(family_path)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -1335,10 +1614,7 @@ func test_existing_intent_caps_overfull_exact_claim_without_mutating_evidence() 
 
 func test_claim_staging_directory_link_fails_closed_and_preserves_evidence() -> void:
 	var file_name: String = "boundary/claim-staging-link.json"
-	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
-	var authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(file_name, observed_result)
-	)
+	var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
 	var descriptor: Dictionary = _descriptor(file_name)
 	var reset_id: String = GFUuid.generate_v4()
 	var retired_paths: Dictionary = _install_reset_intent_and_retire_exact(
@@ -1382,6 +1658,9 @@ func test_claim_staging_directory_link_fails_closed_and_preserves_evidence() -> 
 	var retired_catalog_bytes: PackedByteArray = FileAccess.get_file_as_bytes(
 		retired_catalog_path
 	)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(file_name)
+	)
 
 	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -1412,11 +1691,8 @@ func test_claim_staging_directory_link_fails_closed_and_preserves_evidence() -> 
 
 func test_claim_staging_bound_ignores_ordinary_siblings_but_caps_target_candidates() -> void:
 	var ordinary_file_name: String = "capacity/ordinary-claim-siblings.json"
-	var ordinary_observed: GFStorageReadResult = _save_and_corrupt_payload(
+	var _ordinary_observed: GFStorageReadResult = _save_and_corrupt_payload(
 		ordinary_file_name
-	)
-	var ordinary_authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(ordinary_file_name, ordinary_observed)
 	)
 	var ordinary_descriptor: Dictionary = _descriptor(ordinary_file_name)
 	var ordinary_reset_id: String = GFUuid.generate_v4()
@@ -1437,6 +1713,9 @@ func test_claim_staging_bound_ignores_ordinary_siblings_but_caps_target_candidat
 		if creation_error != OK:
 			break
 	assert_eq(creation_error, OK)
+	var ordinary_authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(ordinary_file_name)
+	)
 	var ordinary_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		ordinary_file_name,
 		ordinary_authorization
@@ -1449,11 +1728,8 @@ func test_claim_staging_bound_ignores_ordinary_siblings_but_caps_target_candidat
 
 	_recreate_storage_fixture_root()
 	var bounded_file_name: String = "capacity/bounded-claim-candidates.json"
-	var bounded_observed: GFStorageReadResult = _save_and_corrupt_payload(
+	var _bounded_observed: GFStorageReadResult = _save_and_corrupt_payload(
 		bounded_file_name
-	)
-	var bounded_authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(bounded_file_name, bounded_observed)
 	)
 	var bounded_descriptor: Dictionary = _descriptor(bounded_file_name)
 	var bounded_reset_id: String = GFUuid.generate_v4()
@@ -1491,6 +1767,9 @@ func test_claim_staging_bound_ignores_ordinary_siblings_but_caps_target_candidat
 	var retired_catalog_bytes: PackedByteArray = FileAccess.get_file_as_bytes(
 		retired_catalog_path
 	)
+	var bounded_authorization: GFStorageFamilyResetAuthorization = (
+		_create_fixture_authorization_for_current_family(bounded_file_name)
+	)
 
 	var bounded_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		bounded_file_name,
@@ -1526,11 +1805,8 @@ func test_exact_wrong_type_identity_leaves_are_retired_and_recreated() -> void:
 			_recreate_storage_fixture_root()
 		var scenario: StringName = scenarios[scenario_index]
 		var file_name: String = "structural/wrong-type-%s.json" % scenario
-		var observed_result: GFStorageReadResult = _save_and_corrupt_payload(
+		var _observed_result: GFStorageReadResult = _save_and_corrupt_payload(
 			file_name
-		)
-		var authorization: GFStorageFamilyResetAuthorization = (
-			_create_available_authorization(file_name, observed_result)
 		)
 		var descriptor: Dictionary = _descriptor(file_name)
 		if scenario == &"family_file":
@@ -1547,6 +1823,9 @@ func test_exact_wrong_type_identity_leaves_are_retired_and_recreated() -> void:
 			)
 			assert_eq(DirAccess.remove_absolute(catalog_path), OK)
 			assert_eq(DirAccess.make_dir_recursive_absolute(catalog_path), OK)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_fixture_authorization_for_current_family(file_name)
+		)
 
 		var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 			file_name,
@@ -1748,6 +2027,251 @@ func test_authorization_mismatch_marks_stale_and_successful_claim_cannot_be_reus
 		claimed_replay,
 		GFStorageFamilyResetResult.FailureKind.UNAUTHORIZED,
 		GFStorageFamilyResetResult.Phase.PREFLIGHT
+	)
+
+
+func test_authorization_rejects_family_changed_after_corrupt_observation() -> void:
+	var file_name: String = "authorization/changed-before-issue.json"
+	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
+	assert_eq(_storage.save_data(file_name, { "generation": 2 }), OK)
+
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_storage.create_family_reset_authorization(file_name, observed_result)
+	)
+
+	_assert_stale_authorization(authorization)
+	var current_result: GFStorageReadResult = _storage.load_data(file_name)
+	assert_true(current_result.ok)
+	assert_eq(GFVariantData.get_option_int(current_result.payload, "generation"), 2)
+
+
+func test_authorization_is_invalidated_by_newer_same_family_save() -> void:
+	var cooperative_storage: CooperativeResetStorageUtility = (
+		CooperativeResetStorageUtility.new()
+	)
+	_replace_storage(cooperative_storage)
+	cooperative_storage.async_execution_mode = (
+		GFStorageUtility.AsyncExecutionMode.COOPERATIVE
+	)
+	var file_name: String = "authorization/newer-save.json"
+	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_available_authorization(file_name, observed_result)
+	)
+	var save_operation: GFStorageAsyncOperation = _storage.save_data_request_async(
+		file_name,
+		{ "generation": 2 }
+	)
+	assert_not_null(save_operation)
+	if save_operation == null:
+		return
+
+	var reset_result: GFStorageFamilyResetResult = _storage.reset_file_family(
+		file_name,
+		authorization
+	)
+
+	_assert_reset_failure(
+		reset_result,
+		GFStorageFamilyResetResult.FailureKind.UNAUTHORIZED,
+		GFStorageFamilyResetResult.Phase.PREFLIGHT
+	)
+	assert_true(authorization.is_stale())
+	assert_true(save_operation.is_completed())
+	assert_eq(save_operation.get_result().get_error_code(), OK)
+	var current_result: GFStorageReadResult = _storage.load_data(file_name)
+	assert_true(current_result.ok)
+	assert_eq(GFVariantData.get_option_int(current_result.payload, "generation"), 2)
+
+
+func test_async_reset_rechecks_authorization_after_queued_same_family_save() -> void:
+	var cooperative_storage: CooperativeResetStorageUtility = (
+		CooperativeResetStorageUtility.new()
+	)
+	_replace_storage(cooperative_storage)
+	cooperative_storage.async_execution_mode = (
+		GFStorageUtility.AsyncExecutionMode.COOPERATIVE
+	)
+	var file_name: String = "authorization/async-newer-save.json"
+	var observed_result: GFStorageReadResult = _save_and_corrupt_payload(file_name)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_available_authorization(file_name, observed_result)
+	)
+	var save_operation: GFStorageAsyncOperation = _storage.save_data_request_async(
+		file_name,
+		{ "generation": 2 }
+	)
+	var reset_operation: GFStorageAsyncOperation = (
+		_storage.reset_file_family_request_async(file_name, authorization)
+	)
+	assert_not_null(save_operation)
+	assert_not_null(reset_operation)
+	if save_operation == null or reset_operation == null:
+		return
+	var operations: Array[GFStorageAsyncOperation] = [
+		save_operation,
+		reset_operation,
+	]
+
+	assert_true(await _pump_until_operations_complete(operations))
+
+	assert_eq(save_operation.get_result().get_error_code(), OK)
+	var reset_result: GFStorageFamilyResetResult = (
+		reset_operation.get_result().get_reset_result()
+	)
+	_assert_reset_failure(
+		reset_result,
+		GFStorageFamilyResetResult.FailureKind.UNAUTHORIZED,
+		GFStorageFamilyResetResult.Phase.PREFLIGHT
+	)
+	var current_result: GFStorageReadResult = _storage.load_data(file_name)
+	assert_true(current_result.ok)
+	assert_eq(GFVariantData.get_option_int(current_result.payload, "generation"), 2)
+
+
+func test_cold_target_structural_corruption_preserves_reset_provenance() -> void:
+	var identity_keys: Array[String] = [
+		"catalog_path",
+		"owner_path",
+		"transaction_path",
+	]
+	for scenario_index: int in range(identity_keys.size()):
+		if scenario_index > 0:
+			_recreate_storage_fixture_root()
+		var identity_key: String = identity_keys[scenario_index]
+		var file_name: String = "provenance/cold-%s.json" % identity_key
+		assert_eq(_storage.save_data(file_name, { "generation": 1 }), OK)
+		var descriptor: Dictionary = _descriptor(file_name)
+		assert_eq(
+			_write_text(
+				GFVariantData.get_option_string(descriptor, identity_key),
+				"{"
+			),
+			OK
+		)
+		_replace_storage_without_init(GFStorageUtility.new())
+
+		var observed_result: GFStorageReadResult = _storage.load_data(file_name)
+
+		assert_false(observed_result.ok)
+		assert_eq(observed_result.error_code, ERR_FILE_CORRUPT)
+		assert_eq(
+			observed_result.failure_kind,
+			GFStorageReadResult.FailureKind.CORRUPT
+		)
+		_assert_read_result_origin(observed_result, file_name, true)
+		var authorization: GFStorageFamilyResetAuthorization = (
+			_create_available_authorization(file_name, observed_result)
+		)
+		assert_true(authorization.is_available())
+
+
+func test_async_cold_target_provenance_overrides_unrelated_scan_budget_error() -> void:
+	var file_name: String = "provenance/cold-async-budget-target.json"
+	assert_eq(_storage.save_data(file_name, { "generation": 1 }), OK)
+	var descriptor: Dictionary = _descriptor(file_name)
+	assert_eq(
+		_write_text(
+			GFVariantData.get_option_string(descriptor, "catalog_path"),
+			"{"
+		),
+		OK
+	)
+	var families_root: String = _storage_root_path.path_join(
+		".gf-storage/v1/families"
+	)
+	var creation_error: Error = OK
+	for entry_index: int in range(256):
+		creation_error = DirAccess.make_dir_recursive_absolute(
+			families_root.path_join("scan-budget-%03d" % entry_index)
+		)
+		if creation_error != OK:
+			break
+	assert_eq(creation_error, OK)
+	var cold_storage: ColdCooperativeResetStorageUtility = (
+		ColdCooperativeResetStorageUtility.new()
+	)
+	_replace_storage_without_init(cold_storage)
+	cold_storage.async_execution_mode = GFStorageUtility.AsyncExecutionMode.COOPERATIVE
+
+	var operation: GFStorageAsyncOperation = _storage.load_data_request_async(
+		file_name
+	)
+
+	assert_not_null(operation)
+	if operation == null:
+		return
+	assert_true(operation.is_completed())
+	var async_result: GFStorageAsyncResult = operation.get_result()
+	assert_not_null(async_result)
+	if async_result == null:
+		return
+	assert_eq(async_result.get_error_code(), ERR_FILE_CORRUPT)
+	var observed_result: GFStorageReadResult = async_result.get_read_result()
+	assert_not_null(observed_result)
+	if observed_result == null:
+		return
+	assert_false(observed_result.ok)
+	assert_eq(observed_result.error_code, ERR_FILE_CORRUPT)
+	assert_eq(
+		observed_result.failure_kind,
+		GFStorageReadResult.FailureKind.CORRUPT
+	)
+	_assert_read_result_origin(observed_result, file_name, true)
+	var authorization: GFStorageFamilyResetAuthorization = (
+		_create_available_authorization(file_name, observed_result)
+	)
+	assert_true(authorization.is_available())
+
+
+func test_cold_global_layout_corruption_stays_unbound_from_target_family() -> void:
+	var file_name: String = "provenance/global-layout-unbound.json"
+	assert_eq(_storage.save_data(file_name, { "generation": 1 }), OK)
+	assert_eq(
+		_write_text(
+			_storage_root_path.path_join(".gf-storage/v1/layout.json"),
+			"{"
+		),
+		OK
+	)
+	_replace_storage_without_init(GFStorageUtility.new())
+
+	var observed_result: GFStorageReadResult = _storage.load_data(file_name)
+
+	assert_false(observed_result.ok)
+	assert_eq(observed_result.error_code, ERR_FILE_CORRUPT)
+	assert_eq(
+		observed_result.failure_kind,
+		GFStorageReadResult.FailureKind.IO_FAILED
+	)
+	_assert_read_result_origin(observed_result, file_name, false)
+	_assert_stale_authorization(
+		_storage.create_family_reset_authorization(file_name, observed_result)
+	)
+
+
+func test_resume_layout_drift_stays_unbound_from_target_family() -> void:
+	var file_name: String = "provenance/layout-drift-unbound.json"
+	assert_eq(_storage.save_data(file_name, { "generation": 1 }), OK)
+	var descriptor: Dictionary = _descriptor(file_name)
+	var _retired_paths: Dictionary = _install_reset_intent_and_retire_exact(
+		descriptor,
+		GFUuid.generate_v4(),
+		GFStorageFamilyResetResult.SourceKind.PAYLOAD_ONLY
+	)
+	_replace_storage_without_init(LayoutDriftDuringResumeStorageUtility.new())
+
+	var resume_result: Dictionary = _storage._resume_pending_reset_for_file_result(
+		_storage_root_path,
+		file_name
+	)
+
+	assert_eq(
+		GFVariantData.get_option_int(resume_result, "error"),
+		ERR_FILE_CORRUPT
+	)
+	assert_false(
+		GFVariantData.get_option_bool(resume_result, "target_provenance")
 	)
 
 
@@ -2460,10 +2984,7 @@ func test_partial_recreate_catalog_failure_reports_progress_and_retries() -> voi
 
 	faulty_storage.fail_catalog_claim = false
 	var retry_authorization: GFStorageFamilyResetAuthorization = (
-		_create_available_authorization(
-			file_name,
-			observed_result.duplicate_result()
-		)
+		_create_fixture_authorization_for_current_family(file_name)
 	)
 	var retry_result: GFStorageFamilyResetResult = _storage.reset_file_family(
 		file_name,
@@ -2744,6 +3265,30 @@ func _create_available_authorization(
 	assert_not_null(authorization)
 	assert_true(authorization.is_available())
 	return authorization
+
+
+func _create_fixture_authorization_for_current_family(
+	file_name: String
+) -> GFStorageFamilyResetAuthorization:
+	var descriptor: Dictionary = _descriptor(file_name)
+	var observation_token: String = _storage._make_family_observation_token(
+		file_name
+	)
+	assert_false(observation_token.is_empty())
+	var observed_result: GFStorageReadResult = _make_read_failure(
+		GFStorageReadResult.FailureKind.CORRUPT,
+		ERR_FILE_CORRUPT
+	)
+	assert_true(
+		observed_result.bind_origin_for_framework(
+			_storage.get_instance_id(),
+			file_name,
+			GFVariantData.get_option_string(descriptor, "file_key"),
+			_storage._read_result_origin_token,
+			observation_token
+		)
+	)
+	return _create_available_authorization(file_name, observed_result)
 
 
 func _assert_stale_authorization(
@@ -3361,6 +3906,31 @@ class GatedThreadedResetStorageUtility extends GFStorageUtility:
 class ColdCooperativeResetStorageUtility extends CooperativeResetStorageUtility:
 	func init() -> void:
 		pass
+
+
+class BoundedReverseScanStorageUtility extends GFStorageUtility:
+	func _get_reset_reverse_scan_entry_limit() -> int:
+		return 4
+
+
+class LayoutDriftDuringResumeStorageUtility extends GFStorageUtility:
+	func _reset_file_family_thread(
+		storage_root_path: String,
+		logical_name: String,
+		expected_observation_token: String = ""
+	) -> Dictionary:
+		var layout_file: FileAccess = FileAccess.open(
+			storage_root_path.path_join(".gf-storage/v1/layout.json"),
+			FileAccess.WRITE
+		)
+		if layout_file != null:
+			var _stored: bool = layout_file.store_string("{") != null
+			layout_file = null
+		return super._reset_file_family_thread(
+			storage_root_path,
+			logical_name,
+			expected_observation_token
+		)
 
 
 class CleanupFailureStorageUtility extends GFStorageUtility:


### PR DESCRIPTION
## Summary

Harden destructive Storage family-reset recovery around cold structural corruption, stale authorization, cross-family transaction evidence, and Save Profile adoption. Reset authorization now carries an opaque family observation that is revalidated at issuance, claim, worker execution, and coordinator consumption; unrelated global failures remain unbound.

This is the focused follow-up for the unresolved reviews on merged PRs #159 and #160.

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: authorized structural recovery can handle target-specific cold corruption, but stale decisions, surviving multi-family transaction records, ambiguous evidence, and unrelated global failures now fail closed before retirement.
- API or extension contract: no new stable public method surface; unreleased reset handles retain their typed API while public docs now state observation invalidation semantics.
- Persisted data, package, protocol, or ProjectSettings impact: no layout/schema bump; pending unpublished intent mismatches are discarded, while exact/published mismatches remain preserved corruption evidence.
- Failure, cancellation, rollback, concurrency, and ownership impact: same-family writes invalidate older observations; sync/async reset and Save Profile coordinator recheck at their serialization boundaries; reverse evidence scanning is invocation-bounded and zero-write on uncertainty/exhaustion.
- Compatibility and migration: compatible tightening within the current `11.0.0-dev.0` line; callers must obtain a fresh authorization after any newer family write or repair.

## Verification

- [x] Focused tests cover the changed behavior and failure path.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only`
- [x] GDScript warning and LSP gates are clean when `.gd` files changed.
- [x] Generated API or knowledge output is fresh when its source changed.
- [x] Draft PR feedback completed through `GF draft gate` when applicable.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

Exact final-head validation:

- import and GDScript warnings: PASS
- Storage/Save focused GUT: 216/216 tests, 15,081 assertions; lifecycle, warning, orphan, ObjectDB, Resource, and RID leak gates all zero
- strict LSP: 1,365 files, 0 diagnostics, 0 file timeouts (one pre-scan initialize timeout followed by a clean identical-command retry)
- API/AI: 853 classes, 1 autoload, 12,615 members current; tracked AI source 829 classes / 1 autoload / 0 issues
- docs: 4/4, 451 pages; authoritative quick: 30/30
- `gf.extension.save` package smoke: two independent passes, each 2 scenarios / 707 installed files / 348 preloads / 0 issues / 0 exit-leak warnings

## Documentation and Release

- [x] Relevant guide and `[未发布]` changelog entries are updated, or the change is not user-visible.
- [x] Development version impact is correct, or the change does not alter the intended SemVer line.
- [x] This PR does not create a tag or publish a release.
