### PR TITLE
feat(console): expose visibility control

### DIFF
--- a/addons/gf/standard/utilities/debug/gf_console_utility.gd
+++ b/addons/gf/standard/utilities/debug/gf_console_utility.gd
@@ -500,6 +500,31 @@ func execute_command(raw_input: String) -> bool:
 	return true
 
 
+## 设置控制台 GUI 可见性。GUI 未创建或已释放时不会执行任何操作。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @param console_visible: 为 true 时显示控制台 GUI。
+func set_console_visible(console_visible: bool) -> void:
+	if not is_instance_valid(_console_gui):
+		return
+
+	_console_gui._set_console_visible(console_visible)
+
+
+## 检查控制台 GUI 是否可见。GUI 未创建或已释放时返回 false。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+## [br]
+## @return 控制台 GUI 可见时返回 true。
+func is_console_visible() -> bool:
+	return is_instance_valid(_console_gui) and _console_gui.visible
+
+
 ## 向控制台输出追加一行 BBCode 文本。
 ## [br]
 ## @api public
@@ -1344,10 +1369,7 @@ class _GFConsoleGUI extends CanvasLayer:
 			if not key_event.pressed or key_event.echo:
 				return
 			if key_event.keycode == toggle_key:
-				visible = not visible
-				if visible:
-					_layout_console()
-					_input_field.call_deferred("grab_focus")
+				_set_console_visible(not visible)
 				get_viewport().set_input_as_handled()
 			elif visible and _input_field.has_focus() and key_event.keycode == KEY_UP:
 				_show_previous_history()
@@ -1441,6 +1463,26 @@ class _GFConsoleGUI extends CanvasLayer:
 
 
 	# --- 私有/辅助方法 ---
+
+	func _set_console_visible(console_visible: bool) -> void:
+		visible = console_visible
+		if not visible:
+			_dragging = false
+			_resizing = false
+			return
+
+		_layout_console()
+		call_deferred("_grab_input_focus_if_visible")
+
+
+	func _grab_input_focus_if_visible() -> void:
+		if is_queued_for_deletion() or not visible or not is_inside_tree():
+			return
+		if not is_instance_valid(_input_field) or not _input_field.is_inside_tree():
+			return
+
+		_input_field.grab_focus()
+
 
 	func _apply_layer() -> void:
 		layer = _TOPMOST_LAYER if keep_topmost else _DEFAULT_LAYER

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "catalog_version": "2.0.0",
   "framework_version": "11.0.0-dev.0",
-  "source_digest": "4fdd6c8f285c4d9be73a7e5cb713e858bbb05e4163dbeaeddf84ce2ec5898040",
+  "source_digest": "9e3ae9c9d4218b545692bfa7eadc7f1bcb2ba25f7d3ae6701c6db97c8a4017fc",
   "class_count": 849,
   "autoload_count": 1,
   "package_count": 56,
@@ -22506,6 +22506,20 @@
           "name": "execute_command",
           "signature": "func execute_command(raw_input: String) -> bool",
           "summary": "解析并执行一条原始输入。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "set_console_visible",
+          "signature": "func set_console_visible(console_visible: bool) -> void",
+          "summary": "设置控制台 GUI 可见性。GUI 未创建或已释放时不会执行任何操作。",
+          "visibility": "public"
+        },
+        {
+          "kind": "func",
+          "name": "is_console_visible",
+          "signature": "func is_console_visible() -> bool",
+          "summary": "检查控制台 GUI 是否可见。GUI 未创建或已释放时返回 false。",
           "visibility": "public"
         },
         {

--- a/docs/api_catalog/classes/GFConsoleUtility.xml
+++ b/docs/api_catalog/classes/GFConsoleUtility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFConsoleUtility" path="addons/gf/standard/utilities/debug/gf_console_utility.gd" module="standard" extends="GFUtility" classDigest="a2deac00a175c2153a5b8d5abd10eb7ae78fe92dc1924fe1c41db6dec2638b03">
+<class name="GFConsoleUtility" path="addons/gf/standard/utilities/debug/gf_console_utility.gd" module="standard" extends="GFUtility" classDigest="78af9702436036db494debbed361ca1d7be96a33d1c8cc44023cf4eb0e3d9987">
 	<description>GFConsoleUtility: 运行时开发者控制台。
 提供命令注册、解析与执行能力，并在初始化时构建覆盖全屏的调试 GUI。
 默认通过快捷键呼出，同时会消费 `GFLogUtility` 的日志信号进行彩色输出。</description>
@@ -230,6 +230,24 @@ prefix 和 raw_input。GF 会按当前参数前缀做一次稳定过滤。</desc
 				<tag name="api">public</tag>
 				<tag name="param">raw_input: 用户输入的完整字符串。</tag>
 				<tag name="return">找到并成功执行命令时返回 `true`。</tag>
+			</tags>
+		</member>
+		<member kind="method" name="set_console_visible">
+			<signature>func set_console_visible(console_visible: bool) -&gt; void:</signature>
+			<description>设置控制台 GUI 可见性。GUI 未创建或已释放时不会执行任何操作。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="param">console_visible: 为 true 时显示控制台 GUI。</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="method" name="is_console_visible">
+			<signature>func is_console_visible() -&gt; bool:</signature>
+			<description>检查控制台 GUI 是否可见。GUI 未创建或已释放时返回 false。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="return">控制台 GUI 可见时返回 true。</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="method" name="append_output_line">

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="c3ea24d6d5fd5aa4c9dd12f1926c3755634bec47fdbd5e40cad0bf5ceffcca63" classCount="873" methodCount="7851" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="b7dedf0103a72708aa2d165f72630ce5313ada6e8e16f52c7b561a70fcd170b7" classCount="873" methodCount="7853" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="77" methodCount="818" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />
@@ -80,7 +80,7 @@
 		<class name="GFWeakMethodInvocation" path="classes/GFWeakMethodInvocation.xml" sourcePath="addons/gf/kernel/core/gf_weak_method_invocation.gd" extends="RefCounted" />
 		<autoload name="Gf" path="autoloads/Gf.xml" sourcePath="addons/gf/kernel/core/gf.gd" extends="Node" packageId="gf.kernel" />
 	</module>
-	<module id="standard" label="Standard" classCount="478" methodCount="4823" autoloadCount="0" autoloadMethodCount="0">
+	<module id="standard" label="Standard" classCount="478" methodCount="4825" autoloadCount="0" autoloadMethodCount="0">
 		<class name="GFActivationTransaction" path="classes/GFActivationTransaction.xml" sourcePath="addons/gf/standard/foundation/policy/gf_activation_transaction.gd" extends="RefCounted" />
 		<class name="GFAnalyticsConfig" path="classes/GFAnalyticsConfig.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_config.gd" extends="Resource" />
 		<class name="GFAnalyticsEventSchema" path="classes/GFAnalyticsEventSchema.xml" sourcePath="addons/gf/standard/utilities/analytics/gf_analytics_event_schema.gd" extends="Resource" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -6,6 +6,7 @@
 
 ### 🚀 新增特性 (Added)
 
+- `GFConsoleUtility` 新增 `set_console_visible()` 与 `is_console_visible()`；项目可从触摸按钮、手柄菜单或自动化调试入口显式控制既有控制台，未创建或已释放的 GUI 保持 no-op 与不可见语义。
 - Combat Projectile 新增 `GFProjectileDefinition2D` / `GFProjectileDefinition3D` 类型化场景拓扑、`GFProjectileBinding2D` / `GFProjectileBinding3D` 校验快照、2D/3D LaunchInput、维度中立 `GFProjectileSession`、per-session MotionState/Intent、BodyResult/BodyAdapter，以及 Transform/CharacterBody 对称适配器；显式 0..N 同维 HitBox/HitScan typed union impact source、实际位移累计、generation 隔离与 first-wins Session 终态共同替代共享 Dictionary 私有状态。
 - Background Work 新增线程安全、只读的 `GFBackgroundWorkContext` 与显式 `pass_cancellation_context` opt-in：CPU/IO worker 可在有界工作段之间观察首次取消原因并协作退出，而默认一参 worker、纯数据 payload 边界和不可强杀线程的行为保持不变。单任务取消、批量取消、`clear_all()` 与 Utility 释放使用稳定且 first-wins 的类型化原因；已启动 CPU/IO 线程任务在主线程 join 后唯一提交取消终态，尚未启动的排队任务立即取消。
 - Storage 新增一次性 `GFStorageFamilyResetAuthorization`、类型化 `GFStorageFamilyResetResult`、`create_family_reset_authorization()`、`reset_file_family()` 与 `reset_file_family_request_async()`：调用方只能用同一 Utility、同一 canonical logical identity 的来源绑定 `CORRUPT` 读取结果授权破坏性 family reset。执行器以持久化 intent、retirement staging 与全新 owner/catalog claim 收敛 structural identity 损坏，并复用同 family FIFO、threaded/cooperative 执行、caller/物理双终态、取消、deadline、quiesce 与迟到诊断。

--- a/docs/zh/reference/api/classes/GFConsoleUtility.md
+++ b/docs/zh/reference/api/classes/GFConsoleUtility.md
@@ -40,6 +40,8 @@
 | 方法 | [`suggest_command_arguments`](#member-gfconsoleutility-methods-suggest_command_arguments) | `func suggest_command_arguments(raw_input: String) -> PackedStringArray:` |
 | 方法 | [`suggest_similar_commands`](#member-gfconsoleutility-methods-suggest_similar_commands) | `func suggest_similar_commands(cmd_name: String, limit: int = 3, threshold: float = 0.5) -> PackedStringArray:` |
 | 方法 | [`execute_command`](#member-gfconsoleutility-methods-execute_command) | `func execute_command(raw_input: String) -> bool:` |
+| 方法 | [`set_console_visible`](#member-gfconsoleutility-methods-set_console_visible) | `func set_console_visible(console_visible: bool) -> void:` |
+| 方法 | [`is_console_visible`](#member-gfconsoleutility-methods-is_console_visible) | `func is_console_visible() -> bool:` |
 | 方法 | [`append_output_line`](#member-gfconsoleutility-methods-append_output_line) | `func append_output_line(bbcode_line: String) -> void:` |
 | 方法 | [`append_output_lines`](#member-gfconsoleutility-methods-append_output_lines) | `func append_output_lines(bbcode_lines: PackedStringArray) -> void:` |
 | 方法 | [`clear_output`](#member-gfconsoleutility-methods-clear_output) | `func clear_output() -> void:` |
@@ -441,6 +443,40 @@ func execute_command(raw_input: String) -> bool:
 | `raw_input` | 用户输入的完整字符串。 |
 
 返回：找到并成功执行命令时返回 `true`。
+
+<a id="member-gfconsoleutility-methods-set_console_visible"></a>
+
+### `set_console_visible`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func set_console_visible(console_visible: bool) -> void:
+```
+
+设置控制台 GUI 可见性。GUI 未创建或已释放时不会执行任何操作。
+
+参数：
+
+| 名称 | 说明 |
+|---|---|
+| `console_visible` | 为 true 时显示控制台 GUI。 |
+
+<a id="member-gfconsoleutility-methods-is_console_visible"></a>
+
+### `is_console_visible`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+func is_console_visible() -> bool:
+```
+
+检查控制台 GUI 是否可见。GUI 未创建或已释放时返回 false。
+
+返回：控制台 GUI 可见时返回 true。
 
 <a id="member-gfconsoleutility-methods-append_output_line"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 77 | 1128 | [Kernel](#module-kernel) |
-| Standard | 478 | 7612 | [Standard](#module-standard) |
+| Standard | 478 | 7614 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -152,7 +152,7 @@
 | [`GFConfigReferenceResolver`](GFConfigReferenceResolver.md#gfconfigreferenceresolver) | 运行时服务 (`runtime_service`) | `RefCounted` | 3 | `addons/gf/standard/utilities/config/gf_config_reference_resolver.gd` |
 | [`GFConfigTableImporter`](GFConfigTableImporter.md#gfconfigtableimporter) | 运行时服务 (`runtime_service`) | `RefCounted` | 9 | `addons/gf/standard/utilities/config/gf_config_table_importer.gd` |
 | [`GFConfigTableMergeTools`](GFConfigTableMergeTools.md#gfconfigtablemergetools) | 运行时服务 (`runtime_service`) | `RefCounted` | 1 | `addons/gf/standard/utilities/config/gf_config_table_merge_tools.gd` |
-| [`GFConsoleUtility`](GFConsoleUtility.md#gfconsoleutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 30 | `addons/gf/standard/utilities/debug/gf_console_utility.gd` |
+| [`GFConsoleUtility`](GFConsoleUtility.md#gfconsoleutility) | 运行时服务 (`runtime_service`) | `GFUtility` | 32 | `addons/gf/standard/utilities/debug/gf_console_utility.gd` |
 | [`GFControlFocusUtility`](GFControlFocusUtility.md#gfcontrolfocusutility) | 运行时服务 (`runtime_service`) | `RefCounted` | 9 | `addons/gf/standard/utilities/ui/gf_control_focus_utility.gd` |
 | [`GFControlValueAdapter`](GFControlValueAdapter.md#gfcontrolvalueadapter) | 运行时服务 (`runtime_service`) | `RefCounted` | 5 | `addons/gf/standard/utilities/ui/gf_control_value_adapter.gd` |
 | [`GFCurve2DMath`](GFCurve2DMath.md#gfcurve2dmath) | 运行时服务 (`runtime_service`) | `RefCounted` | 17 | `addons/gf/standard/foundation/math/gf_curve_2d_math.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -7,8 +7,8 @@
 - 源码根目录：`addons/gf`
 - 公开类：`873`
 - 公开 AutoLoad：`1`
-- 公开成员：`12700`
-- 公开方法：`7851`
+- 公开成员：`12702`
+- 公开方法：`7853`
 - AutoLoad 公开方法：`65`
 
 ## 模块
@@ -16,7 +16,7 @@
 | 模块 | 类 | AutoLoad | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---:|---|
 | Kernel | 77 | 1 | 1197 | 883 | [kernel.md](kernel.md) |
-| Standard | 478 | 0 | 7612 | 4823 | [standard.md](standard.md) |
+| Standard | 478 | 0 | 7614 | 4825 | [standard.md](standard.md) |
 | Action Queue | 16 | 0 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 0 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 0 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -6,7 +6,7 @@
 
 | 类别 | 类 | 成员 | 方法 |
 |---|---:|---:|---:|
-| [运行时服务](#category-runtime_service) | 193 | 3483 | 2363 |
+| [运行时服务](#category-runtime_service) | 193 | 3485 | 2365 |
 | [协议与扩展点](#category-protocol) | 26 | 345 | 273 |
 | [资源定义](#category-resource_definition) | 122 | 1573 | 797 |
 | [运行时句柄](#category-runtime_handle) | 56 | 961 | 617 |

--- a/docs/zh/standard/utilities/runtime/debug-observability/developer-console/display-lifecycle.md
+++ b/docs/zh/standard/utilities/runtime/debug-observability/developer-console/display-lifecycle.md
@@ -18,6 +18,15 @@ console.keep_topmost = true
 
 `windowed = true` 更适合边运行边观察状态或执行调试命令；拖拽区域位于标题文本，右下角手柄用于缩放。
 
+触摸按钮、手柄菜单或项目自己的调试入口可以显式控制同一个控制台，不需要访问 GUI 私有节点：
+
+```gdscript
+console.set_console_visible(true)
+console.set_console_visible(not console.is_console_visible())
+```
+
+显式显示与快捷键使用相同的布局和输入框聚焦流程。控制台 GUI 尚未创建或已经 `dispose()` 时，`set_console_visible()` 不执行操作，`is_console_visible()` 返回 `false`；调用不会创建第二个 GUI，也不会保存待显示状态。
+
 `debug_only = true` 会在非 debug 构建中跳过 GUI 创建，适合把控制台注册代码留在通用启动流程里，但仍由项目发布策略决定是否注册调试命令。
 
 正常运行中，控制台 GUI 在 `dispose()` 时会立即脱离场景树，并断开日志信号，避免关闭架构后同一帧仍留下调试输入层。Gf AutoLoad 正在执行 `_exit_tree()` 的同步释放作用域时只断开连接并登记延迟释放，不会重入修改正在拆除子节点的父节点。

--- a/tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd
+++ b/tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd
@@ -73,6 +73,23 @@ func test_init_is_idempotent_for_console_overlay() -> void:
 	assert_eq(_count_console_overlays(), 1, "重复 init 不应创建多个控制台 overlay。")
 
 
+func test_console_visibility_can_be_controlled_explicitly() -> void:
+	assert_false(_console.is_console_visible(), "控制台 GUI 初始应保持隐藏。")
+	_console.set_console_visible(true)
+	assert_true(_console.is_console_visible(), "显式显示后应报告可见。")
+	_console._console_gui._dragging = true
+	_console._console_gui._resizing = true
+	_console.set_console_visible(false)
+	assert_false(_console.is_console_visible(), "显式隐藏后应报告不可见。")
+	assert_false(_console._console_gui._dragging, "显式隐藏应结束窗口拖拽状态。")
+	assert_false(_console._console_gui._resizing, "显式隐藏应结束窗口缩放状态。")
+
+	_console.dispose()
+
+	_console.set_console_visible(true)
+	assert_false(_console.is_console_visible(), "GUI 已释放时应报告不可见。")
+
+
 func test_subscription_cancels_command_registration() -> void:
 	var cb: Callable = func(_args: PackedStringArray) -> void:
 		pass
@@ -574,12 +591,14 @@ func test_dispose_detaches_console_gui_immediately() -> void:
 
 func test_dispose_leaves_console_attached_during_autoload_tree_exit() -> void:
 	var gui: CanvasLayer = _console._console_gui
+	_console.set_console_visible(true)
 	GFAutoload.begin_tree_exit_scope()
 
 	_console.dispose()
 	_console = null
 
 	assert_not_null(gui.get_parent(), "AutoLoad 退出时不应重入修改控制台 GUI 的父节点。")
+	assert_true(gui.is_queued_for_deletion(), "AutoLoad 退出时仍应登记 GUI 延迟释放。")
 
 	GFAutoload.end_tree_exit_scope()
 	await get_tree().process_frame


### PR DESCRIPTION
## Summary

Projects could only toggle the built-in developer console through its configured keyboard shortcut, so touch, controller, menu, and automation entry points had to reach into private GUI state. This PR adds a small public set/query surface for the existing console and keeps keyboard and programmatic visibility on the same layout/focus path.

## Contract and Risk

- Change type: feat
- Consumer-visible behavior: projects can call `set_console_visible(bool)` and `is_console_visible()` on `GFConsoleUtility` to control and query the existing console GUI.
- API or extension contract: two additive `@api public` methods with `@since unreleased`; no aliases, second GUI, signal, or pending visibility state are introduced.
- Persisted data, package, protocol, or ProjectSettings impact: none.
- Failure, cancellation, rollback, concurrency, and ownership impact: when the GUI was not created or has been disposed, setting visibility is a no-op and querying returns `false`. Hiding ends active drag/resize interaction. Showing uses bounded deferred focus that rejects detached or queued-for-deletion GUI state.
- Compatibility and migration: backward-compatible addition on the existing GF 11 development line; no migration is required.

## Verification

- [x] Focused tests cover the changed behavior and failure path.
- [ ] `python tools/gf_maintenance.py check --suite quick --failed-only` (not run separately; the stronger `full` suite passed)
- [x] GDScript warning and LSP gates are clean when `.gd` files changed.
- [x] Generated API or knowledge output is fresh when its source changed.
- [ ] Draft PR feedback completed through `GF draft gate` when applicable. (not applicable; this is a Ready PR)
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

Exact local results:

- Focused GUT selection for `res://tests/gf_core/standard/utilities/debug/test_gf_console_utility.gd`: 43/43 tests, 139 assertions, lifecycle gate clean.
- `python -B tools/gf_maintenance.py check --suite full --json`: 39/39 checks passed across `framework-static`, `framework-integration`, `framework-gut`, and `framework-lsp` in 1630.912 seconds.
- `python -B tools/gf_maintenance.py check --suite api --json`: 4/4 checks passed; the AI Developer Kit test entry ran 273 tests successfully (1 skipped).
- `python -B tools/gf_maintenance.py check --check gdscript_warnings --json`: passed.
- `python -B tools/gf_maintenance.py check --check gdscript_lsp_diagnostics --json`: a cold-start handshake timed out once; the clean retry passed with 1376 files, 0 diagnostics, and 0 file timeouts. The `full` LSP shard also passed.
- `python -B tools/generate_api_reference.py --check`: 873 classes, 1 autoload, and 12702 members; Catalog and Reference current.
- `python -B tools/build_gf_ai_developer_kit.py --check-source --json`: passed with 849 classes and 1 autoload.
- `python -B tools/gf_maintenance.py check --suite docs --json`: passed.
- `python -B tools/gf_maintenance.py api-since-touched --json`, `public-api-boundary --json`, `public-docs-boundary --json`, `api-baseline-diff --version 11.0.0 --enforce-version --json`, `project-settings-drift --json`, and `git diff --check`: passed.

## Documentation and Release

- [x] Relevant guide and `[未发布]` changelog entries are updated, or the change is not user-visible.
- [x] Development version impact is correct, or the change does not alter the intended SemVer line.
- [x] This PR does not create a tag or publish a release.

## Demand-gated follow-ups (not implemented)

- Project localization audit: consider only after repeated cross-project demand and explicit catalog/include/exclude requirements; editor and headless use must share one audit result.
- Optional Godot native Logger bridge: consider only after validated demand for engine/print/warning capture; it must be default-off, bounded, thread-safe, recursion-safe, and feed the existing console rather than create another logging UI.
- Schema-driven config authoring UI: consider only after validated demand for in-editor authoring; it must remain a thin UI over the existing Config Pipeline and editor field tools, without a second data backend.
