### PR TITLE
fix(combat): preserve projectile retirement semantics

### DIFF
--- a/addons/gf/extensions/combat/projectiles/gf_projectile_session.gd
+++ b/addons/gf/extensions/combat/projectiles/gf_projectile_session.gd
@@ -115,6 +115,7 @@ var _metadata: Dictionary = {}
 var _notification_barrier_depth: int = 0
 var _finished_notification_pending: bool = false
 var _terminal_body_observation_recorded: bool = false
+var _root_tree_exiting_callback: Callable = Callable()
 
 
 # --- 公共方法 ---
@@ -268,6 +269,7 @@ func finish(reason: EndReason = EndReason.CALLER_FINISHED) -> bool:
 		return false
 	_status = Status.FINISHED
 	_end_reason = reason
+	_disconnect_root_tree_exiting_observer()
 	_stop_body_once()
 	if _notification_barrier_depth > 0:
 		_finished_notification_pending = true
@@ -319,12 +321,20 @@ func activate_for_framework(
 		or not is_instance_valid(body_adapter)
 	):
 		return ERR_INVALID_PARAMETER
+	var root_tree_exiting_callback: Callable = _on_instance_root_tree_exiting
+	var connect_error: Error = instance_root.tree_exiting.connect(
+		root_tree_exiting_callback,
+		CONNECT_ONE_SHOT as Object.ConnectFlags
+	) as Error
+	if connect_error != OK:
+		return connect_error
 	_dimension = dimension
 	_generation = generation
 	_root_ref = weakref(instance_root)
 	_runtime_ref = weakref(runtime)
 	_body_adapter = body_adapter
 	_metadata = metadata.duplicate(true)
+	_root_tree_exiting_callback = root_tree_exiting_callback
 	_status = Status.ACTIVE
 	return OK
 
@@ -446,6 +456,21 @@ func release_notification_barrier_for_framework() -> Error:
 
 # --- 私有/辅助方法 ---
 
+func _disconnect_root_tree_exiting_observer() -> void:
+	var callback: Callable = _root_tree_exiting_callback
+	_root_tree_exiting_callback = Callable()
+	if not callback.is_valid() or _root_ref == null:
+		return
+	var root_value: Variant = _root_ref.get_ref()
+	if typeof(root_value) != TYPE_OBJECT or not is_instance_valid(root_value):
+		return
+	if not root_value is Node:
+		return
+	var root: Node = root_value
+	if root.tree_exiting.is_connected(callback):
+		root.tree_exiting.disconnect(callback)
+
+
 func _stop_body_once() -> void:
 	var root: Node = get_instance_root()
 	if root == null or _body_adapter == null or not is_instance_valid(_body_adapter):
@@ -468,3 +493,11 @@ func _node_from_ref(weak_reference: WeakRef) -> Node:
 			return null
 		return node
 	return null
+
+
+# --- 信号处理函数 ---
+
+func _on_instance_root_tree_exiting() -> void:
+	# one-shot signal 正在发射时只清本地 receipt，避免回调栈内反向 disconnect。
+	_root_tree_exiting_callback = Callable()
+	var _root_lost: bool = finish(EndReason.ROOT_LOST)

--- a/addons/gf/standard/utilities/nodes/gf_object_pool_utility.gd
+++ b/addons/gf/standard/utilities/nodes/gf_object_pool_utility.gd
@@ -314,52 +314,10 @@ func release(node: Node, scene: PackedScene) -> void:
 	if not _active_generations.has(node_id):
 		push_warning("[GFObjectPoolUtility] release 失败：节点不属于当前借用代次。")
 		return
-
-	var current_serial: int = _lifecycle_serial
-	var release_generation: int = _take_operation_generation()
-	_erase_active_lease(node_id)
-	node.set_meta(_META_ACTIVE, false)
-	_transition_generations[node_id] = release_generation
-	if not _run_guarded_tree_operation(
+	var _release_accepted: bool = _release_authoritative_active_lease(
 		node,
-		_TreeOperation.RELEASE_HOOKS,
-		node_id,
-		_NodeOwnershipPhase.TRANSITION,
-		release_generation,
-		current_serial
-	):
-		_discard_candidate_if_lifecycle_changed(node, current_serial)
-		return
-	if not _run_guarded_tree_state_operation(
-		node, false, node_id, _NodeOwnershipPhase.TRANSITION,
-		release_generation, current_serial
-	):
-		_discard_candidate_if_lifecycle_changed(node, current_serial)
-		return
-
-	if not _available_pools.has(owner_scene):
-		_available_pools[owner_scene] = []
-
-	_prune_invalid_available_nodes_if_needed(owner_scene)
-	var available_pool: Array = _get_available_pool(owner_scene)
-	if max_available_per_scene > 0 and available_pool.size() >= max_available_per_scene:
-		var _capacity_transition_erased: bool = _transition_generations.erase(node_id)
-		_remove_node_from_scene_pool(node, owner_scene)
-		_queue_free_detached(node)
-		return
-
-	_move_to_pool_root(node)
-	if not _node_operation_matches(
-		node,
-		node_id,
-		_NodeOwnershipPhase.TRANSITION,
-		release_generation,
-		current_serial
-	):
-		_discard_candidate_if_lifecycle_changed(node, current_serial)
-		return
-	var _release_transition_erased: bool = _transition_generations.erase(node_id)
-	available_pool.push_back(node)
+		owner_scene
+	)
 
 
 ## 预热对象池，预先实例化指定数量的节点以避免首次使用时的卡顿。
@@ -680,7 +638,9 @@ func get_debug_snapshot() -> Dictionary:
 ## [br]
 ## @param scene: acquire 时冻结的 PackedScene identity。
 ## [br]
-## @return: 当前 active generation 被本次调用接纳时返回 true；queued-live 节点不执行 hook 或树操作，仅移除精确 tracking；生命周期切换已清除 lease 或身份不匹配时返回 false 且零 mutation。
+## @return: 当前 active generation 被本次调用接纳并同步擦除 authoritative lease 时返回 true；
+## 准入不依赖可变 Node metadata。queued-live 节点不执行 hook 或树操作，仅移除精确
+## tracking；生命周期切换已清除 lease 或身份不匹配时返回 false 且零 mutation。
 func release_for_framework(node: Node, scene: PackedScene) -> bool:
 	if (
 		_is_disposed
@@ -711,8 +671,7 @@ func release_for_framework(node: Node, scene: PackedScene) -> bool:
 			node_id,
 			tracked_node
 		)
-	release(node, scene)
-	return true
+	return _release_authoritative_active_lease(node, scene)
 
 
 ## 结算已被外部同步销毁、无法再走 `release()` 的 ACTIVE lease。
@@ -759,6 +718,72 @@ func retire_lost_lease_for_framework(scene: PackedScene, instance_id: int) -> bo
 
 
 # --- 私有/辅助方法 ---
+
+func _release_authoritative_active_lease(
+	node: Node,
+	owner_scene: PackedScene
+) -> bool:
+	if (
+		_is_disposed
+		or node == null
+		or not is_instance_valid(node)
+		or owner_scene == null
+		or not is_instance_valid(owner_scene)
+		or not _all_nodes.has(owner_scene)
+		or not _get_all_nodes_pool(owner_scene).has(node)
+	):
+		return false
+	var node_id: int = node.get_instance_id()
+	if not _active_generations.has(node_id):
+		return false
+
+	var current_serial: int = _lifecycle_serial
+	var release_generation: int = _take_operation_generation()
+	_erase_active_lease(node_id)
+	node.set_meta(_META_ACTIVE, false)
+	node.set_meta(_META_SOURCE_SCENE, owner_scene)
+	_transition_generations[node_id] = release_generation
+	if not _run_guarded_tree_operation(
+		node,
+		_TreeOperation.RELEASE_HOOKS,
+		node_id,
+		_NodeOwnershipPhase.TRANSITION,
+		release_generation,
+		current_serial
+	):
+		_discard_candidate_if_lifecycle_changed(node, current_serial)
+		return true
+	if not _run_guarded_tree_state_operation(
+		node, false, node_id, _NodeOwnershipPhase.TRANSITION,
+		release_generation, current_serial
+	):
+		_discard_candidate_if_lifecycle_changed(node, current_serial)
+		return true
+
+	if not _available_pools.has(owner_scene):
+		_available_pools[owner_scene] = []
+
+	_prune_invalid_available_nodes_if_needed(owner_scene)
+	var available_pool: Array = _get_available_pool(owner_scene)
+	if max_available_per_scene > 0 and available_pool.size() >= max_available_per_scene:
+		var _capacity_transition_erased: bool = _transition_generations.erase(node_id)
+		_remove_node_from_scene_pool(node, owner_scene)
+		_queue_free_detached(node)
+		return true
+
+	_move_to_pool_root(node)
+	if not _node_operation_matches(
+		node,
+		node_id,
+		_NodeOwnershipPhase.TRANSITION,
+		release_generation,
+		current_serial
+	):
+		_discard_candidate_if_lifecycle_changed(node, current_serial)
+		return true
+	var _release_transition_erased: bool = _transition_generations.erase(node_id)
+	available_pool.push_back(node)
+	return true
 
 func _request_pool_lifecycle_transition(transition: int) -> void:
 	if transition not in [_PoolLifecycleTransition.INITIALIZE, _PoolLifecycleTransition.DISPOSE]:

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -201,6 +201,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 direct Projectile launch 的完整 root 在 `queue_free()` / 退树时被 child runtime 误报为 `RUNTIME_LOST`，以及对象池 authoritative lease 已匹配但可变 Node metadata 漂移时 `release_for_framework()` 假成功的问题；Session 现在直接观察 frozen root 的一次性退树信号并保留 `ROOT_LOST` first-wins，framework pool 入口则绕过 legacy metadata 准入、修复 metadata 并在返回成功前同步擦除精确 active lease。
 - 修复 Combat Projectile 在 binding 失败时丢失 `GFProjectileBinding.FailureReason`、对象池活动 lease 被 `init()` 清除 tracking 后完整 root 无法退休、失败/非有限 capture 仍进入 Motion、有限 velocity/delta 的乘法或候选位置溢出会先污染权威 root、Session 累计指标溢出，以及 locked Homing 的 arrival clamp 仍读取 live target 的问题；2D/3D Emitter 现在提供有界 `binding_failure_reason`，池结算只归还精确 active lease 并对失效 tracking 的自有 root 单次 free fallback，Runtime 在失败 capture 后立即终结，Intent 与 Transform/CharacterBody Adapter 则在任何宿主写入前拒绝非有限结果，Session 保留最后有限指标；`track_target=false` 时 live target 后续移动不再改写 launch 快照，目标失效后沿锁定方向继续并禁用 clamp。
 - 修复类型化场景请求的四个终端边界：非主线程配置失败不再返回无法终结的半配置 Operation 或派发 Broker Lease；preload 在调用 Broker poll 前进入 settlement fence，终态回调中的同路径重入以 busy 失败关闭，不再递归轮询旧 aggregate；同步自定义切场的显式确认与同步 `scene_changed` 只记录 current-generation 回执，并在 override 返回 true 及 owner/token 复核后结算；同路径异步 override 用 `_defer_target_scene_commit()` 区分合法等待与 same-root no-op，不同路径 legacy async observer 保持兼容；基础 pathless commit 预实例化并只接受精确 root，自定义 pathless commit 则必须显式确认精确回执，不再把任意新空路径或同路径旧 root 误认成冻结目标。
 - 修复 required Binding Plan 把与直接注册键冲突的 alias、或同一 alias 指向不同 target 的覆盖写入误报为成功的问题；required 路径现在拒绝会被直接键遮蔽或改写既有目标的 alias，同时保留指向同一 target 的幂等映射。

--- a/tests/gf_core/extensions/combat/test_gf_projectiles.gd
+++ b/tests/gf_core/extensions/combat/test_gf_projectiles.gd
@@ -5710,3 +5710,66 @@ func test_projectile_direct_runtime_removal_finishes_runtime_lost_after_tree_exi
 	assert_true(session_3d.is_finished())
 	assert_eq(session_3d.get_end_reason(), GFProjectileSession.EndReason.RUNTIME_LOST)
 	runtime_3d.free()
+
+
+func test_projectile_direct_root_queue_free_finishes_root_lost() -> void:
+	var root_2d: Node2D = _make_bound_projectile_root_2d()
+	add_child_autofree(root_2d)
+	var definition_2d: GFProjectileDefinition2D = _make_projectile_definition_2d()
+	var binding_2d: GFProjectileBinding2D = definition_2d.bind_instance(root_2d)
+	var runtime_2d: GFProjectile2D = _runtime_2d_from(root_2d)
+	var session_2d: GFProjectileSession = runtime_2d.launch(binding_2d)
+	var root_ref_2d: WeakRef = weakref(root_2d)
+	root_2d.queue_free()
+	assert_true(root_2d.is_queued_for_deletion())
+	assert_null(session_2d.get_instance_root(), "public getter 不得重新暴露 queued root。")
+	assert_true(session_2d.is_active(), "root tree-exit 前 session 仍应保持 ACTIVE。")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_true(session_2d.is_finished())
+	assert_eq(
+		session_2d.get_end_reason(),
+		GFProjectileSession.EndReason.ROOT_LOST,
+		"direct 2D launch 的完整 root queue_free 必须保持 ROOT_LOST。"
+	)
+	assert_true(root_ref_2d.get_ref() == null)
+
+	var root_3d: Node3D = _make_bound_projectile_root_3d()
+	add_child_autofree(root_3d)
+	var definition_3d: GFProjectileDefinition3D = _make_projectile_definition_3d()
+	var binding_3d: GFProjectileBinding3D = definition_3d.bind_instance(root_3d)
+	var runtime_3d: GFProjectile3D = _runtime_3d_from(root_3d)
+	var session_3d: GFProjectileSession = runtime_3d.launch(binding_3d)
+	var root_ref_3d: WeakRef = weakref(root_3d)
+	root_3d.queue_free()
+	assert_true(root_3d.is_queued_for_deletion())
+	assert_null(session_3d.get_instance_root())
+	assert_true(session_3d.is_active())
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_true(session_3d.is_finished())
+	assert_eq(
+		session_3d.get_end_reason(),
+		GFProjectileSession.EndReason.ROOT_LOST,
+		"direct 3D launch 必须与 2D 使用同一 root-loss 判别。"
+	)
+	assert_true(root_ref_3d.get_ref() == null)
+
+
+func test_projectile_direct_root_remove_child_finishes_root_lost() -> void:
+	var root: Node2D = _make_bound_projectile_root_2d()
+	add_child_autofree(root)
+	var definition: GFProjectileDefinition2D = _make_projectile_definition_2d()
+	var binding: GFProjectileBinding2D = definition.bind_instance(root)
+	var runtime: GFProjectile2D = _runtime_2d_from(root)
+	var session: GFProjectileSession = runtime.launch(binding)
+
+	remove_child(root)
+	await get_tree().process_frame
+	assert_true(session.is_finished())
+	assert_eq(
+		session.get_end_reason(),
+		GFProjectileSession.EndReason.ROOT_LOST,
+		"direct root remove_child 必须优先于 child runtime 的 deferred RUNTIME_LOST。"
+	)
+	root.free()

--- a/tests/gf_core/standard/utilities/nodes/test_gf_object_pool_utility.gd
+++ b/tests/gf_core/standard/utilities/nodes/test_gf_object_pool_utility.gd
@@ -142,6 +142,61 @@ func test_release_for_framework_requires_current_active_lease() -> void:
 	assert_eq(_pool.get_available_count(_scene), 0)
 
 
+func test_release_for_framework_uses_authoritative_lease_after_metadata_drift() -> void:
+	var node: Node = _pool.acquire(_scene, _parent)
+	assert_not_null(node)
+	if node == null:
+		return
+	node.set_meta(&"_gf_pool_active", false)
+
+	assert_true(
+		_pool.release_for_framework(node, _scene),
+		"framework exact-lease 入口不得把可变 Node metadata 当作授权证据。"
+	)
+	assert_eq(
+		_pool.get_active_count(_scene),
+		0,
+		"返回 true 时必须已经结算 authoritative active lease。"
+	)
+	assert_eq(
+		_pool.get_available_count(_scene),
+		1,
+		"metadata 漂移不得阻止精确 lease 正常归还所属池。"
+	)
+	assert_false(
+		_pool.release_for_framework(node, _scene),
+		"首次返回 true 后 authoritative lease 必须已退休，重复调用应拒绝。"
+	)
+
+	# 旧实现会在 legacy release() 的 metadata guard 处早退；保持失败用例可清理。
+	if _pool.get_available_count(_scene) == 0:
+		node.set_meta(&"_gf_pool_active", true)
+		_pool.release(node, _scene)
+
+	var reused: Node = _pool.acquire(_scene, _parent)
+	assert_same(reused, node)
+	var wrong_scene: PackedScene = _make_node_scene()
+	reused.set_meta(&"_gf_pool_source_scene", wrong_scene)
+	var wrong_source_accepted: bool = _pool.release_for_framework(reused, _scene)
+	var wrong_source_available: int = _pool.get_available_count(_scene)
+	if wrong_source_available == 0:
+		# 仅旧实现委托 metadata-sensitive legacy release() 时产生；消费红测诊断。
+		assert_push_warning(
+			"[GFObjectPoolUtility] release 收到不匹配的 PackedScene，已回退到节点原始所属池。"
+		)
+		assert_push_warning("[GFObjectPoolUtility] release 失败：节点不属于当前对象池。")
+	assert_true(wrong_source_accepted)
+	assert_eq(
+		wrong_source_available,
+		1,
+		"source-scene metadata 漂移也不得让 framework 入口假成功。"
+	)
+	assert_false(_pool.release_for_framework(reused, _scene))
+	if wrong_source_available == 0:
+		reused.set_meta(&"_gf_pool_source_scene", _scene)
+		_pool.release(reused, _scene)
+
+
 func test_release_for_framework_settles_exact_queued_active_lease() -> void:
 	var queued_scene: PackedScene = _make_lifecycle_hook_scene()
 	var node: LifecycleHookNode = _acquire_lifecycle_hook_node(queued_scene)


### PR DESCRIPTION
## Summary

- observe the frozen Projectile instance root directly so complete-root exits finish direct launches with `ROOT_LOST` before the child runtime's deferred `RUNTIME_LOST` fallback
- make framework pool settlement rely on the authoritative active-lease maps after exact identity checks, while preserving legacy public `release()` metadata admission
- add discriminating regressions for `queue_free()`, child-first root removal, and both active/source metadata drift cases

## Review follow-up

This follows up the two actionable P2 threads on merged PR #172:

- https://github.com/C76GN/gf-framework/pull/172#discussion_r3854427381
- https://github.com/C76GN/gf-framework/pull/172#discussion_r3854427392

Tests-first evidence on `7d63ff5a` reproduced both failures before the production changes: direct root exits reported `RUNTIME_LOST`, and metadata drift left the authoritative pool lease active while `release_for_framework()` returned success.

## Validation

- `godot_import` + `gdscript_warnings`: PASS
- focused Projectile: 100/100 tests, 1213 assertions, lifecycle 0/0, strict exit leaks 0
- focused ObjectPool: 61/61 tests, 204 assertions, lifecycle 0/0, strict exit leaks 0
- full framework GUT: 370 scripts, 7263/7263 tests, 87787 assertions, lifecycle 0/0
- strict GDScript LSP: 1387 files, 0 diagnostics, 0 timeouts
- API Reference / AI source: current (873 classes / 12700 members; 849 AI classes)
- docs: 4/4 PASS; canonical quick: 30/30 PASS
- package contract: 12/12 PASS
- `gf.extension.combat` package smoke: 2 scenarios, 672 installed files, 331 preloads, 0 issues/leak warnings