### PR TITLE
Validate configuration array references with element diagnostics

### DIFF
--- a/addons/gf/standard/utilities/config/gf_config_reference_resolver.gd
+++ b/addons/gf/standard/utilities/config/gf_config_reference_resolver.gd
@@ -1,6 +1,6 @@
 ## GFConfigReferenceResolver: 通用导表引用校验与解析工具。
 ##
-## 在多张表加载后统一检查引用、构建复合索引，并可把记录中的引用解析为目标记录副本。
+## 在多张表加载后统一检查字段或数组元素引用、构建共享索引，并可把 FIELDS 引用解析为目标记录副本。
 ## [br]
 ## @api public
 ## [br]
@@ -85,9 +85,11 @@ static func validate_tables(
 	return report
 
 
-## 解析单条记录的引用目标。
+## 解析单条记录的 FIELDS 引用目标。ARRAY_ELEMENTS 仅参与校验，此入口跳过数组引用。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 ## [br]
 ## @param record: 来源记录。
 ## [br]
@@ -119,6 +121,8 @@ static func resolve_record_references(
 	var reference_index_cache: Dictionary = {}
 	for reference_definition: GFConfigTableReference in schema.references:
 		if reference_definition == null or not reference_definition.is_valid_definition():
+			continue
+		if reference_definition.source_mode != GFConfigTableReference.SourceMode.FIELDS:
 			continue
 		var source_key: String = reference_definition.make_source_key(record)
 		if source_key.is_empty():
@@ -189,8 +193,11 @@ static func _validate_schema_references(
 			target_fields,
 			reference_index_cache
 		)
-		for entry: Dictionary in _normalize_rows(_get_table_by_name(tables_by_name, schema.get_table_key())):
+		for entry: Dictionary in _normalize_rows(_get_table_by_name(tables_by_name, schema.get_table_key()), schema.id_field):
 			var record: Dictionary = _get_row_record(entry)
+			if reference_definition.source_mode == GFConfigTableReference.SourceMode.ARRAY_ELEMENTS:
+				_validate_array_reference(reference_definition, schema.get_table_key(), entry, target_index, report)
+				continue
 			var source_key: String = reference_definition.make_source_key(record)
 			if source_key.is_empty():
 				if reference_definition.required:
@@ -201,7 +208,8 @@ static func _validate_schema_references(
 						schema.get_table_key(),
 						_get_row_key(entry),
 						_first_field(reference_definition.source_fields),
-						"引用来源字段缺失：%s。" % String(reference_definition.get_reference_id())
+						"引用来源字段缺失：%s。" % String(reference_definition.get_reference_id()),
+						{ "row_index": GFVariantData.get_option_int(entry, "row_index") }
 					)
 				continue
 			if reference_definition.required and not target_index.has(source_key):
@@ -212,8 +220,64 @@ static func _validate_schema_references(
 					schema.get_table_key(),
 					_get_row_key(entry),
 					_first_field(reference_definition.source_fields),
-					"引用目标不存在：%s。" % String(reference_definition.get_reference_id())
+					"引用目标不存在：%s。" % String(reference_definition.get_reference_id()),
+					{ "row_index": GFVariantData.get_option_int(entry, "row_index") }
 				)
+
+
+static func _validate_array_reference(
+	reference_definition: GFConfigTableReference,
+	table_name: StringName,
+	row_entry: Dictionary,
+	target_index: Dictionary,
+	report: Dictionary
+) -> void:
+	var field_name: StringName = _first_field(reference_definition.source_fields)
+	var row_key: Variant = _get_row_key(row_entry)
+	var record: Dictionary = _get_row_record(row_entry)
+	var reference_id: String = String(reference_definition.get_reference_id())
+	var row_index: int = GFVariantData.get_option_int(row_entry, "row_index")
+	if not record.has(field_name):
+		if reference_definition.required:
+			_add_issue(
+				report, "error", "missing_reference_value", table_name, row_key, field_name,
+				"引用来源字段缺失：%s。" % reference_id, { "row_index": row_index }
+			)
+		return
+	var source_value: Variant = record[field_name]
+	if not source_value is Array:
+		_add_issue(
+			report, "error", "invalid_reference_value", table_name, row_key, field_name,
+			"数组引用来源必须为 Array：%s。" % reference_id, { "row_index": row_index }
+		)
+		return
+	var elements: Array = source_value
+	for element_index: int in range(elements.size()):
+		var element: Variant = elements[element_index]
+		var context: Dictionary = { "row_index": row_index, "element_index": element_index, "value": element }
+		if not _is_reference_element(element, reference_definition.allow_null_values):
+			_add_issue(
+				report, "error", "invalid_reference_element", table_name, row_key, field_name,
+				"数组引用元素类型无效：%s[%d]。" % [reference_id, element_index], context
+			)
+			continue
+		if not reference_definition.required:
+			continue
+		var element_key: String = _make_key({ field_name: element }, reference_definition.source_fields, reference_definition.allow_null_values)
+		if not target_index.has(element_key):
+			_add_issue(
+				report, "error", "missing_reference", table_name, row_key, field_name,
+				"数组引用目标不存在：%s[%d]。" % [reference_id, element_index], context
+			)
+
+
+static func _is_reference_element(value: Variant, allow_null_values: bool) -> bool:
+	if value == null:
+		return allow_null_values
+	if value is float:
+		var number: float = value
+		return is_finite(number)
+	return value is bool or value is int or value is String or value is StringName
 
 
 static func _build_schema_lookup(schemas: Array[GFConfigTableSchema]) -> Dictionary:
@@ -276,7 +340,7 @@ static func _get_row_key(row_entry: Dictionary) -> Variant:
 	return GFVariantData.get_option_value(row_entry, "row_key")
 
 
-static func _normalize_rows(table_data: Variant) -> Array[Dictionary]:
+static func _normalize_rows(table_data: Variant, id_field: StringName = &"id") -> Array[Dictionary]:
 	var rows: Array[Dictionary] = []
 	if table_data is Array:
 		var array_table: Array = GFVariantData.as_array(table_data)
@@ -285,17 +349,21 @@ static func _normalize_rows(table_data: Variant) -> Array[Dictionary]:
 			if row_variant is Dictionary:
 				var row: Dictionary = GFVariantData.as_dictionary(row_variant)
 				rows.append({
-					"row_key": GFVariantData.get_option_value(row, &"id", index),
+					"row_key": GFVariantData.get_option_value(row, id_field, index) if id_field != &"" else index,
+					"row_index": index,
 					"record": row.duplicate(true),
 				})
 	elif table_data is Dictionary:
 		var table: Dictionary = GFVariantData.as_dictionary(table_data)
-		for key: Variant in table.keys():
+		var keys: Array = table.keys()
+		for row_index: int in range(keys.size()):
+			var key: Variant = keys[row_index]
 			var row_variant: Variant = table[key]
 			if row_variant is Dictionary:
 				var row: Dictionary = GFVariantData.as_dictionary(row_variant)
 				rows.append({
 					"row_key": key,
+					"row_index": row_index,
 					"record": row.duplicate(true),
 				})
 	return rows
@@ -325,9 +393,10 @@ static func _add_issue(
 	table_name: StringName,
 	row_key: Variant,
 	field_name: StringName,
-	message: String
+	message: String,
+	context: Dictionary = {}
 ) -> void:
-	GFConfigValidationReport.new().add_issue(report, severity, kind, table_name, row_key, field_name, message)
+	GFConfigValidationReport.new().add_issue(report, severity, kind, table_name, row_key, field_name, message, context)
 
 
 static func _merge_report(target: Dictionary, source: Dictionary) -> void:

--- a/addons/gf/standard/utilities/config/gf_config_table_editor_tools.gd
+++ b/addons/gf/standard/utilities/config/gf_config_table_editor_tools.gd
@@ -478,15 +478,8 @@ static func _build_field_reference_descriptors(
 			continue
 
 		var target_schema: GFConfigTableSchema = _get_reference_target_schema(database, reference_definition)
-		var reference_descriptor: Dictionary = {
-			"reference_id": reference_definition.get_reference_id(),
-			"source_fields": reference_definition.source_fields.duplicate(),
-			"target_table_name": reference_definition.target_table_name,
-			"target_fields": reference_definition.get_target_fields(target_schema),
-			"required": reference_definition.required,
-			"allow_null_values": reference_definition.allow_null_values,
-			"metadata": reference_definition.metadata.duplicate(true),
-		}
+		var reference_descriptor: Dictionary = reference_definition.describe()
+		reference_descriptor["target_fields"] = reference_definition.get_target_fields(target_schema)
 		if include_choices:
 			reference_descriptor["choices"] = (
 				build_reference_choice_records_for_database(database, reference_definition, options)

--- a/addons/gf/standard/utilities/config/gf_config_table_reference.gd
+++ b/addons/gf/standard/utilities/config/gf_config_table_reference.gd
@@ -1,6 +1,6 @@
 ## GFConfigTableReference: 导表跨表引用声明。
 ##
-## 描述当前记录的一组字段如何指向另一张表的一组字段。
+## 描述当前记录的一组字段如何指向另一张表的一组字段，或声明一维数组中每个标量值的引用约束。
 ## [br]
 ## @api public
 ## [br]
@@ -9,6 +9,21 @@
 ## @since 3.17.0
 class_name GFConfigTableReference
 extends Resource
+
+
+# --- 枚举 ---
+
+## 来源引用的取值方式。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+enum SourceMode {
+	## 将来源字段的完整值组成一个引用键。
+	FIELDS,
+	## 逐项校验单个 Array 字段，目标必须是单字段键；不自动解析目标记录。
+	ARRAY_ELEMENTS,
+}
 
 
 # --- 导出变量 ---
@@ -23,6 +38,14 @@ extends Resource
 ## @api public
 @export var source_fields: PackedStringArray = PackedStringArray()
 
+## 来源取值方式。ARRAY_ELEMENTS 只接受单个一维 Array 字段，不转换元素类型。
+## 元素支持 bool、int、有限 float、String、StringName，以及允许的 null；空数组合法，重复值按各自位置校验。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var source_mode: SourceMode = SourceMode.FIELDS
+
 ## 目标表名。
 ## [br]
 ## @api public
@@ -33,14 +56,20 @@ extends Resource
 ## @api public
 @export var target_fields: PackedStringArray = PackedStringArray()
 
-## 为 true 时，非空引用必须能在目标表中找到。
+## 为 true 时，来源字段必须存在且每个引用键必须匹配目标；为 false 时允许来源缺失或目标不匹配。
+## ARRAY_ELEMENTS 的容器与元素类型约束不受此开关影响。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 @export var required: bool = true
 
-## 是否允许来源字段值为 null。
+## 是否允许来源字段值为 null；ARRAY_ELEMENTS 中只作用于元素，整个来源字段仍必须为 Array。
+## 允许的 null 作为键参与目标匹配，不会跳过 required 约束。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 @export var allow_null_values: bool = true
 
 ## 可选元数据，供导入器、编辑器或项目层扩展使用。
@@ -61,7 +90,8 @@ extends Resource
 func get_reference_id() -> StringName:
 	if reference_id != &"":
 		return reference_id
-	return StringName("%s->%s" % ["+".join(source_fields), String(target_table_name)])
+	var source_suffix: String = "[]" if source_mode == SourceMode.ARRAY_ELEMENTS else ""
+	return StringName("%s%s->%s" % ["+".join(source_fields), source_suffix, String(target_table_name)])
 
 
 ## 检查引用声明是否有效。
@@ -70,7 +100,18 @@ func get_reference_id() -> StringName:
 ## [br]
 ## @return 有效返回 true。
 func is_valid_definition() -> bool:
-	return not source_fields.is_empty() and target_table_name != &""
+	if source_fields.is_empty() or target_table_name == &"":
+		return false
+	match source_mode:
+		SourceMode.FIELDS:
+			return true
+		SourceMode.ARRAY_ELEMENTS:
+			return (
+				source_fields.size() == 1
+				and not source_fields[0].is_empty()
+				and (target_fields.is_empty() or (target_fields.size() == 1 and not target_fields[0].is_empty()))
+			)
+	return false
 
 
 ## 获取目标字段名。
@@ -89,16 +130,20 @@ func get_target_fields(target_schema: GFConfigTableSchema = null) -> PackedStrin
 	return result
 
 
-## 根据来源记录构建引用键。
+## 根据来源记录构建 FIELDS 模式的引用键。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param record: 来源记录。
 ## [br]
-## @return 引用键；字段缺失或 null 不允许时返回空字符串。
+## @return 引用键；字段缺失、null 不允许或使用 ARRAY_ELEMENTS 时返回空字符串。
 ## [br]
 ## @schema record: Dictionary，用于构建引用键的来源配置记录。
 func make_source_key(record: Dictionary) -> String:
+	if source_mode != SourceMode.FIELDS:
+		return ""
 	return _make_key(record, source_fields)
 
 
@@ -126,6 +171,7 @@ func duplicate_reference() -> GFConfigTableReference:
 	var reference_copy: GFConfigTableReference = GFConfigTableReference.new()
 	reference_copy.reference_id = reference_id
 	reference_copy.source_fields = source_fields.duplicate()
+	reference_copy.source_mode = source_mode
 	reference_copy.target_table_name = target_table_name
 	reference_copy.target_fields = target_fields.duplicate()
 	reference_copy.required = required
@@ -138,13 +184,16 @@ func duplicate_reference() -> GFConfigTableReference:
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @return 引用声明字典。
 ## [br]
-## @schema return: Dictionary，包含 reference_id、source_fields、target_table_name、target_fields、required、allow_null_values 和 metadata。
+## @schema return: Dictionary，包含 reference_id、source_fields、source_mode、target_table_name、target_fields、required、allow_null_values 和 metadata。
 func describe() -> Dictionary:
 	return {
 		"reference_id": get_reference_id(),
 		"source_fields": source_fields.duplicate(),
+		"source_mode": source_mode,
 		"target_table_name": target_table_name,
 		"target_fields": target_fields.duplicate(),
 		"required": required,

--- a/addons/gf/standard/utilities/config/gf_config_validation_report.gd
+++ b/addons/gf/standard/utilities/config/gf_config_validation_report.gd
@@ -13,9 +13,11 @@ extends RefCounted
 
 # --- 常量 ---
 
-## 从校验上下文复制到单条 issue 的字段名。
+## 从校验上下文复制到单条 issue 的字段名。element_index 表示原始字段内从 0 开始的数组元素位置，不替换 field。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 const CONTEXT_FIELDS: Array[String] = [
 	"row_key",
 	"field",
@@ -24,6 +26,7 @@ const CONTEXT_FIELDS: Array[String] = [
 	"column",
 	"row_index",
 	"column_index",
+	"element_index",
 	"rule_id",
 	"value",
 	"expected_value",
@@ -66,6 +69,8 @@ func make_report(table_name: StringName = &"", row_count: int = 0) -> Dictionary
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param table_name: 表名。
 ## [br]
 ## @param kind: 稳定问题类型。
@@ -76,7 +81,7 @@ func make_report(table_name: StringName = &"", row_count: int = 0) -> Dictionary
 ## [br]
 ## @return 校验报告字典。
 ## [br]
-## @schema context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段。
+## @schema context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、element_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段；element_index 为从 0 开始的数组元素位置。
 ## [br]
 ## @schema return: GFConfigValidationReport 兼容 Dictionary，包含一条 error issue。
 func make_error_report(
@@ -126,7 +131,7 @@ func make_error_report(
 ## [br]
 ## @schema row_key: Variant，经报告 codec 规范化为 JSON-safe 值后复制到 issue 中的行标识。
 ## [br]
-## @schema context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段。
+## @schema context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、element_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段；element_index 为从 0 开始的数组元素位置。
 func add_issue(
 	report: Dictionary,
 	severity: String,

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "catalog_version": "2.0.0",
   "framework_version": "12.0.0-dev.0",
-  "source_digest": "3d3457e426596e76c4fadc2b9f17f5c2e494dfe77b3d6fd47e082cf3ba76b3c7",
+  "source_digest": "77788fd92ba51bf4d2f2d2c010f1f4b3895f1a3c56d7d0e9829a9e5a762ff540",
   "class_count": 853,
   "autoload_count": 1,
   "package_count": 57,
@@ -20128,7 +20128,7 @@
         {
           "kind": "const",
           "name": "IMPLEMENTATION_VERSION",
-          "signature": "const IMPLEMENTATION_VERSION: int = 2",
+          "signature": "const IMPLEMENTATION_VERSION: int = 3",
           "summary": "Target 阶段的实现版本；改变 Resource 或 JSON 物化语义时递增。",
           "visibility": "public"
         },
@@ -20500,7 +20500,7 @@
       "module": "standard",
       "package_id": "gf.standard.config",
       "path": "addons/gf/standard/utilities/config/gf_config_reference_resolver.gd",
-      "summary": "GFConfigReferenceResolver: 通用导表引用校验与解析工具。 在多张表加载后统一检查引用、构建复合索引，并可把记录中的引用解析为目标记录副本。",
+      "summary": "GFConfigReferenceResolver: 通用导表引用校验与解析工具。 在多张表加载后统一检查字段或数组元素引用、构建共享索引，并可把 FIELDS 引用解析为目标记录副本。",
       "visibility": "public",
       "category": "runtime_service",
       "since": "3.17.0",
@@ -20523,7 +20523,7 @@
           "kind": "func",
           "name": "resolve_record_references",
           "signature": "static func resolve_record_references( record: Dictionary, schema: GFConfigTableSchema, tables_by_name: Dictionary, schemas_by_name: Dictionary = {} ) -> Dictionary",
-          "summary": "解析单条记录的引用目标。",
+          "summary": "解析单条记录的 FIELDS 引用目标。ARRAY_ELEMENTS 仅参与校验，此入口跳过数组引用。",
           "visibility": "public"
         }
       ]
@@ -21517,11 +21517,18 @@
       "module": "standard",
       "package_id": "gf.standard.config",
       "path": "addons/gf/standard/utilities/config/gf_config_table_reference.gd",
-      "summary": "GFConfigTableReference: 导表跨表引用声明。 描述当前记录的一组字段如何指向另一张表的一组字段。",
+      "summary": "GFConfigTableReference: 导表跨表引用声明。 描述当前记录的一组字段如何指向另一张表的一组字段，或声明一维数组中每个标量值的引用约束。",
       "visibility": "public",
       "category": "resource_definition",
       "since": "3.17.0",
       "members": [
+        {
+          "kind": "enum",
+          "name": "SourceMode",
+          "signature": "enum SourceMode {\n\t## 将来源字段的完整值组成一个引用键。\n\tFIELDS,\n\t## 逐项校验单个 Array 字段，目标必须是单字段键；不自动解析目标记录。\n\tARRAY_ELEMENTS,\n}",
+          "summary": "来源引用的取值方式。",
+          "visibility": "public"
+        },
         {
           "kind": "var",
           "name": "reference_id",
@@ -21534,6 +21541,13 @@
           "name": "source_fields",
           "signature": "var source_fields: PackedStringArray = PackedStringArray()",
           "summary": "当前表中参与引用的字段名。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
+          "name": "source_mode",
+          "signature": "var source_mode: SourceMode = SourceMode.FIELDS",
+          "summary": "来源取值方式。ARRAY_ELEMENTS 只接受单个一维 Array 字段，不转换元素类型。",
           "visibility": "public"
         },
         {
@@ -21554,14 +21568,14 @@
           "kind": "var",
           "name": "required",
           "signature": "var required: bool = true",
-          "summary": "为 true 时，非空引用必须能在目标表中找到。",
+          "summary": "为 true 时，来源字段必须存在且每个引用键必须匹配目标；为 false 时允许来源缺失或目标不匹配。",
           "visibility": "public"
         },
         {
           "kind": "var",
           "name": "allow_null_values",
           "signature": "var allow_null_values: bool = true",
-          "summary": "是否允许来源字段值为 null。",
+          "summary": "是否允许来源字段值为 null；ARRAY_ELEMENTS 中只作用于元素，整个来源字段仍必须为 Array。",
           "visibility": "public"
         },
         {
@@ -21596,7 +21610,7 @@
           "kind": "func",
           "name": "make_source_key",
           "signature": "func make_source_key(record: Dictionary) -> String",
-          "summary": "根据来源记录构建引用键。",
+          "summary": "根据来源记录构建 FIELDS 模式的引用键。",
           "visibility": "public"
         },
         {
@@ -22012,8 +22026,8 @@
         {
           "kind": "const",
           "name": "CONTEXT_FIELDS",
-          "signature": "const CONTEXT_FIELDS: Array[String] = [\n\t\"row_key\",\n\t\"field\",\n\t\"source\",\n\t\"line\",\n\t\"column\",\n\t\"row_index\",\n\t\"column_index\",\n\t\"rule_id\",\n\t\"value\",\n\t\"expected_value\",\n\t\"actual_value\",\n\t\"supported_values\",\n\t\"supported_values_count\",\n\t\"supported_values_sample\",\n\t\"supported_values_preview_hash\",\n\t\"supported_values_truncated\",\n\t\"supported_formats\",\n\t\"supported_content_types\",\n]",
-          "summary": "从校验上下文复制到单条 issue 的字段名。",
+          "signature": "const CONTEXT_FIELDS: Array[String] = [\n\t\"row_key\",\n\t\"field\",\n\t\"source\",\n\t\"line\",\n\t\"column\",\n\t\"row_index\",\n\t\"column_index\",\n\t\"element_index\",\n\t\"rule_id\",\n\t\"value\",\n\t\"expected_value\",\n\t\"actual_value\",\n\t\"supported_values\",\n\t\"supported_values_count\",\n\t\"supported_values_sample\",\n\t\"supported_values_preview_hash\",\n\t\"supported_values_truncated\",\n\t\"supported_formats\",\n\t\"supported_content_types\",\n]",
+          "summary": "从校验上下文复制到单条 issue 的字段名。element_index 表示原始字段内从 0 开始的数组元素位置，不替换 field。",
           "visibility": "public"
         },
         {

--- a/addons/gf/tools/config_pipeline/gf_config_pipeline_artifact_manifest.gd
+++ b/addons/gf/tools/config_pipeline/gf_config_pipeline_artifact_manifest.gd
@@ -111,6 +111,8 @@ const _COMPILER_STAGE_DEFINITIONS: Array[Dictionary] = [
 			"res://addons/gf/tools/config_pipeline/gf_config_pipeline_table_ir.gd",
 			"res://addons/gf/standard/utilities/config/gf_config_database_resource.gd",
 			"res://addons/gf/standard/utilities/config/gf_config_table_resource.gd",
+			"res://addons/gf/standard/utilities/config/gf_config_reference_resolver.gd",
+			"res://addons/gf/standard/utilities/config/gf_config_table_reference.gd",
 			"res://addons/gf/standard/utilities/config/gf_config_validation_report.gd",
 			"res://addons/gf/standard/foundation/variant/gf_variant_data.gd",
 		],

--- a/addons/gf/tools/config_pipeline/gf_config_pipeline_target_stage.gd
+++ b/addons/gf/tools/config_pipeline/gf_config_pipeline_target_stage.gd
@@ -26,7 +26,7 @@ const STAGE_ID: String = "gf.config.target.godot_resource"
 ## @api public
 ## [br]
 ## @since 9.0.0
-const IMPLEMENTATION_VERSION: int = 2
+const IMPLEMENTATION_VERSION: int = 3
 
 const _JSON_EXPORT_FORMAT: String = "gf.config.database"
 const _JSON_EXPORT_VERSION: int = 1
@@ -88,6 +88,7 @@ func materialize_table(
 
 
 ## 将数据库 IR 物化为 Godot Resource，并可执行数据库级引用校验。
+## 引用问题的位置从 IR 来源映射补全；来源未提供物理行列时不推测位置。
 ## [br]
 ## @api public
 ## [br]
@@ -142,6 +143,7 @@ func materialize_database(
 		report = database.validate_database({
 			"validate_schema": GFVariantData.get_option_bool(options, "validate_schema", false),
 		})
+		_enrich_issue_source_locations(report, compilation_ir)
 	else:
 		GFConfigValidationReport.new().finalize_report(report)
 	var success: bool = GFVariantData.get_option_bool(report, "ok", true)
@@ -284,6 +286,8 @@ func get_stage_descriptor() -> Dictionary:
 			"res://addons/gf/tools/config_pipeline/gf_config_pipeline_table_ir.gd",
 			"res://addons/gf/standard/utilities/config/gf_config_database_resource.gd",
 			"res://addons/gf/standard/utilities/config/gf_config_table_resource.gd",
+			"res://addons/gf/standard/utilities/config/gf_config_reference_resolver.gd",
+			"res://addons/gf/standard/utilities/config/gf_config_table_reference.gd",
 			"res://addons/gf/standard/utilities/config/gf_config_validation_report.gd",
 			"res://addons/gf/standard/foundation/variant/gf_variant_data.gd",
 		],
@@ -297,6 +301,62 @@ func get_stage_descriptor() -> Dictionary:
 
 
 # --- 私有/辅助方法 ---
+
+func _enrich_issue_source_locations(report: Dictionary, compilation_ir: GFConfigPipelineIR) -> void:
+	var source_maps: Dictionary = {}
+	for table_ir: GFConfigPipelineTableIR in compilation_ir.get_tables():
+		var source_map: Dictionary = table_ir.get_source_map()
+		if GFVariantData.get_option_string(source_map, "source").is_empty():
+			source_map["source"] = table_ir.get_source_path()
+		source_maps[table_ir.get_table_name()] = source_map
+
+	var issues: Array = GFVariantData.get_option_array(report, "issues")
+	for issue_value: Variant in issues:
+		if not (issue_value is Dictionary):
+			continue
+		var issue: Dictionary = issue_value
+		var table_name: StringName = GFVariantData.get_option_string_name(issue, "table_name")
+		var source_map: Dictionary = GFVariantData.as_dictionary(GFVariantData.get_option_value(source_maps, table_name))
+		var location: Dictionary = _make_issue_source_location(issue, source_map)
+		for key: String in ["source", "line", "column", "column_index"]:
+			if not issue.has(key) and location.has(key):
+				issue[key] = location[key]
+	report["issues"] = issues
+
+
+func _make_issue_source_location(issue: Dictionary, source_map: Dictionary) -> Dictionary:
+	var location: Dictionary = {}
+	_copy_source_location(location, source_map)
+	var row_index_value: Variant = GFVariantData.get_option_value(issue, "row_index")
+	if not (row_index_value is int):
+		return location
+	var row_index: int = row_index_value
+	var row_locations: Array = GFVariantData.as_array(GFVariantData.get_option_value(source_map, "row_locations"))
+	if row_index < 0 or row_index >= row_locations.size():
+		return location
+	var row_location: Dictionary = GFVariantData.as_dictionary(row_locations[row_index])
+	_copy_source_location(location, row_location)
+	var field_name: StringName = GFVariantData.get_option_string_name(issue, "field")
+	var fields: Dictionary = GFVariantData.as_dictionary(GFVariantData.get_option_value(row_location, "fields"))
+	var field_location: Dictionary = GFVariantData.as_dictionary(GFVariantData.get_option_value(fields, field_name))
+	_copy_source_location(location, field_location)
+	return location
+
+
+func _copy_source_location(target: Dictionary, source: Dictionary) -> void:
+	var source_value: Variant = GFVariantData.get_option_value(source, "source")
+	if source_value is String:
+		var source_path: String = source_value
+		if not source_path.is_empty():
+			target["source"] = source_path
+	for key: String in ["line", "column", "column_index"]:
+		var value: Variant = GFVariantData.get_option_value(source, key)
+		if value is int:
+			var position: int = value
+			var minimum: int = 0 if key == "column_index" else 1
+			if position >= minimum:
+				target[key] = position
+
 
 func _make_table_export(
 	table_resource: GFConfigTableResource,

--- a/docs/api_catalog/classes/GFConfigPipelineTargetStage.xml
+++ b/docs/api_catalog/classes/GFConfigPipelineTargetStage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFConfigPipelineTargetStage" path="addons/gf/tools/config_pipeline/gf_config_pipeline_target_stage.gd" module="tools" extends="RefCounted" classDigest="d2b9f4c8d3330b55fb8fa6d8c0a01e3d95fd7fd02e74ba2cb632bc9e7a063871">
+<class name="GFConfigPipelineTargetStage" path="addons/gf/tools/config_pipeline/gf_config_pipeline_target_stage.gd" module="tools" extends="RefCounted" classDigest="5cd9acf493d69886b5356dfaee126db3fb09576ced63944586d01735b8059c34">
 	<description>GFConfigPipelineTargetStage: Config Pipeline 的内置目标物化阶段。
 只接受版本化 IR，并将其物化为 GFConfigTableResource、GFConfigDatabaseResource 或 JSON 兼容数据。
 Target 不读取来源，也不重新推导 schema 或解释项目业务语义。</description>
@@ -20,7 +20,7 @@ Target 不读取来源，也不重新推导 schema 或解释项目业务语义�
 			</tags>
 		</member>
 		<member kind="const" name="IMPLEMENTATION_VERSION">
-			<signature>const IMPLEMENTATION_VERSION: int = 2</signature>
+			<signature>const IMPLEMENTATION_VERSION: int = 3</signature>
 			<description>Target 阶段的实现版本；改变 Resource 或 JSON 物化语义时递增。</description>
 			<tags>
 				<tag name="api">public</tag>
@@ -45,7 +45,8 @@ Target 不读取来源，也不重新推导 schema 或解释项目业务语义�
 		</member>
 		<member kind="method" name="materialize_database">
 			<signature>func materialize_database( compilation_ir: GFConfigPipelineIR, options: Dictionary = {} ) -&gt; Dictionary:</signature>
-			<description>将数据库 IR 物化为 Godot Resource，并可执行数据库级引用校验。</description>
+			<description>将数据库 IR 物化为 Godot Resource，并可执行数据库级引用校验。
+引用问题的位置从 IR 来源映射补全；来源未提供物理行列时不推测位置。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">compilation_ir: 已完成单表校验的版本化数据库 IR。</tag>

--- a/docs/api_catalog/classes/GFConfigReferenceResolver.xml
+++ b/docs/api_catalog/classes/GFConfigReferenceResolver.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFConfigReferenceResolver" path="addons/gf/standard/utilities/config/gf_config_reference_resolver.gd" module="standard" extends="RefCounted" classDigest="3970069d8ca63a78ba0ec24fe47a5329fc477df3366c68ee73e2ea6e6a3bfce4">
+<class name="GFConfigReferenceResolver" path="addons/gf/standard/utilities/config/gf_config_reference_resolver.gd" module="standard" extends="RefCounted" classDigest="95e7e4a5be651a9a8797bcf71a6b231dfe40ed447de5ff9c177be6f26c0bafd5">
 	<description>GFConfigReferenceResolver: 通用导表引用校验与解析工具。
-在多张表加载后统一检查引用、构建复合索引，并可把记录中的引用解析为目标记录副本。</description>
+在多张表加载后统一检查字段或数组元素引用、构建共享索引，并可把 FIELDS 引用解析为目标记录副本。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">runtime_service</tag>
@@ -41,7 +41,7 @@
 		</member>
 		<member kind="method" name="resolve_record_references">
 			<signature>static func resolve_record_references( record: Dictionary, schema: GFConfigTableSchema, tables_by_name: Dictionary, schemas_by_name: Dictionary = {} ) -&gt; Dictionary:</signature>
-			<description>解析单条记录的引用目标。</description>
+			<description>解析单条记录的 FIELDS 引用目标。ARRAY_ELEMENTS 仅参与校验，此入口跳过数组引用。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">record: 来源记录。</tag>
@@ -53,6 +53,7 @@
 				<tag name="schema">tables_by_name: Dictionary，键为表名 StringName，值为 Array[Dictionary] 或 Dictionary 表数据。</tag>
 				<tag name="schema">schemas_by_name: Dictionary，键为表名 StringName，值为 GFConfigTableSchema。</tag>
 				<tag name="schema">return: Dictionary，键为 reference_id，值为解析出的目标记录 Dictionary 副本。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/classes/GFConfigTableReference.xml
+++ b/docs/api_catalog/classes/GFConfigTableReference.xml
@@ -1,14 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFConfigTableReference" path="addons/gf/standard/utilities/config/gf_config_table_reference.gd" module="standard" extends="Resource" classDigest="2069bb4858f092ebb47577669f010009658d2bc905bda7db949471588dc91ade">
+<class name="GFConfigTableReference" path="addons/gf/standard/utilities/config/gf_config_table_reference.gd" module="standard" extends="Resource" classDigest="c0e419bfbae3fabc5de58f87fac51dc94d6da2b641a034b7d5242a602e7c57fe">
 	<description>GFConfigTableReference: 导表跨表引用声明。
-描述当前记录的一组字段如何指向另一张表的一组字段。</description>
+描述当前记录的一组字段如何指向另一张表的一组字段，或声明一维数组中每个标量值的引用约束。</description>
 	<tags>
 		<tag name="api">public</tag>
 		<tag name="category">resource_definition</tag>
 		<tag name="since">3.17.0</tag>
 	</tags>
 	<signals />
-	<enums />
+	<enums>
+		<member kind="enum" name="SourceMode">
+			<signature>enum SourceMode {
+	## 将来源字段的完整值组成一个引用键。
+	FIELDS,
+	## 逐项校验单个 Array 字段，目标必须是单字段键；不自动解析目标记录。
+	ARRAY_ELEMENTS,
+}</signature>
+			<description>来源引用的取值方式。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+	</enums>
 	<constants />
 	<properties>
 		<member kind="property" name="reference_id" decorators="@export">
@@ -23,6 +37,15 @@
 			<description>当前表中参与引用的字段名。</description>
 			<tags>
 				<tag name="api">public</tag>
+			</tags>
+		</member>
+		<member kind="property" name="source_mode" decorators="@export">
+			<signature>var source_mode: SourceMode = SourceMode.FIELDS</signature>
+			<description>来源取值方式。ARRAY_ELEMENTS 只接受单个一维 Array 字段，不转换元素类型。
+元素支持 bool、int、有限 float、String、StringName，以及允许的 null；空数组合法，重复值按各自位置校验。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
 			</tags>
 		</member>
 		<member kind="property" name="target_table_name" decorators="@export">
@@ -41,16 +64,20 @@
 		</member>
 		<member kind="property" name="required" decorators="@export">
 			<signature>var required: bool = true</signature>
-			<description>为 true 时，非空引用必须能在目标表中找到。</description>
+			<description>为 true 时，来源字段必须存在且每个引用键必须匹配目标；为 false 时允许来源缺失或目标不匹配。
+ARRAY_ELEMENTS 的容器与元素类型约束不受此开关影响。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="allow_null_values" decorators="@export">
 			<signature>var allow_null_values: bool = true</signature>
-			<description>是否允许来源字段值为 null。</description>
+			<description>是否允许来源字段值为 null；ARRAY_ELEMENTS 中只作用于元素，整个来源字段仍必须为 Array。
+允许的 null 作为键参与目标匹配，不会跳过 required 约束。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="property" name="metadata" decorators="@export">
@@ -90,12 +117,13 @@
 		</member>
 		<member kind="method" name="make_source_key">
 			<signature>func make_source_key(record: Dictionary) -&gt; String:</signature>
-			<description>根据来源记录构建引用键。</description>
+			<description>根据来源记录构建 FIELDS 模式的引用键。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">record: 来源记录。</tag>
-				<tag name="return">引用键；字段缺失或 null 不允许时返回空字符串。</tag>
+				<tag name="return">引用键；字段缺失、null 不允许或使用 ARRAY_ELEMENTS 时返回空字符串。</tag>
 				<tag name="schema">record: Dictionary，用于构建引用键的来源配置记录。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="make_target_key">
@@ -123,7 +151,8 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="return">引用声明字典。</tag>
-				<tag name="schema">return: Dictionary，包含 reference_id、source_fields、target_table_name、target_fields、required、allow_null_values 和 metadata。</tag>
+				<tag name="schema">return: Dictionary，包含 reference_id、source_fields、source_mode、target_table_name、target_fields、required、allow_null_values 和 metadata。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/classes/GFConfigValidationReport.xml
+++ b/docs/api_catalog/classes/GFConfigValidationReport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFConfigValidationReport" path="addons/gf/standard/utilities/config/gf_config_validation_report.gd" module="standard" extends="RefCounted" classDigest="7dd17e8535e0aa8c6ec9526e5f83738be652ee89746622dbf4fb6fff7bfc6eeb">
+<class name="GFConfigValidationReport" path="addons/gf/standard/utilities/config/gf_config_validation_report.gd" module="standard" extends="RefCounted" classDigest="1907872a9011a7d89b94547d83ecdce90e3a106da621164cc2af0f2161896ea0">
 	<description>GFConfigValidationReport: 配置表校验报告构建工具。
 统一创建、合并和补全配置表校验报告，保证 schema、导入器、引用解析和补丁合并使用相同问题结构。</description>
 	<tags>
@@ -19,6 +19,7 @@
 	"column",
 	"row_index",
 	"column_index",
+	"element_index",
 	"rule_id",
 	"value",
 	"expected_value",
@@ -31,9 +32,10 @@
 	"supported_formats",
 	"supported_content_types",
 ]</signature>
-			<description>从校验上下文复制到单条 issue 的字段名。</description>
+			<description>从校验上下文复制到单条 issue 的字段名。element_index 表示原始字段内从 0 开始的数组元素位置，不替换 field。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</constants>
@@ -60,8 +62,9 @@
 				<tag name="param">message: 问题描述。</tag>
 				<tag name="param">context: 可选上下文。</tag>
 				<tag name="return">校验报告字典。</tag>
-				<tag name="schema">context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段。</tag>
+				<tag name="schema">context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、element_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段；element_index 为从 0 开始的数组元素位置。</tag>
 				<tag name="schema">return: GFConfigValidationReport 兼容 Dictionary，包含一条 error issue。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="add_issue">
@@ -79,7 +82,7 @@
 				<tag name="param">context: 可选上下文。</tag>
 				<tag name="schema">report: GFConfigValidationReport 兼容 Dictionary，会被当前方法修改。</tag>
 				<tag name="schema">row_key: Variant，经报告 codec 规范化为 JSON-safe 值后复制到 issue 中的行标识。</tag>
-				<tag name="schema">context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段。</tag>
+				<tag name="schema">context: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、element_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段；element_index 为从 0 开始的数组元素位置。</tag>
 				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="d776e8dbac4cad65e476f046137ecb33fde70fe6dc9cc822a134fbeee73fec06" classCount="877" methodCount="7846" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="69367449209ff912229c52bc17cd7a9584c854d6c1b74d1b8d463fe9c434e894" classCount="877" methodCount="7846" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="78" methodCount="826" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -12,6 +12,7 @@
 - 新增 [Scene Groups 场景组查询](editor/tools/scene-groups.md)。从已保存的 `.tscn` / `.scn` 查找持久化 Group 声明，支持搜索、分页和来源节点定位；扫描取消、读取失败或预算耗尽时明确报告结果不完整。
 - [Flow 图编辑器](extensions/flow/editor-model.md) 的连线、删除节点与布局编辑接入 Godot 撤销/重做，删除节点时一并恢复关联连接与布局，一次拖动对应一次编辑动作。
 - [Resource 表格](editor/resource-table-editor.md) 支持多行选择、属性混合值呈现和暂存编辑；应用时只修改实际编辑的分量，取消或切换选择会丢弃暂存输入。
+- [配置跨表引用](standard/utilities/io/config-remote-outbox/config-provider/relations-builds/indexes-references.md#数组元素引用) 支持逐项校验一维 Array 中的标量键；错误保留原字段名、元素位置和值，导表继续附加可用的来源与单元格位置。
 
 ### 🔄 机制更改 (Changed)
 
@@ -51,6 +52,7 @@
 - `dispose()` 立即拒绝新借用并撤销所有 Lease，清理在安全点执行；需要等待时调用 `await pool.wait_disposed()`。该等待包含已接纳请求与 Lease 的终态通知，不保证引擎已完成 `queue_free()`。注册到架构的池参与正常异步关停与替换的静默期等待。
 - 保留已有接口的首次发布 `@since` 版本，不因本次签名或语义重做而改为 `unreleased`。
 - Flow 面板与 Resource 表格新增 `set_editor_context()`。新增 `GFEditorMultiPropertyField`，通过暂存值生成属性批处理请求，提交仍复用既有命令与资源历史；不改变 Flow 图的持久化格式或运行时执行协议。
+- `GFConfigTableReference` 新增 `SourceMode` 与 `source_mode`，默认 `FIELDS` 保持原有字段引用行为；`ARRAY_ELEMENTS` 校验单个数组字段到目标单字段键的引用。元素问题增加零基 `element_index`；`resolve_record_references()` 仍只解析 `FIELDS` 引用。
 
 ### 📘 升级指南 (Migration Guide)
 

--- a/docs/zh/editor/tools/config-pipeline.md
+++ b/docs/zh/editor/tools/config-pipeline.md
@@ -190,6 +190,8 @@ int!,string,float
 
 类型化表头生成的是已有的 `GFConfigTableSchema` / `GFConfigTableColumn`，默认启用字段转换、默认不允许未声明字段。显式挂在 `source.schema` 上的 schema 优先级更高；类型化表头适合降低简单表的维护成本，不替代复杂表的索引、引用和业务校验资源。
 
+显式 schema 可以通过 `GFConfigTableReference.SourceMode.ARRAY_ELEMENTS` 声明[数组元素跨表引用](../../standard/utilities/io/config-remote-outbox/config-provider/relations-builds/indexes-references.md#数组元素引用)。引用问题保留原 `field`，并用从 `0` 开始的 `element_index` 标识数组内的位置。Pipeline 还会从已有来源映射补充 `source` 和可用的单元格行列信息；JSON 来源只有文件位置时，不会生成不存在的行列坐标。原生 JSON、ConfigFile 或内存记录可提供 Array 值；内置 CSV 读取不会自动把单元格中的 JSON 字符串解析为数组，项目需要在自定义布局或转换阶段完成这类适配。
+
 ## 使用边界
 
 当前工具包只沉淀稳定通用机制：来源声明、版本化 IR、分阶段编译、Profile 路径执行、CSV / JSON / ConfigFile / XLSX 解析、schema 校验、跨表引用校验、记录转换、索引重建、`.tres/.res` 保存、JSON 目标和文件提交事务。

--- a/docs/zh/reference/api/classes/GFConfigPipelineTargetStage.md
+++ b/docs/zh/reference/api/classes/GFConfigPipelineTargetStage.md
@@ -16,7 +16,7 @@ Config Pipeline 的内置目标物化阶段。 只接受版本化 IR，并将其
 | 类型 | 名称 | 签名 |
 |---|---|---|
 | 常量 | [`STAGE_ID`](#member-gfconfigpipelinetargetstage-constants-stage_id) | `const STAGE_ID: String = "gf.config.target.godot_resource"` |
-| 常量 | [`IMPLEMENTATION_VERSION`](#member-gfconfigpipelinetargetstage-constants-implementation_version) | `const IMPLEMENTATION_VERSION: int = 2` |
+| 常量 | [`IMPLEMENTATION_VERSION`](#member-gfconfigpipelinetargetstage-constants-implementation_version) | `const IMPLEMENTATION_VERSION: int = 3` |
 | 方法 | [`materialize_table`](#member-gfconfigpipelinetargetstage-methods-materialize_table) | `func materialize_table( table_ir: GFConfigPipelineTableIR, options: Dictionary = {} ) -> Dictionary:` |
 | 方法 | [`materialize_database`](#member-gfconfigpipelinetargetstage-methods-materialize_database) | `func materialize_database( compilation_ir: GFConfigPipelineIR, options: Dictionary = {} ) -> Dictionary:` |
 | 方法 | [`make_database_export`](#member-gfconfigpipelinetargetstage-methods-make_database_export) | `func make_database_export( database: GFConfigDatabaseResource, options: Dictionary = {} ) -> Dictionary:` |
@@ -46,7 +46,7 @@ Target 阶段的稳定实现标识。
 - 首次版本：`9.0.0`
 
 ```gdscript
-const IMPLEMENTATION_VERSION: int = 2
+const IMPLEMENTATION_VERSION: int = 3
 ```
 
 Target 阶段的实现版本；改变 Resource 或 JSON 物化语义时递增。
@@ -91,7 +91,7 @@ func materialize_table( table_ir: GFConfigPipelineTableIR, options: Dictionary =
 func materialize_database( compilation_ir: GFConfigPipelineIR, options: Dictionary = {} ) -> Dictionary:
 ```
 
-将数据库 IR 物化为 Godot Resource，并可执行数据库级引用校验。
+将数据库 IR 物化为 Godot Resource，并可执行数据库级引用校验。 引用问题的位置从 IR 来源映射补全；来源未提供物理行列时不推测位置。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFConfigReferenceResolver.md
+++ b/docs/zh/reference/api/classes/GFConfigReferenceResolver.md
@@ -9,7 +9,7 @@
 - 类别：运行时服务 (`runtime_service`)
 - 首次版本：`3.17.0`
 
-通用导表引用校验与解析工具。 在多张表加载后统一检查引用、构建复合索引，并可把记录中的引用解析为目标记录副本。
+通用导表引用校验与解析工具。 在多张表加载后统一检查字段或数组元素引用、构建共享索引，并可把 FIELDS 引用解析为目标记录副本。
 
 ## 成员概览
 
@@ -81,12 +81,13 @@ static func validate_tables( tables_by_name: Dictionary, schemas: Array[GFConfig
 ### `resolve_record_references`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 static func resolve_record_references( record: Dictionary, schema: GFConfigTableSchema, tables_by_name: Dictionary, schemas_by_name: Dictionary = {} ) -> Dictionary:
 ```
 
-解析单条记录的引用目标。
+解析单条记录的 FIELDS 引用目标。ARRAY_ELEMENTS 仅参与校验，此入口跳过数组引用。
 
 参数：
 

--- a/docs/zh/reference/api/classes/GFConfigTableReference.md
+++ b/docs/zh/reference/api/classes/GFConfigTableReference.md
@@ -9,14 +9,16 @@
 - 类别：资源定义 (`resource_definition`)
 - 首次版本：`3.17.0`
 
-导表跨表引用声明。 描述当前记录的一组字段如何指向另一张表的一组字段。
+导表跨表引用声明。 描述当前记录的一组字段如何指向另一张表的一组字段，或声明一维数组中每个标量值的引用约束。
 
 ## 成员概览
 
 | 类型 | 名称 | 签名 |
 |---|---|---|
+| 枚举 | [`SourceMode`](#member-gfconfigtablereference-enums-sourcemode) | `enum SourceMode` |
 | 属性 | [`reference_id`](#member-gfconfigtablereference-properties-reference_id) | `var reference_id: StringName = &""` |
 | 属性 | [`source_fields`](#member-gfconfigtablereference-properties-source_fields) | `var source_fields: PackedStringArray = PackedStringArray()` |
+| 属性 | [`source_mode`](#member-gfconfigtablereference-properties-source_mode) | `var source_mode: SourceMode = SourceMode.FIELDS` |
 | 属性 | [`target_table_name`](#member-gfconfigtablereference-properties-target_table_name) | `var target_table_name: StringName = &""` |
 | 属性 | [`target_fields`](#member-gfconfigtablereference-properties-target_fields) | `var target_fields: PackedStringArray = PackedStringArray()` |
 | 属性 | [`required`](#member-gfconfigtablereference-properties-required) | `var required: bool = true` |
@@ -29,6 +31,26 @@
 | 方法 | [`make_target_key`](#member-gfconfigtablereference-methods-make_target_key) | `func make_target_key(record: Dictionary, target_schema: GFConfigTableSchema = null) -> String:` |
 | 方法 | [`duplicate_reference`](#member-gfconfigtablereference-methods-duplicate_reference) | `func duplicate_reference() -> GFConfigTableReference:` |
 | 方法 | [`describe`](#member-gfconfigtablereference-methods-describe) | `func describe() -> Dictionary:` |
+
+## 枚举
+
+<a id="member-gfconfigtablereference-enums-sourcemode"></a>
+
+### `SourceMode`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+enum SourceMode {
+	## 将来源字段的完整值组成一个引用键。
+	FIELDS,
+	## 逐项校验单个 Array 字段，目标必须是单字段键；不自动解析目标记录。
+	ARRAY_ELEMENTS,
+}
+```
+
+来源引用的取值方式。
 
 ## 属性
 
@@ -55,6 +77,19 @@ var source_fields: PackedStringArray = PackedStringArray()
 ```
 
 当前表中参与引用的字段名。
+
+<a id="member-gfconfigtablereference-properties-source_mode"></a>
+
+### `source_mode`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var source_mode: SourceMode = SourceMode.FIELDS
+```
+
+来源取值方式。ARRAY_ELEMENTS 只接受单个一维 Array 字段，不转换元素类型。 元素支持 bool、int、有限 float、String、StringName，以及允许的 null；空数组合法，重复值按各自位置校验。
 
 <a id="member-gfconfigtablereference-properties-target_table_name"></a>
 
@@ -85,24 +120,26 @@ var target_fields: PackedStringArray = PackedStringArray()
 ### `required`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var required: bool = true
 ```
 
-为 true 时，非空引用必须能在目标表中找到。
+为 true 时，来源字段必须存在且每个引用键必须匹配目标；为 false 时允许来源缺失或目标不匹配。 ARRAY_ELEMENTS 的容器与元素类型约束不受此开关影响。
 
 <a id="member-gfconfigtablereference-properties-allow_null_values"></a>
 
 ### `allow_null_values`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var allow_null_values: bool = true
 ```
 
-是否允许来源字段值为 null。
+是否允许来源字段值为 null；ARRAY_ELEMENTS 中只作用于元素，整个来源字段仍必须为 Array。 允许的 null 作为键参与目标匹配，不会跳过 required 约束。
 
 <a id="member-gfconfigtablereference-properties-metadata"></a>
 
@@ -175,12 +212,13 @@ func get_target_fields(target_schema: GFConfigTableSchema = null) -> PackedStrin
 ### `make_source_key`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func make_source_key(record: Dictionary) -> String:
 ```
 
-根据来源记录构建引用键。
+根据来源记录构建 FIELDS 模式的引用键。
 
 参数：
 
@@ -188,7 +226,7 @@ func make_source_key(record: Dictionary) -> String:
 |---|---|
 | `record` | 来源记录。 |
 
-返回：引用键；字段缺失或 null 不允许时返回空字符串。
+返回：引用键；字段缺失、null 不允许或使用 ARRAY_ELEMENTS 时返回空字符串。
 
 结构：
 
@@ -238,6 +276,7 @@ func duplicate_reference() -> GFConfigTableReference:
 ### `describe`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func describe() -> Dictionary:
@@ -249,4 +288,4 @@ func describe() -> Dictionary:
 
 结构：
 
-- `return`: Dictionary，包含 reference_id、source_fields、target_table_name、target_fields、required、allow_null_values 和 metadata。
+- `return`: Dictionary，包含 reference_id、source_fields、source_mode、target_table_name、target_fields、required、allow_null_values 和 metadata。

--- a/docs/zh/reference/api/classes/GFConfigValidationReport.md
+++ b/docs/zh/reference/api/classes/GFConfigValidationReport.md
@@ -15,7 +15,7 @@
 
 | 类型 | 名称 | 签名 |
 |---|---|---|
-| 常量 | [`CONTEXT_FIELDS`](#member-gfconfigvalidationreport-constants-context_fields) | `const CONTEXT_FIELDS: Array[String] = [ 	"row_key", 	"field", 	"source", 	"line", 	"column", 	"row_index", 	"column_index", 	"rule_id", 	"value", 	"expected_value", 	"actual_value", 	"supported_values", 	"supported_values_count", 	"supported_values_sample", 	"supported_values_preview_hash", 	"supported_values_truncated", 	"supported_formats", 	"supported_content_types", ]` |
+| 常量 | [`CONTEXT_FIELDS`](#member-gfconfigvalidationreport-constants-context_fields) | `const CONTEXT_FIELDS: Array[String] = [ 	"row_key", 	"field", 	"source", 	"line", 	"column", 	"row_index", 	"column_index", 	"element_index", 	"rule_id", 	"value", 	"expected_value", 	"actual_value", 	"supported_values", 	"supported_values_count", 	"supported_values_sample", 	"supported_values_preview_hash", 	"supported_values_truncated", 	"supported_formats", 	"supported_content_types", ]` |
 | 方法 | [`make_report`](#member-gfconfigvalidationreport-methods-make_report) | `func make_report(table_name: StringName = &"", row_count: int = 0) -> Dictionary:` |
 | 方法 | [`make_error_report`](#member-gfconfigvalidationreport-methods-make_error_report) | `func make_error_report( table_name: StringName, kind: String, message: String, context: Dictionary = {} ) -> Dictionary:` |
 | 方法 | [`add_issue`](#member-gfconfigvalidationreport-methods-add_issue) | `func add_issue( report: Dictionary, severity: String, kind: String, table_name: StringName, row_key: Variant, field_name: StringName, message: String, context: Dictionary = {} ) -> void:` |
@@ -29,6 +29,7 @@
 ### `CONTEXT_FIELDS`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 const CONTEXT_FIELDS: Array[String] = [
@@ -39,6 +40,7 @@ const CONTEXT_FIELDS: Array[String] = [
 	"column",
 	"row_index",
 	"column_index",
+	"element_index",
 	"rule_id",
 	"value",
 	"expected_value",
@@ -53,7 +55,7 @@ const CONTEXT_FIELDS: Array[String] = [
 ]
 ```
 
-从校验上下文复制到单条 issue 的字段名。
+从校验上下文复制到单条 issue 的字段名。element_index 表示原始字段内从 0 开始的数组元素位置，不替换 field。
 
 ## 方法
 
@@ -87,6 +89,7 @@ func make_report(table_name: StringName = &"", row_count: int = 0) -> Dictionary
 ### `make_error_report`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func make_error_report( table_name: StringName, kind: String, message: String, context: Dictionary = {} ) -> Dictionary:
@@ -107,7 +110,7 @@ func make_error_report( table_name: StringName, kind: String, message: String, c
 
 结构：
 
-- `context`: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段。
+- `context`: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、element_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段；element_index 为从 0 开始的数组元素位置。
 - `return`: GFConfigValidationReport 兼容 Dictionary，包含一条 error issue。
 
 <a id="member-gfconfigvalidationreport-methods-add_issue"></a>
@@ -140,7 +143,7 @@ func add_issue( report: Dictionary, severity: String, kind: String, table_name: 
 
 - `report`: GFConfigValidationReport 兼容 Dictionary，会被当前方法修改。
 - `row_key`: Variant，经报告 codec 规范化为 JSON-safe 值后复制到 issue 中的行标识。
-- `context`: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段。
+- `context`: Dictionary，可包含 row_key、field、source、line、column、row_index、column_index、element_index、rule_id、value、expected_value、actual_value、supported_values、supported_formats 和 supported_content_types 字段；element_index 为从 0 开始的数组元素位置。
 
 <a id="member-gfconfigvalidationreport-methods-merge_report"></a>
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 78 | 1137 | [Kernel](#module-kernel) |
-| Standard | 479 | 7569 | [Standard](#module-standard) |
+| Standard | 479 | 7571 | [Standard](#module-standard) |
 | Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -366,7 +366,7 @@
 | [`GFConfigTableColumn`](GFConfigTableColumn.md#gfconfigtablecolumn) | 资源定义 (`resource_definition`) | `Resource` | 14 | `addons/gf/standard/utilities/config/gf_config_table_column.gd` |
 | [`GFConfigTableIndexDefinition`](GFConfigTableIndexDefinition.md#gfconfigtableindexdefinition) | 资源定义 (`resource_definition`) | `Resource` | 10 | `addons/gf/standard/utilities/config/gf_config_table_index_definition.gd` |
 | [`GFConfigTableMergePolicy`](GFConfigTableMergePolicy.md#gfconfigtablemergepolicy) | 资源定义 (`resource_definition`) | `Resource` | 15 | `addons/gf/standard/utilities/config/gf_config_table_merge_policy.gd` |
-| [`GFConfigTableReference`](GFConfigTableReference.md#gfconfigtablereference) | 资源定义 (`resource_definition`) | `Resource` | 14 | `addons/gf/standard/utilities/config/gf_config_table_reference.gd` |
+| [`GFConfigTableReference`](GFConfigTableReference.md#gfconfigtablereference) | 资源定义 (`resource_definition`) | `Resource` | 16 | `addons/gf/standard/utilities/config/gf_config_table_reference.gd` |
 | [`GFConfigTableResource`](GFConfigTableResource.md#gfconfigtableresource) | 资源定义 (`resource_definition`) | `Resource` | 21 | `addons/gf/standard/utilities/config/gf_config_table_resource.gd` |
 | [`GFConfigTableSchema`](GFConfigTableSchema.md#gfconfigtableschema) | 资源定义 (`resource_definition`) | `Resource` | 29 | `addons/gf/standard/utilities/config/gf_config_table_schema.gd` |
 | [`GFConsoleCommandDefinition`](GFConsoleCommandDefinition.md#gfconsolecommanddefinition) | 资源定义 (`resource_definition`) | `Resource` | 6 | `addons/gf/standard/utilities/debug/gf_console_command_definition.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -7,7 +7,7 @@
 - 源码根目录：`addons/gf`
 - 公开类：`877`
 - 公开 AutoLoad：`1`
-- 公开成员：`12665`
+- 公开成员：`12667`
 - 公开方法：`7846`
 - AutoLoad 公开方法：`65`
 
@@ -16,7 +16,7 @@
 | 模块 | 类 | AutoLoad | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---:|---|
 | Kernel | 78 | 1 | 1206 | 891 | [kernel.md](kernel.md) |
-| Standard | 479 | 0 | 7569 | 4804 | [standard.md](standard.md) |
+| Standard | 479 | 0 | 7571 | 4804 | [standard.md](standard.md) |
 | Action Queue | 16 | 0 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 0 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 0 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -8,7 +8,7 @@
 |---|---:|---:|---:|
 | [运行时服务](#category-runtime_service) | 193 | 3475 | 2359 |
 | [协议与扩展点](#category-protocol) | 26 | 345 | 273 |
-| [资源定义](#category-resource_definition) | 122 | 1573 | 797 |
+| [资源定义](#category-resource_definition) | 122 | 1575 | 797 |
 | [运行时句柄](#category-runtime_handle) | 56 | 950 | 606 |
 | [值对象](#category-value_object) | 58 | 985 | 631 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |

--- a/docs/zh/standard/utilities/io/config-remote-outbox/config-provider/relations-builds/indexes-references.md
+++ b/docs/zh/standard/utilities/io/config-remote-outbox/config-provider/relations-builds/indexes-references.md
@@ -10,7 +10,7 @@
 
 ## 跨表引用
 
-`resolve_record_references()` 可把一条记录的引用解析为目标记录副本。GF 只理解字段、复合键和报告结构，不解释外键背后的业务含义。
+`GFConfigTableReference.source_mode` 默认为 `SourceMode.FIELDS`，把来源字段的完整值组成单字段键或复合键。`resolve_record_references()` 只处理这一模式，可把一条记录的引用解析为目标记录副本。GF 只理解字段、键和报告结构，表关系及其业务含义由项目声明。
 
 如果多张表已经聚合到 `GFConfigDatabaseResource`，可以直接调用 `validate_database()`，它会复用 `GFConfigReferenceResolver.validate_tables()` 检查整包 schema、表数据和跨表引用。
 
@@ -44,3 +44,69 @@ var key := table.make_index_key(&"item_variant", {
 })
 var item := table.get_index_record(&"item_variant", key)
 ```
+
+## 数组元素引用
+
+当一个字段保存多个目标 ID 时，把 `source_mode` 设为 `SourceMode.ARRAY_ELEMENTS`。此模式要求 `source_fields` 恰好包含一个字段；`target_fields` 可以显式指定一个字段，也可以留空以使用目标 schema 的 `id_field`。它逐项校验一维 `Array`，每个元素匹配一个目标键。
+
+下面的内存记录示例检查 `collections.catalog_ids` 中每个值是否存在于 `catalog.id`：
+
+```gdscript
+var catalog_rows: Array[Dictionary] = [{"id": 101}, {"id": 102}]
+var collection_rows: Array[Dictionary] = [
+	{"id": 7, "catalog_ids": [101, 102, 999]},
+]
+var catalog_schema: GFConfigTableSchema = GFConfigTableSchema.infer_from_records(
+	&"catalog", catalog_rows
+)
+var collection_schema: GFConfigTableSchema = GFConfigTableSchema.infer_from_records(
+	&"collections", collection_rows
+)
+
+var catalog_reference: GFConfigTableReference = GFConfigTableReference.new()
+catalog_reference.source_mode = GFConfigTableReference.SourceMode.ARRAY_ELEMENTS
+catalog_reference.source_fields = PackedStringArray(["catalog_ids"])
+catalog_reference.target_table_name = &"catalog"
+catalog_reference.required = true
+catalog_reference.allow_null_values = false
+# target_fields 留空，使用 catalog_schema.id_field。
+collection_schema.references = [catalog_reference]
+
+var schemas: Array[GFConfigTableSchema] = [catalog_schema, collection_schema]
+var reference_report: Dictionary = GFConfigReferenceResolver.validate_tables({
+	&"catalog": catalog_rows,
+	&"collections": collection_rows,
+}, schemas)
+```
+
+`999` 没有匹配目标，报告中的 issue 包含以下字段：
+
+```json
+{
+  "kind": "missing_reference",
+  "table_name": "collections",
+  "row_key": 7,
+  "field": "catalog_ids",
+  "element_index": 2,
+  "value": 999
+}
+```
+
+`field` 始终是原字段名，`element_index` 从 `0` 开始；读取报告时无需拆解 `catalog_ids[2]` 这样的拼接字段名。重复值按各自位置检查，例如 `[999, 999]` 会分别报告位置 `0` 和 `1`。
+
+下表以引用声明有效、目标表存在为前提；独立的 schema 校验仍然生效。
+
+| 来源情况 | `required=true` | `required=false` |
+| --- | --- | --- |
+| 来源字段缺失 | `missing_reference_value` | 允许缺失 |
+| 空 `Array` | 通过 | 通过 |
+| 合法元素匹配目标键 | 通过 | 通过 |
+| 合法元素没有匹配目标键 | `missing_reference`，包含元素位置和值 | 允许未匹配 |
+| 来源不是 `Array`，包括整个字段为 `null` | `invalid_reference_value` | `invalid_reference_value` |
+| 元素类型非法，或 `null` 元素被禁止 | `invalid_reference_element`，包含元素位置和值 | `invalid_reference_element`，包含元素位置和值 |
+
+元素支持 `bool`、`int`、有限 `float`、`String` 和 `StringName`。引用匹配不转换类型，例如整数 `101`、浮点数 `101.0`、字符串 `"101"` 与 `StringName` 值 `&"101"` 是不同的键。嵌套数组、Dictionary、PackedArray、对象等值不属于元素支持范围；PackedArray 也不能作为来源容器。
+
+`allow_null_values` 默认为 `true`，在数组模式下只控制元素能否为 `null`。这个元素仍作为键参与匹配：当 `required=true` 且目标不存在 `null` 键时，仍报 `missing_reference`；它不会跳过必需引用。设置为 `false` 时，`null` 元素报 `invalid_reference_element`。整个字段为 `null` 在两种设置下都不是合法数组。
+
+`duplicate_reference()`、`describe()` 以及 Resource 保存与加载都会保留 `source_mode`。未显式指定 `reference_id` 时，数组模式生成的标识形如 `catalog_ids[]->catalog`，与字段模式分开。数组模式只提供引用校验，`make_source_key()` 返回空字符串，`resolve_record_references()` 跳过该模式；需要读取目标记录时，由项目使用已有表查询入口组织结果。

--- a/tests/gf_core/standard/utilities/config/test_gf_config_provider.gd
+++ b/tests/gf_core/standard/utilities/config/test_gf_config_provider.gd
@@ -376,6 +376,27 @@ func test_config_database_resource_can_round_trip_as_tres() -> void:
 	assert_eq(GFVariantData.get_option_string(GFVariantData.as_dictionary(provider.get_record(&"items", 1)), "name"), "Potion", "加载后的数据库资源应能通过 Provider 读取记录。")
 
 
+func test_array_reference_mode_survives_resource_round_trip() -> void:
+	var reference_definition: GFConfigTableReference = GFConfigTableReference.new()
+	reference_definition.source_mode = GFConfigTableReference.SourceMode.ARRAY_ELEMENTS
+	reference_definition.source_fields = PackedStringArray(["related_ids"])
+	reference_definition.target_table_name = &"catalog"
+	reference_definition.allow_null_values = false
+	var path: String = _track_path("user://gf_config_array_reference_%d.tres" % Time.get_ticks_usec())
+	assert_eq(ResourceSaver.save(reference_definition, path), OK, "逐元素引用声明应能保存为 Resource。")
+	var loaded_resource: Resource = ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+	assert_true(loaded_resource is GFConfigTableReference, "保存的引用应恢复为正确资源类型。")
+	if not loaded_resource is GFConfigTableReference:
+		return
+	var loaded_reference: GFConfigTableReference = loaded_resource
+	assert_eq(loaded_reference.source_mode, GFConfigTableReference.SourceMode.ARRAY_ELEMENTS, "重载后必须保留逐元素语义。")
+	assert_eq(loaded_reference.source_fields, PackedStringArray(["related_ids"]), "重载后应保留来源字段。")
+	assert_eq(loaded_reference.target_table_name, &"catalog", "重载后应保留目标表。")
+	assert_false(loaded_reference.allow_null_values, "重载后应保留元素 null 策略。")
+	assert_eq(loaded_reference.get_reference_id(), &"related_ids[]->catalog", "重载后默认引用标识应保持稳定。")
+	assert_eq(loaded_reference.make_source_key({ "related_ids": [1] }), "", "重载后不得退回完整数组键语义。")
+
+
 # --- 私有/辅助方法 ---
 
 func _is_null(value: Variant) -> bool:

--- a/tests/gf_core/standard/utilities/config/test_gf_config_table_editor_tools.gd
+++ b/tests/gf_core/standard/utilities/config/test_gf_config_table_editor_tools.gd
@@ -195,6 +195,37 @@ func test_build_field_editor_descriptors_embeds_reference_choices_when_database_
 	assert_eq(GFVariantData.get_option_string(first_choice, "label"), "Potion", "引用候选应复用 label_fields。")
 
 
+func test_array_reference_descriptor_preserves_mode_and_array_property_type() -> void:
+	var reference_definition: GFConfigTableReference = GFConfigTableReference.new()
+	reference_definition.source_mode = GFConfigTableReference.SourceMode.ARRAY_ELEMENTS
+	reference_definition.source_fields = PackedStringArray(["related_ids"])
+	reference_definition.target_table_name = &"catalog"
+	reference_definition.target_fields = PackedStringArray(["id"])
+	var schema: GFConfigTableSchema = GFConfigTableSchema.new()
+	schema.columns = [_make_column(&"related_ids", GFConfigTableColumn.ValueType.ARRAY)]
+	schema.references = [reference_definition]
+
+	var descriptors: Array[Dictionary] = GFConfigTableEditorTools.build_field_editor_descriptors(schema)
+	var descriptor: Dictionary = _find_descriptor(descriptors, &"related_ids")
+	var references: Array = GFVariantData.get_option_array(descriptor, "references")
+	assert_eq(references.size(), 1, "数组字段应包含一个逐元素引用描述。")
+	if references.is_empty():
+		return
+	var reference_descriptor: Dictionary = GFVariantData.as_dictionary(references[0])
+	assert_eq(
+		GFVariantData.get_option_int(reference_descriptor, "source_mode"),
+		GFConfigTableReference.SourceMode.ARRAY_ELEMENTS,
+		"编辑器消费者必须能够区分逐元素引用与单个完整键。"
+	)
+	assert_eq(GFVariantData.get_option_int(descriptor, "property_type"), TYPE_ARRAY, "引用提示不得将数组属性改成标量。")
+	var target_fields_value: Variant = reference_descriptor.get("target_fields")
+	assert_true(target_fields_value is PackedStringArray, "引用描述应保留目标键的数组类型。")
+	if not target_fields_value is PackedStringArray:
+		return
+	var target_fields: PackedStringArray = target_fields_value
+	assert_eq(target_fields, PackedStringArray(["id"]), "引用描述应保留目标键。")
+
+
 # --- 私有/辅助方法 ---
 
 func _make_column(field_name: StringName, value_type: GFConfigTableColumn.ValueType) -> GFConfigTableColumn:

--- a/tests/gf_core/standard/utilities/config/test_gf_config_table_schema.gd
+++ b/tests/gf_core/standard/utilities/config/test_gf_config_table_schema.gd
@@ -585,6 +585,217 @@ func test_reference_resolver_cache_identity_distinguishes_field_boundaries() -> 
 		)
 
 
+func test_reference_source_mode_defaults_to_fields_and_survives_copy_and_description() -> void:
+	var reference: GFConfigTableReference = _make_reference(
+		&"owner_item", PackedStringArray(["item_ids"]), &"items", PackedStringArray(["id"])
+	)
+	assert_eq(reference.source_mode, GFConfigTableReference.SourceMode.FIELDS, "既有引用默认仍按字段构建键。")
+	reference.source_mode = GFConfigTableReference.SourceMode.ARRAY_ELEMENTS
+	reference.required = false
+	reference.allow_null_values = false
+	var copied: GFConfigTableReference = reference.duplicate_reference()
+	var description: Dictionary = reference.describe()
+	assert_ne(copied, reference, "引用拷贝应独立。")
+	assert_eq(copied.source_mode, GFConfigTableReference.SourceMode.ARRAY_ELEMENTS, "拷贝应保留逐元素模式。")
+	assert_false(copied.required, "拷贝应保留可选引用语义。")
+	assert_false(copied.allow_null_values, "拷贝应保留 null 策略。")
+	assert_eq(
+		_reference_issue_int(description, "source_mode"),
+		GFConfigTableReference.SourceMode.ARRAY_ELEMENTS,
+		"描述应提供实际整型来源模式。"
+	)
+	assert_eq(reference.make_source_key({ "item_ids": [1, 2] }), "", "数组声明没有代表整个数组的单一来源键。")
+	assert_false(reference.make_target_key({ "id": 1 }).is_empty(), "数组声明仍能构造单个目标记录键。")
+
+
+func test_array_reference_definition_requires_one_source_and_at_most_one_target_field() -> void:
+	var reference: GFConfigTableReference = _make_array_reference()
+	assert_true(reference.is_valid_definition(), "单来源、单目标字段是有效数组引用。")
+	reference.target_fields = PackedStringArray()
+	assert_true(reference.is_valid_definition(), "空目标字段允许稍后使用目标 schema 的 id_field。")
+	reference.source_fields = PackedStringArray()
+	assert_false(reference.is_valid_definition(), "数组引用必须有来源字段。")
+	reference.source_fields = PackedStringArray(["item_ids", "other_ids"])
+	assert_false(reference.is_valid_definition(), "数组引用不得隐式组合多个来源字段。")
+	reference.source_fields = PackedStringArray(["item_ids"])
+	reference.target_fields = PackedStringArray(["id", "kind"])
+	assert_false(reference.is_valid_definition(), "数组元素不得隐式展开为复合目标键。")
+	reference.target_fields = PackedStringArray(["id"])
+	reference.set(&"source_mode", -1)
+	assert_false(reference.is_valid_definition(), "未知来源模式应拒绝。")
+
+
+func test_array_reference_accepts_supported_scalar_ids_empty_arrays_and_duplicates() -> void:
+	var report: Dictionary = _validate_array_reference(
+		[
+			{ "id": 10, "item_ids": [true, 1, 1.5, "item", &"named", 1, true] },
+			{ "id": 11, "item_ids": [] },
+		],
+		[{ "id": true }, { "id": 1 }, { "id": 1.5 }, { "id": "item" }, { "id": &"named" }]
+	)
+	assert_true(GFVariantData.get_option_bool(report, "ok"), "支持的标量 ID、重复有效 ID 和空数组均应通过。")
+	assert_eq(GFVariantData.get_option_array(report, "issues").size(), 0, "空数组与重复引用不应制造问题。")
+
+
+func test_array_reference_does_not_coerce_scalar_id_types() -> void:
+	var report: Dictionary = _validate_array_reference(
+		[{ "id": 10, "item_ids": [1, true, 1.0, "1", &"1"] }], [{ "id": 1 }]
+	)
+	var issues: Array = GFVariantData.get_option_array(report, "issues")
+	assert_false(GFVariantData.get_option_bool(report, "ok"), "数值或文本相近的不同类型 ID 不得自动匹配。")
+	assert_eq(issues.size(), 4, "只有真正的 int ID 应匹配 int 目标。")
+	for index: int in range(issues.size()):
+		var issue: Dictionary = GFVariantData.as_dictionary(issues[index])
+		assert_eq(GFVariantData.get_option_string(issue, "kind"), "missing_reference", "合法但类型不同的元素是缺少目标。")
+		assert_eq(_reference_issue_int(issue, "element_index"), index + 1, "应定位原始数组中的元素。")
+		assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "字段名不得改写为带下标的路径。")
+
+
+func test_array_reference_missing_field_obeys_required_without_element_location() -> void:
+	var reference: GFConfigTableReference = _make_array_reference()
+	var required_report: Dictionary = _validate_array_reference([{ "id": 10 }], [], reference)
+	var issues: Array = GFVariantData.get_option_array(required_report, "issues")
+	var issue: Dictionary = _find_issue_kind(issues, "missing_reference_value")
+	assert_false(GFVariantData.get_option_bool(required_report, "ok"), "必填引用缺少来源字段应失败。")
+	assert_eq(issues.size(), 1, "缺少容器只应报告一次。")
+	assert_false(issue.is_empty(), "缺失来源字段应使用稳定问题类型。")
+	assert_false(issue.has("element_index"), "不存在的数组不得伪造元素位置。")
+	assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "缺失来源仍应保留字段名。")
+	reference.required = false
+	var optional_report: Dictionary = _validate_array_reference([{ "id": 10 }], [], reference)
+	assert_true(GFVariantData.get_option_bool(optional_report, "ok"), "可选引用允许完全省略来源字段。")
+	assert_eq(GFVariantData.get_option_array(optional_report, "issues").size(), 0, "可选缺字段不应产生问题。")
+
+
+func test_array_reference_rejects_invalid_containers_even_when_optional() -> void:
+	var reference: GFConfigTableReference = _make_array_reference()
+	reference.required = false
+	for container: Variant in [null, 1, "1", { "id": 1 }, PackedInt32Array([1])]:
+		var report: Dictionary = _validate_array_reference([{ "id": 10, "item_ids": container }], [], reference)
+		var issues: Array = GFVariantData.get_option_array(report, "issues")
+		var issue: Dictionary = _find_issue_kind(issues, "invalid_reference_value")
+		assert_false(GFVariantData.get_option_bool(report, "ok"), "已提供的来源必须是普通 Array，包括允许 null 时。")
+		assert_eq(issues.size(), 1, "非法容器只应报告一次。")
+		assert_false(issue.is_empty(), "非法容器应与缺失字段区分。")
+		assert_false(issue.has("element_index"), "容器错误没有元素位置。")
+		assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "容器错误保留原字段名。")
+
+
+func test_array_reference_reports_each_invalid_element_even_when_optional() -> void:
+	var reference: GFConfigTableReference = _make_array_reference()
+	reference.required = false
+	reference.allow_null_values = false
+	var elements: Array = [null, [], {}, Vector2(1.0, 2.0), Resource.new(), PackedInt32Array([1]), NAN, INF, -INF]
+	var report: Dictionary = _validate_array_reference([{ "id": 10, "item_ids": elements }], [], reference)
+	var issues: Array = GFVariantData.get_option_array(report, "issues")
+	assert_false(GFVariantData.get_option_bool(report, "ok"), "可选引用仍须拒绝非法元素与非有限数值。")
+	assert_eq(issues.size(), elements.size(), "每个非法元素均应报告，不得首错后终止。")
+	for index: int in range(issues.size()):
+		var issue: Dictionary = GFVariantData.as_dictionary(issues[index])
+		assert_eq(GFVariantData.get_option_string(issue, "kind"), "invalid_reference_element", "元素类型错误不应伪装成缺少目标。")
+		assert_eq(_reference_issue_int(issue, "element_index"), index, "非法元素应保留零基位置。")
+		assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "元素错误保留原字段名。")
+		assert_true(issue.has("value"), "元素错误应保存实际值或报告 codec 编码后的值。")
+	var encoded: String = JSON.stringify(report)
+	assert_true(encoded.contains("__gf_report_value__"), "对象元素应经报告 codec 脱敏，不能泄漏活对象。")
+	assert_true(encoded.contains(GFVariantJsonCodec.JSON_MARKER_KEY), "非有限数值与特殊 Variant 应使用 JSON 安全编码。")
+
+
+func test_array_reference_null_elements_match_null_targets_only_when_allowed() -> void:
+	var reference: GFConfigTableReference = _make_array_reference()
+	reference.allow_null_values = true
+	var matching_report: Dictionary = _validate_array_reference([{ "id": 10, "item_ids": [null] }], [{ "id": null }], reference)
+	assert_true(GFVariantData.get_option_bool(matching_report, "ok"), "允许 null 时，null 元素应匹配目标的实际 null 键。")
+	var missing_report: Dictionary = _validate_array_reference([{ "id": 10, "item_ids": [null] }], [], reference)
+	var missing_issue: Dictionary = _find_issue_kind(GFVariantData.get_option_array(missing_report, "issues"), "missing_reference")
+	assert_false(GFVariantData.get_option_bool(missing_report, "ok"), "允许 null 不代表忽略目标匹配。")
+	assert_eq(_reference_issue_int(missing_issue, "element_index"), 0, "null 缺少目标也应有元素位置。")
+	assert_true(missing_issue.has("value"), "null 实际值不能与缺少 value 键混淆。")
+	var missing_value: Variant = missing_issue.get("value")
+	assert_true(missing_value == null, "报告应保留实际 null 元素。")
+	reference.required = false
+	var optional_report: Dictionary = _validate_array_reference([{ "id": 10, "item_ids": [null, 99] }], [], reference)
+	assert_true(GFVariantData.get_option_bool(optional_report, "ok"), "可选引用允许合法元素没有目标记录。")
+	reference.allow_null_values = false
+	var forbidden_report: Dictionary = _validate_array_reference([{ "id": 10, "item_ids": [null] }], [{ "id": null }], reference)
+	assert_true(
+		_has_issue_kind(GFVariantData.get_option_array(forbidden_report, "issues"), "invalid_reference_element"),
+		"禁用 null 时，即使存在目标且引用可选，也应拒绝该元素。"
+	)
+
+
+func test_array_reference_reports_repeated_missing_ids_at_each_original_position() -> void:
+	var report: Dictionary = _validate_array_reference(
+		[{ "id": 10, "item_ids": [1, 99, 1, 99] }], [{ "id": 1 }]
+	)
+	var issues: Array = GFVariantData.get_option_array(report, "issues")
+	assert_eq(issues.size(), 2, "重复无效 ID 应按位置报告，重复有效 ID 不应报告。")
+	for index: int in range(issues.size()):
+		var issue: Dictionary = GFVariantData.as_dictionary(issues[index])
+		assert_eq(GFVariantData.get_option_string(issue, "kind"), "missing_reference", "合法元素缺少目标应使用 missing_reference。")
+		assert_eq(_reference_issue_int(issue, "element_index"), 1 + index * 2, "问题应定位原始位置，不能使用去重后的索引。")
+		assert_eq(_reference_issue_int(issue, "value"), 99, "应保存具体元素，不能保存整个来源数组。")
+		assert_eq(_reference_issue_int(issue, "row_key"), 10, "元素问题应保留来源记录标识。")
+		assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "元素问题应保留来源字段名。")
+
+
+func test_array_reference_uses_custom_target_and_source_id_fields() -> void:
+	var reference: GFConfigTableReference = _make_array_reference()
+	reference.target_fields = PackedStringArray()
+	var report: Dictionary = _validate_array_reference(
+		[{ "owner_key": 73, "id": 900, "item_ids": [1, 2] }],
+		[{ "code": 1, "id": 999 }], reference, &"owner_key", &"code"
+	)
+	var issues: Array = GFVariantData.get_option_array(report, "issues")
+	var issue: Dictionary = _find_issue_kind(issues, "missing_reference")
+	assert_eq(issues.size(), 1, "省略目标字段时应使用目标 schema 的 code 字段匹配。")
+	assert_eq(_reference_issue_int(issue, "row_key"), 73, "行标识应使用来源 schema 的 owner_key，不能硬编码 id。")
+	assert_eq(_reference_issue_int(issue, "element_index"), 1, "只有缺少目标的第二个元素应报告。")
+	assert_eq(_reference_issue_int(issue, "value"), 2, "自定义 ID 字段不应改变实际元素值。")
+
+
+func test_fields_reference_retains_composite_and_whole_array_keys() -> void:
+	var composite: GFConfigTableReference = _make_reference(
+		&"composite", PackedStringArray(["item_id", "kind"]), &"items", PackedStringArray(["id", "kind"])
+	)
+	var whole_array: GFConfigTableReference = _make_reference(
+		&"whole_array", PackedStringArray(["item_ids"]), &"items", PackedStringArray(["ids"])
+	)
+	assert_eq(
+		composite.make_source_key({ "item_id": 1, "kind": "tool" }),
+		composite.make_target_key({ "id": 1, "kind": "tool" }),
+		"默认 FIELDS 模式仍按整个字段 tuple 匹配复合键。"
+	)
+	assert_eq(
+		whole_array.make_source_key({ "item_ids": [1, 2] }), whole_array.make_target_key({ "ids": [1, 2] }),
+		"旧 FIELDS 声明中的数组仍是完整字段值，不应自动切换为逐元素引用。"
+	)
+	assert_ne(
+		whole_array.make_source_key({ "item_ids": [1, 2] }), whole_array.make_target_key({ "ids": [2, 1] }),
+		"原有数组字段键应保留元素顺序。"
+	)
+	composite.allow_null_values = false
+	assert_eq(composite.make_source_key({ "item_id": 1, "kind": null }), "", "原有字段模式的 null 策略应保留。")
+
+
+func test_resolve_record_references_only_resolves_fields_in_mixed_schema() -> void:
+	var scalar: GFConfigTableReference = _make_reference(
+		&"primary_item", PackedStringArray(["item_id"]), &"items", PackedStringArray(["id"])
+	)
+	var array_reference: GFConfigTableReference = _make_array_reference()
+	var schema: GFConfigTableSchema = GFConfigTableSchema.new()
+	schema.table_name = &"owners"
+	schema.references = [scalar, array_reference]
+	var resolved: Dictionary = GFConfigReferenceResolver.resolve_record_references(
+		{ "item_id": 1, "item_ids": [1, 2] }, schema,
+		{ &"items": [{ "id": 1, "name": "Potion" }, { "id": 2, "name": "Shield" }] }
+	)
+	assert_eq(resolved.size(), 1, "单记录解析 API 不应隐式新增数组解析结果或覆盖既有映射。")
+	assert_false(resolved.has(array_reference.get_reference_id()), "逐元素声明只参与校验，不参与单记录解析。")
+	var primary_item: Dictionary = GFVariantData.get_option_dictionary(resolved, &"primary_item")
+	assert_eq(GFVariantData.get_option_string(primary_item, "name"), "Potion", "混合 schema 中既有标量解析应继续工作。")
+
+
 func test_column_validation_rules_report_common_data_errors() -> void:
 	var schema: GFConfigTableSchema = GFConfigTableSchema.new()
 	schema.table_name = &"items"
@@ -982,6 +1193,44 @@ func _make_reference(
 	reference.target_fields = target_fields
 	reference.required = true
 	return reference
+
+
+func _make_array_reference() -> GFConfigTableReference:
+	var reference: GFConfigTableReference = _make_reference(
+		&"owner_items", PackedStringArray(["item_ids"]), &"items", PackedStringArray(["id"])
+	)
+	reference.source_mode = GFConfigTableReference.SourceMode.ARRAY_ELEMENTS
+	return reference
+
+
+func _validate_array_reference(
+	source_rows: Array,
+	target_rows: Array,
+	reference: GFConfigTableReference = null,
+	source_id_field: StringName = &"id",
+	target_id_field: StringName = &"id"
+) -> Dictionary:
+	var owner_schema: GFConfigTableSchema = GFConfigTableSchema.new()
+	owner_schema.table_name = &"owners"
+	owner_schema.id_field = source_id_field
+	var item_schema: GFConfigTableSchema = GFConfigTableSchema.new()
+	item_schema.table_name = &"items"
+	item_schema.id_field = target_id_field
+	if reference == null:
+		reference = _make_array_reference()
+	owner_schema.references = [reference]
+	return GFConfigReferenceResolver.validate_tables(
+		{ &"owners": source_rows, &"items": target_rows }, [owner_schema, item_schema], { "validate_schema": false }
+	)
+
+
+func _reference_issue_int(issue: Dictionary, field: String) -> int:
+	var value: Variant = issue.get(field)
+	assert_true(value is int, "%s 应保留真正的 int 类型。" % field)
+	if value is int:
+		var int_value: int = value
+		return int_value
+	return -1
 
 
 func _has_issue_kind(issues: Array, kind: String) -> bool:

--- a/tests/gf_core/standard/utilities/config/test_gf_config_validation_report.gd
+++ b/tests/gf_core/standard/utilities/config/test_gf_config_validation_report.gd
@@ -92,3 +92,55 @@ func test_report_helper_sanitizes_positional_row_key_for_json() -> void:
 	assert_true(text.contains("__gf_report_value__"), "Object row_key 应使用报告 codec 脱敏。")
 	assert_true(text.contains(GFVariantJsonCodec.JSON_MARKER_KEY), "Variant row_key 应保留 typed marker。")
 	assert_false(text.contains("\"row_key\":null"), "非有限 row_key 不得在最终 stringify 时才退化为 null。")
+
+
+func test_report_helper_preserves_element_index_through_merge_and_json() -> void:
+	var helper: GFConfigValidationReport = GFConfigValidationReport.new()
+	var source: Dictionary = helper.make_report(&"owners", 1)
+	helper.add_issue(source, "error", "missing_reference", &"owners", 73, &"item_ids", "元素缺少目标。", {
+		"element_index": 0,
+		"value": 99,
+	})
+	var target: Dictionary = helper.make_report(&"all_tables")
+	helper.merge_report(target, source)
+	helper.finalize_report(target)
+	var issues: Array = GFVariantData.get_option_array(target, "issues")
+	assert_eq(issues.size(), 1, "合并应保留数组元素问题。")
+	if issues.size() != 1:
+		return
+	var issue: Dictionary = GFVariantData.as_dictionary(issues[0])
+	var element_index: Variant = issue.get("element_index")
+	var value: Variant = issue.get("value")
+	assert_true(element_index is int, "元素下标应保留 int 类型，不能转换成字符串。")
+	assert_eq(GFVariantData.get_option_int(issue, "element_index", -1), 0, "零基第一个元素的位置不可丢失。")
+	assert_true(value is int, "实际标量元素值应保留 int 类型。")
+	assert_eq(GFVariantData.get_option_int(issue, "value", -1), 99, "合并应保留具体元素值。")
+	assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "字段名应保持原始声明名称。")
+	var text: String = JSON.stringify(target)
+	var parsed: Variant = JSON.parse_string(text)
+	assert_true(parsed is Dictionary, "包含元素位置的最终报告应能通过 JSON 往返。")
+	if parsed is Dictionary:
+		var parsed_report: Dictionary = parsed
+		var parsed_issues: Array = GFVariantData.get_option_array(parsed_report, "issues")
+		assert_eq(parsed_issues.size(), 1, "JSON 往返不得丢失元素问题。")
+		if parsed_issues.size() == 1:
+			var parsed_issue: Dictionary = GFVariantData.as_dictionary(parsed_issues[0])
+			assert_eq(GFVariantData.get_option_int(parsed_issue, "element_index", -1), 0, "JSON 往返应保留元素位置。")
+			assert_eq(GFVariantData.get_option_int(parsed_issue, "value", -1), 99, "JSON 往返应保留实际元素值。")
+
+
+func test_report_helper_does_not_invent_element_index_for_container_issue() -> void:
+	var helper: GFConfigValidationReport = GFConfigValidationReport.new()
+	var source: Dictionary = helper.make_report(&"owners", 1)
+	helper.add_issue(source, "error", "invalid_reference_value", &"owners", 73, &"item_ids", "来源不是数组。", { "value": null })
+	var target: Dictionary = helper.make_report(&"all_tables")
+	helper.merge_report(target, source)
+	var issues: Array = GFVariantData.get_option_array(target, "issues")
+	assert_eq(issues.size(), 1, "容器问题应保留。")
+	if issues.size() != 1:
+		return
+	var issue: Dictionary = GFVariantData.as_dictionary(issues[0])
+	assert_false(issue.has("element_index"), "无元素位置的容器问题不应补零或其他虚构下标。")
+	assert_true(issue.has("value"), "容器问题仍应保存实际 null 值。")
+	var value: Variant = issue.get("value")
+	assert_true(value == null, "null 容器值应保持 null。")

--- a/tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd
+++ b/tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd
@@ -1853,6 +1853,93 @@ func test_pipeline_database_validates_cross_table_references() -> void:
 	assert_true(_has_issue_kind(GFVariantData.get_option_array(report, "issues"), "missing_reference"), "数据库报告应包含跨表引用缺失问题。")
 
 
+func test_pipeline_array_reference_issues_keep_csv_adapter_source_positions() -> void:
+	var sources: Array[GFConfigPipelineTableSource] = _make_array_reference_sources("csv_locations")
+	# CSV 数组语法由项目 Layout 适配器解释，内置 CSV 继续只负责文本与真实来源位置。
+	var pipeline: GFConfigPipeline = GFConfigPipeline.new().configure_stages(null, _ArrayCellLayoutStage.new())
+	var build_result: Dictionary = pipeline.build_database(sources)
+	var report: Dictionary = GFVariantData.get_option_dictionary(build_result, "report")
+	var issues: Array[Dictionary] = _get_reference_issues(report)
+
+	assert_false(GFVariantData.get_option_bool(build_result, "success"), "数组中的坏引用应阻止数据库构建成功。")
+	assert_eq(GFVariantData.get_option_int(report, "error_count"), 2, "相同坏 ID 的两个位置应分别报告，合法前缀不应误报。")
+	assert_eq(issues.size(), 2, "每个缺失的数组元素应有独立 issue。")
+	for index: int in range(issues.size()):
+		var issue: Dictionary = issues[index]
+		assert_eq(GFVariantData.get_option_string(issue, "source"), sources[1].source_path, "来源应属于包含引用的表。")
+		assert_eq(GFVariantData.get_option_string_name(issue, "table_name"), &"owners", "问题应保留来源表名。")
+		assert_eq(GFVariantData.get_option_string(issue, "row_key"), "bad", "行标识应使用 schema 自定义主键。")
+		assert_eq(GFVariantData.get_option_string_name(issue, "field"), &"item_ids", "字段名不应拼接元素下标。")
+		assert_eq(_get_issue_int(issue, "row_index"), 1, "规范记录顺序应排除注释行。")
+		assert_eq(_get_issue_int(issue, "element_index"), index + 1, "重复坏 ID 应保留各自的零基元素位置。")
+		assert_eq(GFVariantData.get_option_string(issue, "value"), "missing", "问题值应是单个坏元素。")
+		assert_eq(_get_issue_int(issue, "line"), 5, "位置应包含前置多行单元格与注释行的物理行偏移。")
+		assert_eq(_get_issue_int(issue, "column"), 4, "位置应保留被过滤注释列之前的物理列号。")
+		assert_eq(_get_issue_int(issue, "column_index"), 3, "列索引应为物理列号的零基形式。")
+
+	var command: GF_CONFIG_PIPELINE_COMMAND_SCRIPT = GF_CONFIG_PIPELINE_COMMAND_SCRIPT.new()
+	var output_text: String = command.make_output_text({
+		"json_report": true,
+		"runner_result": { "report": report },
+	}, false)
+	var parsed: Dictionary = GFVariantData.as_dictionary(JSON.parse_string(output_text))
+	var runner_result: Dictionary = GFVariantData.get_option_dictionary(parsed, "runner_result")
+	var decoded_issues: Array[Dictionary] = _get_reference_issues(GFVariantData.get_option_dictionary(runner_result, "report"))
+	assert_eq(decoded_issues.size(), 2, "命令 JSON 输出不得丢失元素问题。")
+	for index: int in range(decoded_issues.size()):
+		var issue: Dictionary = decoded_issues[index]
+		assert_eq(GFVariantData.get_option_int(issue, "element_index", -1), index + 1, "JSON 输出应保留元素下标。")
+		assert_eq(GFVariantData.get_option_int(issue, "line", -1), 5, "JSON 输出应保留物理来源行。")
+		assert_eq(GFVariantData.get_option_string(issue, "source"), sources[1].source_path, "JSON 输出应保留文件来源。")
+
+
+func test_pipeline_native_json_array_reference_does_not_invent_line_or_column() -> void:
+	var sources: Array[GFConfigPipelineTableSource] = _make_array_reference_sources("json_locations", false)
+	var build_result: Dictionary = GFConfigPipeline.new().build_database(sources)
+	var report: Dictionary = GFVariantData.get_option_dictionary(build_result, "report")
+	var issues: Array[Dictionary] = _get_reference_issues(report)
+
+	assert_false(GFVariantData.get_option_bool(build_result, "success"), "原生 JSON 数组中的坏 ID 应使构建失败。")
+	assert_eq(issues.size(), 1, "合法 JSON 数组元素不应误报。")
+	if issues.is_empty():
+		return
+	var issue: Dictionary = issues[0]
+	assert_eq(GFVariantData.get_option_string(issue, "source"), sources[1].source_path, "JSON 引用问题仍应有来源文件。")
+	assert_eq(GFVariantData.get_option_string(issue, "row_key"), "bad", "JSON 引用问题应使用自定义主键。")
+	assert_eq(_get_issue_int(issue, "row_index"), 0, "记录索引不依赖物理行信息。")
+	assert_eq(_get_issue_int(issue, "element_index"), 1, "原生数组问题应保留零基元素索引。")
+	assert_eq(GFVariantData.get_option_string(issue, "value"), "missing", "问题应指向坏元素。")
+	assert_false(issue.has("line"), "JSON Layout 未提供物理行时不得推测行号。")
+	assert_false(issue.has("column"), "JSON Layout 未提供物理列时不得推测列号。")
+	assert_false(issue.has("column_index"), "字段顺序不能充当 JSON 物理列索引。")
+
+
+func test_pipeline_array_reference_failure_does_not_publish_artifacts() -> void:
+	var sources: Array[GFConfigPipelineTableSource] = _make_array_reference_sources("no_publish")
+	var previous_text: String = "{\"previous_artifact\":true}\n"
+	var output_path: String = _write_text(
+		"user://gf_config_pipeline_array_previous_%d.json" % Time.get_ticks_usec(),
+		previous_text
+	)
+	var access_path: String = "user://gf_config_pipeline_array_access_%d.gd" % Time.get_ticks_usec()
+	_temporary_paths.append(access_path)
+	var profile: GFConfigPipelineProfile = GFConfigPipelineProfile.new()
+	profile.profile_id = &"array_reference_failure"
+	profile.sources = sources
+	profile.output_path = output_path
+	profile.access_output_path = access_path
+	var pipeline: GFConfigPipeline = GFConfigPipeline.new().configure_stages(null, _ArrayCellLayoutStage.new())
+	var export_result: Dictionary = pipeline.export_profile(profile, { "scan_filesystem": false })
+	var report: Dictionary = GFVariantData.get_option_dictionary(export_result, "report")
+
+	assert_false(GFVariantData.get_option_bool(export_result, "success"), "引用校验失败必须阻止发布。")
+	assert_eq(_get_reference_issues(report).size(), 2, "导出结果应保留逐元素诊断。")
+	assert_true(GFVariantData.get_option_dictionary(export_result, "save_result").is_empty(), "失败构建不应进入数据库保存。")
+	assert_true(GFVariantData.get_option_dictionary(export_result, "access_result").is_empty(), "失败构建不应进入访问器生成。")
+	assert_eq(FileAccess.get_file_as_string(output_path), previous_text, "原有产物必须保持原字节。")
+	assert_false(FileAccess.file_exists(access_path), "不得留下部分生成的访问器。")
+
+
 func test_pipeline_reports_unsupported_auto_format() -> void:
 	var source: GFConfigPipelineTableSource = GFConfigPipelineTableSource.new()
 	source.table_name = &"items"
@@ -2293,6 +2380,71 @@ func _make_item_schema() -> GFConfigTableSchema:
 	return schema
 
 
+func _make_array_reference_sources(label: String, use_csv: bool = true) -> Array[GFConfigPipelineTableSource]:
+	var item_source: GFConfigPipelineTableSource = GFConfigPipelineTableSource.new()
+	item_source.table_name = &"items"
+	item_source.source_path = _write_text(
+		"user://gf_config_pipeline_array_%s_items_%d.csv" % [label, Time.get_ticks_usec()],
+		"code\npotion\n"
+	)
+	item_source.schema = GFConfigTableSchema.new()
+	item_source.schema.table_name = &"items"
+	item_source.schema.id_field = &"code"
+	item_source.schema.columns = [_make_column(&"code", GFConfigTableColumn.ValueType.STRING)]
+	var owner_source: GFConfigPipelineTableSource = GFConfigPipelineTableSource.new()
+	owner_source.table_name = &"owners"
+	owner_source.schema = GFConfigTableSchema.new()
+	owner_source.schema.table_name = &"owners"
+	owner_source.schema.id_field = &"owner_key"
+	owner_source.schema.columns = [
+		_make_column(&"owner_key", GFConfigTableColumn.ValueType.STRING),
+		_make_column(&"note", GFConfigTableColumn.ValueType.STRING),
+		_make_column(&"item_ids", GFConfigTableColumn.ValueType.ARRAY),
+	]
+	var reference: GFConfigTableReference = GFConfigTableReference.new()
+	reference.source_mode = GFConfigTableReference.SourceMode.ARRAY_ELEMENTS
+	reference.source_fields = PackedStringArray(["item_ids"])
+	reference.target_table_name = &"items"
+	owner_source.schema.references = [reference]
+	var owner_text: String = "[{\"owner_key\":\"bad\",\"note\":\"entry\",\"item_ids\":[\"potion\",\"missing\"]}]"
+	var extension: String = "json"
+	if use_csv:
+		extension = "csv"
+		owner_source.parse_options = { "comment_prefixes": PackedStringArray(["#"]) }
+		owner_text = "\n".join([
+			"owner_key,note,#ignored,item_ids",
+			"keep,\"first",
+			"line\",ignored,\"[\"\"potion\"\"]\"",
+			"# ignored,ignored,ignored,ignored",
+			"bad,entry,ignored,\"[\"\"potion\"\",\"\"missing\"\",\"\"missing\"\"]\"",
+			"",
+		])
+	owner_source.source_path = _write_text(
+		"user://gf_config_pipeline_array_%s_owners_%d.%s" % [label, Time.get_ticks_usec(), extension],
+		owner_text
+	)
+	return [item_source, owner_source]
+
+
+func _get_reference_issues(report: Dictionary) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for issue_value: Variant in GFVariantData.get_option_array(report, "issues"):
+		if issue_value is Dictionary:
+			var issue: Dictionary = issue_value
+			if GFVariantData.get_option_string(issue, "kind") == "missing_reference":
+				result.append(issue)
+	return result
+
+
+func _get_issue_int(issue: Dictionary, field_name: String) -> int:
+	var value: Variant = GFVariantData.get_option_value(issue, field_name)
+	assert_true(value is int, "问题字段 %s 必须保留真实 int 类型。" % field_name)
+	if value is int:
+		var integer: int = value
+		return integer
+	return -1
+
+
 func _make_owner_schema() -> GFConfigTableSchema:
 	var id_column: GFConfigTableColumn = _make_column(&"id", GFConfigTableColumn.ValueType.INT)
 	var item_id_column: GFConfigTableColumn = _make_column(&"item_id", GFConfigTableColumn.ValueType.INT)
@@ -2613,6 +2765,31 @@ func _has_issue_kind(issues: Array, kind: String) -> bool:
 
 
 # --- 内部类 ---
+
+class _ArrayCellLayoutStage extends GFConfigPipelineLayoutStage:
+	func decode_source(
+		source: GFConfigPipelineTableSource,
+		read_result: Dictionary,
+		options: Dictionary = {}
+	) -> Dictionary:
+		var result: Dictionary = super.decode_source(source, read_result, options)
+		if not GFVariantData.get_option_bool(result, "success"):
+			return result
+		# 仅作为项目数组单元格语法的测试适配，不改写内置 Layout 的来源映射。
+		var records: Array = GFVariantData.get_option_array(result, "data")
+		for record_value: Variant in records:
+			if not (record_value is Dictionary):
+				continue
+			var record: Dictionary = record_value
+			if not record.has("item_ids"):
+				continue
+			var cell: String = GFVariantData.get_option_string(record, "item_ids")
+			var parsed: Variant = JSON.parse_string(cell)
+			if parsed is Array:
+				record["item_ids"] = parsed
+		result["data"] = records
+		return result
+
 
 class _FailingAccessCommitPipeline extends GFConfigPipeline:
 	var actual_scan_filesystem: bool = true


### PR DESCRIPTION
## Summary

配置数组现在可以显式声明逐元素跨表引用。例如 `related_ids = [101, 102, 999]` 中的 `999` 不存在时，报告保留原表、行、字段名，并指出 `element_index = 2` 和实际值。校验复用目标索引，导表结果附加来源映射中已有的文件与单元格位置。

空数组、重复 ID、严格类型匹配、可选引用和 null 的行为均明确；错误容器与错误元素使用不同问题类型。引用失败阻止导出，已存在的产物保持原字节。

## Contract and Risk

- Change type: feat
- Consumer-visible behavior: 一维 Array 中的标量引用逐项校验，重复无效值按各自位置报告；`field` 保持字段名，`element_index` 从 0 开始。JSON 来源没有物理行列时只报告文件位置。CSV 数组适配继续由项目布局或转换阶段负责。
- API or extension contract: `GFConfigTableReference` 新增 `SourceMode` 和 `source_mode`；`ARRAY_ELEMENTS` 要求一个来源字段到一个目标字段，后者可由目标 schema 的 `id_field` 补齐。元素支持 bool、int、有限 float、String、StringName，以及策略允许的 null，不转换元素类型。`required=false` 允许来源缺失或目标不匹配，仍拒绝非法类型。允许的 null 作为实际键匹配，不跳过 required 约束。
- Persisted data, package, protocol, or ProjectSettings impact: Reference Resource 的新导出属性保留模式，默认 `FIELDS`；配置 IR 与输出格式、模块依赖和项目设置未改变。Target 实现版本与两处编译器依赖描述同步更新，旧增量指纹会触发重新构建。
- Failure, cancellation, rollback, concurrency, and ownership impact: 复用既有报告 codec 与共享索引；无新增后台任务、资源所有者或全局状态。导出前校验失败不会发布数据库或访问器，已有文件事务继续生效。
- Compatibility and migration: 既有 FIELDS 标量、复合键和完整数组键保持其语义；单记录解析仍只处理 FIELDS，不隐式构建数组对象图。新增报告上下文字段及 describe schema 已同步文档，严格匹配固定 issue/schema 字段的消费者需接纳这些字段。开发身份保持 `12.0.0-dev.0`，本 PR 不发布版本。

## Verification

- [x] 最终定向 GUT：7 个脚本、217 tests、6400 assertions 全部通过，包含引用/报告/编辑器描述、Resource 保存重载、管线和 API 注释契约。
- [x] 新增 19 项回归，包含真实 JSON 数组、项目 CSV 布局适配后保留多行单元格及备注过滤的物理位置、命令 JSON 输出、失败不发布，以及原有增量导出路径。来源位置先取得失败证据，再验证修复。
- [x] 定向生命周期门禁：零孤儿节点、零未处理警告。
- [x] Quick：30 项检查通过，`python tools/gf_maintenance.py check --suite quick --failed-only --json-output build/config-array-quick.json`。
- [x] 修复后的严格 LSP 与 GDScript warning 门禁：1391 个脚本、零诊断、零超时；`python tools/gf_maintenance.py check --check gdscript_lsp_diagnostics --check gdscript_warnings --failed-only --json-output build/config-array-diagnostics-final.json`。
- [x] 冻结快照的三轨独立审查及身份/摘要复核：配置核心、导表集成、标准与 API；无剩余问题。
- [x] Draft PR feedback completed through `GF draft gate`（run 34341808547）。
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate`：[完整 CI](https://github.com/C76GN/gf-framework/actions/runs/34342292485) 的四个框架分片、Windows 进程监督与 frozen-base Full marker 全部通过；验证提交为 `069fd777e47f10f6708249a6d8aa048eda3f5fb2`。

本地执行 `python tools/gf_maintenance.py check --suite full --jobs 4 --failed-only --json-output build/config-array-full.json`：38/39 项通过，GUT 的 372 个脚本、7212 tests、88106 assertions 全通过，生命周期零问题。该次 Full 退出码为 1，仅因新增测试的 3 处 LSP 类型警告；已通过类型判断和布尔断言修复，未压制 warning。随后只调整字典空格及测试断言，定向 GUT 和诊断门禁复验修复，最终提交由 Ready CI 运行完整验证。

定向测试通过 `maintenance.run_command("gut", command, 300)` 启动，使用进程监督及 pre/post 生命周期门禁。以下是传入命令的 PowerShell 写法；引擎和工作区绝对路径已替换为 `godot` 与仓库相对路径：

```powershell
godot --headless `
  --log-file ai_analysis/godot_logs/config_array_references_focused.log `
  --path . -s res://tests/gf_core/support/gf_gut_cli.gd `
  -gconfig= `
  -gtest=res://tests/gf_core/standard/utilities/config/test_gf_config_table_schema.gd `
  -gtest=res://tests/gf_core/standard/utilities/config/test_gf_config_validation_report.gd `
  -gtest=res://tests/gf_core/standard/utilities/config/test_gf_config_table_editor_tools.gd `
  -gtest=res://tests/gf_core/standard/utilities/config/test_gf_config_provider.gd `
  -gtest=res://tests/gf_core/tools/config_pipeline/test_gf_config_pipeline.gd `
  -gtest=res://tests/gf_core/maintenance/test_api_docs_validation.gd `
  -gtest=res://tests/gf_core/maintenance/test_api_surface_contract_validation.gd `
  -gpre_run_script=res://tests/gf_core/support/gf_gut_pre_run_hook.gd `
  -gpost_run_script=res://tests/gf_core/support/gf_gut_post_run_hook.gd `
  -gexit
```

## Documentation and Release

- [x] 配置引用、导表指南及 `[未发布]` changelog 已更新。
- [x] API Catalog、API Reference 和知识索引由各自生成器生成。
- [x] 保持当前开发版本，不创建 tag 或发布 release。

