### PR TITLE
fix(assets): harden Node owner tree-exit cleanup

### DIFF
--- a/addons/gf/standard/utilities/assets/gf_asset_utility.gd
+++ b/addons/gf/standard/utilities/assets/gf_asset_utility.gd
@@ -143,7 +143,6 @@ var _pinned_cache_paths: Dictionary = {}
 var _reference_counts: Dictionary = {}
 var _owner_reference_counts: Dictionary = {}
 var _owner_refs: Dictionary = {}
-var _owner_release_connected: Dictionary = {}
 var _handle_refs: Array[WeakRef] = []
 var _group_paths: Dictionary = {}
 var _group_pin_counts: Dictionary = {}
@@ -174,7 +173,6 @@ func init() -> void:
 	_reference_counts.clear()
 	_owner_reference_counts.clear()
 	_owner_refs.clear()
-	_owner_release_connected.clear()
 	_handle_refs.clear()
 	_group_paths.clear()
 	_group_pin_counts.clear()
@@ -218,7 +216,6 @@ func dispose() -> void:
 	_reference_counts.clear()
 	_owner_reference_counts.clear()
 	_owner_refs.clear()
-	_owner_release_connected.clear()
 	_handle_refs.clear()
 	_group_paths.clear()
 	_group_pin_counts.clear()
@@ -1446,27 +1443,6 @@ func _get_callback_entry_type_hint(entry: Dictionary) -> String:
 	return GFVariantData.get_option_string(entry, "type_hint", "")
 
 
-func _connect_signal_checked(
-	source_signal: Signal,
-	callback: Callable,
-	one_shot: bool = false
-) -> void:
-	if not source_signal.is_null() and callback.is_valid():
-		var connected_callback: Callable = callback
-		if one_shot:
-			var one_shot_callback: Callable
-			one_shot_callback = func() -> void:
-				if source_signal.is_connected(one_shot_callback):
-					source_signal.disconnect(one_shot_callback)
-				var callback_result: Variant = callback.call()
-				if callback_result != null:
-					return
-			connected_callback = one_shot_callback
-		var error: Error = source_signal.connect(connected_callback) as Error
-		if error != OK and error != ERR_ALREADY_EXISTS:
-			push_warning("[GFAssetUtility] Signal 连接失败：%d。" % error)
-
-
 func _append_report_path(report: Dictionary, key: String, path: String) -> void:
 	var paths: PackedStringArray = _get_packed_string_array_value(
 		GFVariantData.get_option_value(report, key, PackedStringArray())
@@ -1838,10 +1814,17 @@ func _track_owner(owner: Object) -> void:
 
 	var owner_id: int = owner.get_instance_id()
 	_owner_refs[owner_id] = weakref(owner)
-	if owner is Node and not GFVariantData.get_option_bool(_owner_release_connected, owner_id, false):
+	if owner is Node:
 		var owner_node: Node = owner
-		_connect_signal_checked(owner_node.tree_exited, _release_owner_id.bind(owner_id), true)
-		_owner_release_connected[owner_id] = true
+		var owner_exit_callback: Callable = _release_owner_id.bind(owner_id)
+		if owner_node.tree_exited.is_connected(owner_exit_callback):
+			return
+		var connect_error: Error = owner_node.tree_exited.connect(
+			owner_exit_callback,
+			CONNECT_ONE_SHOT as Object.ConnectFlags
+		) as Error
+		if connect_error != OK:
+			push_warning("[GFAssetUtility] owner 退出树信号连接失败：%d。" % connect_error)
 
 
 func _track_handle(handle: GFAssetHandle) -> void:
@@ -1906,7 +1889,6 @@ func _release_owner_id(owner_id: int) -> int:
 
 	_release_owner_handles(owner_id)
 	_erase_dictionary_key(_owner_refs, owner_id)
-	_erase_dictionary_key(_owner_release_connected, owner_id)
 	return released_count
 
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -199,6 +199,7 @@
 
 ### 🐛 Bug 修复 (Fixed)
 
+- 修复 `GFAssetUtility` 为 Node owner 注册 `tree_exited` 一次性回调时，自引用局部 `Callable` 在退树阶段变为空并触发引擎错误的问题；改由 Godot 原生 `CONNECT_ONE_SHOT` 管理断开，并以实际信号连接状态去重，使 `release_owner()` / `handle.release()` 后重获以及节点退树重入都能保持单一生命周期连接并精确释放句柄。
 - 修复 direct Projectile launch 的完整 root 在 `queue_free()` / 退树时被 child runtime 误报为 `RUNTIME_LOST`，以及对象池 authoritative lease 已匹配但可变 Node metadata 漂移时 `release_for_framework()` 假成功的问题；Session 现在直接观察 frozen root 的一次性退树信号并保留 `ROOT_LOST` first-wins，framework pool 入口则绕过 legacy metadata 准入、修复 metadata 并在返回成功前同步擦除精确 active lease。
 - 修复 Combat Projectile 在 binding 失败时丢失 `GFProjectileBinding.FailureReason`、对象池活动 lease 被 `init()` 清除 tracking 后完整 root 无法退休、失败/非有限 capture 仍进入 Motion、有限 velocity/delta 的乘法或候选位置溢出会先污染权威 root、Session 累计指标溢出，以及 locked Homing 的 arrival clamp 仍读取 live target 的问题；2D/3D Emitter 现在提供有界 `binding_failure_reason`，池结算只归还精确 active lease 并对失效 tracking 的自有 root 单次 free fallback，Runtime 在失败 capture 后立即终结，Intent 与 Transform/CharacterBody Adapter 则在任何宿主写入前拒绝非有限结果，Session 保留最后有限指标；`track_target=false` 时 live target 后续移动不再改写 launch 快照，目标失效后沿锁定方向继续并禁用 clamp。
 - 修复类型化场景请求的四个终端边界：非主线程配置失败不再返回无法终结的半配置 Operation 或派发 Broker Lease；preload 在调用 Broker poll 前进入 settlement fence，终态回调中的同路径重入以 busy 失败关闭，不再递归轮询旧 aggregate；同步自定义切场的显式确认与同步 `scene_changed` 只记录 current-generation 回执，并在 override 返回 true 及 owner/token 复核后结算；同路径异步 override 用 `_defer_target_scene_commit()` 区分合法等待与 same-root no-op，不同路径 legacy async observer 保持兼容；基础 pathless commit 预实例化并只接受精确 root，自定义 pathless commit 则必须显式确认精确回执，不再把任意新空路径或同路径旧 root 误认成冻结目标。

--- a/tests/gf_core/standard/utilities/assets/test_gf_asset_utility.gd
+++ b/tests/gf_core/standard/utilities/assets/test_gf_asset_utility.gd
@@ -227,6 +227,134 @@ func test_release_owner_releases_owned_asset_handles() -> void:
 	handle_owner.free()
 
 
+func test_node_owner_exit_releases_asset_handle_without_engine_error() -> void:
+	var handle_owner: Node = Node.new()
+	add_child(handle_owner)
+	watch_signals(_utility)
+	var handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_tree_exit.tres",
+		handle_owner,
+		&"",
+		"",
+		Resource.new()
+	)
+
+	handle_owner.queue_free()
+	await get_tree().process_frame
+
+	assert_true(handle.is_released(), "Node owner 退出树后应自动释放对应句柄。")
+	assert_eq(
+		_utility.get_asset_reference_count("res://owned_tree_exit.tres"),
+		0,
+		"Node owner 退出树后路径引用计数应归零。"
+	)
+	assert_signal_emit_count(_utility, "asset_handle_released", 1)
+	assert_engine_error_count(0, "Node owner 退出树时不得使用空 Callable 查询或断开信号。")
+
+
+func test_release_owner_then_reacquire_reuses_tree_exit_connection() -> void:
+	var handle_owner: Node = Node.new()
+	add_child(handle_owner)
+	var first_handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_reacquire.tres",
+		handle_owner,
+		&"",
+		"",
+		Resource.new()
+	)
+
+	assert_eq(_utility.release_owner(handle_owner), 1)
+	assert_true(first_handle.is_released())
+	var second_handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_reacquire.tres",
+		handle_owner
+	)
+
+	assert_not_null(second_handle, "同一 owner 在显式释放后应能重新获取句柄。")
+	assert_eq(
+		handle_owner.tree_exited.get_connections().size(),
+		1,
+		"同一 owner 的 tree_exited 生命周期只应保留一个连接。"
+	)
+
+	handle_owner.queue_free()
+	await get_tree().process_frame
+
+	assert_true(second_handle.is_released(), "重新获取的句柄仍应在 owner 退出树时释放。")
+	assert_eq(_utility.get_asset_reference_count("res://owned_reacquire.tres"), 0)
+	assert_engine_error_count(0, "重新获取不得重复连接信号或在退出树时使用空 Callable。")
+
+
+func test_handle_release_then_reacquire_keeps_single_tree_exit_lifecycle() -> void:
+	var handle_owner: Node = Node.new()
+	add_child(handle_owner)
+	var first_handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_handle_reacquire.tres",
+		handle_owner,
+		&"",
+		"",
+		Resource.new()
+	)
+
+	assert_true(first_handle.release(), "首次句柄应能显式释放。")
+	var second_handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_handle_reacquire.tres",
+		handle_owner
+	)
+
+	assert_not_null(second_handle, "同一 owner 在句柄释放后应能重新获取。")
+	assert_eq(
+		handle_owner.tree_exited.get_connections().size(),
+		1,
+		"重新获取后仍只能有一个 owner 退出树生命周期连接。"
+	)
+
+	handle_owner.queue_free()
+	await get_tree().process_frame
+
+	assert_true(second_handle.is_released(), "重新获取的句柄应在 owner 退出树时释放。")
+	assert_eq(_utility.get_asset_reference_count("res://owned_handle_reacquire.tres"), 0)
+	assert_engine_error_count(0, "句柄释放后重获取不得重复连接或使用空 Callable。")
+
+
+func test_node_owner_reentry_reconnects_next_tree_exit_lifecycle() -> void:
+	var handle_owner: Node = Node.new()
+	add_child(handle_owner)
+	var first_handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_reentry.tres",
+		handle_owner,
+		&"",
+		"",
+		Resource.new()
+	)
+
+	remove_child(handle_owner)
+	await get_tree().process_frame
+
+	assert_true(first_handle.is_released(), "首次退出树应释放第一份句柄。")
+	assert_eq(handle_owner.tree_exited.get_connections().size(), 0)
+
+	add_child(handle_owner)
+	var second_handle: GFAssetHandle = _utility.acquire_handle(
+		"res://owned_reentry.tres",
+		handle_owner
+	)
+	assert_not_null(second_handle)
+	assert_eq(
+		handle_owner.tree_exited.get_connections().size(),
+		1,
+		"one-shot 连接消费后，下一次获取应建立新的生命周期连接。"
+	)
+
+	remove_child(handle_owner)
+	await get_tree().process_frame
+
+	assert_true(second_handle.is_released(), "再次退出树应释放重新获取的句柄。")
+	assert_eq(_utility.get_asset_reference_count("res://owned_reentry.tres"), 0)
+	assert_engine_error_count(0, "owner 重入树后的下一次生命周期不得产生引擎错误。")
+	handle_owner.free()
+
+
 func test_preload_group_async_registers_and_unloads_group() -> void:
 	var completing: CompletingAssetUtility = CompletingAssetUtility.new()
 	_replace_utility(completing)


### PR DESCRIPTION
## Summary

Fix `GFAssetUtility` Node-owner cleanup so `tree_exited` never evaluates a null self-referential `Callable`. The owner lifecycle now uses Godot's native one-shot connection and the Signal's actual connection state as the single source of truth.

Before this change, leaving a scene could emit `Cannot determine if connected to 'tree_exited': the provided callable is null`, even though handle cleanup continued afterward. After this change, owner exit releases handles exactly once without engine errors, and reacquiring through the same owner does not create duplicate connections.

## Contract and Risk

- Change type: fix
- Consumer-visible behavior: Node-owned asset handles are still released on `tree_exited`, now without an engine error.
- API or extension contract: No public/protected API, extension manifest, or API Reference change.
- Persisted data, package, protocol, or ProjectSettings impact: None.
- Failure, cancellation, rollback, concurrency, and ownership impact: Connection failures remain warning-visible and retryable on a later acquisition. Native `CONNECT_ONE_SHOT` disconnects before callback dispatch; `release_owner()` and `handle.release()` followed by reacquisition reuse the pending lifecycle connection, while a Node that exits and re-enters establishes a new one for the next lifecycle.
- Compatibility and migration: Compatible fix; no consumer migration. Scene switching, pause layers, Spawn Controllers, cache policy, and async-load cancellation are unaffected.

## Verification

- [x] Focused tests cover the changed behavior and failure path: old implementation failed all 4 new lifecycle tests (`48/52`); fixed implementation passes `52/52` with a clean lifecycle gate.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only` (`30/30`).
- [x] GDScript warning and LSP gates are clean when `.gd` files changed (`1376` files, 0 diagnostics/timeouts).
- [x] Generated API or knowledge output is fresh when its source changed; formal API generation passed and the ignored local AI API analysis snapshot was refreshed.
- [x] Draft PR feedback completed through `GF draft gate`.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`.
- [x] `python tools/gf_maintenance.py resource-boundary --json` (0 issues).
- [x] `python tools/gf_maintenance.py asset-lifecycle-boundary --json` (0 issues).
- [x] `python tools/gf_maintenance.py check --suite full --jobs 3 --failed-only` (`39/39`).
- [x] `python tools/gf_maintenance.py project-settings-drift --json`.
- [x] `git diff --check` and `git diff --cached --check`.

The first Ready `static and docs` run hit an unrelated one-second thread-settlement timeout in `test_windows_tcp_native_query_obeys_operation_deadline_and_health`. The source SHA was unchanged; rerunning the failed job passed the complete static shard, Full validation, and merge gate.

## Documentation and Release

- [x] The `[未发布]` changelog records the consumer-visible fix; the existing asset-handle guide already states the intended owner-exit contract.
- [x] Development version remains `11.0.0-dev.0`; this compatible private implementation fix does not alter the intended SemVer line.
- [x] This PR does not create a tag or publish a release.