### PR TITLE
feat(action-queue): add custom tween easing curves

### DIFF
--- a/addons/gf/extensions/action_queue/editor/gf_tween_preview_plan.gd
+++ b/addons/gf/extensions/action_queue/editor/gf_tween_preview_plan.gd
@@ -16,10 +16,14 @@ extends RefCounted
 
 const _CONFIG_SCRIPT = preload("res://addons/gf/extensions/action_queue/tween/gf_tween_action_config.gd")
 const _STEP_SCRIPT = preload("res://addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd")
+const _EASING_CURVE_SCRIPT = preload("res://addons/gf/extensions/action_queue/tween/gf_tween_easing_curve.gd")
+const _VARIANT_ACCESS_SCRIPT = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
 const _MAX_STEPS: int = 128
 const _MAX_LOOPS: int = 32
 const _MAX_SECONDS: float = 120.0
 const _MAX_VALUE_MAGNITUDE: float = 1000000.0
+const _MAX_CURVE_SAMPLES: int = 65536
+const _MAX_CURVE_POINTS: int = 4096
 
 
 # --- 公共变量 ---
@@ -33,7 +37,7 @@ var error: String = ""
 ## [br]
 ## @api framework_internal
 ## [br]
-## @schema steps: Array[Dictionary]，每项包含 property_name: NodePath、target_value: 有限数值或 Vector2/Vector3/Color、duration: float、delay: float、as_relative: bool、parallel: bool、transition_type: int、ease_type: int；duration 与 delay 已完成缩放。
+## @schema steps: Array[Dictionary]，每项包含 property_name: NodePath、target_value: 有限数值或 Vector2/Vector3/Color、duration: float、delay: float、as_relative: bool、parallel: bool、transition_type: int、ease_type: int、easing_curve_data: Dictionary（空或独立的 positions/tangents/modes/bake_resolution/value_range 纯值曲线数据）；duration 与 delay 已完成缩放。
 var steps: Array[Dictionary] = []
 
 ## 有限播放次数，成功计划取值为 1 至 32。
@@ -102,6 +106,8 @@ static func capture(config: Resource, target_kind: int) -> GFTweenPreviewPlan:
 	var total_seconds: float = 0.0
 	var completed_groups_seconds: float = 0.0
 	var current_group_seconds: float = 0.0
+	var curve_sample_count: int = 0
+	var curve_point_count: int = 0
 	for index: int in range(source_steps.size()):
 		var step_value: Variant = source_steps[index]
 		if not (step_value is Resource):
@@ -111,6 +117,11 @@ static func capture(config: Resource, target_kind: int) -> GFTweenPreviewPlan:
 		if not step_error.is_empty():
 			return _reject(plan, "步骤 %d：%s" % [index, step_error])
 		var captured_step: Dictionary = plan.steps[plan.steps.size() - 1]
+		var curve_data: Dictionary = _VARIANT_ACCESS_SCRIPT.get_option_dictionary(captured_step, "easing_curve_data")
+		curve_sample_count += _EASING_CURVE_SCRIPT.get_sample_count(curve_data)
+		curve_point_count += _EASING_CURVE_SCRIPT.get_point_count(curve_data)
+		if curve_sample_count > _MAX_CURVE_SAMPLES or curve_point_count > _MAX_CURVE_POINTS:
+			return _reject(plan, "预览曲线累计不能超过 65536 个烘焙采样和 4096 个控制点。")
 		var duration_value: Variant = captured_step["duration"]
 		var delay_value: Variant = captured_step["delay"]
 		var effective_duration: float = _read_number(duration_value)
@@ -265,6 +276,17 @@ static func _capture_step(
 		return "transition_type 超出合法枚举范围。"
 	if ease_kind < Tween.EASE_IN or ease_kind > Tween.EASE_OUT_IN:
 		return "ease_type 超出合法枚举范围。"
+	var curve_value: Variant = source.get(&"easing_curve")
+	if curve_value != null and not (curve_value is Curve):
+		return "easing_curve 必须为原生 Curve 或 null。"
+	var source_curve: Curve = null
+	if curve_value is Curve:
+		source_curve = curve_value
+	var curve_capture: Dictionary = _EASING_CURVE_SCRIPT.capture(source_curve)
+	var curve_error: String = _VARIANT_ACCESS_SCRIPT.get_option_string(curve_capture, "error")
+	if not curve_error.is_empty():
+		return "Invalid easing_curve: %s" % curve_error
+	var curve_data: Dictionary = _VARIANT_ACCESS_SCRIPT.get_option_dictionary(curve_capture, "data")
 
 	plan.steps.append({
 		"property_name": property_path,
@@ -275,6 +297,7 @@ static func _capture_step(
 		"parallel": parallel,
 		"transition_type": transition,
 		"ease_type": ease_kind,
+		"easing_curve_data": curve_data,
 	})
 	return ""
 

--- a/addons/gf/extensions/action_queue/editor/gf_tween_preview_viewport.gd
+++ b/addons/gf/extensions/action_queue/editor/gf_tween_preview_viewport.gd
@@ -22,6 +22,7 @@ signal state_changed
 
 const _PREVIEW_SIZE: Vector2i = Vector2i(480, 320)
 const _SAMPLE_COLOR: Color = Color(0.35, 0.72, 1.0)
+const _VARIANT_ACCESS_SCRIPT = preload("res://addons/gf/kernel/core/gf_variant_access.gd")
 
 
 # --- 私有变量 ---
@@ -411,7 +412,8 @@ func _build_session_tween() -> bool:
 			_step_bool(step, "as_relative"),
 			_step_bool(step, "parallel"),
 			_step_int(step, "transition_type") as Tween.TransitionType,
-			_step_int(step, "ease_type") as Tween.EaseType
+			_step_int(step, "ease_type") as Tween.EaseType,
+			_VARIANT_ACCESS_SCRIPT.get_option_dictionary(step, "easing_curve_data")
 		)
 		if tweener == null:
 			_fail("Unable to construct the validated preview step.")

--- a/addons/gf/extensions/action_queue/gf_extension.json
+++ b/addons/gf/extensions/action_queue/gf_extension.json
@@ -2,7 +2,7 @@
   "id": "gf.action_queue",
   "display_name": "GF Action Queue",
   "version": "12.0.0-dev.0",
-  "extension_version": "2.4.0",
+  "extension_version": "2.5.0",
   "kind": "extension",
   "description": "Presentation action queue primitives, interceptors, tween configs, and reusable visual actions.",
   "dependencies": ["gf.kernel", "gf.standard"],

--- a/addons/gf/extensions/action_queue/tween/gf_tween_action_config.gd
+++ b/addons/gf/extensions/action_queue/tween/gf_tween_action_config.gd
@@ -166,7 +166,7 @@ func capture_initial_values(target: Object) -> Dictionary:
 		var key: String = String(step.property_name)
 		if key.is_empty() or snapshot.has(key):
 			continue
-		if not step.get_validation_error(target).is_empty():
+		if not step.get_property_validation_error(target).is_empty():
 			continue
 		snapshot[key] = step.capture_initial_value(target)
 	return snapshot
@@ -215,7 +215,9 @@ func get_validation_report(target: Object) -> GFValidationReport:
 ## [br]
 ## @api public
 ## [br]
-## @return 新配置。
+## @since 3.17.0
+## [br]
+## @return 新配置；任一步骤的 easing_curve 无法复制时发出警告并返回 null。
 func duplicate_config() -> GFTweenActionConfig:
 	var config: GFTweenActionConfig = GFTweenActionConfig.new()
 	config.duration_scale = duration_scale
@@ -226,5 +228,11 @@ func duplicate_config() -> GFTweenActionConfig:
 	config.restore_initial_values_on_cancel = restore_initial_values_on_cancel
 	config.restore_initial_values_on_finish = restore_initial_values_on_finish
 	for step: GFTweenActionStep in steps:
-		config.steps.append(step.duplicate_step() if step != null else null)
+		if step == null:
+			config.steps.append(null)
+			continue
+		var copied_step: GFTweenActionStep = step.duplicate_step()
+		if copied_step == null:
+			return null
+		config.steps.append(copied_step)
 	return config

--- a/addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd
+++ b/addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd
@@ -14,6 +14,7 @@ extends Resource
 # --- 常量 ---
 
 const _ACTION_TIME_POLICY = preload("res://addons/gf/extensions/action_queue/core/gf_action_time_policy.gd")
+const _EASING_CURVE_SCRIPT = preload("res://addons/gf/extensions/action_queue/tween/gf_tween_easing_curve.gd")
 
 
 # --- 导出变量 ---
@@ -72,6 +73,16 @@ const _ACTION_TIME_POLICY = preload("res://addons/gf/extensions/action_queue/cor
 ## @api public
 @export var ease_type: Tween.EaseType = Tween.EASE_OUT
 
+## 可选原生缓动曲线；设置后覆盖 transition_type/ease_type，按线性时间进度进行 sample_baked。
+## 横轴域为 0..1，首尾点必须为 (0,0)/(1,1)，X 严格递增；支持回弹和超调。
+## 只接受无脚本、2..256 点、2..1000 烘焙采样的 Curve；坐标、切线与编辑范围须有限，
+## 编辑范围须包含 0..1 及全部点值，烘焙输出绝对值不超过 16。创建 Tweener 时捕获独立数据。
+## [br]
+## @api public
+## [br]
+## @since unreleased
+@export var easing_curve: Curve = null
+
 ## 可选步骤标记。非空时 GFConfiguredTweenAction 会在步骤结束后发出 marker_reached；
 ## 标记通知不会改变相邻步骤声明的并行拓扑。
 ## [br]
@@ -105,10 +116,16 @@ var _delay: float = 0.0
 func append_to_tween(tween: Tween, target: Object, duration_scale: float = 1.0) -> Variant:
 	if tween == null:
 		return null
-	var validation_error: String = get_validation_error(target)
+	var validation_error: String = get_property_validation_error(target)
 	if not validation_error.is_empty():
 		push_warning("[GFTweenActionStep] 跳过无效 Tween 步骤：%s" % validation_error)
 		return null
+	var captured_curve: Dictionary = _EASING_CURVE_SCRIPT.capture(easing_curve)
+	var curve_error: String = GFVariantData.get_option_string(captured_curve, "error")
+	if not curve_error.is_empty():
+		push_warning("[GFTweenActionStep] 跳过无效 Tween 步骤：Invalid easing_curve: %s" % curve_error)
+		return null
+	var curve_data: Dictionary = GFVariantData.get_option_dictionary(captured_curve, "data")
 
 	var effective_scale: float = _ACTION_TIME_POLICY.sanitize_non_negative_seconds(duration_scale)
 	var effective_duration: float = _ACTION_TIME_POLICY.sanitize_non_negative_seconds(
@@ -119,17 +136,19 @@ func append_to_tween(tween: Tween, target: Object, duration_scale: float = 1.0) 
 	)
 	return append_property_tweener(
 		tween, target, property_name, target_value, effective_duration, effective_delay,
-		as_relative, parallel, transition_type, ease_type
+		as_relative, parallel, transition_type, ease_type, curve_data
 	)
 
 
-## 立即应用步骤目标值。
+## 立即应用步骤目标值；仅校验属性，不采样或校验 easing_curve。
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param target: 目标对象。
 func apply_instant(target: Object) -> void:
-	var validation_error: String = get_validation_error(target)
+	var validation_error: String = get_property_validation_error(target)
 	if not validation_error.is_empty():
 		push_warning("[GFTweenActionStep] 跳过无效即时步骤：%s" % validation_error)
 		return
@@ -139,12 +158,18 @@ func apply_instant(target: Object) -> void:
 		target.set_indexed(property_name, target_value)
 
 
-## 创建深拷贝。
+## 创建深拷贝；曲线只复制原生数据，不携带脚本或 metadata。
 ## [br]
 ## @api public
 ## [br]
-## @return 新步骤。
+## @since 3.17.0
+## [br]
+## @return 新步骤；easing_curve 无效时发出警告并返回 null。
 func duplicate_step() -> GFTweenActionStep:
+	var copied_curve: Curve = _EASING_CURVE_SCRIPT.duplicate_curve(easing_curve)
+	if easing_curve != null and copied_curve == null:
+		push_warning("[GFTweenActionStep] 无法复制无效 easing_curve；请先校验步骤。")
+		return null
 	var step: GFTweenActionStep = GFTweenActionStep.new()
 	step.property_name = property_name
 	step.target_value = GFVariantData.duplicate_variant(target_value)
@@ -154,6 +179,7 @@ func duplicate_step() -> GFTweenActionStep:
 	step.parallel = parallel
 	step.transition_type = transition_type
 	step.ease_type = ease_type
+	step.easing_curve = copied_curve
 	step.marker_id = marker_id
 	return step
 
@@ -169,19 +195,59 @@ func can_apply_to(target: Object) -> bool:
 	return get_validation_error(target).is_empty()
 
 
-## 获取当前步骤对目标对象的校验错误。
+## 获取当前步骤的属性与 easing_curve 校验错误。
 ## [br]
 ## @api public
+## [br]
+## @since 3.17.0
 ## [br]
 ## @param target: 目标对象。
 ## [br]
 ## @return 校验通过时返回空字符串。
 func get_validation_error(target: Object) -> String:
+	var property_error: String = get_property_validation_error(target)
+	if not property_error.is_empty():
+		return property_error
+	var captured_curve: Dictionary = _EASING_CURVE_SCRIPT.capture(easing_curve)
+	var curve_error: String = GFVariantData.get_option_string(captured_curve, "error")
+	if not curve_error.is_empty():
+		return "Invalid easing_curve: %s" % curve_error
+	return ""
+
+
+## 捕获当前属性值；仅校验属性，不采样或校验 easing_curve。
+## [br]
+## @api public
+## [br]
+## @since 3.17.0
+## [br]
+## @param target: 目标对象。
+## [br]
+## @return 属性值；步骤无效时返回 null。
+## [br]
+## @schema return: Variant，目标属性的深拷贝值；步骤无效时为 null。
+func capture_initial_value(target: Object) -> Variant:
+	if not get_property_validation_error(target).is_empty():
+		return null
+	return GFVariantData.duplicate_variant(target.get_indexed(property_name))
+
+
+# --- 框架内部方法 ---
+
+## 校验可读写属性和值，供即时终点应用和初值恢复使用，不要求插值曲线有效。
+## [br]
+## @api framework_internal
+## [br]
+## @since unreleased
+## [br]
+## @param target: 要读取或写入的目标对象。
+## [br]
+## @return: 属性校验通过时为空字符串，否则为错误原因。
+func get_property_validation_error(target: Object) -> String:
 	if not is_instance_valid(target):
 		return "Target is invalid."
 	if property_name.is_empty():
 		return "Property name is empty."
-
 	var root_property: String = _get_root_property_name()
 	if root_property.is_empty():
 		return "Property name is empty."
@@ -190,29 +256,11 @@ func get_validation_error(target: Object) -> String:
 	if as_relative and not _can_resolve_relative_value(target):
 		return "Relative value type mismatch for property: %s" % String(property_name)
 	if not as_relative and not _are_tween_values_compatible(
-		target.get_indexed(property_name),
-		target_value
+		target.get_indexed(property_name), target_value
 	):
 		return "Tween value type mismatch for property: %s" % String(property_name)
 	return ""
 
-
-## 捕获当前属性值。
-## [br]
-## @api public
-## [br]
-## @param target: 目标对象。
-## [br]
-## @return 属性值；步骤无效时返回 null。
-## [br]
-## @schema return: Variant，目标属性的深拷贝值；步骤无效时为 null。
-func capture_initial_value(target: Object) -> Variant:
-	if not get_validation_error(target).is_empty():
-		return null
-	return GFVariantData.duplicate_variant(target.get_indexed(property_name))
-
-
-# --- 框架内部方法 ---
 
 ## 以调用方已校验的属性数据构建原生 Tweener，不读取配置资源或添加标记回调。
 ## [br]
@@ -238,9 +286,13 @@ func capture_initial_value(target: Object) -> Variant:
 ## [br]
 ## @param p_ease_type: 已校验的缓动类型。
 ## [br]
+## @param easing_curve_data: 已捕获的曲线纯值数据；空字典沿用预设缓动。
+## [br]
 ## @return: 新建的属性 Tweener；Tween 或目标失效、创建失败时为 null。
 ## [br]
 ## @schema p_target_value: Variant，调用方已确认与目标属性兼容的值。
+## [br]
+## @schema easing_curve_data: Dictionary，空或包含 positions: PackedVector2Array、tangents: PackedVector2Array、modes: PackedInt32Array、bake_resolution: int、value_range: Vector2，由内部曲线捕获器校验生成。
 static func append_property_tweener(
 	tween: Tween,
 	target: Object,
@@ -251,9 +303,13 @@ static func append_property_tweener(
 	p_as_relative: bool,
 	p_parallel: bool,
 	p_transition_type: Tween.TransitionType,
-	p_ease_type: Tween.EaseType
+	p_ease_type: Tween.EaseType,
+	easing_curve_data: Dictionary = {}
 ) -> PropertyTweener:
 	if not is_instance_valid(tween) or not is_instance_valid(target):
+		return null
+	var interpolator: Callable = _EASING_CURVE_SCRIPT.create_interpolator(easing_curve_data)
+	if not easing_curve_data.is_empty() and not interpolator.is_valid():
 		return null
 	if p_parallel:
 		var _parallel_result: Tween = tween.parallel()
@@ -262,7 +318,10 @@ static func append_property_tweener(
 	)
 	if tweener == null:
 		return null
-	var _ease_result: PropertyTweener = tweener.set_trans(p_transition_type).set_ease(p_ease_type)
+	if interpolator.is_valid():
+		var _curve_result: PropertyTweener = tweener.set_trans(Tween.TRANS_LINEAR).set_custom_interpolator(interpolator)
+	else:
+		var _ease_result: PropertyTweener = tweener.set_trans(p_transition_type).set_ease(p_ease_type)
 	if effective_delay > 0.0:
 		var _delay_result: PropertyTweener = tweener.set_delay(effective_delay)
 	if p_as_relative:

--- a/addons/gf/extensions/action_queue/tween/gf_tween_easing_curve.gd
+++ b/addons/gf/extensions/action_queue/tween/gf_tween_easing_curve.gd
@@ -1,0 +1,262 @@
+# Action Queue 内部缓动曲线捕获；只保留原生 Curve 数据，不保留来源资源或脚本。
+extends RefCounted
+
+
+# --- 常量 ---
+
+const _MAX_POINTS: int = 256
+const _MIN_BAKE_RESOLUTION: int = 2
+# 原生 Curve.set_bake_resolution 的上限为 1000。
+const _MAX_BAKE_RESOLUTION: int = 1000
+const _MAX_SAMPLE_MAGNITUDE: float = 16.0
+
+
+# --- 层内方法 ---
+
+## 捕获独立纯值数据，并校验实际消费的原生烘焙曲线。
+## 仅保证烘焙采样输出有限且绝对值不超过 16，不保证未采样原曲线的极值。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/action_queue
+## [br]
+## @since unreleased
+## [br]
+## @param source: 无脚本的原生 Curve；null 表示继续使用 Tween 预设。
+## [br]
+## @return: 错误说明与独立数据；错误时没有部分数据。
+## [br]
+## @schema return: Dictionary，error: String（空字符串表示成功）、data: Dictionary。data 为空表示无曲线；否则包含 positions: PackedVector2Array、tangents: PackedVector2Array（每点左、右切线）、modes: PackedInt32Array（每点左、右模式交错）、bake_resolution: int、value_range: Vector2（编辑器最小、最大值）。
+static func capture(source: Curve) -> Dictionary:
+	if source == null:
+		return { "error": "", "data": {} }
+	if source.get_script() != null:
+		return _failure("Easing curves must be native Curve resources without a script.")
+	var point_count: int = source.get_point_count()
+	if point_count < 2 or point_count > _MAX_POINTS:
+		return _failure("Easing curves require 2 to 256 points.")
+	if source.min_domain != 0.0 or source.max_domain != 1.0:
+		return _failure("Easing curve domains must be exactly 0 to 1.")
+	var positions: PackedVector2Array = PackedVector2Array()
+	var tangents: PackedVector2Array = PackedVector2Array()
+	var modes: PackedInt32Array = PackedInt32Array()
+	for index: int in range(point_count):
+		var _position_added: bool = positions.append(source.get_point_position(index))
+		var _tangent_added: bool = tangents.append(Vector2(
+			source.get_point_left_tangent(index), source.get_point_right_tangent(index)
+		))
+		var _left_mode_added: bool = modes.append(source.get_point_left_mode(index))
+		var _right_mode_added: bool = modes.append(source.get_point_right_mode(index))
+	var data: Dictionary = {
+		"positions": positions,
+		"tangents": tangents,
+		"modes": modes,
+		"bake_resolution": source.bake_resolution,
+		"value_range": Vector2(source.min_value, source.max_value),
+	}
+	var data_error: String = _get_data_error(data)
+	if not data_error.is_empty():
+		return _failure(data_error)
+	var private_curve: Curve = _build_curve(data)
+	var sample_error: String = _get_sample_error(private_curve)
+	if not sample_error.is_empty():
+		return _failure(sample_error)
+	return { "error": "", "data": data }
+
+
+## 从已捕获的数据重建独立的无脚本原生 Curve，不复制来源 metadata。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/action_queue
+## [br]
+## @since unreleased
+## [br]
+## @param data: capture 成功返回的非空 data；不得修改其中的已校验数据。
+## [br]
+## @schema data: Dictionary，结构同 capture 返回值的 data。
+## [br]
+## @return: 已烘焙的私有 Curve；空数据或无效数据返回 null。
+static func create_curve(data: Dictionary) -> Curve:
+	if data.is_empty() or not _get_data_error(data).is_empty():
+		return null
+	var private_curve: Curve = _build_curve(data)
+	if not _get_sample_error(private_curve).is_empty():
+		return null
+	return private_curve
+
+
+## 创建只强持私有原生 Curve 的插值闭包；不持有来源步骤、动作或节点。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/action_queue
+## [br]
+## @since unreleased
+## [br]
+## @param data: capture 成功返回的 data；空数据表示没有自定义曲线。
+## [br]
+## @schema data: Dictionary，结构同 capture 返回值的 data。
+## [br]
+## @return: 原生烘焙插值闭包；没有曲线或数据无效时返回空 Callable。
+## [br]
+## @schema return: Callable(progress: float) -> float；progress 为有限的 0..1 时间进度，返回已校验的烘焙插值进度。
+static func create_interpolator(data: Dictionary) -> Callable:
+	var private_curve: Curve = create_curve(data)
+	if private_curve == null:
+		return Callable()
+	return func(progress: float) -> float:
+		return private_curve.sample_baked(progress)
+
+
+## 复制有效曲线的原生数据；不会复制脚本、metadata 或来源引用。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/action_queue
+## [br]
+## @since unreleased
+## [br]
+## @param source: 待复制的原生 Curve。
+## [br]
+## @return: 独立曲线；来源为空或无效时返回 null。
+static func duplicate_curve(source: Curve) -> Curve:
+	var result: Dictionary = capture(source)
+	var data_value: Variant = result.get("data")
+	if data_value is Dictionary:
+		var data: Dictionary = data_value
+		return create_curve(data)
+	return null
+
+
+## 返回曲线数据所需的烘焙采样数，供调用方累计整组预算。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/action_queue
+## [br]
+## @since unreleased
+## [br]
+## @param data: capture 成功返回的 data。
+## [br]
+## @schema data: Dictionary，结构同 capture 返回值的 data。
+## [br]
+## @return: 烘焙采样数；空数据或字段类型不符时返回 0。
+static func get_sample_count(data: Dictionary) -> int:
+	var count_value: Variant = data.get("bake_resolution")
+	if count_value is int:
+		var count: int = count_value
+		return count
+	return 0
+
+
+## 返回曲线数据的点数，供调用方累计整组预算。
+## [br]
+## @api layer_internal
+## [br]
+## @layer extensions/action_queue
+## [br]
+## @since unreleased
+## [br]
+## @param data: capture 成功返回的 data。
+## [br]
+## @schema data: Dictionary，结构同 capture 返回值的 data。
+## [br]
+## @return: 曲线点数；空数据或字段类型不符时返回 0。
+static func get_point_count(data: Dictionary) -> int:
+	var positions_value: Variant = data.get("positions")
+	if positions_value is PackedVector2Array:
+		var positions: PackedVector2Array = positions_value
+		return positions.size()
+	return 0
+
+
+# --- 私有/辅助方法 ---
+
+static func _failure(message: String) -> Dictionary:
+	return { "error": message, "data": {} }
+
+
+static func _get_data_error(data: Dictionary) -> String:
+	var positions_value: Variant = data.get("positions")
+	var tangents_value: Variant = data.get("tangents")
+	var modes_value: Variant = data.get("modes")
+	var resolution_value: Variant = data.get("bake_resolution")
+	var range_value: Variant = data.get("value_range")
+	if not (
+		positions_value is PackedVector2Array and tangents_value is PackedVector2Array
+		and modes_value is PackedInt32Array and resolution_value is int and range_value is Vector2
+	):
+		return "Easing curve snapshot fields have invalid types."
+	var positions: PackedVector2Array = positions_value
+	var tangents: PackedVector2Array = tangents_value
+	var modes: PackedInt32Array = modes_value
+	var resolution: int = resolution_value
+	var value_range: Vector2 = range_value
+	var point_count: int = positions.size()
+	if point_count < 2 or point_count > _MAX_POINTS:
+		return "Easing curves require 2 to 256 points."
+	if tangents.size() != point_count or modes.size() != point_count * 2:
+		return "Easing curve point, tangent and mode counts must agree."
+	if resolution < _MIN_BAKE_RESOLUTION or resolution > _MAX_BAKE_RESOLUTION:
+		return "Easing curve bake_resolution must be between 2 and 1000."
+	if not value_range.is_finite() or value_range.x > 0.0 or value_range.y < 1.0:
+		return "Easing curve editing ranges must be finite and include 0 to 1."
+	if positions[0] != Vector2.ZERO or positions[point_count - 1] != Vector2.ONE:
+		return "Easing curves must start exactly at (0, 0) and end exactly at (1, 1)."
+	for index: int in range(point_count):
+		var position: Vector2 = positions[index]
+		if not position.is_finite() or not tangents[index].is_finite():
+			return "Easing curve points and tangents must be finite."
+		if position.y < value_range.x or position.y > value_range.y:
+			return "Easing curve points must lie within their editing value range."
+		if index > 0 and position.x <= positions[index - 1].x:
+			return "Easing curve point X coordinates must be strictly increasing."
+		for mode_index: int in range(index * 2, index * 2 + 2):
+			if modes[mode_index] != Curve.TANGENT_FREE and modes[mode_index] != Curve.TANGENT_LINEAR:
+				return "Easing curve tangent modes must be valid native modes."
+	return ""
+
+
+static func _build_curve(data: Dictionary) -> Curve:
+	var positions_value: Variant = data["positions"]
+	var tangents_value: Variant = data["tangents"]
+	var modes_value: Variant = data["modes"]
+	var range_value: Variant = data["value_range"]
+	if not (
+		positions_value is PackedVector2Array and tangents_value is PackedVector2Array
+		and modes_value is PackedInt32Array and range_value is Vector2
+	):
+		return null
+	var positions: PackedVector2Array = positions_value
+	var tangents: PackedVector2Array = tangents_value
+	var modes: PackedInt32Array = modes_value
+	var value_range: Vector2 = range_value
+	var private_curve: Curve = Curve.new()
+	private_curve.min_value = value_range.x
+	private_curve.max_value = value_range.y
+	private_curve.bake_resolution = get_sample_count(data)
+	var point_data: Array = []
+	for index: int in range(positions.size()):
+		point_data.append(positions[index])
+		point_data.append(tangents[index].x)
+		point_data.append(tangents[index].y)
+		point_data.append(modes[index * 2])
+		point_data.append(modes[index * 2 + 1])
+	# add_point 会重算 LINEAR 切线，使删除控制点后的合法原生曲线改变形状。
+	# 只向新建无脚本 Curve 写入已校验的原生存储数据，保留切线数值和模式。
+	private_curve.set(&"_data", point_data)
+	private_curve.bake()
+	return private_curve
+
+
+static func _get_sample_error(private_curve: Curve) -> String:
+	if private_curve == null:
+		return "Easing curve snapshot could not be reconstructed."
+	var resolution: int = private_curve.bake_resolution
+	for index: int in range(resolution):
+		var progress: float = float(index) / float(resolution - 1)
+		var sample_value: float = private_curve.sample_baked(progress)
+		if not is_finite(sample_value) or absf(sample_value) > _MAX_SAMPLE_MAGNITUDE:
+			return "Easing curve baked samples must be finite and have magnitude at most 16."
+	return ""

--- a/addons/gf/extensions/action_queue/tween/gf_tween_easing_curve.gd.uid
+++ b/addons/gf/extensions/action_queue/tween/gf_tween_easing_curve.gd.uid
@@ -1,0 +1,1 @@
+uid://crbhfdfcpxcdd

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "catalog_version": "2.0.0",
   "framework_version": "12.0.0-dev.0",
-  "source_digest": "6ab00d476186450f3b7aa817a76a996023e1e409df4968fff59ecc1dee5660fd",
+  "source_digest": "0a663ed8bad9264ed6f88c1f5a2f9860a946b23bd1f9425b9d5b706e5d74a1f0",
   "class_count": 859,
   "autoload_count": 1,
   "package_count": 59,
@@ -93436,6 +93436,13 @@
         },
         {
           "kind": "var",
+          "name": "easing_curve",
+          "signature": "var easing_curve: Curve = null",
+          "summary": "可选原生缓动曲线；设置后覆盖 transition_type/ease_type，按线性时间进度进行 sample_baked。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
           "name": "marker_id",
           "signature": "var marker_id: StringName = &\"\"",
           "summary": "可选步骤标记。非空时 GFConfiguredTweenAction 会在步骤结束后发出 marker_reached；",
@@ -93452,14 +93459,14 @@
           "kind": "func",
           "name": "apply_instant",
           "signature": "func apply_instant(target: Object) -> void",
-          "summary": "立即应用步骤目标值。",
+          "summary": "立即应用步骤目标值；仅校验属性，不采样或校验 easing_curve。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "duplicate_step",
           "signature": "func duplicate_step() -> GFTweenActionStep",
-          "summary": "创建深拷贝。",
+          "summary": "创建深拷贝；曲线只复制原生数据，不携带脚本或 metadata。",
           "visibility": "public"
         },
         {
@@ -93473,14 +93480,14 @@
           "kind": "func",
           "name": "get_validation_error",
           "signature": "func get_validation_error(target: Object) -> String",
-          "summary": "获取当前步骤对目标对象的校验错误。",
+          "summary": "获取当前步骤的属性与 easing_curve 校验错误。",
           "visibility": "public"
         },
         {
           "kind": "func",
           "name": "capture_initial_value",
           "signature": "func capture_initial_value(target: Object) -> Variant",
-          "summary": "捕获当前属性值。",
+          "summary": "捕获当前属性值；仅校验属性，不采样或校验 easing_curve。",
           "visibility": "public"
         }
       ]

--- a/docs/api_catalog/classes/GFTweenActionConfig.xml
+++ b/docs/api_catalog/classes/GFTweenActionConfig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTweenActionConfig" path="addons/gf/extensions/action_queue/tween/gf_tween_action_config.gd" module="extensions/action_queue" extends="Resource" classDigest="10b8188a8126981d074e1c29765d5e4d07481075d9b85df018f01394fdcfb049">
+<class name="GFTweenActionConfig" path="addons/gf/extensions/action_queue/tween/gf_tween_action_config.gd" module="extensions/action_queue" extends="Resource" classDigest="565d443f45e95a0e02e7943f655ce11b3fddb0961b4ca0e17e1b27a87bc4695b">
 	<description>GFTweenActionConfig: 配置化 Tween 动作资源。
 可复用地描述一组属性 Tween 步骤，并生成 GFVisualAction。</description>
 	<tags>
@@ -151,7 +151,8 @@
 			<description>创建深拷贝。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">新配置。</tag>
+				<tag name="return">新配置；任一步骤的 easing_curve 无法复制时发出警告并返回 null。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/classes/GFTweenActionStep.xml
+++ b/docs/api_catalog/classes/GFTweenActionStep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFTweenActionStep" path="addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd" module="extensions/action_queue" extends="Resource" classDigest="07b7f966b671ab67ae36238a54cfad3a484ef3393abbdce052a984df9b9dc433">
+<class name="GFTweenActionStep" path="addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd" module="extensions/action_queue" extends="Resource" classDigest="cc91b89477b99aefd05de393cc476f500161c0e38490c8ea9f2030706bc70f2f">
 	<description>GFTweenActionStep: 配置化 Tween 属性步骤。
 描述一个目标对象属性如何缓动，不绑定具体节点或业务动作。</description>
 	<tags>
@@ -70,6 +70,17 @@
 				<tag name="api">public</tag>
 			</tags>
 		</member>
+		<member kind="property" name="easing_curve" decorators="@export">
+			<signature>var easing_curve: Curve = null</signature>
+			<description>可选原生缓动曲线；设置后覆盖 transition_type/ease_type，按线性时间进度进行 sample_baked。
+横轴域为 0..1，首尾点必须为 (0,0)/(1,1)，X 严格递增；支持回弹和超调。
+只接受无脚本、2..256 点、2..1000 烘焙采样的 Curve；坐标、切线与编辑范围须有限，
+编辑范围须包含 0..1 及全部点值，烘焙输出绝对值不超过 16。创建 Tweener 时捕获独立数据。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
 		<member kind="property" name="marker_id" decorators="@export">
 			<signature>var marker_id: StringName = &amp;""</signature>
 			<description>可选步骤标记。非空时 GFConfiguredTweenAction 会在步骤结束后发出 marker_reached；
@@ -95,18 +106,20 @@
 		</member>
 		<member kind="method" name="apply_instant">
 			<signature>func apply_instant(target: Object) -&gt; void:</signature>
-			<description>立即应用步骤目标值。</description>
+			<description>立即应用步骤目标值；仅校验属性，不采样或校验 easing_curve。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">target: 目标对象。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="duplicate_step">
 			<signature>func duplicate_step() -&gt; GFTweenActionStep:</signature>
-			<description>创建深拷贝。</description>
+			<description>创建深拷贝；曲线只复制原生数据，不携带脚本或 metadata。</description>
 			<tags>
 				<tag name="api">public</tag>
-				<tag name="return">新步骤。</tag>
+				<tag name="return">新步骤；easing_curve 无效时发出警告并返回 null。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="can_apply_to">
@@ -120,21 +133,23 @@
 		</member>
 		<member kind="method" name="get_validation_error">
 			<signature>func get_validation_error(target: Object) -&gt; String:</signature>
-			<description>获取当前步骤对目标对象的校验错误。</description>
+			<description>获取当前步骤的属性与 easing_curve 校验错误。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">target: 目标对象。</tag>
 				<tag name="return">校验通过时返回空字符串。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="capture_initial_value">
 			<signature>func capture_initial_value(target: Object) -&gt; Variant:</signature>
-			<description>捕获当前属性值。</description>
+			<description>捕获当前属性值；仅校验属性，不采样或校验 easing_curve。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">target: 目标对象。</tag>
 				<tag name="return">属性值；步骤无效时返回 null。</tag>
 				<tag name="schema">return: Variant，目标属性的深拷贝值；步骤无效时为 null。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</methods>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="ad397e356be113468efd4cd7b7a2e5051f463ac9220519ac37fa99a6643c109c" classCount="883" methodCount="7883" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="72a419086218144a5afa4c13de94bec8444c81a42456b19e8b9b52e14dbd1f41" classCount="883" methodCount="7883" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="78" methodCount="826" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -6,6 +6,7 @@
 
 ### 🚀 新增特性 (Added)
 
+- [配置化 Tween](extensions/action-queue/tween-config.md#自定义缓动曲线) 支持步骤级原生 `Curve`，可制作回弹与超调效果；运行时独立捕获曲线，Inspector 预览与时间定位使用同一配置快照。
 - 新增 [方格视野查询](standard/foundation/grid-spatial/grid-2d-hex/grid-math.md)，通过显式阻挡回调计算有限半径内的可见格，返回稳定顺序与失败诊断；视野不接管地图节点、探索记忆或阵营规则。
 - [Tween Inspector 预览](extensions/action-queue/tween-config.md#在-inspector-中预览) 支持时间滑条与秒数定位，可反复检查同一配置快照的中间姿态和动画终点；定位仅操作工具自有样机，并保持暂停。
 - [模板列表](standard/utilities/runtime/settings-ui-scene/settings-display/list-repeat-binding.md#按稳定-id-更新模板列表) 支持调用方提供稳定 ID，按条目复用、更新、移动和释放节点，保留普通 Container 布局及未被项目回调重置的局部交互状态。
@@ -63,7 +64,7 @@
 - 保留已有接口的首次发布 `@since` 版本，不因本次签名或语义重做而改为 `unreleased`。
 - Flow 面板与 Resource 表格新增 `set_editor_context()`。新增 `GFEditorMultiPropertyField`，通过暂存值生成属性批处理请求，提交仍复用既有命令与资源历史；不改变 Flow 图的持久化格式或运行时执行协议。
 - `GFConfigTableReference` 新增 `SourceMode` 与 `source_mode`，默认 `FIELDS` 保持原有字段引用行为；`ARRAY_ELEMENTS` 校验单个数组字段到目标单字段键的引用。元素问题增加零基 `element_index`；`resolve_record_references()` 仍只解析 `FIELDS` 引用。
-- `gf.action_queue` 的 `extension_version` 升为 `2.4.0`，新增编辑器预览与指定时间定位；既有 Tween 资源格式与运行时执行语义保持不变。
+- `GFTweenActionStep` 新增可选 `easing_curve: Curve`；为空时保留既有预设缓动，设置后使用经校验的独立曲线覆盖 transition/ease。`duplicate_step()` / `duplicate_config()` 深复制有效曲线，无效曲线使复制返回 `null` 并警告。`gf.action_queue` 的 `extension_version` 升为 `2.5.0`，包含编辑器预览、指定时间定位与自定义曲线。
 
 ### 📘 升级指南 (Migration Guide)
 

--- a/docs/zh/extensions/action-queue/tween-config.md
+++ b/docs/zh/extensions/action-queue/tween-config.md
@@ -12,13 +12,47 @@ config.add_property_step(^"modulate", Color.WHITE, 0.12)
 q_sys.enqueue(config.create_action(card_node))
 ```
 
-`GFTweenActionConfig` 只描述属性路径、目标值、时长、缓动和并行关系。每一段属性变化由 `GFTweenActionStep` 保存，支持延迟、相对值、并行、transition、ease 和可选 `marker_id`。
+`GFTweenActionConfig` 只描述属性路径、目标值、时长、缓动和并行关系。每一段属性变化由 `GFTweenActionStep` 保存，支持延迟、相对值、并行、transition、ease、可选 `easing_curve` 和 `marker_id`。
+
+## 自定义缓动曲线
+
+`GFTweenActionStep.easing_curve` 默认为 `null`，继续使用 `transition_type` 和 `ease_type`。设置原生 `Curve` 后，它会替代这两个预设：Godot Tween 先提供线性时间进度，再由 `Curve.sample_baked()` 得到属性插值进度，不叠加第二层预设缓动。
+
+可以在 Inspector 的步骤资源中创建或指定 `Curve`，使用 Godot 自带曲线编辑器调整，也可以用代码创建：
+
+```gdscript
+var easing: Curve = Curve.new()
+easing.bake_resolution = 128
+var _start_index: int = easing.add_point(Vector2.ZERO)
+var _middle_index: int = easing.add_point(Vector2(0.35, 0.15))
+var _end_index: int = easing.add_point(Vector2.ONE)
+
+var config: GFTweenActionConfig = GFTweenActionConfig.new()
+var movement: GFTweenActionStep = config.add_property_step(
+    ^"position", Vector2(240, 0), 0.6
+)
+movement.easing_curve = easing
+```
+
+这段配置让属性在前段缓慢变化，再到达目标值。曲线横轴表示 `0..1` 时间进度，纵轴表示插值进度；曲线可以回弹或超调，输出不会被截到 `0..1`。需要超调控制点时，先在原生曲线编辑器中扩大纵轴编辑范围。
+
+| 约束 | 要求 |
+| --- | --- |
+| 资源 | 原生 `Curve`，不能附带脚本 |
+| 横轴 | `min_domain = 0`、`max_domain = 1`；点的 x 严格递增 |
+| 控制点 | 2–256 个；首尾必须精确为 `(0, 0)` 和 `(1, 1)` |
+| 数值 | 控制点与左右切线有限；纵轴编辑范围有限、覆盖 `0..1`，并包含控制点的 y 值 |
+| 烘焙 | `bake_resolution` 为 2–1000；实际使用的烘焙输出有限且绝对值不超过 16 |
+
+输出限制针对 `sample_baked()` 使用的结果，不保证未烘焙曲线在任意位置的极值。每个属性 Tweener 持有独立的原生曲线副本；创建后修改源曲线不会改变该 Tweener 的求值。重新播放会采用修改后的曲线。
+
+`duplicate_step()` 和 `duplicate_config()` 会深复制有效曲线；无效曲线会使复制返回 `null` 并给出警告，调用方应先校验并检查复制结果。`apply_instant()` 和强制 `finish()` 不沿曲线求中间值，仍按已有规则应用终点及恢复策略。
 
 ## 执行前校验
 
-`GFTweenActionStep.can_apply_to(target)` 和 `get_validation_error(target)` 可在执行前检查目标属性是否存在、目标值类型是否兼容。absolute 步骤接受相同 Variant 类型或 `int` / `float` 数值互转；relative 步骤当前支持数值、`Vector2`、`Vector3` 和 `Color` 的同类相加。`GFTweenActionConfig.get_validation_report(target)` 会把整组步骤整理成 `GFValidationReport`，便于 Inspector、CI 或项目工具统一展示。
+`GFTweenActionStep.can_apply_to(target)` 和 `get_validation_error(target)` 可在执行前检查目标属性是否存在、目标值类型是否兼容，以及缓动曲线是否有效。absolute 步骤接受相同 Variant 类型或 `int` / `float` 数值互转；relative 步骤当前支持数值、`Vector2`、`Vector3` 和 `Color` 的同类相加。`GFTweenActionConfig.get_validation_report(target)` 会把整组步骤整理成 `GFValidationReport`，便于 Inspector、CI 或项目工具统一展示。
 
-无效步骤会被跳过并给出警告，避免把拼写错误推迟到 Tween 执行时才暴露。
+运行时通过 Tween 执行步骤时，无效步骤会被跳过并给出警告；编辑器预览则拒绝整组配置并显示原因，避免把不完整的效果当成成功预览。直接应用终点不需要有效的缓动曲线，但目标属性和值仍须有效。
 
 ## 标记点与恢复
 
@@ -42,7 +76,7 @@ q_sys.enqueue(config.create_action(card_node))
 | 停止 | 终止播放，保留画面和可定位的快照；再次播放从初值读取最新配置 |
 | 复位 | 终止本次预览、丢弃定位快照并恢复样机初值 |
 
-先点击一次播放以捕获配置，时间控件才会启用。定位始终使用该次捕获的步骤和样机初值，不会读取之后修改的配置。要查看最新配置，请停止后重新播放。定位会暂停画面，点击继续从所选时刻向前播放；时间滑条显示串行组与并行组形成的实际时长，包含延迟、时长缩放和有限循环，而非所有步骤时长简单相加。
+先点击一次播放以捕获配置，时间控件才会启用。定位始终使用该次捕获的步骤、曲线纯值快照和样机初值，不会读取之后修改的配置。要查看最新配置或曲线，请停止后重新播放。定位会暂停画面，点击继续从所选时刻向前播放；时间滑条显示串行组与并行组形成的实际时长，包含延迟、时长缩放和有限循环，而非所有步骤时长简单相加。
 
 定位到时间轴末端时会保留动画终值，方便检查最后姿态；此时点击继续才执行正常完成策略。正常播放完成遵循 `restore_initial_values_on_finish`，完成后仍能定位检查同一快照。全零时长配置仅应用一轮瞬时步骤；点击定位按钮检查其唯一的 `0` 秒位置，可查看这一轮的终值，不累计多次相对偏移。
 
@@ -58,4 +92,6 @@ q_sys.enqueue(config.create_action(card_node))
 
 2D 与 UI 位置以画布中心为原点，3D 使用独立相机。属性读数可以辅助观察移出画面的目标。预览使用工具自己创建的节点，不操作当前场景，不执行项目脚本或步骤标记通知，也不产生撤销记录。它采用独立的编辑器时钟，运行时的 `process_mode`、`pause_mode` 和 `ignore_time_scale` 不参与预览调度。
 
-预览只接受原生 `GFTweenActionConfig` 和 `GFTweenActionStep` 资源，暂不执行自定义子类、对象目标值或任意嵌套资源属性。目标值及样机初值须为类型匹配的有限数值、`Vector2`、`Vector3` 或 `Color`，各数值分量绝对值不超过 1,000,000。单次预览最多 128 个步骤、32 次有限循环；按全部步骤的缩放后时长与延迟之和乘循环次数计算，保守预算上限为 120 秒，时间轴实际时长可以更短。定位通过从初值重建原生 Tween 并向前求值完成，不逐帧追赶，也不更换插值算法。无限循环与超出范围的配置会在播放前显示原因。这些范围只约束编辑器预览，不改变运行时的配置合同。
+预览只接受原生 `GFTweenActionConfig` 和 `GFTweenActionStep` 资源，暂不执行自定义子类、对象目标值或任意嵌套资源属性。目标值及样机初值须为类型匹配的有限数值、`Vector2`、`Vector3` 或 `Color`，各数值分量绝对值不超过 1,000,000。单次预览最多 128 个步骤、32 次有限循环；按全部步骤的缩放后时长与延迟之和乘循环次数计算，保守预算上限为 120 秒，时间轴实际时长可以更短。自定义曲线除满足前述单条约束外，整组累计最多 65,536 个烘焙样本和 4,096 个控制点。
+
+定位通过从初值与快照重建原生 Tween 并向前求值完成，不逐帧追赶，也不更换插值算法。无限循环、无效曲线与超出预算的配置会在播放前显示原因。步骤数、循环数、总时长及整组曲线预算只约束编辑器预览，不限制运行时的组规模。

--- a/docs/zh/reference/api/classes/GFTweenActionConfig.md
+++ b/docs/zh/reference/api/classes/GFTweenActionConfig.md
@@ -303,6 +303,7 @@ func get_validation_report(target: Object) -> GFValidationReport:
 ### `duplicate_config`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func duplicate_config() -> GFTweenActionConfig:
@@ -310,4 +311,4 @@ func duplicate_config() -> GFTweenActionConfig:
 
 创建深拷贝。
 
-返回：新配置。
+返回：新配置；任一步骤的 easing_curve 无法复制时发出警告并返回 null。

--- a/docs/zh/reference/api/classes/GFTweenActionStep.md
+++ b/docs/zh/reference/api/classes/GFTweenActionStep.md
@@ -23,6 +23,7 @@
 | 属性 | [`parallel`](#member-gftweenactionstep-properties-parallel) | `var parallel: bool = false` |
 | 属性 | [`transition_type`](#member-gftweenactionstep-properties-transition_type) | `var transition_type: Tween.TransitionType = Tween.TRANS_CUBIC` |
 | 属性 | [`ease_type`](#member-gftweenactionstep-properties-ease_type) | `var ease_type: Tween.EaseType = Tween.EASE_OUT` |
+| 属性 | [`easing_curve`](#member-gftweenactionstep-properties-easing_curve) | `var easing_curve: Curve = null` |
 | 属性 | [`marker_id`](#member-gftweenactionstep-properties-marker_id) | `var marker_id: StringName = &""` |
 | 方法 | [`append_to_tween`](#member-gftweenactionstep-methods-append_to_tween) | `func append_to_tween(tween: Tween, target: Object, duration_scale: float = 1.0) -> Variant:` |
 | 方法 | [`apply_instant`](#member-gftweenactionstep-methods-apply_instant) | `func apply_instant(target: Object) -> void:` |
@@ -135,6 +136,19 @@ var ease_type: Tween.EaseType = Tween.EASE_OUT
 
 Tween 缓动类型。
 
+<a id="member-gftweenactionstep-properties-easing_curve"></a>
+
+### `easing_curve`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var easing_curve: Curve = null
+```
+
+可选原生缓动曲线；设置后覆盖 transition_type/ease_type，按线性时间进度进行 sample_baked。 横轴域为 0..1，首尾点必须为 (0,0)/(1,1)，X 严格递增；支持回弹和超调。 只接受无脚本、2..256 点、2..1000 烘焙采样的 Curve；坐标、切线与编辑范围须有限， 编辑范围须包含 0..1 及全部点值，烘焙输出绝对值不超过 16。创建 Tweener 时捕获独立数据。
+
 <a id="member-gftweenactionstep-properties-marker_id"></a>
 
 ### `marker_id`
@@ -181,12 +195,13 @@ func append_to_tween(tween: Tween, target: Object, duration_scale: float = 1.0) 
 ### `apply_instant`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func apply_instant(target: Object) -> void:
 ```
 
-立即应用步骤目标值。
+立即应用步骤目标值；仅校验属性，不采样或校验 easing_curve。
 
 参数：
 
@@ -199,14 +214,15 @@ func apply_instant(target: Object) -> void:
 ### `duplicate_step`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func duplicate_step() -> GFTweenActionStep:
 ```
 
-创建深拷贝。
+创建深拷贝；曲线只复制原生数据，不携带脚本或 metadata。
 
-返回：新步骤。
+返回：新步骤；easing_curve 无效时发出警告并返回 null。
 
 <a id="member-gftweenactionstep-methods-can_apply_to"></a>
 
@@ -233,12 +249,13 @@ func can_apply_to(target: Object) -> bool:
 ### `get_validation_error`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func get_validation_error(target: Object) -> String:
 ```
 
-获取当前步骤对目标对象的校验错误。
+获取当前步骤的属性与 easing_curve 校验错误。
 
 参数：
 
@@ -253,12 +270,13 @@ func get_validation_error(target: Object) -> String:
 ### `capture_initial_value`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func capture_initial_value(target: Object) -> Variant:
 ```
 
-捕获当前属性值。
+捕获当前属性值；仅校验属性，不采样或校验 easing_curve。
 
 参数：
 

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -8,7 +8,7 @@
 |---|---:|---:|---|
 | Kernel | 78 | 1137 | [Kernel](#module-kernel) |
 | Standard | 480 | 7576 | [Standard](#module-standard) |
-| Action Queue | 16 | 214 | [Action Queue](#module-extensions-action_queue) |
+| Action Queue | 16 | 215 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
 | Camera | 8 | 138 | [Camera](#module-extensions-camera) |
@@ -613,7 +613,7 @@
 | [`GFActionInterceptor`](GFActionInterceptor.md#gfactioninterceptor) | 协议与扩展点 (`protocol`) | `RefCounted` | 4 | `addons/gf/extensions/action_queue/core/gf_action_interceptor.gd` |
 | [`GFVisualAction`](GFVisualAction.md#gfvisualaction) | 协议与扩展点 (`protocol`) | `RefCounted` | 17 | `addons/gf/extensions/action_queue/actions/gf_visual_action.gd` |
 | [`GFTweenActionConfig`](GFTweenActionConfig.md#gftweenactionconfig) | 资源定义 (`resource_definition`) | `Resource` | 17 | `addons/gf/extensions/action_queue/tween/gf_tween_action_config.gd` |
-| [`GFTweenActionStep`](GFTweenActionStep.md#gftweenactionstep) | 资源定义 (`resource_definition`) | `Resource` | 15 | `addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd` |
+| [`GFTweenActionStep`](GFTweenActionStep.md#gftweenactionstep) | 资源定义 (`resource_definition`) | `Resource` | 16 | `addons/gf/extensions/action_queue/tween/gf_tween_action_step.gd` |
 | [`GFAudioAction`](GFAudioAction.md#gfaudioaction) | 运行时句柄 (`runtime_handle`) | `GFVisualAction` | 5 | `addons/gf/extensions/action_queue/actions/gf_audio_action.gd` |
 | [`GFCallableAction`](GFCallableAction.md#gfcallableaction) | 运行时句柄 (`runtime_handle`) | `GFVisualAction` | 3 | `addons/gf/extensions/action_queue/actions/gf_callable_action.gd` |
 | [`GFConfiguredTweenAction`](GFConfiguredTweenAction.md#gfconfiguredtweenaction) | 运行时句柄 (`runtime_handle`) | `GFVisualAction` | 10 | `addons/gf/extensions/action_queue/actions/gf_configured_tween_action.gd` |

--- a/docs/zh/reference/api/extensions-action-queue.md
+++ b/docs/zh/reference/api/extensions-action-queue.md
@@ -8,7 +8,7 @@
 |---|---:|---:|---:|
 | [运行时服务](#category-runtime_service) | 2 | 59 | 55 |
 | [协议与扩展点](#category-protocol) | 2 | 21 | 15 |
-| [资源定义](#category-resource_definition) | 2 | 32 | 15 |
+| [资源定义](#category-resource_definition) | 2 | 33 | 15 |
 | [运行时句柄](#category-runtime_handle) | 9 | 90 | 43 |
 | [值对象](#category-value_object) | 1 | 12 | 8 |
 

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -7,7 +7,7 @@
 - 源码根目录：`addons/gf`
 - 公开类：`883`
 - 公开 AutoLoad：`1`
-- 公开成员：`12722`
+- 公开成员：`12723`
 - 公开方法：`7883`
 - AutoLoad 公开方法：`65`
 
@@ -17,7 +17,7 @@
 |---|---:|---:|---:|---:|---|
 | Kernel | 78 | 1 | 1206 | 891 | [kernel.md](kernel.md) |
 | Standard | 480 | 0 | 7576 | 4806 | [standard.md](standard.md) |
-| Action Queue | 16 | 0 | 214 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
+| Action Queue | 16 | 0 | 215 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 0 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 0 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |
 | Camera | 8 | 0 | 138 | 46 | [extensions-camera.md](extensions-camera.md) |

--- a/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
+++ b/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
@@ -152,6 +152,25 @@ func _configured_tween_action(action: GFVisualAction) -> GFConfiguredTweenAction
 	return null
 
 
+func _make_easing_curve(midpoint_y: float = 0.25) -> Curve:
+	var curve: Curve = Curve.new()
+	curve.min_value = minf(0.0, midpoint_y)
+	curve.max_value = maxf(1.0, midpoint_y)
+	var _first_point: int = curve.add_point(Vector2.ZERO)
+	var _middle_point: int = curve.add_point(Vector2(0.5, midpoint_y))
+	var _last_point: int = curve.add_point(Vector2.ONE)
+	return curve
+
+
+func _make_many_point_easing_curve(point_count: int, resolution: int) -> Curve:
+	var curve: Curve = Curve.new()
+	curve.bake_resolution = resolution
+	for index: int in range(point_count):
+		var progress: float = float(index) / float(point_count - 1)
+		var _point: int = curve.add_point(Vector2(progress, progress))
+	return curve
+
+
 func _make_shader_material(initial_strength: float = 0.0) -> ShaderMaterial:
 	var shader: Shader = Shader.new()
 	shader.code = (
@@ -298,6 +317,296 @@ func test_configured_tween_action_applies_zero_duration_steps_immediately() -> v
 
 	assert_true(result == null, "零时长配置化 Tween 应立即完成。")
 	assert_eq(node.position, Vector2(8.0, 12.0), "零时长配置化 Tween 应写入目标属性。")
+
+
+func test_tween_easing_curve_is_frozen_for_each_created_property_tweener() -> void:
+	var curve: Curve = _make_easing_curve(0.25)
+	var step: GFTweenActionStep = GFTweenActionStep.new()
+	step.property_name = ^"position:x"
+	step.target_value = 8.0
+	step.duration = 1.0
+	step.transition_type = Tween.TRANS_CUBIC
+	step.ease_type = Tween.EASE_IN
+	step.easing_curve = curve
+	var first_target: Node2D = Node2D.new()
+	var second_target: Node2D = Node2D.new()
+	add_child_autofree(first_target)
+	add_child_autofree(second_target)
+	var first_tween: Tween = first_target.create_tween()
+	first_tween.pause()
+	var first_result: Variant = step.append_to_tween(first_tween, first_target)
+	assert_true(first_result is PropertyTweener)
+	var original_midpoint: float = curve.sample_baked(0.5)
+	curve.set_point_value(1, 0.75)
+	var second_tween: Tween = second_target.create_tween()
+	second_tween.pause()
+	var second_result: Variant = step.append_to_tween(second_tween, second_target)
+	assert_true(second_result is PropertyTweener)
+	var _first_running: bool = first_tween.custom_step(0.5)
+	var _second_running: bool = second_tween.custom_step(0.5)
+	assert_almost_eq(first_target.position.x, 8.0 * original_midpoint, 0.001)
+	assert_almost_eq(second_target.position.x, 8.0 * curve.sample_baked(0.5), 0.001)
+	assert_gt(second_target.position.x, first_target.position.x)
+	first_tween.kill()
+	second_tween.kill()
+
+
+func test_tween_easing_curve_null_keeps_existing_transition_and_ease() -> void:
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	var step: GFTweenActionStep = GFTweenActionStep.new()
+	step.property_name = ^"position:x"
+	step.target_value = 8.0
+	step.duration = 1.0
+	step.transition_type = Tween.TRANS_CUBIC
+	step.ease_type = Tween.EASE_IN
+	var tween: Tween = target.create_tween()
+	tween.pause()
+	var result: Variant = step.append_to_tween(tween, target)
+	assert_true(result is PropertyTweener)
+	var _running: bool = tween.custom_step(0.5)
+	assert_almost_eq(target.position.x, 1.0, 0.001)
+	tween.kill()
+
+
+func test_tween_easing_curve_invalid_timed_step_is_reported_and_skipped() -> void:
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	var bad_step: GFTweenActionStep = config.add_property_step(^"position:x", 8.0, 1.0)
+	bad_step.easing_curve = Curve.new()
+	var good_step: GFTweenActionStep = config.add_property_step(^"position:y", 6.0, 1.0)
+	good_step.transition_type = Tween.TRANS_LINEAR
+	var error_text: String = bad_step.get_validation_error(target)
+	assert_true(error_text.begins_with("Invalid easing_curve: "))
+	assert_false(bad_step.can_apply_to(target))
+	var report: GFValidationReport = config.get_validation_report(target)
+	assert_false(report.is_ok())
+	var tween: Tween = target.create_tween()
+	tween.pause()
+	var bad_result: Variant = bad_step.append_to_tween(tween, target)
+	var bad_step_was_skipped: bool = bad_result == null
+	assert_true(bad_step_was_skipped)
+	assert_push_warning("[GFTweenActionStep] 跳过无效 Tween 步骤：%s" % error_text)
+	var good_result: Variant = good_step.append_to_tween(tween, target)
+	assert_true(good_result is PropertyTweener)
+	var _running: bool = tween.custom_step(1.0)
+	assert_eq(target.position, Vector2(0.0, 6.0))
+	tween.kill()
+
+
+func test_tween_easing_curve_point_resolution_and_domain_limits_are_validated() -> void:
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	var step: GFTweenActionStep = GFTweenActionStep.new()
+	step.target_value = Vector2.ONE
+	for point_count: int in [2, 256]:
+		for resolution: int in [2, 1000]:
+			step.easing_curve = _make_many_point_easing_curve(point_count, resolution)
+			assert_eq(step.get_validation_error(target), "")
+	var invalid_curves: Array[Curve] = [
+		_make_many_point_easing_curve(257, 2),
+		_make_many_point_easing_curve(2, 1),
+	]
+	var non_unit_domain: Curve = _make_easing_curve(0.25)
+	non_unit_domain.min_domain = -1.0
+	invalid_curves.append(non_unit_domain)
+	var wrong_endpoint: Curve = _make_easing_curve(0.25)
+	wrong_endpoint.set_point_value(2, 0.9)
+	invalid_curves.append(wrong_endpoint)
+	var repeated_x: Curve = _make_easing_curve(0.25)
+	var _duplicate_point: int = repeated_x.add_point(Vector2(0.5, 0.75))
+	assert_eq(repeated_x.get_point_count(), 4)
+	invalid_curves.append(repeated_x)
+	for curve: Curve in invalid_curves:
+		step.easing_curve = curve
+		assert_true(step.get_validation_error(target).begins_with("Invalid easing_curve: "))
+
+
+func test_tween_easing_curve_invalid_data_does_not_change_instant_or_finish_endpoints() -> void:
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	target.position = Vector2(2.0, 4.0)
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	var step: GFTweenActionStep = config.add_property_step(^"position:x", 8.0, 0.0)
+	step.easing_curve = Curve.new()
+	step.apply_instant(target)
+	assert_eq(target.position, Vector2(8.0, 4.0), "Instant application only needs the endpoint.")
+	target.position.x = 2.0
+	step.as_relative = true
+	config.apply_instant(target)
+	assert_eq(target.position, Vector2(10.0, 4.0))
+	target.position.x = 2.0
+	step.as_relative = false
+	step.duration = 1.0
+	step.easing_curve = _make_easing_curve(0.25)
+	var action: GFVisualAction = config.create_action(target)
+	var result: Variant = action.execute()
+	assert_true(result is Signal)
+	var completed: Array[bool] = [false]
+	var wait_for_finish: Callable = func() -> void:
+		await action.await_result_safely(result)
+		completed[0] = true
+	wait_for_finish.call()
+	action.pause()
+	step.easing_curve = Curve.new()
+	action.finish()
+	assert_eq(target.position, Vector2(8.0, 4.0), "Finish must not read a replacement easing curve.")
+	await get_tree().process_frame
+	assert_true(completed[0], "Finish must release a waiter registered before completion.")
+
+
+func test_invalid_curve_instant_action_still_captures_finish_restore_baseline() -> void:
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	target.position = Vector2(2.0, 4.0)
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	config.restore_initial_values_on_finish = true
+	var step: GFTweenActionStep = config.add_property_step(^"position:x", 8.0, 0.0)
+	step.easing_curve = Curve.new()
+	var action: GFVisualAction = config.create_action(target)
+	var result: Variant = action.execute()
+	var is_instant: bool = result == null
+	assert_true(is_instant)
+	assert_eq(target.position, Vector2(2.0, 4.0), "Invalid easing must not prevent endpoint baseline capture.")
+
+
+func test_tween_easing_curve_duplicate_step_and_config_have_independent_curves() -> void:
+	var curve: Curve = _make_easing_curve(0.25)
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	var step: GFTweenActionStep = config.add_property_step(^"position:x", 8.0, 1.0)
+	step.easing_curve = curve
+	var copied_step: GFTweenActionStep = step.duplicate_step()
+	var copied_config: GFTweenActionConfig = config.duplicate_config()
+	assert_not_null(copied_step)
+	assert_not_null(copied_config)
+	if copied_step == null or copied_config == null:
+		return
+	assert_not_null(copied_step.easing_curve)
+	assert_eq(copied_config.steps.size(), 1)
+	if copied_step.easing_curve == null or copied_config.steps.size() != 1:
+		return
+	var config_curve: Curve = copied_config.steps[0].easing_curve
+	assert_not_null(config_curve)
+	if config_curve == null:
+		return
+	assert_ne(copied_step.easing_curve, curve)
+	assert_ne(config_curve, curve)
+	assert_ne(config_curve, copied_step.easing_curve)
+	var copied_step_is_native: bool = copied_step.easing_curve.get_script() == null
+	assert_true(copied_step_is_native)
+	var original_midpoint: float = curve.sample_baked(0.5)
+	curve.set_point_value(1, 0.75)
+	assert_almost_eq(copied_step.easing_curve.sample_baked(0.5), original_midpoint, 0.00001)
+	assert_almost_eq(config_curve.sample_baked(0.5), original_midpoint, 0.00001)
+	copied_step.easing_curve.set_point_value(1, 0.5)
+	assert_almost_eq(config_curve.sample_baked(0.5), original_midpoint, 0.00001)
+
+
+func test_tween_easing_curve_invalid_copy_fails_without_partial_config() -> void:
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	var good_step: GFTweenActionStep = config.add_property_step(^"position:x", 4.0, 1.0)
+	good_step.easing_curve = _make_easing_curve(0.25)
+	var bad_step: GFTweenActionStep = config.add_property_step(^"position:y", 8.0, 1.0)
+	bad_step.easing_curve = Curve.new()
+	var copied_step: GFTweenActionStep = bad_step.duplicate_step()
+	var step_copy_failed: bool = copied_step == null
+	assert_true(step_copy_failed)
+	assert_push_warning("[GFTweenActionStep] 无法复制无效 easing_curve；请先校验步骤。")
+	var copied_config: GFTweenActionConfig = config.duplicate_config()
+	var config_copy_failed: bool = copied_config == null
+	assert_true(config_copy_failed)
+	assert_push_warning("[GFTweenActionStep] 无法复制无效 easing_curve；请先校验步骤。")
+	assert_eq(config.steps.size(), 2)
+	assert_eq(good_step.easing_curve.get_point_count(), 3)
+	assert_eq(bad_step.easing_curve.get_point_count(), 0)
+
+
+func test_tween_easing_curve_resource_roundtrip_preserves_shape() -> void:
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	var step: GFTweenActionStep = config.add_property_step(^"position:x", 8.0, 1.0)
+	step.easing_curve = _make_easing_curve(0.25)
+	var saved_path: String = "user://gf_tween_easing_roundtrip.tres"
+	var save_error: Error = ResourceSaver.save(config, saved_path)
+	assert_eq(save_error, OK)
+	if save_error != OK:
+		return
+	var reloaded: Resource = ResourceLoader.load(saved_path, "", ResourceLoader.CACHE_MODE_IGNORE_DEEP)
+	var remove_error: Error = DirAccess.remove_absolute(ProjectSettings.globalize_path(saved_path))
+	assert_eq(remove_error, OK)
+	assert_true(reloaded is GFTweenActionConfig)
+	if not (reloaded is GFTweenActionConfig):
+		return
+	var loaded_config: GFTweenActionConfig = reloaded
+	assert_eq(loaded_config.steps.size(), 1)
+	if loaded_config.steps.size() != 1:
+		return
+	var loaded_curve: Curve = loaded_config.steps[0].easing_curve
+	assert_not_null(loaded_curve)
+	if loaded_curve == null:
+		return
+	assert_ne(loaded_curve, step.easing_curve)
+	assert_eq(loaded_curve.get_point_count(), 3)
+	assert_eq(loaded_curve.bake_resolution, step.easing_curve.bake_resolution)
+	for progress: float in [0.0, 0.25, 0.5, 0.75, 1.0]:
+		assert_almost_eq(loaded_curve.sample_baked(progress), step.easing_curve.sample_baked(progress), 0.00001)
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	var tween: Tween = target.create_tween()
+	tween.pause()
+	var result: Variant = loaded_config.steps[0].append_to_tween(tween, target)
+	assert_true(result is PropertyTweener)
+	var _running: bool = tween.custom_step(0.5)
+	assert_almost_eq(target.position.x, 8.0 * loaded_curve.sample_baked(0.5), 0.001)
+	tween.kill()
+
+
+func test_configured_curve_action_keeps_marker_parallel_topology() -> void:
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	var config: GFTweenActionConfig = GFTweenActionConfig.new()
+	var first: GFTweenActionStep = config.add_property_step(^"position:x", 8.0, 0.15)
+	first.easing_curve = _make_easing_curve(0.25)
+	first.marker_id = &"curve_done"
+	var parallel_step: GFTweenActionStep = config.add_property_step(^"rotation", 1.0, 0.15)
+	parallel_step.parallel = true
+	parallel_step.easing_curve = _make_easing_curve(0.75)
+	var action: GFConfiguredTweenAction = _configured_tween_action(config.create_action(target))
+	var markers: Array[StringName] = []
+	var _connected: Error = action.marker_reached.connect(
+		func(marker_id: StringName, _index: int, _target: Object) -> void:
+			markers.append(marker_id)
+	) as Error
+	var result: Variant = action.execute()
+	var completed: Array[bool] = [false]
+	var wait_for_completion: Callable = func() -> void:
+		await action.await_result_safely(result)
+		completed[0] = true
+	wait_for_completion.call()
+	await get_tree().create_timer(0.05).timeout
+	assert_gt(target.position.x, 0.0)
+	assert_gt(target.rotation, 0.0)
+	await get_tree().create_timer(0.25).timeout
+	assert_true(completed[0], "Natural completion must release the already registered waiter.")
+	if not completed[0]:
+		action.cancel()
+		await get_tree().process_frame
+		return
+	assert_eq(markers, [&"curve_done"])
+	assert_almost_eq(target.position.x, 8.0, 0.001)
+	assert_almost_eq(target.rotation, 1.0, 0.001)
+	config.restore_initial_values_on_cancel = true
+	var cancel_result: Variant = action.execute()
+	var cancelled: Array[bool] = [false]
+	var wait_for_cancel: Callable = func() -> void:
+		await action.await_result_safely(cancel_result)
+		cancelled[0] = true
+	wait_for_cancel.call()
+	action.cancel()
+	await get_tree().process_frame
+	assert_true(cancelled[0], "Cancel must release a waiter registered before cancellation.")
+	assert_almost_eq(target.position.x, 8.0, 0.001)
+	assert_eq(markers, [&"curve_done"], "Cancelling the new playback must not synthesize a marker.")
 
 
 func test_configured_tween_action_waits_for_timed_steps() -> void:

--- a/tests/gf_core/tools/action_queue.editor/fixtures/gf_tween_preview_editor_smoke.gd
+++ b/tests/gf_core/tools/action_queue.editor/fixtures/gf_tween_preview_editor_smoke.gd
@@ -10,6 +10,7 @@ const _INSPECTOR_PLUGIN_SCRIPT = preload("res://addons/gf/extensions/action_queu
 const _SCENE_PATH: String = "res://tests/gf_core/tools/action_queue.editor/fixtures/gf_tween_preview_scene.tscn"
 const _CONFIG_PATH: String = "res://tests/gf_core/tools/action_queue.editor/fixtures/gf_tween_preview_saved_config.tres"
 const _RELOAD_PATH: String = "user://gf_tween_preview_reloaded.tres"
+const _CURVE_RELOAD_PATH: String = "user://gf_tween_preview_curve_reloaded.tres"
 const _DEADLINE_MSEC: int = 60000
 
 
@@ -103,7 +104,127 @@ func _run_probe() -> void:
 	if target_ref.get_ref() != null:
 		_fail("The native probe target survived explicit cleanup.")
 		return
+	if not _probe_curve():
+		return
 	_begin_inspector_smoke(source, reloaded)
+
+
+func _probe_curve() -> bool:
+	var source: Resource = ResourceLoader.load(_CONFIG_PATH, "", ResourceLoader.CACHE_MODE_IGNORE_DEEP)
+	if source == null:
+		_fail("The curve probe could not load its independent configuration.")
+		return false
+	var steps_value: Variant = source.get(&"steps")
+	if not steps_value is Array:
+		_fail("The curve probe configuration had no steps.")
+		return false
+	var steps: Array = steps_value
+	if steps.size() != 1 or not steps[0] is Resource:
+		_fail("The curve probe configuration did not contain one resource step.")
+		return false
+	var source_step: Resource = steps[0]
+	var source_curve: Curve = Curve.new()
+	source_curve.bake_resolution = 101
+	var _first_point: int = source_curve.add_point(
+		Vector2.ZERO, 0.0, 0.0, Curve.TANGENT_LINEAR, Curve.TANGENT_LINEAR
+	)
+	var _middle_point: int = source_curve.add_point(
+		Vector2(0.5, 0.75), 0.0, 0.0, Curve.TANGENT_LINEAR, Curve.TANGENT_LINEAR
+	)
+	var _last_point: int = source_curve.add_point(
+		Vector2.ONE, 0.0, 0.0, Curve.TANGENT_LINEAR, Curve.TANGENT_LINEAR
+	)
+	source.set(&"duration_scale", 1.0)
+	source_step.set(&"duration", 1.0)
+	source_step.set(&"delay", 0.0)
+	source_step.set(&"property_name", ^"position:x")
+	source_step.set(&"target_value", 16.0)
+	source_step.set(&"transition_type", Tween.TRANS_QUAD)
+	source_step.set(&"ease_type", Tween.EASE_IN)
+	source_step.set(&"easing_curve", source_curve)
+	var save_error: Error = ResourceSaver.save(source, _CURVE_RELOAD_PATH)
+	if save_error != OK:
+		_fail("Saving the curve probe configuration failed: %d" % save_error)
+		return false
+	var reloaded: Resource = ResourceLoader.load(_CURVE_RELOAD_PATH, "", ResourceLoader.CACHE_MODE_IGNORE_DEEP)
+	if reloaded == null or reloaded.get_script() != source.get_script():
+		_fail("The curve probe lost its non-tool configuration script after reloading.")
+		return false
+	var reloaded_steps_value: Variant = reloaded.get(&"steps")
+	if not reloaded_steps_value is Array:
+		_fail("The reloaded curve probe had no steps.")
+		return false
+	var reloaded_steps: Array = reloaded_steps_value
+	if reloaded_steps.size() != 1 or not reloaded_steps[0] is Resource:
+		_fail("The reloaded curve probe lost its one resource step.")
+		return false
+	var reloaded_step: Resource = reloaded_steps[0]
+	var reloaded_curve_value: Variant = reloaded_step.get(&"easing_curve")
+	if not reloaded_curve_value is Curve:
+		_fail("The saved easing_curve field did not reload as a native Curve.")
+		return false
+	var reloaded_curve: Curve = reloaded_curve_value
+	if (
+		reloaded_step.get_script() != source_step.get_script()
+		or not _number_equals(reloaded.get(&"duration_scale"), 1.0)
+		or not _number_equals(reloaded_step.get(&"duration"), 1.0)
+		or not _number_equals(reloaded_step.get(&"delay"), 0.0)
+		or reloaded_curve == source_curve or reloaded_curve.get_script() != null
+		or reloaded_curve.get_point_count() != 3 or reloaded_curve.bake_resolution != 101
+		or reloaded_curve.get_point_position(1) != Vector2(0.5, 0.75)
+	):
+		_fail("Reloading the curve probe changed its fields or retained the original curve identity.")
+		return false
+	var saved_digest: String = FileAccess.get_sha256(_CURVE_RELOAD_PATH)
+	var probe_root: Node = Node.new()
+	add_child(probe_root)
+	var preview: GFTweenPreviewViewport = GFTweenPreviewViewport.new()
+	probe_root.add_child(preview)
+	preview.configure(reloaded)
+	var preview_ref: WeakRef = weakref(preview)
+	var target: Node = preview.find_child("PreviewTarget", true, false)
+	var target_ref: WeakRef = weakref(target) if target != null else null
+	var probe_error: String = _check_curve_preview(preview, reloaded_curve)
+	preview.dispose_preview()
+	probe_root.free()
+	if preview_ref.get_ref() != null or (target_ref != null and target_ref.get_ref() != null):
+		_fail("The independent curve preview or its target survived explicit cleanup.")
+		return false
+	if not probe_error.is_empty():
+		_fail(probe_error)
+		return false
+	if saved_digest.is_empty() or FileAccess.get_sha256(_CURVE_RELOAD_PATH) != saved_digest:
+		_fail("Curve preview playback or seeking changed its saved configuration file.")
+		return false
+	if source_curve.get_point_position(1) != Vector2(0.5, 0.75):
+		_fail("Editing the reloaded curve also changed the original resource.")
+		return false
+	return true
+
+
+func _check_curve_preview(preview: GFTweenPreviewViewport, source_curve: Curve) -> String:
+	if not preview.play():
+		return "The saved curve configuration could not start in the real editor: " + preview.get_error()
+	preview.advance(0.5)
+	if not is_equal_approx(_position_x(preview), 12.0):
+		return "Native editor preview did not use the saved curve instead of preset/composed easing."
+	if not preview.seek(0.5) or preview.get_state() != &"paused":
+		return "The native curve preview did not accept time inspection."
+	if not is_equal_approx(_position_x(preview), 12.0):
+		return "Native curve seeking disagreed with forward playback."
+	source_curve.set_point_value(1, 0.25)
+	if not preview.seek(0.25) or not preview.seek(0.5):
+		return "Source curve editing invalidated an already captured inspection session."
+	if not is_equal_approx(_position_x(preview), 12.0):
+		return "Source curve editing changed the old seek snapshot."
+	preview.stop()
+	if not preview.play() or not preview.seek(0.5):
+		return "A new curve playback did not capture the edited resource."
+	if not is_equal_approx(_position_x(preview), 4.0):
+		return "New playback ignored the edited source curve."
+	if not preview.seek(1.0) or not is_equal_approx(_position_x(preview), 16.0):
+		return "The native curve preview did not preserve its exact endpoint."
+	return ""
 
 
 func _begin_inspector_smoke(source: Resource, reloaded: Resource) -> void:

--- a/tests/gf_core/tools/action_queue.editor/test_gf_tween_preview.gd
+++ b/tests/gf_core/tools/action_queue.editor/test_gf_tween_preview.gd
@@ -25,6 +25,261 @@ func test_preview_starts_idle_and_uses_only_its_own_target() -> void:
 	preview.dispose_preview()
 
 
+func test_easing_curve_overrides_presets_with_native_curve_value() -> void:
+	var config: GFTweenActionConfig = _config(^"position:x", 8.0)
+	config.steps[0].transition_type = Tween.TRANS_CUBIC
+	config.steps[0].ease_type = Tween.EASE_IN
+	var curve: Curve = Curve.new()
+	var _first_point: int = curve.add_point(Vector2.ZERO)
+	var _middle_point: int = curve.add_point(Vector2(0.5, 0.25))
+	var _last_point: int = curve.add_point(Vector2.ONE)
+	config.steps[0].set(&"easing_curve", curve)
+	var preview: GFTweenPreviewViewport = _preview(config)
+	assert_true(preview.play())
+	preview.advance(0.5)
+	assert_almost_eq(
+		_vector2(preview, "position").x,
+		8.0 * curve.sample_baked(0.5),
+		0.001,
+		"The curve must receive linear progress instead of an already eased value."
+	)
+	preview.dispose_preview()
+
+
+func test_easing_curve_preserves_native_tangents_after_point_removal() -> void:
+	var curve: Curve = _easing_curve(0.25)
+	for index: int in range(curve.get_point_count()):
+		curve.set_point_left_mode(index, Curve.TANGENT_LINEAR)
+		curve.set_point_right_mode(index, Curve.TANGENT_LINEAR)
+	curve.remove_point(1)
+	var config: GFTweenActionConfig = _config(^"position:x", 8.0)
+	config.steps[0].easing_curve = curve
+	var copied: GFTweenActionStep = config.steps[0].duplicate_step()
+	assert_not_null(copied)
+	if copied == null:
+		return
+	for index: int in range(curve.get_point_count()):
+		assert_eq(copied.easing_curve.get_point_left_mode(index), curve.get_point_left_mode(index))
+		assert_eq(copied.easing_curve.get_point_right_mode(index), curve.get_point_right_mode(index))
+		assert_eq(copied.easing_curve.get_point_left_tangent(index), curve.get_point_left_tangent(index))
+		assert_eq(copied.easing_curve.get_point_right_tangent(index), curve.get_point_right_tangent(index))
+	var preview: GFTweenPreviewViewport = _preview(config)
+	assert_true(preview.play())
+	var target: Node2D = Node2D.new()
+	add_child_autofree(target)
+	var tween: Tween = target.create_tween()
+	tween.pause()
+	var tweener: Variant = config.steps[0].append_to_tween(tween, target)
+	assert_true(tweener is PropertyTweener)
+	for progress: float in [0.25, 0.5, 0.75, 1.0]:
+		var _running: bool = tween.custom_step(0.25)
+		assert_true(preview.seek(progress))
+		var expected: float = 8.0 * curve.sample_baked(progress)
+		assert_almost_eq(target.position.x, expected, 0.001)
+		assert_almost_eq(_vector2(preview, "position").x, expected, 0.001)
+		assert_almost_eq(copied.easing_curve.sample_baked(progress) * 8.0, expected, 0.001)
+	tween.kill()
+	preview.dispose_preview()
+
+
+func test_easing_curve_null_preserves_preset_and_curve_can_overshoot() -> void:
+	var config: GFTweenActionConfig = _config(^"position:x", 8.0)
+	config.steps[0].transition_type = Tween.TRANS_CUBIC
+	config.steps[0].ease_type = Tween.EASE_IN
+	var preview: GFTweenPreviewViewport = _preview(config)
+	assert_true(preview.play())
+	preview.advance(0.5)
+	assert_almost_eq(_vector2(preview, "position").x, 1.0, 0.001)
+	config.steps[0].easing_curve = _easing_curve(1.5)
+	preview.configure(config)
+	assert_true(preview.play())
+	assert_true(preview.seek(0.5))
+	assert_gt(_vector2(preview, "position").x, 8.0, "A bounded overshoot must remain observable.")
+	assert_true(preview.seek(1.0))
+	assert_almost_eq(_vector2(preview, "position").x, 8.0, 0.001)
+	config.steps[0].easing_curve = null
+	preview.configure(config)
+	assert_true(preview.play())
+	assert_true(preview.seek(0.5))
+	assert_almost_eq(_vector2(preview, "position").x, 1.0, 0.001)
+	preview.dispose_preview()
+
+
+func test_easing_curve_seek_uses_captured_values_until_new_playback() -> void:
+	var curve: Curve = _easing_curve(0.25)
+	var config: GFTweenActionConfig = _config(^"position:x", 8.0)
+	config.steps[0].easing_curve = curve
+	var preview: GFTweenPreviewViewport = _preview(config)
+	assert_true(preview.play())
+	assert_true(preview.seek(0.5))
+	var captured_values: Dictionary = preview.get_current_values()
+	curve.set_point_value(1, 0.75)
+	assert_true(preview.seek(0.8))
+	assert_true(preview.seek(0.5))
+	assert_eq(preview.get_current_values(), captured_values)
+	config.steps[0].easing_curve = Curve.new()
+	assert_true(preview.seek(0.5), "Replacing the source with an invalid curve cannot poison a session.")
+	assert_eq(preview.get_current_values(), captured_values)
+	assert_true(preview.play())
+	preview.advance(0.25)
+	assert_eq(preview.get_state(), &"playing")
+	preview.reset_preview()
+	assert_false(preview.play(), "A new playback must validate the replacement curve.")
+	config.steps[0].easing_curve = curve
+	preview.configure(config)
+	assert_true(preview.play())
+	assert_true(preview.seek(0.5))
+	assert_almost_eq(_vector2(preview, "position").x, 8.0 * curve.sample_baked(0.5), 0.001)
+	assert_ne(preview.get_current_values(), captured_values)
+	preview.dispose_preview()
+
+
+func test_easing_curve_seek_matches_independent_native_parallel_relative_playback() -> void:
+	var curve: Curve = _easing_curve(0.25)
+	var config: GFTweenActionConfig = _config(^"position:x", 8.0, 0.5)
+	config.steps[0].delay = 0.25
+	config.steps[0].easing_curve = curve
+	var parallel_step: GFTweenActionStep = _step(^"position:y", 4.0, 1.0)
+	parallel_step.parallel = true
+	parallel_step.easing_curve = curve
+	config.steps.append(parallel_step)
+	var relative_step: GFTweenActionStep = _step(^"position:x", 2.0, 0.5)
+	relative_step.as_relative = true
+	relative_step.easing_curve = curve
+	config.steps.append(relative_step)
+	config.loop_count = 2
+	var preview: GFTweenPreviewViewport = _preview(config)
+	var native_target: Node2D = Node2D.new()
+	add_child_autofree(native_target)
+	var native_tween: Tween = _native_easing_tween(native_target, curve)
+	assert_true(preview.play())
+	assert_eq(preview.get_duration_seconds(), 3.0)
+	var native_time: float = 0.0
+	for checkpoint: float in [0.375, 1.25, 2.75, 3.0]:
+		var step_count: int = ceili((checkpoint - native_time) / 0.125)
+		for _index: int in range(step_count):
+			var delta: float = minf(0.125, checkpoint - native_time)
+			var _still_running: bool = native_tween.custom_step(delta)
+			native_time += delta
+		assert_true(preview.seek(checkpoint))
+		assert_almost_eq(_vector2(preview, "position").x, native_target.position.x, 0.001)
+		assert_almost_eq(_vector2(preview, "position").y, native_target.position.y, 0.001)
+	assert_true(preview.seek(0.375))
+	assert_true(preview.seek(2.75))
+	assert_true(preview.play())
+	preview.advance(0.25)
+	assert_eq(preview.get_state(), &"finished")
+	assert_almost_eq(_vector2(preview, "position").x, native_target.position.x, 0.001)
+	native_tween.kill()
+	preview.dispose_preview()
+
+
+func test_easing_curve_zero_duration_and_finish_restore_keep_existing_contracts() -> void:
+	var config: GFTweenActionConfig = _config(^"position:x", 3.0, 0.0)
+	config.steps[0].easing_curve = _easing_curve(0.25)
+	config.steps[0].as_relative = true
+	config.loop_count = 32
+	config.restore_initial_values_on_finish = true
+	var preview: GFTweenPreviewViewport = _preview(config)
+	assert_true(preview.set_initial_value(&"position", Vector2(2.0, 4.0)))
+	assert_true(preview.play())
+	assert_eq(_vector2(preview, "position"), Vector2(2.0, 4.0))
+	assert_true(preview.seek(0.0))
+	assert_eq(_vector2(preview, "position"), Vector2(5.0, 4.0))
+	assert_true(preview.play())
+	assert_eq(preview.get_state(), &"finished")
+	assert_eq(_vector2(preview, "position"), Vector2(2.0, 4.0))
+	config.steps[0].duration = 1.0
+	config.loop_count = 1
+	preview.configure(config)
+	assert_true(preview.play())
+	assert_true(preview.seek(1.0))
+	assert_almost_eq(_vector2(preview, "position").x, 3.0, 0.001)
+	assert_true(preview.play())
+	assert_eq(_vector2(preview, "position"), Vector2.ZERO)
+	preview.dispose_preview()
+
+
+func test_easing_curve_invalid_second_step_rejects_whole_preview_before_writes() -> void:
+	var invalid_curves: Array[Curve] = [Curve.new(), _easing_curve(0.25)]
+	invalid_curves[1].set_point_value(0, 0.1)
+	var one_point: Curve = Curve.new()
+	var _only_point: int = one_point.add_point(Vector2.ZERO)
+	invalid_curves.append(one_point)
+	var incomplete_domain: Curve = Curve.new()
+	var _incomplete_first: int = incomplete_domain.add_point(Vector2(0.1, 0.0))
+	var _incomplete_last: int = incomplete_domain.add_point(Vector2.ONE)
+	invalid_curves.append(incomplete_domain)
+	var invalid_tangent: Curve = _easing_curve(0.25)
+	invalid_tangent.set_point_right_tangent(0, INF)
+	assert_false(is_finite(invalid_tangent.get_point_right_tangent(0)))
+	invalid_curves.append(invalid_tangent)
+	var excessive_overshoot: Curve = Curve.new()
+	var _overshoot_first: int = excessive_overshoot.add_point(Vector2.ZERO, 0.0, 128.0)
+	var _overshoot_last: int = excessive_overshoot.add_point(Vector2.ONE, -128.0, 0.0)
+	assert_gt(excessive_overshoot.sample_baked(0.5), 16.0)
+	invalid_curves.append(excessive_overshoot)
+	var preview: GFTweenPreviewViewport = _preview(null)
+	for curve: Curve in invalid_curves:
+		var config: GFTweenActionConfig = _config(^"position:x", 10.0, 0.0)
+		var invalid_step: GFTweenActionStep = _step(^"position:y", 20.0)
+		invalid_step.easing_curve = curve
+		config.steps.append(invalid_step)
+		preview.configure(config)
+		assert_false(preview.play())
+		assert_eq(preview.get_state(), &"error")
+		assert_false(preview.get_error().is_empty())
+		assert_eq(_vector2(preview, "position"), Vector2.ZERO)
+		assert_false(preview.has_session())
+	preview.dispose_preview()
+
+
+func test_easing_curve_script_is_rejected_without_copying_or_executing_it() -> void:
+	var scripted_curve: RejectedEasingCurve = RejectedEasingCurve.new()
+	var _first_point: int = scripted_curve.add_point(Vector2.ZERO)
+	var _last_point: int = scripted_curve.add_point(Vector2.ONE)
+	var config: GFTweenActionConfig = _config(^"position:x", 8.0)
+	config.steps[0].easing_curve = scripted_curve
+	var constructions_before: int = RejectedEasingCurve.constructions
+	var property_reads_before: int = scripted_curve.property_reads
+	var preview: GFTweenPreviewViewport = _preview(config)
+	assert_false(preview.play())
+	assert_eq(RejectedEasingCurve.constructions, constructions_before)
+	assert_eq(scripted_curve.property_reads, property_reads_before)
+	assert_eq(_vector2(preview, "position"), Vector2.ZERO)
+	preview.dispose_preview()
+
+
+func test_easing_curve_preview_bounds_aggregate_point_and_sample_work() -> void:
+	var point_config: GFTweenActionConfig = GFTweenActionConfig.new()
+	for _index: int in range(16):
+		var step: GFTweenActionStep = _step(^"position:x", 1.0, 0.01)
+		step.easing_curve = _many_point_easing_curve(256, 2)
+		point_config.steps.append(step)
+	var point_plan: GFTweenPreviewPlan = GFTweenPreviewPlan.capture(point_config, 0)
+	assert_eq(point_plan.error, "", "Exactly 4096 points must remain admissible.")
+	var extra_step: GFTweenActionStep = _step(^"position:x", 2.0, 0.01)
+	extra_step.easing_curve = _easing_curve(0.25)
+	point_config.steps.append(extra_step)
+	point_plan = GFTweenPreviewPlan.capture(point_config, 0)
+	assert_false(point_plan.error.is_empty())
+	assert_true(point_plan.steps.is_empty())
+	var sample_config: GFTweenActionConfig = GFTweenActionConfig.new()
+	for _index: int in range(64):
+		var step: GFTweenActionStep = _step(^"position:x", 1.0, 0.01)
+		step.easing_curve = _many_point_easing_curve(2, 1000)
+		sample_config.steps.append(step)
+	var sample_plan: GFTweenPreviewPlan = GFTweenPreviewPlan.capture(sample_config, 0)
+	assert_eq(sample_plan.error, "")
+	for _index: int in range(2):
+		var step: GFTweenActionStep = _step(^"position:x", 2.0, 0.01)
+		step.easing_curve = _many_point_easing_curve(2, 1000)
+		sample_config.steps.append(step)
+	sample_plan = GFTweenPreviewPlan.capture(sample_config, 0)
+	assert_false(sample_plan.error.is_empty())
+	assert_true(sample_plan.steps.is_empty())
+
+
 func test_pause_stop_reset_and_replay_have_distinct_observable_effects() -> void:
 	var preview: GFTweenPreviewViewport = _preview(_config(^"position:x", 10.0))
 	assert_true(preview.set_initial_value(&"position", Vector2.ZERO))
@@ -783,6 +1038,42 @@ func test_disposed_panel_rejects_late_control_signals_without_rebuilding_sample(
 
 # --- 私有/辅助方法 ---
 
+func _easing_curve(midpoint_y: float = 0.25) -> Curve:
+	var curve: Curve = Curve.new()
+	curve.min_value = minf(0.0, midpoint_y)
+	curve.max_value = maxf(1.0, midpoint_y)
+	var _first_point: int = curve.add_point(Vector2.ZERO)
+	var _middle_point: int = curve.add_point(Vector2(0.5, midpoint_y))
+	var _last_point: int = curve.add_point(Vector2.ONE)
+	return curve
+
+
+func _many_point_easing_curve(point_count: int, resolution: int) -> Curve:
+	var curve: Curve = Curve.new()
+	curve.bake_resolution = resolution
+	for index: int in range(point_count):
+		var progress: float = float(index) / float(point_count - 1)
+		var _point: int = curve.add_point(Vector2(progress, progress))
+	return curve
+
+
+func _native_easing_tween(target: Node2D, curve: Curve) -> Tween:
+	var native_tween: Tween = target.create_tween()
+	native_tween.pause()
+	var _loops: Tween = native_tween.set_loops(2)
+	var first: PropertyTweener = native_tween.tween_property(target, ^"position:x", 8.0, 0.5)
+	var _first_options: PropertyTweener = first.set_delay(0.25).set_trans(Tween.TRANS_LINEAR)
+	var _first_curve: PropertyTweener = first.set_custom_interpolator(curve.sample_baked)
+	var _parallel: Tween = native_tween.parallel()
+	var second: PropertyTweener = native_tween.tween_property(target, ^"position:y", 4.0, 1.0)
+	var _second_options: PropertyTweener = second.set_trans(Tween.TRANS_LINEAR)
+	var _second_curve: PropertyTweener = second.set_custom_interpolator(curve.sample_baked)
+	var relative: PropertyTweener = native_tween.tween_property(target, ^"position:x", 2.0, 0.5)
+	var _relative_options: PropertyTweener = relative.set_trans(Tween.TRANS_LINEAR).as_relative()
+	var _relative_curve: PropertyTweener = relative.set_custom_interpolator(curve.sample_baked)
+	return native_tween
+
+
 func _native_parallel_relative_tween(target: Node2D) -> Tween:
 	var native_tween: Tween = target.create_tween()
 	native_tween.pause()
@@ -910,6 +1201,20 @@ func _time_input(panel: GFTweenPreviewPanel) -> SpinBox:
 
 
 # --- 内部类 ---
+
+class RejectedEasingCurve:
+	extends Curve
+
+	static var constructions: int = 0
+	var property_reads: int = 0
+
+	func _init() -> void:
+		constructions += 1
+
+	func _get(_property: StringName) -> Variant:
+		property_reads += 1
+		return null
+
 
 class RejectedConfig:
 	extends GFTweenActionConfig


### PR DESCRIPTION
## Summary

配置化 Tween 原先只能选择预设缓动，无法通过曲线调整同一动画资源的节奏。新增可选 `GFTweenActionStep.easing_curve`，运行时与现有 Inspector 预览、时间定位共用原生求值；未设置曲线时保持原有行为。

播放捕获独立曲线数据，后续编辑资源不会改变当前会话。复制、运行时和预览保留原生切线数值及模式，包括删除控制点后的曲线形状。

## Contract and Risk

- Change type: feat
- Consumer-visible behavior: 可编辑原生 Curve 覆盖 transition/ease，支持回弹及超调；不新增动画 DSL、时间线或业务规则。
- API or extension contract: 新增 `easing_curve: Curve = null`；`gf.action_queue` 的 `extension_version` 为 `2.5.0`。
- Persisted data, package, protocol, or ProjectSettings impact: 可选资源字段，旧资源无需迁移；没有新包依赖、协议或设置。
- Failure, cancellation, rollback, concurrency, and ownership impact: 拒绝脚本曲线、无效端点/数值和超出预算的数据。运行时跳过无效 Tween 步骤，预览整组拒绝；无效曲线使深复制返回 null 并警告。即时终点和初值恢复仅校验属性。私有原生 Curve 随 Tweener 释放，预览纯值快照随会话释放。
- Compatibility and migration: 兼容新增能力；根开发身份保持 `12.0.0-dev.0`。曲线约束和复制失败返回在指南中明确说明。

## Verification

- [x] 聚焦 GUT：`test_gf_visual_actions.gd` 与 `test_gf_tween_preview.gd` 共 121/121，859 个断言，零未处理警告和孤立节点。
- [x] 两次 RED→GREEN：曲线覆盖预设，以及删除控制点后的原生切线保真。
- [x] 真实 EditorPlugin 生命周期：保存/重载、曲线播放与 seek、源编辑隔离、2D/UI/3D 渲染、样机释放和源文件不变。
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only`
- [x] `python tools/gf_maintenance.py check --suite full`：40 项检查全部通过；377 个脚本、7,395 个 GUT 测试、91,439 个断言通过，GDScript warning/LSP、API/文档、包边界和维护工具验收均通过。
- [x] Generated API or knowledge output is fresh when its source changed.
- [x] Draft PR feedback completed through `GF draft gate`.
- [ ] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

## Documentation and Release

- [x] Relevant guide and `[未发布]` changelog entries are updated.
- [x] Development version impact is correct.
- [x] This PR does not create a tag or publish a release.
