### PR TITLE
Add optional GDScript review hotspot reports

### DIFF
--- a/docs/maintainers/index.md
+++ b/docs/maintainers/index.md
@@ -203,7 +203,7 @@ python tools\gf_maintenance.py release-status --version 3.19.0 --artifact-manife
 
 ### 函数审查热点报告
 
-`review-hotspots` 按当前 GDScript 源码列出函数位置和结构观测，帮助维护者安排审查顺序。默认读取 `addons/gf`；可重复传入 `--path` 合并文件或目录范围。路径按仓库相对字面值匹配，支持 Windows 路径分隔符，不接受绝对路径、上级跳转或 Git pathspec。只纳入 Git 已跟踪和未忽略的文件，不执行 GDScript，也不扫描历史提交。
+`review-hotspots` 按当前 GDScript 源码列出函数位置和结构观测，帮助维护者安排审查顺序。默认读取 `addons/gf`；可重复传入 `--path` 合并文件或目录范围。路径按仓库相对字面值匹配，支持 Windows 路径分隔符，不接受绝对路径、上级跳转或 Git pathspec。只纳入 Git 已跟踪和未忽略的文件，不执行 GDScript，也不扫描历史提交。Git 为嵌套仓库返回的目录标记经过路径校验后排除，报告不递归进入这些独立仓库。
 
 ```powershell
 python tools\gf_maintenance.py review-hotspots --path addons/gf/kernel/core/gf_architecture.gd
@@ -221,6 +221,8 @@ JSON 的 `schema_version` 为 `1`。每个函数保留内类限定名、起止�
 一次最多扫描 4096 个文件、每文件 1 MiB、总计 64 MiB 和 100000 个函数；源码扫描时间预算为 30 秒，Git 清单单独受 30 秒进程 deadline、2 MiB 输出和 20000 条路径限制。结构扫描另有行数、函数数与嵌套预算。`--limit` 为 1–500，默认 30；仅限制展示数量，`omitted_function_count` 说明省略数量，不把正常分页当作扫描失败。
 
 完整报告退出码为 0；输入错误或不完整报告为 1，表示观测覆盖不足，与指标高低无关。该命令保持显式调用，不进入默认 CI、检查套件或合并门禁；其解析与捕获回归测试由现有维护生成器测试负责。
+
+清单的 UTF-8、路径和截断错误保留各自的诊断码，区别于 Git 进程失败。总字节预算成为读取限制时，报告以 `review_hotspots.total_bytes_limit` 停止后续扫描；单文件超过其独立上限仍使用 `path_security.file_too_large`。
 
 Git 清单只有在原进程 deadline 内确认整个进程树已清理后才可使用；无法完成清理时保留监督错误并失败退出，不把清理责任降级为普通扫描问题。
 

--- a/docs/maintainers/index.md
+++ b/docs/maintainers/index.md
@@ -191,6 +191,7 @@ python tools\gf_maintenance.py workspace-status
 python tools\gf_maintenance.py api-search GFAudioClip
 python tools\gf_maintenance.py api-class GFValidationReportDictionary
 python tools\gf_maintenance.py api-module extensions/domain
+python tools\gf_maintenance.py review-hotspots --path addons/gf/kernel/core --limit 20
 python tools\generate_api_coverage_matrix.py
 python tools\gf_maintenance.py check --suite quick
 python tools\gf_maintenance.py check --suite full
@@ -199,6 +200,29 @@ python tools\gf_maintenance.py release-status --version 3.19.0 --artifact-manife
 ```
 
 `quick` 面向本地开发内环，不包含维护工具自身的契约自测；修改 `tools/gf_maintenance*.py`、CI 或 release workflow 时，需另外运行 `python tools\gf_maintenance.py maintenance-self-test`。正式 `framework` / `full` 质量门仍会执行该自测。
+
+### 函数审查热点报告
+
+`review-hotspots` 按当前 GDScript 源码列出函数位置和结构观测，帮助维护者安排审查顺序。默认读取 `addons/gf`；可重复传入 `--path` 合并文件或目录范围。路径按仓库相对字面值匹配，支持 Windows 路径分隔符，不接受绝对路径、上级跳转或 Git pathspec。只纳入 Git 已跟踪和未忽略的文件，不执行 GDScript，也不扫描历史提交。
+
+```powershell
+python tools\gf_maintenance.py review-hotspots --path addons/gf/kernel/core/gf_architecture.gd
+python tools\gf_maintenance.py review-hotspots --path addons/gf/standard --limit 50 --json-output build/review-hotspots.json
+```
+
+报告逐项展示分支数、循环数、最大控制块嵌套和有效代码行，依次降序排列，再按文件路径与函数位置稳定排序。没有加权总分或“超过多少必须重构”的阈值。正常的取消、重入和预算保护同样会增加这些观测值；审查时应结合职责、调用约束和测试判断，不能为降低数字而删除保护逻辑或机械拆函数。
+
+JSON 的 `schema_version` 为 `1`。每个函数保留内类限定名、起止行、结构指标和扫描状态；同名函数通过文件、限定名与起始行区分。`files` 保留扫描文件的 SHA-256 和问题。文件读取固定普通文件及其父目录身份，拒绝符号链接、junction/reparse 和读取期间的替换；这是逐文件观测，不声称整个仓库来自同一个原子快照。源码后续变化时，应重新生成报告并按摘要核对。
+
+`complete` 只表示支持的词法与结构观测完成，不表示通过 Godot 编译或获得精确圈复杂度。注释和字符串不计控制结构，多行签名与表达式不因换行增加嵌套；lambda 体计入最近外层命名函数。条件表达式与 match 分支有单独计数，指标的具体口径见 `tools/gf_review_hotspots.py` 模块说明。遇到不完整语法、未知结构、文件读取失败或预算耗尽，报告明确标记不完整并列出问题。
+
+当前不解析控制条件内部的多行 lambda，也不解析分号连接的多条语句；含这些结构的文件会标记为 `incomplete`，其函数结果仍可辅助阅读，但不能当作完整计数。JSON 同时给出 `algorithm_version`、`metric_definitions` 和排序规则，后续算法变化应先核对这些字段再比较报告。每文件最多展示 16 条问题，多余问题通过 `omitted_issue_count` 显式计数。
+
+一次最多扫描 4096 个文件、每文件 1 MiB、总计 64 MiB 和 100000 个函数；源码扫描时间预算为 30 秒，Git 清单单独受 30 秒进程 deadline、2 MiB 输出和 20000 条路径限制。结构扫描另有行数、函数数与嵌套预算。`--limit` 为 1–500，默认 30；仅限制展示数量，`omitted_function_count` 说明省略数量，不把正常分页当作扫描失败。
+
+完整报告退出码为 0；输入错误或不完整报告为 1，表示观测覆盖不足，与指标高低无关。该命令保持显式调用，不进入默认 CI、检查套件或合并门禁；其解析与捕获回归测试由现有维护生成器测试负责。
+
+Git 清单只有在原进程 deadline 内确认整个进程树已清理后才可使用；无法完成清理时保留监督错误并失败退出，不把清理责任降级为普通扫描问题。
 
 本地构建结果统一写入 `build/`；已跟踪的 `build/.gdignore` 会阻止 Godot 将这些生成物当成 `res://` 资源扫描，清理脚本不得删除它。保存机器可读结果时使用 `python tools\gf_maintenance.py --json-output build\quick-result.json check --suite quick`，该参数会隐含 `--json` 并以无 BOM 的 UTF-8 原子写入。在 Windows PowerShell 5.1 中不要使用默认 `>` 或 `Out-File` 生成 JSON，它们会把原本的 UTF-8 stdout 转写成 UTF-16。
 

--- a/tests/gf_core/tools/test_gf_maintenance_execution.py
+++ b/tests/gf_core/tools/test_gf_maintenance_execution.py
@@ -1401,7 +1401,7 @@ class MaintenanceSelfTestModuleTests(unittest.TestCase):
 
 class ValidationCatalogContractTests(unittest.TestCase):
 	_AUTHORITY_SNAPSHOT_SHA256 = (
-		"6533e4096a6dd5c17a5fa82850c4f066599f4c7f344c0da6e1d30e3d767ddd99"
+		"6d702b880a323b6d260af93bd2ad7c987d490373d89e7c6ab48f789709286a6c"
 	)
 	_PRE_MIGRATION_EXECUTOR_PROJECTION_SHA256 = (
 		"414df23ef834a3c471a1c559ea7f1e5577375e3fd468c99381b828501e4816ef"

--- a/tests/gf_core/tools/test_gf_review_hotspot_report.py
+++ b/tests/gf_core/tools/test_gf_review_hotspot_report.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import hashlib
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from dataclasses import replace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT / "tools") not in sys.path:
+	sys.path.insert(0, str(ROOT / "tools"))
+
+import gf_maintenance
+import gf_review_hotspot_report as reports
+from gf_path_security import PinnedReadError
+
+
+def binary_result(**changes: object) -> gf_maintenance.gf_process_supervisor.SupervisedBinaryProcessResult:
+	return replace(
+		gf_maintenance.gf_process_supervisor.SupervisedBinaryProcessResult(
+			return_code=0, stdout=b"a.gd\0", stderr=b"", timed_out=False,
+			duration_seconds=0.01, pid=8123, cleanup_complete=True,
+		),
+		**changes,
+	)
+
+
+class DeferredCleanupFixture:
+	def __init__(self, *, completed: bool = True, pid: int = 8123) -> None:
+		self.completed = completed
+		self.pid = pid
+		self.waited: list[float | None] = []
+
+	def wait(self, timeout_seconds: float | None) -> bool:
+		self.waited.append(timeout_seconds)
+		return self.completed
+
+	def snapshot_before_deadline(self, _deadline: float) -> object:
+		return gf_maintenance.gf_process_supervisor.SupervisedBinaryCleanupStatus(
+			complete=self.completed, cleanup_complete=self.completed,
+			owner_closed=self.completed, process_tree_empty=self.completed, pid=self.pid,
+		)
+
+
+class ReviewHotspotReportTests(unittest.TestCase):
+	def test_literal_scope_deduplication_ranking_and_source_digest(self) -> None:
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "addons/gf").mkdir(parents=True)
+			first = "func small():\n\tpass\n"
+			second = "func larger():\n\tif true:\n\t\tfor item in []:\n\t\t\tprint(item)\n"
+			(root / "addons/gf/a.gd").write_text(first, encoding="utf-8", newline="\n")
+			(root / "addons/gf/b.gd").write_text(second, encoding="utf-8", newline="\n")
+			result = reports.build_report(
+				root, ["addons/gf/a.gd", "addons/gf/b.gd", "addons/gf2/outside.gd"],
+				scopes=["addons\\gf", "addons/gf/a.gd"], limit=1,
+			)
+			self.assertTrue(result["ok"], result)
+			self.assertTrue(result["observation_only"])
+			self.assertEqual(result["selected_file_count"], 2)
+			self.assertEqual(result["function_count"], 2)
+			self.assertEqual(result["omitted_function_count"], 1)
+			self.assertEqual(result["functions"][0]["name"], "larger")
+			self.assertEqual(result["files"][0]["sha256"], hashlib.sha256(first.encode()).hexdigest())
+			self.assertIn("addons/gf/b.gd:1", reports.render_text(result))
+			self.assertEqual((root / "addons/gf/a.gd").read_text(), first)
+			self.assertEqual(sorted(path.name for path in (root / "addons/gf").iterdir()), ["a.gd", "b.gd"])
+
+	def test_top_limit_never_turns_high_observations_into_a_failure(self) -> None:
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "guard.gd").write_text(
+				"func guarded():\n" + "\tif true:\n\t\treturn\n" * 200,
+				encoding="utf-8",
+			)
+			result = reports.build_report(root, ["guard.gd"], scopes=["guard.gd"])
+			self.assertTrue(result["ok"], result)
+			self.assertGreaterEqual(result["functions"][0]["metrics"]["branch_count"], 200)
+
+	def test_missing_invalid_and_incomplete_source_are_not_clean_observations(self) -> None:
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "invalid.gd").write_bytes(b"\xff")
+			(root / "incomplete.gd").write_text("func broken(\n", encoding="utf-8")
+			result = reports.build_report(
+				root, ["missing.gd", "invalid.gd", "incomplete.gd"],
+				scopes=["missing.gd", "invalid.gd", "incomplete.gd", "unmatched"],
+			)
+			self.assertFalse(result["ok"])
+			self.assertEqual(result["status"], "incomplete")
+			self.assertEqual(result["selected_file_count"], 3)
+			self.assertEqual(result["scanned_file_count"], 1)
+			self.assertNotEqual(result["files"][0]["status"], "complete")
+			self.assertEqual(len(result["issues"]), 3)
+
+	def test_pinned_read_drift_failure_is_preserved(self) -> None:
+		with mock.patch.object(
+			reports.gf_path_security, "read_pinned_regular_file",
+			side_effect=PinnedReadError("path_security.file_changed"),
+		):
+			result = reports.build_report(Path.cwd(), ["a.gd"], scopes=["a.gd"])
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["issues"][0]["code"], "path_security.file_changed")
+		self.assertEqual(result["scanned_file_count"], 0)
+
+	def test_report_limits_refuse_silent_partial_success(self) -> None:
+		with (
+			mock.patch.object(reports, "MAX_FILES", 1),
+			mock.patch.object(reports.gf_path_security, "read_pinned_regular_file") as read,
+		):
+			result = reports.build_report(Path.cwd(), ["a/a.gd", "a/b.gd"], scopes=["a"])
+		self.assertFalse(result["ok"])
+		read.assert_not_called()
+		with (
+			mock.patch.object(reports.time, "monotonic", side_effect=[0.0, 31.0]),
+			mock.patch.object(reports.gf_path_security, "read_pinned_regular_file") as read,
+		):
+			result = reports.build_report(Path.cwd(), ["a.gd"], scopes=["a.gd"])
+		self.assertEqual(result["issues"][0]["code"], "review_hotspots.deadline")
+		read.assert_not_called()
+
+	def test_source_budget_is_enforced_before_parse(self) -> None:
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "a.gd").write_bytes(b"x" * 65)
+			with mock.patch.object(reports, "MAX_FILE_BYTES", 64):
+				result = reports.build_report(root, ["a.gd"], scopes=["a.gd"])
+			self.assertFalse(result["ok"])
+			self.assertEqual(result["scanned_file_count"], 0)
+
+	def test_scopes_cannot_escape_repository_or_become_git_pathspecs(self) -> None:
+		for value in (".", "../outside", "/absolute", "C:\\outside", "a/../b", "a//b", "a/", ":(glob)*", "a\n"):
+			with self.subTest(value=value), self.assertRaises(ValueError):
+				reports.normalize_scope(value)
+		self.assertEqual(reports.normalize_scope("a[b]"), "a[b]")
+		self.assertEqual(reports.normalize_scope("space dir/a.gd"), "space dir/a.gd")
+
+	def test_inventory_is_strict_and_bounded(self) -> None:
+		self.assertEqual(reports.parse_inventory(b"a.gd\0b.gd\0a.gd\0"), ["a.gd", "b.gd"])
+		self.assertEqual(reports.parse_inventory(b""), [])
+		for payload in (b"a.gd", b"\xff\0", b"../outside\0", b"a\\b\0", b"a\0\0"):
+			with self.subTest(payload=payload), self.assertRaises(ValueError):
+				reports.parse_inventory(payload)
+		with mock.patch.object(reports, "MAX_INVENTORY_BYTES", 3), self.assertRaises(ValueError):
+			reports.parse_inventory(b"a.gd\0")
+
+	def test_cli_inventory_rejects_truncation_stderr_and_nonzero_exit(self) -> None:
+		for changes in ({"stdout_truncated": True}, {"stderr_truncated": True}, {"stderr": b"warning"}, {"return_code": 1}, {"timed_out": True}, {"output_drain_failed": True}):
+			with (
+				mock.patch.object(gf_maintenance.gf_process_supervisor, "run_supervised_process_bytes", return_value=binary_result(**changes)),
+				mock.patch.object(reports, "build_report") as build,
+			):
+				report = gf_maintenance.review_hotspots.__wrapped__(paths=["a.gd"])
+			self.assertFalse(report["ok"])
+			build.assert_not_called()
+
+	def test_cli_does_not_delegate_user_paths_to_git(self) -> None:
+		process = binary_result(stdout=b"literal[1]/a.gd\0")
+		with (
+			mock.patch.object(gf_maintenance.gf_process_supervisor, "run_supervised_process_bytes", return_value=process) as git,
+			mock.patch.object(reports, "build_report", return_value={"ok": True}) as build,
+		):
+			result = gf_maintenance.review_hotspots.__wrapped__(paths=["literal[1]"], limit=2)
+		self.assertTrue(result["ok"])
+		self.assertNotIn("literal[1]", git.call_args.args[0])
+		self.assertEqual(git.call_args.kwargs["max_stdout_bytes"], reports.MAX_INVENTORY_BYTES)
+		self.assertEqual(build.call_args.kwargs["scopes"], ["literal[1]"])
+
+	def test_report_command_remains_outside_all_quality_check_plans(self) -> None:
+		self.assertNotIn("review_hotspots", gf_maintenance.CHECK_DEFINITIONS)
+		for checks in gf_maintenance.CHECK_SUITES.values():
+			self.assertNotIn("review_hotspots", checks)
+		self.assertIn(
+			"tests/gf_core/tools/test_gf_review_hotspot_report.py",
+			gf_maintenance.CHECK_DEFINITIONS["maintenance_generator_tests"],
+		)
+
+	def test_cli_json_round_trip_and_coverage_exit_status(self) -> None:
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			(root / "selected.gd").write_text("func selected():\n\tpass\n", encoding="utf-8")
+			process = binary_result(stdout=b"selected.gd\0")
+			for scope, expected_code in (("selected.gd", 0), ("missing.gd", 1)):
+				output = io.StringIO()
+				with (
+					mock.patch.object(gf_maintenance, "ROOT", root),
+					mock.patch.object(gf_maintenance.gf_process_supervisor, "run_supervised_process_bytes", return_value=process),
+					mock.patch.object(sys, "argv", ["gf_maintenance.py", "review-hotspots", "--path", scope, "--limit", "1", "--json"]),
+					contextlib.redirect_stdout(output),
+				):
+					self.assertEqual(gf_maintenance.main(), expected_code)
+				data = json.loads(output.getvalue())
+				self.assertEqual(data["ok"], expected_code == 0)
+				self.assertEqual(data["scopes"], [scope])
+				self.assertIn("metric_definitions", data)
+
+	def test_cli_observes_deferred_cleanup_under_the_original_deadline(self) -> None:
+		supervisor = gf_maintenance.gf_process_supervisor
+		operation = DeferredCleanupFixture()
+		handle = supervisor.SupervisedBinaryCleanupHandle(operation)
+		process = binary_result(cleanup_complete=False, deferred_cleanup=handle)
+		with (
+			mock.patch.object(supervisor, "run_supervised_process_bytes", return_value=process) as run,
+			mock.patch.object(supervisor, "require_supervised_binary_quiet_boundary", wraps=supervisor.require_supervised_binary_quiet_boundary) as quiet,
+			mock.patch.object(reports, "build_report", return_value={"ok": True}),
+		):
+			self.assertTrue(gf_maintenance.review_hotspots.__wrapped__(paths=["a.gd"])["ok"])
+		self.assertEqual(run.call_args.kwargs["deadline"], quiet.call_args.kwargs["deadline"])
+		self.assertEqual(len(operation.waited), 1)
+		self.assertGreaterEqual(operation.waited[0], 0.0)
+		self.assertLessEqual(operation.waited[0], 30.0)
+
+	def test_cli_preserves_cleanup_debt_and_rejects_pid_mismatch(self) -> None:
+		supervisor = gf_maintenance.gf_process_supervisor
+		for operation in (DeferredCleanupFixture(completed=False), DeferredCleanupFixture(pid=9999)):
+			handle = supervisor.SupervisedBinaryCleanupHandle(operation)
+			with (
+				mock.patch.object(supervisor, "run_supervised_process_bytes", return_value=binary_result(cleanup_complete=False, deferred_cleanup=handle)),
+				mock.patch.object(reports, "build_report") as build,
+				self.assertRaises(supervisor.SupervisedProcessCleanupError) as raised,
+			):
+				gf_maintenance.review_hotspots.__wrapped__(paths=["a.gd"])
+			self.assertIs(raised.exception.deferred_cleanup, handle)
+			self.assertTrue(supervisor.exception_has_cleanup_debt(raised.exception))
+			build.assert_not_called()
+
+	def test_cli_does_not_swallow_cleanup_exception_from_spawn(self) -> None:
+		supervisor = gf_maintenance.gf_process_supervisor
+		error = supervisor.SupervisedProcessCleanupError("owned process cleanup failed")
+		with (
+			mock.patch.object(supervisor, "run_supervised_process_bytes", side_effect=error),
+			self.assertRaises(supervisor.SupervisedProcessCleanupError) as raised,
+		):
+			gf_maintenance.review_hotspots.__wrapped__(paths=["a.gd"])
+		self.assertIs(raised.exception, error)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/gf_core/tools/test_gf_review_hotspot_report.py
+++ b/tests/gf_core/tools/test_gf_review_hotspot_report.py
@@ -150,6 +150,53 @@ class ReviewHotspotReportTests(unittest.TestCase):
 		with mock.patch.object(reports, "MAX_INVENTORY_BYTES", 3), self.assertRaises(ValueError):
 			reports.parse_inventory(b"a.gd\0")
 
+	def test_inventory_directory_markers_do_not_hide_selected_scripts(self) -> None:
+		inventory = reports.parse_inventory(b"nested/\0src/a.gd\0other.gd/\0")
+		self.assertEqual(inventory, ["src/a.gd"])
+		for marker in (b"/\0", b"../nested/\0", b"nested//\0", b"nested\\repo/\0"):
+			with self.subTest(marker=marker), self.assertRaisesRegex(ValueError, "review_hotspots.invalid_inventory_path"):
+				reports.parse_inventory(marker)
+
+	def test_cli_preserves_specific_inventory_errors(self) -> None:
+		for payload, code in (
+			(b"\xff\0", "review_hotspots.invalid_inventory_utf8"),
+			(b"../outside\0", "review_hotspots.invalid_inventory_path"),
+			(b"a.gd", "review_hotspots.incomplete_inventory"),
+		):
+			with (
+				self.subTest(code=code),
+				mock.patch.object(gf_maintenance.gf_process_supervisor, "run_supervised_process_bytes", return_value=binary_result(stdout=payload)),
+				mock.patch.object(reports, "build_report") as build,
+			):
+				result = gf_maintenance.review_hotspots.__wrapped__(paths=["a.gd"])
+				self.assertEqual(result["issues"], [{"code": code}])
+				build.assert_not_called()
+
+	def test_aggregate_budget_stops_with_its_own_diagnostic(self) -> None:
+		with tempfile.TemporaryDirectory() as directory:
+			root = Path(directory)
+			for name in ("a.gd", "b.gd", "c.gd"):
+				(root / name).write_bytes(b"func a():\n\tpass\n")
+			with (
+				mock.patch.object(reports, "MAX_TOTAL_BYTES", 25),
+				mock.patch.object(reports.gf_path_security, "read_pinned_regular_file", wraps=reports.gf_path_security.read_pinned_regular_file) as read,
+			):
+				result = reports.build_report(root, ["a.gd", "b.gd", "c.gd"], scopes=["a.gd", "b.gd", "c.gd"])
+			self.assertFalse(result["ok"])
+			self.assertEqual(result["scanned_file_count"], 1)
+			self.assertEqual(result["issues"], [{"code": "review_hotspots.total_bytes_limit", "path": "b.gd"}])
+			self.assertEqual(read.call_count, 2, "Total exhaustion stops the scan, without trying later files.")
+			self.assertEqual(read.call_args.kwargs["max_bytes"], 9)
+
+	def test_exact_aggregate_exhaustion_never_attempts_another_read(self) -> None:
+		with (
+			mock.patch.object(reports, "MAX_TOTAL_BYTES", 16),
+			mock.patch.object(reports.gf_path_security, "read_pinned_regular_file", return_value=b"func a():\n\tpass\n") as read,
+		):
+			result = reports.build_report(Path.cwd(), ["a.gd", "b.gd"], scopes=["a.gd", "b.gd"])
+		self.assertEqual(read.call_count, 1)
+		self.assertEqual(result["issues"], [{"code": "review_hotspots.total_bytes_limit", "path": "b.gd"}])
+
 	def test_cli_inventory_rejects_truncation_stderr_and_nonzero_exit(self) -> None:
 		for changes in ({"stdout_truncated": True}, {"stderr_truncated": True}, {"stderr": b"warning"}, {"return_code": 1}, {"timed_out": True}, {"output_drain_failed": True}):
 			with (
@@ -158,6 +205,7 @@ class ReviewHotspotReportTests(unittest.TestCase):
 			):
 				report = gf_maintenance.review_hotspots.__wrapped__(paths=["a.gd"])
 			self.assertFalse(report["ok"])
+			self.assertEqual(report["issues"], [{"code": "review_hotspots.git_inventory_failed"}])
 			build.assert_not_called()
 
 	def test_cli_does_not_delegate_user_paths_to_git(self) -> None:

--- a/tests/gf_core/tools/test_gf_review_hotspots.py
+++ b/tests/gf_core/tools/test_gf_review_hotspots.py
@@ -222,6 +222,51 @@ class ReviewHotspotsTests(unittest.TestCase):
 		self.assertEqual(report["functions"][0]["qualified_name"], "Inner.检查")
 		self.assertEqual(report["functions"][0]["end_line"], 3)
 
+	def test_unicode_continuations_preserve_complete_raw_function_names(self) -> None:
+		names = ["cafe\u0301", "caf\u00e9", "middle\u00b7dot", "value\u203fpart", "\u2118work", "नाम"]
+		for name in names:
+			self.assertTrue(name.isidentifier())
+		report = self.analyze("".join(f"func {name}(): pass\n" for name in names))
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual([row["name"] for row in report["functions"]], names)
+		self.assertEqual([row["qualified_name"] for row in report["functions"]], names)
+		self.assertEqual([row["id"] for row in report["functions"]], [
+			f"addons/gf/sample.gd::{name}@{index}" for index, name in enumerate(names, 1)
+		])
+		self.assertEqual(report["script_lambda_count"], 0)
+		self.assertEqual([row["end_line"] for row in report["functions"]], list(range(1, len(names) + 1)))
+
+	def test_unicode_owner_and_multiline_static_method_keep_lexical_boundaries(self) -> None:
+		report = self.analyze(
+			'class_name Cafe\u0301\n'
+			'class Inner\u203fPart:\n'
+			'\tstatic func re\u0301sume(\n'
+			'\t\tvalue\u0301: int\n'
+			'\t) -> int:\n'
+			'\t\tvar callback = func name\u0301(item): return item\n'
+			'\t\tif value\u0301 > 0:\n'
+			'\t\t\treturn callback.call(value\u0301)\n'
+			'\t\treturn 0\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual(len(report["functions"]), 1)
+		row = report["functions"][0]
+		self.assertEqual(row["qualified_name"], "Cafe\u0301.Inner\u203fPart.re\u0301sume")
+		self.assertEqual((row["start_line"], row["end_line"]), (3, 9))
+		self.assertEqual(row["metrics"]["lambda_count"], 1)
+		self.assertEqual(row["metrics"]["branch_count"], 1)
+		self.assertEqual(row["metrics"]["effective_code_lines"], 4)
+		self.assertEqual(report["script_lambda_count"], 0)
+
+	def test_unicode_continuations_cannot_bypass_identifier_budget(self) -> None:
+		name = "a" + "\u0301" * 60_000
+		self.assertTrue(name.isidentifier())
+		report = self.analyze(f"func {name}(): pass\n")
+		self.assertEqual(report["status"], "incomplete")
+		self.assertIn("identifier_limit", {issue["code"] for issue in report["issues"]})
+		self.assertEqual(report["functions"], [])
+		self.assertNotIn(name, json.dumps(report))
+
 	def test_literal_path_is_only_identity_and_source_is_never_executed(self) -> None:
 		report = hotspots.analyze_source('func x(): OS.execute("never", [])\n', '../../literal;$(path).gd')
 		self.assertEqual(report["path"], '../../literal;$(path).gd')

--- a/tests/gf_core/tools/test_gf_review_hotspots.py
+++ b/tests/gf_core/tools/test_gf_review_hotspots.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Behavior tests for optional GDScript structure observations."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT / "tools") not in sys.path:
+	sys.path.insert(0, str(ROOT / "tools"))
+
+import gf_review_hotspots as hotspots
+
+
+class ReviewHotspotsTests(unittest.TestCase):
+	def analyze(self, source: str) -> dict:
+		return hotspots.analyze_source(source, "addons/gf/sample.gd")
+
+	def test_explicit_control_observations_are_not_boolean_path_scores(self) -> None:
+		report = self.analyze(
+			"func choose(value):\n"
+			"\tif value and ready:\n"
+			"\t\tfor entry in values:\n"
+			"\t\t\twhile entry.active:\n"
+			"\t\t\t\tbreak\n"
+			"\telif alternate or fallback:\n"
+			"\t\treturn 2\n"
+			"\telse:\n"
+			"\t\treturn 3 if ready else 4\n"
+		)
+		self.assertEqual(report["status"], "complete")
+		row = report["functions"][0]
+		self.assertEqual((row["start_line"], row["end_line"]), (1, 9))
+		self.assertEqual(row["metrics"], {
+			"branch_count": 3, "loop_count": 2, "match_arm_count": 0,
+			"max_nesting": 3, "effective_code_lines": 8, "lambda_count": 0,
+			"conditional_expression_count": 1,
+		})
+		self.assertNotIn("score", row)
+
+	def test_comments_strings_and_multiline_literal_decoys_are_not_declarations(self) -> None:
+		report = self.analyze(
+			'# func fake():\n'
+			'var text = """\nfunc fake2():\n\tif invented:\n"""\n'
+			'func real():\n'
+			'\tvar label = "for if # func fake3():" # while\n'
+			'\tvar escaped = "quote \\\" elif"\n'
+			'\t# if decoy:\n'
+			'\treturn label\n'
+		)
+		self.assertEqual(report["status"], "complete")
+		self.assertEqual([row["name"] for row in report["functions"]], ["real"])
+		self.assertEqual(report["functions"][0]["metrics"]["branch_count"], 0)
+		self.assertEqual(report["functions"][0]["metrics"]["effective_code_lines"], 3)
+
+	def test_multiline_static_signature_annotations_and_nested_classes_have_unique_ids(self) -> None:
+		report = self.analyze(
+			'class_name Example\n'
+			'class First:\n'
+			'\t@warning_ignore("unused_parameter")\n'
+			'\tstatic func same(\n'
+			'\t\tvalue: Dictionary = {"func": ":"},\n'
+			'\t) -> Array[String]:\n'
+			'\t\treturn []\n'
+			'\tclass Nested:\n'
+			'\t\tfunc same():\n'
+			'\t\t\tpass\n'
+			'class Second:\n'
+			'\tfunc same(): pass\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		rows = {row["qualified_name"]: row for row in report["functions"]}
+		self.assertEqual(set(rows), {"Example.First.same", "Example.First.Nested.same", "Example.Second.same"})
+		self.assertEqual(rows["Example.First.same"]["start_line"], 4)
+		self.assertEqual(rows["Example.First.same"]["metrics"]["effective_code_lines"], 1)
+		self.assertEqual(len({row["id"] for row in rows.values()}), 3)
+		self.assertTrue(all(row["id"].startswith("addons/gf/sample.gd::") for row in rows.values()))
+
+	def test_match_patterns_guards_and_wildcard_are_one_arm_each(self) -> None:
+		report = self.analyze(
+			'func inspect(value):\n'
+			'\tmatch value:\n'
+			'\t\t1, 2:\n'
+			'\t\t\treturn 1\n'
+			'\t\t{"name": var name} when name != "":\n'
+			'\t\t\tif name.length() > 1:\n'
+			'\t\t\t\treturn 2\n'
+			'\t\t"a:b", "#": return 3\n'
+			'\t\t_: return 0\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		metrics = report["functions"][0]["metrics"]
+		self.assertEqual(metrics["match_arm_count"], 4)
+		self.assertEqual(metrics["branch_count"], 5)
+		self.assertEqual(metrics["max_nesting"], 3)
+
+	def test_multiline_expressions_and_backslash_continuation_do_not_inflate_nesting(self) -> None:
+		report = self.analyze(
+			'func inspect():\n'
+			'\tvar table = {\n'
+			'\t\t"x": [1, 2],\n'
+			'\t}\n'
+			'\tif (\n'
+			'\t\tready\n'
+			'\t\tand active\n'
+			'\t):\n'
+			'\t\treturn 1 + \\\n'
+			'\t\t\t2\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		metrics = report["functions"][0]["metrics"]
+		self.assertEqual((metrics["branch_count"], metrics["max_nesting"]), (1, 1))
+		self.assertEqual(metrics["effective_code_lines"], 9)
+
+	def test_lambda_bodies_belong_to_nearest_named_function_without_duplicate_rows(self) -> None:
+		report = self.analyze(
+			'var at_script = func(): return 0\n'
+			'func outer():\n'
+			'\tvar callback = func named(value):\n'
+			'\t\tif value:\n'
+			'\t\t\treturn value\n'
+			'\tinvoke(\n'
+			'\t\tfunc():\n'
+			'\t\t\tfor value in values:\n'
+			'\t\t\t\tpass\n'
+			'\t)\n'
+			'\treturn callback\n'
+			'func next(): pass\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		rows = {row["name"]: row for row in report["functions"]}
+		self.assertEqual(set(rows), {"outer", "next"})
+		self.assertEqual(rows["outer"]["metrics"]["lambda_count"], 2)
+		self.assertEqual(rows["outer"]["metrics"]["branch_count"], 1)
+		self.assertEqual(rows["outer"]["metrics"]["loop_count"], 1)
+		self.assertEqual(rows["next"]["metrics"]["lambda_count"], 0)
+		self.assertEqual(report["script_lambda_count"], 1)
+
+	def test_property_accessors_are_not_misreported_as_named_functions(self) -> None:
+		report = self.analyze('var enabled: bool:\n\tget:\n\t\treturn true\n\tset(value):\n\t\tpass\nfunc method(): pass\n')
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual([row["name"] for row in report["functions"]], ["method"])
+
+	def test_sort_is_explicit_stable_and_independent_of_declaration_order_ties(self) -> None:
+		source = 'func plain(): pass\nfunc branch():\n\tif ready:\n\t\tpass\nfunc later(): pass\n'
+		first = self.analyze(source)
+		self.assertEqual(first, self.analyze(source))
+		self.assertEqual([row["name"] for row in first["functions"]], ["branch", "plain", "later"])
+		json.dumps(first, allow_nan=False)
+
+	def test_duplicate_names_remain_unique_and_are_marked_incomplete(self) -> None:
+		report = self.analyze('func same(): pass\nfunc same(): pass\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertEqual(len({row["id"] for row in report["functions"]}), 2)
+		self.assertIn("duplicate_function", {issue["code"] for issue in report["issues"]})
+
+	def test_empty_source_is_complete_without_hotspots(self) -> None:
+		report = self.analyze('# no function\n\n')
+		self.assertEqual(report["status"], "complete")
+		self.assertEqual(report["functions"], [])
+
+	def test_unterminated_strings_and_delimiters_are_never_complete(self) -> None:
+		for source in [
+			'func x():\n\tvar bad = "unterminated\n',
+			"func x():\n\tvar bad = '''unterminated\n",
+			'func x(\n\tvalue: int\n',
+			'func x():\n\treturn ([)]\n',
+		]:
+			with self.subTest(source=source):
+				report = self.analyze(source)
+				self.assertEqual(report["status"], "incomplete")
+				self.assertTrue(report["issues"])
+				self.assertTrue(all(row["status"] == "incomplete" for row in report["functions"]))
+
+	def test_missing_body_and_unknown_block_are_explicit(self) -> None:
+		for source in ['func x():\n# nothing\n', 'func x():\n\twith unknown:\n\t\tpass\n', 'func x()\n\tpass\n']:
+			with self.subTest(source=source):
+				self.assertEqual(self.analyze(source)["status"], "incomplete")
+
+	def test_mixed_indent_is_not_silently_interpreted(self) -> None:
+		report = self.analyze('func x():\n\t if yes:\n\t  pass\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertIn("mixed_indentation", {issue["code"] for issue in report["issues"]})
+
+	def test_size_line_and_function_budgets_are_explicit(self) -> None:
+		with mock.patch.object(hotspots, "MAX_SOURCE_BYTES", 16):
+			report = self.analyze('é' * 9)
+		self.assertEqual(report["status"], "unknown")
+		self.assertEqual(report["functions"], [])
+		with mock.patch.object(hotspots, "MAX_LINES", 2):
+			self.assertEqual(self.analyze('\n\n\n')["status"], "unknown")
+		with mock.patch.object(hotspots, "MAX_FUNCTIONS", 1):
+			report = self.analyze('func one(): pass\nfunc two(): pass\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertLessEqual(len(report["functions"]), 1)
+		self.assertIn("function_limit", {issue["code"] for issue in report["issues"]})
+
+	def test_nested_bracket_and_block_budgets_do_not_recurse(self) -> None:
+		with mock.patch.object(hotspots, "MAX_BRACKET_DEPTH", 3):
+			report = self.analyze('func x():\n\treturn [[[[0]]]]\n')
+		self.assertEqual(report["status"], "incomplete")
+		with mock.patch.object(hotspots, "MAX_NESTING", 3):
+			report = self.analyze('func x():\n\tif a:\n\t\tif b:\n\t\t\tif c:\n\t\t\t\tif d:\n\t\t\t\t\tpass\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertIn("nesting_limit", {issue["code"] for issue in report["issues"]})
+
+	def test_invalid_unicode_and_control_input_fail_without_echoing_source(self) -> None:
+		for source in ['\ud800', '\x00secret', '\x1bsecret', '\x85secret']:
+			with self.subTest(source=repr(source)):
+				report = self.analyze(source)
+				self.assertEqual(report["status"], "unknown")
+				self.assertNotIn('secret', json.dumps(report))
+
+	def test_crlf_and_unicode_identifiers_have_consistent_line_locations(self) -> None:
+		report = self.analyze('\ufeffclass Inner:\r\n\tfunc 检查():\r\n\t\treturn true\r\n')
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual(report["functions"][0]["qualified_name"], "Inner.检查")
+		self.assertEqual(report["functions"][0]["end_line"], 3)
+
+	def test_literal_path_is_only_identity_and_source_is_never_executed(self) -> None:
+		report = hotspots.analyze_source('func x(): OS.execute("never", [])\n', '../../literal;$(path).gd')
+		self.assertEqual(report["path"], '../../literal;$(path).gd')
+		self.assertEqual(report["status"], 'complete')
+
+	def test_semicolon_separated_bodies_are_explicitly_incomplete(self) -> None:
+		for source in ['func x(): first(); second()\n', 'func x():\n\tfirst(); if ready: pass\n']:
+			with self.subTest(source=source):
+				report = self.analyze(source)
+				self.assertEqual(report["status"], "incomplete")
+				self.assertIn("unsupported_statement_separator", {issue["code"] for issue in report["issues"]})
+
+	def test_large_multiline_container_is_bounded_and_does_not_create_scope_nesting(self) -> None:
+		report = self.analyze('func x():\n\tvar items = [\n' + '\t\t1,\n' * 20_000 + '\t]\n\treturn items\n')
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual(len(report["functions"]), 1)
+		self.assertEqual(report["functions"][0]["metrics"]["max_nesting"], 0)
+		self.assertEqual(report["functions"][0]["metrics"]["effective_code_lines"], 20_003)
+
+	def test_issue_and_token_limits_are_reported_without_unbounded_diagnostics(self) -> None:
+		with mock.patch.object(hotspots, "MAX_ISSUES", 2):
+			report = self.analyze('func x():\n' + '\t with unsupported:\n' * 20)
+		self.assertEqual(report["status"], "incomplete")
+		self.assertEqual(len(report["issues"]), 2)
+		self.assertGreater(report["omitted_issue_count"], 0)
+		with mock.patch.object(hotspots, "MAX_TOKENS", 8):
+			report = self.analyze('func x():\n\treturn [1,2,3,4,5]\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertIn("token_limit", {issue["code"] for issue in report["issues"]})
+
+	def test_algorithm_contract_is_in_report_and_sort_key_is_reusable(self) -> None:
+		report = self.analyze('func x(): pass\n')
+		self.assertEqual(report["algorithm_version"], hotspots.ALGORITHM_VERSION)
+		self.assertEqual(report["metric_definitions"], hotspots.METRIC_DEFINITIONS)
+		self.assertEqual(report["sort_order"], hotspots.SORT_ORDER)
+		self.assertEqual(sorted(report["functions"], key=hotspots.function_sort_key), report["functions"])
+
+	def test_typed_for_iterator_colon_is_not_the_loop_body_colon(self) -> None:
+		report = self.analyze('func x():\n\tfor item: Dictionary[String, Variant] in items:\n\t\tif item.ready:\n\t\t\treturn item\n\treturn null\n')
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual(report["functions"][0]["metrics"]["loop_count"], 1)
+		self.assertEqual(report["functions"][0]["metrics"]["max_nesting"], 2)
+
+	def test_sibling_lambdas_and_following_call_arguments_keep_enclosing_ownership(self) -> None:
+		report = self.analyze(
+			'func x():\n'
+			'\treturn invoke(\n'
+			'\t\tfunc(value):\n'
+			'\t\t\tif value:\n'
+			'\t\t\t\treturn value,\n'
+			'\t\tfunc named(value):\n'
+			'\t\t\treturn value,\n'
+			'\t\towner,\n'
+			'\t\t{"next": func():\n'
+			'\t\t\treturn null,\n'
+			'\t\t"limit": 10}\n'
+			'\t)\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		self.assertEqual(len(report["functions"]), 1)
+		self.assertEqual(report["functions"][0]["metrics"]["lambda_count"], 3)
+		self.assertEqual(report["functions"][0]["metrics"]["branch_count"], 1)
+		self.assertEqual(report["functions"][0]["end_line"], 12)
+
+	def test_multiline_lambda_in_control_header_has_explicit_support_limit(self) -> None:
+		report = self.analyze('func x():\n\tif values.any(func(item):\n\t\treturn item == null\n\t):\n\t\treturn true\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertIn("unsupported_lambda_in_control_header", {issue["code"] for issue in report["issues"]})
+
+	def test_declaration_names_and_identity_have_independent_length_budgets(self) -> None:
+		for source in ['class_name ' + 'A' * 257, 'class ' + 'A' * 257 + ':\n\tpass\n', 'func ' + 'a' * 257 + '(): pass\n']:
+			with self.subTest(source_length=len(source)):
+				report = self.analyze(source)
+				self.assertEqual(report["status"], "incomplete")
+				self.assertIn("identifier_limit", {issue["code"] for issue in report["issues"]})
+		with mock.patch.object(hotspots, "MAX_QUALIFIED_NAME_LENGTH", 8):
+			report = self.analyze('class Owner:\n\tfunc method(): pass\n')
+		self.assertEqual(report["status"], "incomplete")
+		self.assertEqual(report["functions"], [])
+		with mock.patch.object(hotspots, "MAX_ID_LENGTH", 8):
+			self.assertEqual(self.analyze('func x(): pass\n')["status"], "incomplete")
+		report = hotspots.analyze_source('func x(): pass\n', 'p' * 4097)
+		self.assertEqual(report["status"], "unknown")
+		self.assertEqual(report["path"], "")
+
+	def test_inline_control_bodies_and_conditions_count_their_lambdas(self) -> None:
+		report = self.analyze(
+			'func inspect(values):\n'
+			'\tif enabled: values.map(func(x): return x)\n'
+			'\telif values.any(func(x): return bool(x)): return 1\n'
+			'\telse: values.filter(func(x): return true)\n'
+			'\twhile values.any(func(x): return bool(x)): break\n'
+			'\tfor item in values.map(func(x): return x): pass\n'
+			'\tmatch code:\n'
+			'\t\t_: values.map(func(x): return x)\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		metrics = report["functions"][0]["metrics"]
+		self.assertEqual(metrics["lambda_count"], 6)
+		self.assertEqual(metrics["branch_count"], 4)
+		self.assertEqual(metrics["loop_count"], 2)
+		self.assertEqual(metrics["match_arm_count"], 1)
+		self.assertEqual(metrics["max_nesting"], 2)
+		self.assertEqual(report["script_lambda_count"], 0)
+
+	def test_explicit_continuation_keeps_named_static_function_identity(self) -> None:
+		report = self.analyze(
+			'func split \\\n'
+			'():\n'
+			'\tpass\n'
+			'class Inner:\n'
+			'\tstatic func same \\\n'
+			'\t(value):\n'
+			'\t\tif value:\n'
+			'\t\t\treturn value\n'
+		)
+		self.assertEqual(report["status"], "complete", report["issues"])
+		rows = {row["qualified_name"]: row for row in report["functions"]}
+		self.assertEqual(set(rows), {"split", "Inner.same"})
+		self.assertEqual((rows["split"]["start_line"], rows["split"]["end_line"]), (1, 3))
+		self.assertEqual((rows["Inner.same"]["start_line"], rows["Inner.same"]["end_line"]), (5, 8))
+		self.assertEqual(rows["split"]["metrics"]["effective_code_lines"], 1)
+		self.assertEqual(rows["Inner.same"]["metrics"]["effective_code_lines"], 2)
+		self.assertEqual(report["script_lambda_count"], 0)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -2409,11 +2409,15 @@ def review_hotspots(*, paths: list[str] | None = None, limit: int = 30) -> dict[
 			or result.timed_out or result.output_drain_failed or not result.cleanup_complete
 		):
 			raise ValueError("review_hotspots.git_inventory_failed")
-		inventory = gf_review_hotspot_report.parse_inventory(result.stdout)
 	except (OSError, ValueError, subprocess.TimeoutExpired) as error:
 		if exception_has_cleanup_debt(error):
 			raise
 		report["issues"].append({"code": "review_hotspots.git_inventory_failed"})
+		return report
+	try:
+		inventory = gf_review_hotspot_report.parse_inventory(result.stdout)
+	except ValueError as error:
+		report["issues"].append({"code": str(error)})
 		return report
 	return gf_review_hotspot_report.build_report(ROOT, inventory, scopes=scopes, limit=limit)
 

--- a/tools/gf_maintenance.py
+++ b/tools/gf_maintenance.py
@@ -1671,6 +1671,20 @@ def main() -> int:
 	)
 	workspace_parser.add_argument("--json", action="store_true", help="Print JSON instead of text.")
 
+	hotspots_parser = subparsers.add_parser(
+		"review-hotspots",
+		help="Report GDScript function structure for human review; never a quality gate.",
+	)
+	hotspots_parser.add_argument(
+		"--path", action="append", default=[],
+		help="Literal repository-relative file or directory; repeat to combine scopes (default: addons/gf).",
+	)
+	hotspots_parser.add_argument(
+		"--limit", type=int, default=30,
+		help="Maximum ranked functions to return, from 1 to 500 (default: 30).",
+	)
+	hotspots_parser.add_argument("--json", action="store_true", help="Print JSON instead of text.")
+
 	path_hygiene_parser = subparsers.add_parser("path-hygiene", help="Check tracked and untracked repository paths for cross-platform hazards.")
 	path_hygiene_parser.add_argument("--json", action="store_true", help="Print JSON instead of text.")
 
@@ -2122,6 +2136,12 @@ def main() -> int:
 		data = workspace_status(paths=args.path)
 		maintenance_rendering.print_output(data, args.json, maintenance_rendering.render_workspace_status_text)
 		return 0
+	if args.command == "review-hotspots":
+		import gf_review_hotspot_report
+
+		data = review_hotspots(paths=args.path, limit=args.limit)
+		maintenance_rendering.print_output(data, args.json, gf_review_hotspot_report.render_text)
+		return 0 if data["ok"] else 1
 	if args.command == "path-hygiene":
 		data = path_hygiene()
 		maintenance_rendering.print_output(data, args.json, maintenance_rendering.render_path_hygiene_text)
@@ -2350,6 +2370,52 @@ def write_internal_complete_output_evidence_report(
 			f"actual={len(payload_bytes)}, limit={max_utf8_bytes}."
 		)
 	maintenance_rendering.write_utf8_json_output(path, payload)
+
+
+@with_maintenance_process_authority
+def review_hotspots(*, paths: list[str] | None = None, limit: int = 30) -> dict[str, Any]:
+	"""Observe current source through a bounded, frozen Git inventory and pinned reads."""
+	import gf_review_hotspot_report
+
+	try:
+		if paths is not None and len(paths) > gf_review_hotspot_report.MAX_SCOPES:
+			raise ValueError("review_hotspots.scope_limit")
+		scopes = [gf_review_hotspot_report.normalize_scope(path) for path in (paths or ["addons/gf"])]
+		if type(limit) is not int or not 1 <= limit <= gf_review_hotspot_report.MAX_RESULT_LIMIT:
+			raise ValueError("review_hotspots.invalid_limit")
+	except ValueError as error:
+		report = gf_review_hotspot_report.empty_report([], 30)
+		report["issues"].append({"code": str(error)})
+		return report
+	report = gf_review_hotspot_report.empty_report(scopes, limit)
+	deadline = time.perf_counter() + 30.0
+	try:
+		git_process = active_or_freeze_maintenance_process_authority().git
+		result = gf_process_supervisor.run_supervised_process_bytes(
+			git_process.command(["ls-files", "-z", "--cached", "--others", "--exclude-standard"]).effective,
+			cwd=ROOT,
+			timeout_seconds=30.0,
+			deadline=deadline,
+			environment=git_process.environment.values(),
+			max_stdout_bytes=gf_review_hotspot_report.MAX_INVENTORY_BYTES,
+			max_stderr_bytes=4096,
+		)
+		result = gf_process_supervisor.require_supervised_binary_quiet_boundary(
+			result, deadline=deadline,
+		)
+		if (
+			result.return_code != 0 or result.stderr
+			or result.stdout_truncated or result.stderr_truncated
+			or result.timed_out or result.output_drain_failed or not result.cleanup_complete
+		):
+			raise ValueError("review_hotspots.git_inventory_failed")
+		inventory = gf_review_hotspot_report.parse_inventory(result.stdout)
+	except (OSError, ValueError, subprocess.TimeoutExpired) as error:
+		if exception_has_cleanup_debt(error):
+			raise
+		report["issues"].append({"code": "review_hotspots.git_inventory_failed"})
+		return report
+	return gf_review_hotspot_report.build_report(ROOT, inventory, scopes=scopes, limit=limit)
 
 
 def project_summary(include_release: bool = False, artifact_manifest: str = "") -> dict[str, Any]:

--- a/tools/gf_review_hotspot_report.py
+++ b/tools/gf_review_hotspot_report.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Capture bounded current-source observations for an optional review report."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+from pathlib import PurePosixPath
+from typing import Any
+
+import gf_path_security
+import gf_review_hotspots
+
+
+MAX_INVENTORY_BYTES = 2 * 1024 * 1024
+MAX_INVENTORY_PATHS = 20_000
+MAX_FILES = 4096
+MAX_FILE_BYTES = 1024 * 1024
+MAX_TOTAL_BYTES = 64 * 1024 * 1024
+MAX_FUNCTIONS = 100_000
+MAX_SCAN_SECONDS = 30.0
+MAX_RESULT_LIMIT = 500
+MAX_SCOPES = 64
+MAX_FILE_ISSUES = 16
+
+
+def normalize_scope(value: str) -> str:
+	"""Accept a literal repository-relative file or directory, never a pathspec."""
+	if not isinstance(value, str):
+		raise ValueError("review_hotspots.invalid_scope")
+	value = value.replace("\\", "/")
+	path = PurePosixPath(value)
+	if (
+		not value
+		or not path.parts
+		or len(value.encode("utf-8")) > 1024
+		or path.is_absolute()
+		or path.as_posix() != value
+		or any(part in {".", ".."} or ":" in part for part in path.parts)
+		or any(ord(character) < 32 or ord(character) == 127 for character in value)
+	):
+		raise ValueError("review_hotspots.invalid_scope")
+	return value
+
+
+def parse_inventory(payload: bytes) -> list[str]:
+	"""Parse one bounded NUL-delimited Git inventory without lossy decoding."""
+	if len(payload) > MAX_INVENTORY_BYTES:
+		raise ValueError("review_hotspots.inventory_limit")
+	if payload and not payload.endswith(b"\0"):
+		raise ValueError("review_hotspots.incomplete_inventory")
+	try:
+		paths = payload.decode("utf-8", errors="strict").split("\0")[:-1]
+	except UnicodeDecodeError:
+		raise ValueError("review_hotspots.invalid_inventory_utf8") from None
+	if len(paths) > MAX_INVENTORY_PATHS:
+		raise ValueError("review_hotspots.inventory_limit")
+	for path in paths:
+		if "\\" in path or normalize_scope(path) != path:
+			raise ValueError("review_hotspots.invalid_inventory_path")
+	return sorted(set(paths))
+
+
+def empty_report(scopes: list[str], limit: int) -> dict[str, Any]:
+	return {
+		"schema_version": 1,
+		"algorithm_version": gf_review_hotspots.ALGORITHM_VERSION,
+		"metric_definitions": dict(gf_review_hotspots.METRIC_DEFINITIONS),
+		"observation_only": True,
+		"ok": False,
+		"status": "incomplete",
+		"scopes": scopes,
+		"limit": limit,
+		"selected_file_count": 0,
+		"scanned_file_count": 0,
+		"function_count": 0,
+		"omitted_function_count": 0,
+		"files": [],
+		"functions": [],
+		"issues": [],
+		"ranking": list(gf_review_hotspots.SORT_ORDER),
+		"source_consistency": "per_file_pinned_read_with_sha256",
+		"limits": {
+			"max_files": MAX_FILES,
+			"max_file_bytes": MAX_FILE_BYTES,
+			"max_total_bytes": MAX_TOTAL_BYTES,
+			"max_functions": MAX_FUNCTIONS,
+			"max_scan_seconds": MAX_SCAN_SECONDS,
+		},
+	}
+
+
+def build_report(
+	root: Path,
+	inventory: list[str],
+	*,
+	scopes: list[str] | None = None,
+	limit: int = 30,
+) -> dict[str, Any]:
+	"""Read matching tracked/unignored files; keep partial coverage explicit."""
+	if scopes is not None and len(scopes) > MAX_SCOPES:
+		raise ValueError("review_hotspots.scope_limit")
+	selected_scopes = sorted({normalize_scope(value) for value in (scopes or ["addons/gf"])})
+	if type(limit) is not int or not 1 <= limit <= MAX_RESULT_LIMIT:
+		raise ValueError("review_hotspots.invalid_limit")
+	report = empty_report(selected_scopes, limit)
+	if len(inventory) > MAX_INVENTORY_PATHS:
+		report["issues"].append({"code": "review_hotspots.inventory_limit"})
+		return report
+	selected: set[str] = set()
+	for scope in selected_scopes:
+		matches = {
+			path for path in inventory
+			if path.endswith(".gd") and (path == scope or path.startswith(scope + "/"))
+		}
+		if not matches:
+			report["issues"].append({"code": "review_hotspots.no_matching_scripts", "path": scope})
+		selected.update(matches)
+	report["selected_file_count"] = len(selected)
+	if len(selected) > MAX_FILES:
+		report["issues"].append({"code": "review_hotspots.file_limit"})
+		return report
+	deadline = time.monotonic() + MAX_SCAN_SECONDS
+	total_bytes = 0
+	functions: list[dict[str, Any]] = []
+	for path in sorted(selected):
+		if time.monotonic() >= deadline:
+			report["issues"].append({"code": "review_hotspots.deadline"})
+			break
+		try:
+			payload = gf_path_security.read_pinned_regular_file(
+				root, path, max_bytes=min(MAX_FILE_BYTES, MAX_TOTAL_BYTES - total_bytes),
+			)
+			total_bytes += len(payload)
+			source = payload.decode("utf-8", errors="strict")
+		except (gf_path_security.PinnedReadError, UnicodeDecodeError) as error:
+			report["issues"].append({
+				"code": getattr(error, "rule_id", "review_hotspots.invalid_utf8"),
+				"path": path,
+			})
+			continue
+		analysis = gf_review_hotspots.analyze_source(source, path)
+		report["scanned_file_count"] += 1
+		report["files"].append({
+			"path": path,
+			"sha256": hashlib.sha256(payload).hexdigest(),
+			"status": analysis["status"],
+			"function_count": len(analysis["functions"]),
+			"issues": analysis["issues"][:MAX_FILE_ISSUES],
+			"omitted_issue_count": analysis["omitted_issue_count"] + max(0, len(analysis["issues"]) - MAX_FILE_ISSUES),
+		})
+		if len(functions) + len(analysis["functions"]) > MAX_FUNCTIONS:
+			report["issues"].append({"code": "review_hotspots.function_limit", "path": path})
+			break
+		functions.extend(analysis["functions"])
+		if time.monotonic() >= deadline:
+			report["issues"].append({"code": "review_hotspots.deadline"})
+			break
+	functions.sort(key=gf_review_hotspots.function_sort_key)
+	report["function_count"] = len(functions)
+	report["functions"] = functions[:limit]
+	report["omitted_function_count"] = max(0, len(functions) - limit)
+	report["ok"] = not report["issues"] and all(
+		item["status"] == "complete" for item in report["files"]
+	)
+	report["status"] = "complete" if report["ok"] else "incomplete"
+	return report
+
+
+def render_text(report: dict[str, Any]) -> str:
+	"""Render locations and individual observations without a quality score."""
+	lines = [
+		f"Review hotspots (observation only): {report['status']}",
+		f"Scopes: {', '.join(report['scopes'])}",
+		f"Files: {report['scanned_file_count']}/{report['selected_file_count']}; "
+		f"functions: {report['function_count']}; omitted by limit: {report['omitted_function_count']}",
+		"Order: nesting, branches, loops, code lines (descending); no pass/fail threshold.",
+	]
+	for function in report["functions"]:
+		metrics = function["metrics"]
+		lines.append(
+			f"{function['path']}:{function['start_line']} "
+			f"{function['qualified_name']} [{function['status']}] "
+			f"nesting={metrics['max_nesting']} branches={metrics['branch_count']} "
+			f"loops={metrics['loop_count']} lines={metrics['effective_code_lines']}"
+		)
+	for issue in report["issues"]:
+		lines.append(f"Issue: {issue.get('path', '')} {issue['code']}")
+	for file in report["files"]:
+		if file["status"] != "complete":
+			lines.append(f"Incomplete source: {file['path']}: {file['issues']}")
+	return "\n".join(lines)

--- a/tools/gf_review_hotspot_report.py
+++ b/tools/gf_review_hotspot_report.py
@@ -56,10 +56,21 @@ def parse_inventory(payload: bytes) -> list[str]:
 		raise ValueError("review_hotspots.invalid_inventory_utf8") from None
 	if len(paths) > MAX_INVENTORY_PATHS:
 		raise ValueError("review_hotspots.inventory_limit")
+	files: set[str] = set()
 	for path in paths:
-		if "\\" in path or normalize_scope(path) != path:
-			raise ValueError("review_hotspots.invalid_inventory_path")
-	return sorted(set(paths))
+		# Git reports untracked nested repositories as directory markers, without
+		# inventorying their contents. Validate their literal spelling, then leave
+		# that separate repository outside this report's source inventory.
+		is_directory = path.endswith("/")
+		literal = path[:-1] if is_directory else path
+		try:
+			if "\\" in literal or normalize_scope(literal) != literal:
+				raise ValueError("review_hotspots.invalid_inventory_path")
+		except ValueError:
+			raise ValueError("review_hotspots.invalid_inventory_path") from None
+		if not is_directory:
+			files.add(literal)
+	return sorted(files)
 
 
 def empty_report(scopes: list[str], limit: int) -> dict[str, Any]:
@@ -128,13 +139,20 @@ def build_report(
 		if time.monotonic() >= deadline:
 			report["issues"].append({"code": "review_hotspots.deadline"})
 			break
+		remaining_bytes = MAX_TOTAL_BYTES - total_bytes
+		if remaining_bytes <= 0:
+			report["issues"].append({"code": "review_hotspots.total_bytes_limit", "path": path})
+			break
 		try:
 			payload = gf_path_security.read_pinned_regular_file(
-				root, path, max_bytes=min(MAX_FILE_BYTES, MAX_TOTAL_BYTES - total_bytes),
+				root, path, max_bytes=min(MAX_FILE_BYTES, remaining_bytes),
 			)
 			total_bytes += len(payload)
 			source = payload.decode("utf-8", errors="strict")
 		except (gf_path_security.PinnedReadError, UnicodeDecodeError) as error:
+			if getattr(error, "rule_id", "") == "path_security.file_too_large" and remaining_bytes < MAX_FILE_BYTES:
+				report["issues"].append({"code": "review_hotspots.total_bytes_limit", "path": path})
+				break
 			report["issues"].append({
 				"code": getattr(error, "rule_id", "review_hotspots.invalid_utf8"),
 				"path": path,

--- a/tools/gf_review_hotspots.py
+++ b/tools/gf_review_hotspots.py
@@ -93,6 +93,31 @@ class _Token:
 	column: int
 
 
+def _tokenize_line(masked: str, line: int) -> list[_Token]:
+	r"""Join adjacent XID continuation fragments without normalizing their spelling.
+
+	Python regex ``\w`` omits combining marks and some other XID characters.
+	Check each fragment once, retaining offsets instead of rebuilding a growing
+	identifier prefix; total work and allocations remain linear in the line size.
+	"""
+	tokens: list[_Token] = []
+	start: int | None = None
+	end = 0
+	is_identifier = False
+	for match in _TOKEN.finditer(masked):
+		value = match.group()
+		if start is not None and match.start() == end and is_identifier and ("_" + value).isidentifier():
+			end = match.end()
+			continue
+		if start is not None:
+			tokens.append(_Token(masked[start:end], line, start))
+		start, end = match.span()
+		is_identifier = value.isidentifier()
+	if start is not None:
+		tokens.append(_Token(masked[start:end], line, start))
+	return tokens
+
+
 @dataclass
 class _Statement:
 	tokens: list[_Token]
@@ -275,7 +300,7 @@ class _Observer:
 				if not _ordinary_quotes_closed(raw, state.multiline_quote):
 					self.issue("unterminated_string", number, "Ordinary string is not closed on its physical line.")
 				masked, _comment, _started_multiline = scan_gdscript_line(raw, state)
-				tokens = [_Token(match.group(), number, match.start()) for match in _TOKEN.finditer(masked)]
+				tokens = _tokenize_line(masked, number)
 				if not tokens:
 					if pending and not state.multiline_quote and len(brackets) <= base_depth:
 						self.observe(_Statement(pending, self.indent(pending[0].line), pending_lines, number, base_depth))
@@ -401,10 +426,10 @@ class _Observer:
 
 	def function(self, tokens: list[_Token], statement: _Statement) -> None:
 		name = parse_function_name(" ".join(token.value for token in tokens))
-		# The API declaration recognizer restricts the first character to ASCII.
-		# Observation also accepts an unambiguous Unicode identifier token, without
-		# changing the API parser's declaration/visibility rules.
-		if not name and len(tokens) >= 3 and tokens[1].value.isidentifier() and tokens[2].value == "(":
+		# The API recognizer restricts the first character to ASCII and can return
+		# only a prefix before Unicode continuation characters. Preserve the whole
+		# validated token without changing API declaration/visibility rules.
+		if len(tokens) >= 3 and tokens[1].value.isidentifier() and tokens[2].value == "(" and name != tokens[1].value:
 			name = tokens[1].value
 		if not name:
 			self.issue("unsupported_function", tokens[0].line, "Named function declaration could not be recognized.")

--- a/tools/gf_review_hotspots.py
+++ b/tools/gf_review_hotspots.py
@@ -1,0 +1,502 @@
+"""Bounded, optional GDScript function structure observations from source text.
+
+This is not a compiler, a quality gate, or a cyclomatic/cognitive complexity
+implementation. ``complete`` means this observation algorithm completed; it
+does not establish valid GDScript, type correctness, or runtime behavior.
+
+The shared API parser supplies literal/comment masking and function-name
+recognition. This module only groups masked statements and observes explicit
+indentation blocks. A small closure audit supplements the shared masker's
+deliberately permissive handling of unfinished strings. No files, Git state,
+source expressions, or external processes are accessed by ``analyze_source``.
+
+Named methods (including static and inner-class methods) receive rows. Lambda
+bodies belong to the nearest enclosing named method, inclusively, and do not
+receive duplicate rows. Lambdas outside named methods are counted separately;
+property accessors and script initializers are not named-method rows. Function
+ranges run from ``func`` through their last observed code line, excluding
+trailing comments/blank lines and preceding annotations. Effective code lines
+count body physical lines containing masked structural code, including literal
+assignments and expression continuations, but excluding literal-only lines.
+
+Branches are explicit if/elif/else headers plus match arms (including wildcard,
+one per arm regardless of pattern alternatives or guards). Match itself adds
+nesting, not a branch. Loops are for/while headers. Nesting counts control
+blocks including match/arm, but not class/function/lambda/container indentation.
+Conditional-expression ``if`` tokens are separate; boolean operators, early
+returns, calls and exception-like semantics add no branches. No call graph,
+expression parser, reachability analysis or semantic validation is attempted.
+
+Malformed observed headers, delimiters, indentation and unsupported block
+forms produce incomplete observations. Any issue conservatively marks every
+row from that source incomplete. Input rejection yields unknown with no rows;
+mid-scan limits retain explicitly incomplete, bounded observations. All limits
+and the stable lexicographic ranking are reported; there is no scalar score.
+Tabs expand to four columns; mixed tab/space prefixes are incomplete. Semicolon
+statement sequences and multiline lambdas embedded in control headers are
+explicit support limits, rather than silently flattened expressions.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from gdscript_api_parser import parse_function_name, scan_gdscript_line
+
+
+SCHEMA_VERSION = 1
+ALGORITHM_VERSION = 1
+MAX_SOURCE_BYTES = 2 * 1024 * 1024
+MAX_LINES = 100_000
+MAX_LINE_LENGTH = 65_536
+MAX_FUNCTIONS = 4_096
+MAX_NESTING = 128
+MAX_BRACKET_DEPTH = 128
+MAX_TOKENS = 300_000
+MAX_ISSUES = 128
+MAX_PATH_LENGTH = 4_096
+MAX_IDENTIFIER_LENGTH = 256
+MAX_QUALIFIED_NAME_LENGTH = 2_048
+MAX_ID_LENGTH = 8_192
+SORT_ORDER = [
+	"max_nesting:descending", "branch_count:descending", "loop_count:descending",
+	"effective_code_lines:descending", "path:ascending", "start_line:ascending", "id:ascending",
+]
+METRIC_DEFINITIONS = {
+	"branch_count": "Explicit if/elif/else headers plus one per match arm, including wildcard; no boolean-operator or guard bonus.",
+	"loop_count": "Explicit for/while headers; comprehensions and call semantics are not inferred.",
+	"match_arm_count": "One per match arm, regardless of alternative patterns or guards.",
+	"max_nesting": "Maximum enclosing control-block depth including match and arms; excludes function/class/lambda/container scopes.",
+	"effective_code_lines": "Distinct body physical lines containing masked structural code; excludes signature, comments, blank and literal-only lines.",
+	"lambda_count": "Lambda declarations within the named function, including nested lambda bodies; no separate lambda rows.",
+	"conditional_expression_count": "Non-header if tokens, observed separately from statement branches.",
+}
+_TOKEN = re.compile(r"\w+|->|:=|[^\s]", re.UNICODE)
+_OPEN = {"(": ")", "[": "]", "{": "}"}
+_CLOSE = frozenset(_OPEN.values())
+_CONTROL = frozenset({"if", "elif", "else", "for", "while", "match"})
+
+
+@dataclass
+class _LexState:
+	# scan_gdscript_line only requires this state field; API ownership parsing is
+	# intentionally not reused as a function-body parser.
+	multiline_quote: str = ""
+
+
+@dataclass(frozen=True)
+class _Token:
+	value: str
+	line: int
+	column: int
+
+
+@dataclass
+class _Statement:
+	tokens: list[_Token]
+	indent: int
+	lines: set[int]
+	end_line: int
+	bracket_depth: int = 0
+
+
+@dataclass
+class _Scope:
+	kind: str
+	indent: int
+	line: int
+	name: str = ""
+	row: dict[str, Any] | None = None
+	body_indent: int | None = None
+
+
+class _LimitReached(Exception):
+	pass
+
+
+def function_sort_key(row: dict[str, Any]) -> tuple[Any, ...]:
+	"""Use the same transparent order within a source and across source reports."""
+	metrics = row["metrics"]
+	return (
+		-metrics["max_nesting"], -metrics["branch_count"], -metrics["loop_count"],
+		-metrics["effective_code_lines"], row["path"], row["start_line"], row["id"],
+	)
+
+
+def analyze_source(source: str, path: str) -> dict[str, Any]:
+	"""Observe supplied text; ``path`` is an opaque display identity, not an IO path.
+
+	Returned keys: schema_version, algorithm_version, path, status, source_bytes,
+	functions, script_lambda_count, issues, omitted_issue_count, limits, sort_order.
+	Issues contain code/line/message; source contents are never included in them.
+	"""
+	report: dict[str, Any] = {
+		"schema_version": SCHEMA_VERSION, "algorithm_version": ALGORITHM_VERSION,
+		"path": path if isinstance(path, str) and len(path) <= MAX_PATH_LENGTH else "", "status": "complete", "source_bytes": 0,
+		"functions": [], "script_lambda_count": 0, "issues": [], "omitted_issue_count": 0,
+		"limits": {
+			"source_bytes": MAX_SOURCE_BYTES, "lines": MAX_LINES, "line_length": MAX_LINE_LENGTH,
+			"functions": MAX_FUNCTIONS, "scopes": MAX_NESTING, "bracket_depth": MAX_BRACKET_DEPTH,
+			"tokens": MAX_TOKENS, "issues": MAX_ISSUES,
+			"identifier_length": MAX_IDENTIFIER_LENGTH, "qualified_name_length": MAX_QUALIFIED_NAME_LENGTH,
+			"id_length": MAX_ID_LENGTH, "path_length": MAX_PATH_LENGTH,
+		},
+		"sort_order": list(SORT_ORDER),
+		"metric_definitions": dict(METRIC_DEFINITIONS),
+	}
+	if not isinstance(source, str) or not isinstance(path, str) or len(path) > MAX_PATH_LENGTH:
+		return _reject(report, "invalid_input", "Expected bounded source and path strings.")
+	if len(source) > MAX_SOURCE_BYTES:
+		return _reject(report, "source_limit", "Source exceeds the byte budget.")
+	try:
+		report["source_bytes"] = len(source.encode("utf-8", errors="strict"))
+	except UnicodeError:
+		return _reject(report, "invalid_unicode", "Source is not encodable as strict UTF-8.")
+	if report["source_bytes"] > MAX_SOURCE_BYTES:
+		return _reject(report, "source_limit", "Source exceeds the byte budget.")
+	if any((ord(char) < 32 and char not in "\t\r\n") or char in "\x85\u2028\u2029" for char in source):
+		return _reject(report, "unsupported_control_character", "Source contains unsupported control characters.")
+	if source.startswith("\ufeff"):
+		source = source[1:]
+	lines = source.splitlines()
+	if len(lines) > MAX_LINES:
+		return _reject(report, "line_limit", "Source exceeds the physical line budget.")
+	if any(len(line) > MAX_LINE_LENGTH for line in lines):
+		return _reject(report, "line_length_limit", "Source exceeds the per-line character budget.")
+	observer = _Observer(report, lines)
+	observer.run()
+	if report["issues"]:
+		report["status"] = "incomplete"
+		for row in report["functions"]:
+			row["status"] = "incomplete"
+	report["functions"].sort(key=function_sort_key)
+	return report
+
+
+def _reject(report: dict[str, Any], code: str, message: str) -> dict[str, Any]:
+	report["status"] = "unknown"
+	report["issues"] = [{"code": code, "line": 0, "message": message}]
+	return report
+
+
+def _ordinary_quotes_closed(text: str, initial_multiline_quote: str) -> bool:
+	"""Audit quote closure only; shared scan_gdscript_line owns structural masking."""
+	quote = initial_multiline_quote
+	i = 0
+	while i < len(text):
+		if quote:
+			if text.startswith(quote, i):
+				i += len(quote)
+				quote = ""
+			elif text[i] == "\\":
+				i += 2
+			else:
+				i += 1
+			continue
+		if text[i] == "#":
+			return True
+		if text.startswith('"""', i) or text.startswith("'''", i):
+			quote = text[i:i + 3]
+			i += 3
+		elif text[i] in "\"'":
+			ordinary = text[i]
+			i += 1
+			while i < len(text):
+				if text[i] == "\\":
+					i += 2
+				elif text[i] == ordinary:
+					i += 1
+					break
+				else:
+					i += 1
+			else:
+				return False
+		else:
+			i += 1
+	return True
+
+
+def _colon_index(tokens: list[_Token]) -> int | None:
+	depth = 0
+	for index, token in enumerate(tokens):
+		if token.value in _OPEN:
+			depth += 1
+		elif token.value in _CLOSE:
+			depth -= 1
+		elif token.value == ":" and depth == 0:
+			return index
+	return None
+
+
+def _without_annotations(tokens: list[_Token]) -> list[_Token]:
+	index = 0
+	while index < len(tokens) and tokens[index].value == "@":
+		index += 2
+		if index < len(tokens) and tokens[index].value == "(":
+			depth = 1
+			index += 1
+			while index < len(tokens) and depth:
+				depth += (tokens[index].value == "(") - (tokens[index].value == ")")
+				index += 1
+	return tokens[index:]
+
+
+class _Observer:
+	def __init__(self, report: dict[str, Any], lines: list[str]) -> None:
+		self.report = report
+		self.lines = lines
+		self.scopes: list[_Scope] = []
+		self.root_name = ""
+		self.seen_names: set[str] = set()
+		self.function_lines: dict[str, set[int]] = {}
+
+	def issue(self, code: str, line: int, message: str) -> None:
+		if len(self.report["issues"]) < MAX_ISSUES:
+			self.report["issues"].append({"code": code, "line": line, "message": message})
+		else:
+			self.report["omitted_issue_count"] += 1
+
+	def limit(self, code: str, line: int, message: str) -> None:
+		self.issue(code, line, message)
+		raise _LimitReached
+
+	def run(self) -> None:
+		state = _LexState()
+		brackets: list[_Token] = []
+		pending: list[_Token] = []
+		pending_lines: set[int] = set()
+		base_depth = 0
+		callable_base_depth: int | None = None
+		token_count = 0
+		try:
+			for number, raw in enumerate(self.lines, 1):
+				if not _ordinary_quotes_closed(raw, state.multiline_quote):
+					self.issue("unterminated_string", number, "Ordinary string is not closed on its physical line.")
+				masked, _comment, _started_multiline = scan_gdscript_line(raw, state)
+				tokens = [_Token(match.group(), number, match.start()) for match in _TOKEN.finditer(masked)]
+				if not tokens:
+					if pending and not state.multiline_quote and len(brackets) <= base_depth:
+						self.observe(_Statement(pending, self.indent(pending[0].line), pending_lines, number, base_depth))
+						pending = []
+						pending_lines = set()
+						callable_base_depth = None
+					continue
+				token_count += len(tokens)
+				if token_count > MAX_TOKENS:
+					self.limit("token_limit", number, "Source exceeds the structural token budget.")
+				if not pending:
+					base_depth = len(brackets)
+				pending_lines.add(number)
+				lambda_header = False
+				for token in tokens:
+					if token.value == "func":
+						callable_base_depth = len(brackets)
+					elif token.value == ":" and callable_base_depth == len(brackets):
+						lambda_header = True
+					if token.value in _OPEN:
+						if len(brackets) >= MAX_BRACKET_DEPTH:
+							self.limit("bracket_depth_limit", number, "Delimiter nesting exceeds the budget.")
+						brackets.append(token)
+					elif token.value in _CLOSE:
+						if not brackets or _OPEN[brackets[-1].value] != token.value:
+							self.issue("unmatched_delimiter", number, "Closing delimiter does not match its opener.")
+						else:
+							brackets.pop()
+				continued = tokens[-1].value == "\\"
+				# The consumed continuation marker joins physical lines; it is not
+				# part of the declaration/expression passed to structural observers.
+				pending.extend(tokens[:-1] if continued else tokens)
+				if (len(brackets) <= base_depth or lambda_header) and not continued and not state.multiline_quote:
+					self.observe(_Statement(pending, self.indent(pending[0].line), pending_lines, number, base_depth))
+					pending = []
+					pending_lines = set()
+					callable_base_depth = None
+			if pending:
+				self.issue("incomplete_statement", pending[0].line, "Continued statement is unfinished.")
+				self.observe(_Statement(pending, self.indent(pending[0].line), pending_lines, pending[-1].line, base_depth))
+			if state.multiline_quote:
+				self.issue("unterminated_multiline_string", len(self.lines), "Multiline string is not closed.")
+			if brackets:
+				self.issue("unclosed_delimiter", brackets[0].line, "Opening delimiter remains unclosed.")
+		except _LimitReached:
+			pass
+		while self.scopes:
+			self.close_scope()
+		for row in self.report["functions"]:
+			row["metrics"]["effective_code_lines"] = len(self.function_lines[row["id"]])
+
+	def indent(self, line: int) -> int:
+		raw = self.lines[line - 1]
+		prefix = raw[:len(raw) - len(raw.lstrip(" \t"))]
+		if " " in prefix and "\t" in prefix:
+			self.issue("mixed_indentation", line, "Indent prefix mixes spaces and tabs.")
+		return len(prefix.expandtabs(4))
+
+	def close_scope(self) -> None:
+		scope = self.scopes.pop()
+		if scope.body_indent is None:
+			self.issue("missing_body", scope.line, "Block has no observed body.")
+
+	def push(self, scope: _Scope) -> None:
+		if len(self.scopes) >= MAX_NESTING:
+			self.limit("nesting_limit", scope.line, "Syntactic scope nesting exceeds the budget.")
+		self.scopes.append(scope)
+
+	def current_function(self) -> dict[str, Any] | None:
+		return next((scope.row for scope in reversed(self.scopes) if scope.row is not None), None)
+
+	def observe(self, statement: _Statement) -> None:
+		tokens = _without_annotations(statement.tokens)
+		if not tokens:
+			return
+		while self.scopes and statement.indent <= self.scopes[-1].indent:
+			self.close_scope()
+		# After a lambda body, the enclosing call/container still owns following
+		# arguments. Their indentation is expression layout, not a new block.
+		in_expression = statement.bracket_depth > 0 and not any(scope.kind == "lambda" for scope in self.scopes)
+		if self.scopes:
+			scope = self.scopes[-1]
+			if scope.body_indent is None:
+				scope.body_indent = statement.indent
+			elif statement.indent != scope.body_indent and not in_expression:
+				self.issue("unexpected_indentation", tokens[0].line, "Indentation has no corresponding observed block.")
+		elif statement.indent and not in_expression:
+			self.issue("unexpected_indentation", tokens[0].line, "Top-level statement is indented.")
+		values = [token.value for token in tokens]
+		first = values[0]
+		if ";" in values:
+			self.issue("unsupported_statement_separator", tokens[0].line, "Multiple statements separated by semicolons are outside this observation grammar.")
+		owner = self.current_function()
+		if first == "class_name" and len(tokens) > 1 and not self.scopes:
+			self.check_identifier(tokens[1])
+			self.root_name = tokens[1].value
+			return
+		if first == "class":
+			if owner is not None or len(tokens) < 3 or _colon_index(tokens) != len(tokens) - 1:
+				self.issue("unsupported_class", tokens[0].line, "Class declaration is not a supported standalone block.")
+				return
+			self.check_identifier(tokens[1])
+			self.push(_Scope("class", statement.indent, tokens[0].line, name=tokens[1].value))
+			return
+		function_offset = 1 if first == "static" else 0
+		is_declaration = (
+			function_offset + 2 < len(values) and values[function_offset] == "func"
+			and values[function_offset + 1].isidentifier() and values[function_offset + 2] == "("
+			and not in_expression
+		)
+		if is_declaration and owner is None and all(scope.kind == "class" for scope in self.scopes):
+			self.function(tokens[function_offset:], statement)
+			return
+		if is_declaration:
+			self.issue("nested_function_declaration", tokens[0].line, "Standalone nested named declaration is unsupported; observations remain with its enclosing function.")
+		if owner is not None:
+			self.record_lines(owner, statement.lines, statement.end_line)
+		self.body(tokens, statement.indent, owner)
+
+	def check_identifier(self, token: _Token) -> None:
+		if len(token.value) > MAX_IDENTIFIER_LENGTH:
+			self.limit("identifier_limit", token.line, "Declaration identifier exceeds the length budget.")
+
+	def function(self, tokens: list[_Token], statement: _Statement) -> None:
+		name = parse_function_name(" ".join(token.value for token in tokens))
+		# The API declaration recognizer restricts the first character to ASCII.
+		# Observation also accepts an unambiguous Unicode identifier token, without
+		# changing the API parser's declaration/visibility rules.
+		if not name and len(tokens) >= 3 and tokens[1].value.isidentifier() and tokens[2].value == "(":
+			name = tokens[1].value
+		if not name:
+			self.issue("unsupported_function", tokens[0].line, "Named function declaration could not be recognized.")
+			return
+		self.check_identifier(tokens[1])
+		if len(self.report["functions"]) >= MAX_FUNCTIONS:
+			self.limit("function_limit", tokens[0].line, "Named function count exceeds the budget.")
+		owners = ([self.root_name] if self.root_name else []) + [scope.name for scope in self.scopes if scope.kind == "class"]
+		qualified = ".".join([*owners, name])
+		identity = f'{self.report["path"]}::{qualified}@{tokens[0].line}'
+		if len(qualified) > MAX_QUALIFIED_NAME_LENGTH or len(identity) > MAX_ID_LENGTH:
+			self.limit("identity_limit", tokens[0].line, "Qualified function identity exceeds the length budget.")
+		if qualified in self.seen_names:
+			self.issue("duplicate_function", tokens[0].line, "Function qualified name is declared more than once.")
+		self.seen_names.add(qualified)
+		row: dict[str, Any] = {
+			"id": identity,
+			"path": self.report["path"], "name": name, "qualified_name": qualified,
+			"start_line": tokens[0].line, "end_line": statement.end_line, "status": "complete",
+			"metrics": {
+				"branch_count": 0, "loop_count": 0, "match_arm_count": 0, "max_nesting": 0,
+				"effective_code_lines": 0, "lambda_count": 0, "conditional_expression_count": 0,
+			},
+		}
+		self.report["functions"].append(row)
+		self.function_lines[row["id"]] = set()
+		colon = _colon_index(tokens)
+		if colon is None:
+			self.issue("incomplete_function_header", tokens[0].line, "Function header has no completed body colon.")
+			self.push(_Scope("function", statement.indent, tokens[0].line, row=row))
+		elif colon == len(tokens) - 1:
+			self.push(_Scope("function", statement.indent, tokens[0].line, row=row))
+		else:
+			body = tokens[colon + 1:]
+			self.record_lines(row, {token.line for token in body}, statement.end_line)
+			self.body(body, statement.indent, row, inline=True)
+
+	def record_lines(self, row: dict[str, Any], lines: set[int], end_line: int) -> None:
+		self.function_lines[row["id"]].update(lines)
+		row["end_line"] = max(row["end_line"], end_line)
+
+	def body(self, tokens: list[_Token], indent: int, owner: dict[str, Any] | None, *, inline: bool = False) -> None:
+		values = [token.value for token in tokens]
+		first = values[0]
+		colon = _colon_index(tokens)
+		if first == "for" and "in" in values:
+			iterator_end = values.index("in") + 1
+			body_colon = _colon_index(tokens[iterator_end:])
+			colon = None if body_colon is None else iterator_end + body_colon
+		is_arm = bool(self.scopes and self.scopes[-1].kind == "match")
+		control = first in _CONTROL or is_arm
+		lambda_indices = [index for index, token in enumerate(tokens) if token.value == "func"]
+		if owner is not None:
+			owner["metrics"]["lambda_count"] += len(lambda_indices)
+		else:
+			self.report["script_lambda_count"] += len(lambda_indices)
+		if owner is not None:
+			metrics = owner["metrics"]
+			metrics["conditional_expression_count"] += values.count("if") - int(first == "if" and not is_arm)
+			if control:
+				if first in {"if", "elif", "else"} or is_arm:
+					metrics["branch_count"] += 1
+				if is_arm:
+					metrics["match_arm_count"] += 1
+				elif first in {"for", "while"}:
+					metrics["loop_count"] += 1
+				depth = 1 + sum(scope.kind in _CONTROL or scope.kind == "arm" for scope in self.scopes)
+				metrics["max_nesting"] = max(metrics["max_nesting"], depth)
+		if control:
+			if colon is None:
+				if "func" in values:
+					self.issue("unsupported_lambda_in_control_header", tokens[0].line, "Multiline lambda embedded in a control header is outside this observation grammar.")
+				else:
+					self.issue("incomplete_control_header", tokens[0].line, "Control header has no completed body colon.")
+			elif inline:
+				self.issue("unsupported_inline_control", tokens[0].line, "Nested compound statement inside an inline body is unsupported.")
+			elif colon == len(tokens) - 1:
+				self.push(_Scope("arm" if is_arm else first, indent, tokens[0].line))
+			elif tokens[colon + 1].value in _CONTROL:
+				self.issue("unsupported_inline_control", tokens[0].line, "Nested compound statement inside an inline body is unsupported.")
+			return
+		if lambda_indices:
+			last = lambda_indices[-1]
+			lambda_colon = _colon_index(tokens[last:])
+			if lambda_colon is None:
+				self.issue("incomplete_lambda", tokens[last].line, "Lambda header has no completed body colon.")
+			elif last + lambda_colon == len(tokens) - 1:
+				self.push(_Scope("lambda", self.indent(tokens[last].line), tokens[last].line))
+			return
+		if tokens[-1].value == ":":
+			if owner is None and first in {"var", "get", "set"}:
+				self.push(_Scope("accessor", indent, tokens[0].line))
+			else:
+				self.issue("unsupported_block", tokens[0].line, "Block form is outside the supported observation grammar.")
+				self.push(_Scope("unknown", indent, tokens[0].line))

--- a/tools/gf_validation_catalog.py
+++ b/tools/gf_validation_catalog.py
@@ -639,7 +639,12 @@ def build_validation_catalog(context: ValidationCatalogContext) -> ValidationCat
 		),
 		subprocess_action(
 			"maintenance_generator_tests",
-			python_script("tests/gf_core/tools/test_gf_maintenance_generators.py"),
+			(
+				python, "-m", "unittest",
+				"tests/gf_core/tools/test_gf_maintenance_generators.py",
+				"tests/gf_core/tools/test_gf_review_hotspots.py",
+				"tests/gf_core/tools/test_gf_review_hotspot_report.py",
+			),
 		),
 		subprocess_action(
 			"maintenance_test_evidence_tests",


### PR DESCRIPTION
## Summary

Add an explicit `review-hotspots` maintenance command that reports GDScript function locations, branches, loops, control nesting, code lines, and lambda observations. Maintainers can select literal file/directory scopes and inspect stable human-readable or JSON results with per-file source digests.

The report provides no scalar quality score or refactoring threshold and does not enter CI or merge gates. Unsupported syntax and incomplete capture remain visible rather than being presented as complete measurements.

## Contract and Risk

- Change type: feat (repository maintenance tooling).
- Consumer-visible behavior: maintainers can request a bounded current-source report; project runtime/editor behavior is unchanged.
- API or extension contract: additive CLI/report schema version 1; no GDScript API or extension changes.
- Persisted data, package, protocol, or ProjectSettings impact: optional JSON output below `build/`; no project data, package, or settings changes.
- Failure, cancellation, rollback, concurrency, and ownership impact: frozen Git environment and bounded native byte capture; the original deadline covers process-tree quiet confirmation. Cleanup debt is propagated. Pinned file reads reject links, replacement, invalid UTF-8, and budget exhaustion. Per-file digests are not an atomic repository snapshot.
- Compatibility and migration: no migration. The existing `12.0.0-dev.0` development line remains unchanged.
- Observation limits: semicolon statement sequences and multiline lambdas embedded in control headers are explicitly incomplete. Top-N omission is separate from incomplete coverage.

## Verification

- [x] Focused tests cover the changed behavior and failure path: 50 report/parser tests passed, including seven new regression cases for Unicode names, inventory diagnostics/directory markers, and aggregate byte budgets. A real Git nested-repository inventory also completed the requested source scope.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only`: all 30 checks passed with UTF-8 Python mode.
- [x] `python tools/gf_maintenance.py maintenance-self-test`: 391/391 passed.
- [x] GDScript warning and LSP gates: no `.gd` files changed; existing generated API/knowledge checks passed in quick.
- [x] Independent read-only review of immutable source snapshots completed; identified parser and process-ownership issues were fixed and regression-tested.
- [x] Real CLI observations: 57 math scripts / 1,097 functions completed; the full source inventory covered 972 scripts / 21,819 functions and explicitly reported the two unsupported control-header lambda files.
- [x] Draft PR feedback completed through `GF draft gate`.
- [x] Ready PR CI completed through `GF repository policy` and `GF merge gate` for c75604e4, including full validation and Windows process supervision.

## Documentation and Release

- [x] The maintainer guide documents usage, metric definitions, scope, budgets, status, and limitations. This is internal maintenance functionality, so no public product changelog entry is needed.
- [x] Development version impact is correct.
- [x] This PR does not create a tag or publish a release.