### PR TITLE
Add independent initial delay to input pulse triggers

### DIFF
--- a/addons/gf/standard/input/triggers/gf_input_pulse_trigger.gd
+++ b/addons/gf/standard/input/triggers/gf_input_pulse_trigger.gd
@@ -24,9 +24,24 @@ extends GFInputTrigger
 			return
 		interval_seconds = maxf(value, 0.001)
 
-## 输入首次变为活跃时是否立即触发。
+## 首次周期脉冲的等待秒数，从输入激活时开始计时；有限负值统一存为 -1，表示使用 interval_seconds。
+## 0 表示激活时触发一次，并与 trigger_immediately 的脉冲合并，随后等待完整周期。
+## 非有限赋值会被拒绝并保留最后有效值。
 ## [br]
 ## @api public
+## [br]
+## @since unreleased
+@export var initial_delay_seconds: float = -1.0:
+	set(value):
+		if not is_finite(value):
+			return
+		initial_delay_seconds = -1.0 if value < 0.0 else value
+
+## 输入首次变为活跃时是否立即触发；initial_delay_seconds 为 0 时始终在激活时触发一次。
+## [br]
+## @api public
+## [br]
+## @since 3.17.0
 @export var trigger_immediately: bool = true
 
 
@@ -36,16 +51,22 @@ extends GFInputTrigger
 ## [br]
 ## @api public
 ## [br]
+## @since 3.17.0
+## [br]
 ## @param state: 触发器运行时状态字典。
 ## [br]
-## @schema state: Dictionary，由输入运行时持有，包含 was_active: bool 和 elapsed: float。
+## @schema state: Dictionary，由输入运行时按动作和玩家隔离持有，包含 was_active: bool、initial_wait_pending: bool 和 elapsed: float。
 func reset_trigger_state(state: Dictionary) -> void:
 	state.clear()
 	state["was_active"] = false
+	state["initial_wait_pending"] = true
 	state["elapsed"] = 0.0
 
 
-## 更新运行时状态。
+## 更新运行时状态；每次最多返回一个脉冲，跨期只保留周期余数，不补发历史脉冲。
+## 激活时产生即时脉冲会忽略当次 delta；否则首次等待消费当次 delta。
+## 持续活跃期间只有有限正 delta 才能触发新的脉冲，事件刷新不会重复触发。
+## 首次等待仅在等待阶段读取，周期每次读取；修改共享配置会影响引用它的动作，但不会共享计时进度。
 ## [br]
 ## @api public
 ## [br]
@@ -59,38 +80,67 @@ func reset_trigger_state(state: Dictionary) -> void:
 ## [br]
 ## @schema _value: Variant，由当前输入映射产生的动作值。
 ## [br]
-## @schema state: Dictionary，由输入运行时持有，包含 was_active: bool 和 elapsed: float。
+## @schema state: Dictionary，由输入运行时按动作和玩家隔离持有，包含 was_active: bool、initial_wait_pending: bool 和 elapsed: float；elapsed 表示首次等待已用时间或周期余数。
 ## [br]
 ## @return 触发状态。
 ## [br]
 ## @since 11.0.0
 func update(raw_active: bool, _value: Variant, delta: float, state: Dictionary) -> TriggerState:
-	var was_active: bool = GFVariantData.get_option_bool(state, "was_active", false)
 	if not raw_active:
 		state["was_active"] = false
+		state["initial_wait_pending"] = true
 		state["elapsed"] = 0.0
 		return TriggerState.INACTIVE
 
-	if trigger_immediately and not was_active:
-		state["was_active"] = true
-		state["elapsed"] = 0.0
-		return TriggerState.TRIGGERED
-
 	var safe_interval: float = interval_seconds if is_finite(interval_seconds) else 0.001
 	safe_interval = maxf(safe_interval, 0.001)
+	var first_delay: float = initial_delay_seconds
+	if not is_finite(first_delay) or first_delay < 0.0:
+		first_delay = safe_interval
+	if not GFVariantData.get_option_bool(state, "was_active", false):
+		state["was_active"] = true
+		state["initial_wait_pending"] = first_delay > 0.0
+		state["elapsed"] = 0.0
+		if trigger_immediately or first_delay == 0.0:
+			return TriggerState.TRIGGERED
+
+	var initial_wait_pending: bool = GFVariantData.get_option_bool(state, "initial_wait_pending", true)
 	var elapsed: float = GFVariantData.get_option_float(state, "elapsed", 0.0)
 	if not is_finite(elapsed) or elapsed < 0.0:
 		elapsed = 0.0
-	elif elapsed >= safe_interval:
+	elif not initial_wait_pending and elapsed >= safe_interval:
 		elapsed = fmod(elapsed, safe_interval)
+	state["elapsed"] = elapsed
 	var safe_delta: float = delta if is_finite(delta) and delta > 0.0 else 0.0
+	if safe_delta == 0.0:
+		return TriggerState.ONGOING
+
+	if initial_wait_pending:
+		var remaining_initial_wait: float = maxf(first_delay - elapsed, 0.0)
+		if safe_delta < remaining_initial_wait:
+			state["elapsed"] = elapsed + safe_delta
+			return TriggerState.ONGOING
+		state["initial_wait_pending"] = false
+		var overdue: float = maxf(elapsed - first_delay, 0.0)
+		state["elapsed"] = _wrap_elapsed(overdue, safe_delta - remaining_initial_wait, safe_interval)
+		return TriggerState.TRIGGERED
+
 	var remaining_until_pulse: float = safe_interval - elapsed
 	if safe_delta >= remaining_until_pulse:
-		var delta_remainder: float = fmod(safe_delta, safe_interval)
-		state["elapsed"] = fmod(elapsed + delta_remainder, safe_interval)
-		state["was_active"] = true
+		state["elapsed"] = _wrap_elapsed(elapsed, safe_delta, safe_interval)
 		return TriggerState.TRIGGERED
 
 	state["elapsed"] = elapsed + safe_delta
-	state["was_active"] = true
 	return TriggerState.ONGOING
+
+
+# --- 私有/辅助方法 ---
+
+func _wrap_elapsed(elapsed: float, delta: float, interval: float) -> float:
+	var elapsed_remainder: float = fmod(elapsed, interval)
+	var delta_remainder: float = fmod(delta, interval)
+	var remaining: float = interval - elapsed_remainder
+	# 先比较再相加，避免两个巨大但有限的余数相加溢出。
+	if delta_remainder >= remaining:
+		return delta_remainder - remaining
+	return elapsed_remainder + delta_remainder

--- a/addons/gf/tools/ai_developer/knowledge/api_index.json
+++ b/addons/gf/tools/ai_developer/knowledge/api_index.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "catalog_version": "2.0.0",
   "framework_version": "12.0.0-dev.0",
-  "source_digest": "0a663ed8bad9264ed6f88c1f5a2f9860a946b23bd1f9425b9d5b706e5d74a1f0",
+  "source_digest": "a615998ba32b69370e0cd42d5ceb2bf6595b1e6bf2eded923ef1d148af4ee8b6",
   "class_count": 859,
   "autoload_count": 1,
   "package_count": 59,
@@ -43003,9 +43003,16 @@
         },
         {
           "kind": "var",
+          "name": "initial_delay_seconds",
+          "signature": "var initial_delay_seconds: float = -1.0",
+          "summary": "首次周期脉冲的等待秒数，从输入激活时开始计时；有限负值统一存为 -1，表示使用 interval_seconds。",
+          "visibility": "public"
+        },
+        {
+          "kind": "var",
           "name": "trigger_immediately",
           "signature": "var trigger_immediately: bool = true",
-          "summary": "输入首次变为活跃时是否立即触发。",
+          "summary": "输入首次变为活跃时是否立即触发；initial_delay_seconds 为 0 时始终在激活时触发一次。",
           "visibility": "public"
         },
         {
@@ -43019,7 +43026,7 @@
           "kind": "func",
           "name": "update",
           "signature": "func update(raw_active: bool, _value: Variant, delta: float, state: Dictionary) -> TriggerState",
-          "summary": "更新运行时状态。",
+          "summary": "更新运行时状态；每次最多返回一个脉冲，跨期只保留周期余数，不补发历史脉冲。",
           "visibility": "public"
         }
       ]

--- a/docs/api_catalog/classes/GFInputPulseTrigger.xml
+++ b/docs/api_catalog/classes/GFInputPulseTrigger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<class name="GFInputPulseTrigger" path="addons/gf/standard/input/triggers/gf_input_pulse_trigger.gd" module="standard" extends="GFInputTrigger" classDigest="7c8abb0ff4c95255c2bd2d7c08f2af25910b2b9e2d6aee415f5963aa7c50af72">
+<class name="GFInputPulseTrigger" path="addons/gf/standard/input/triggers/gf_input_pulse_trigger.gd" module="standard" extends="GFInputTrigger" classDigest="80cb7906d4890f648389c847b9bcf749386c8f109bc7c8ac463f9498f17ded84">
 	<description>GFInputPulseTrigger: 周期脉冲触发器。
 输入持续活跃时按固定间隔触发一次，可用于连发、菜单重复导航等通用场景。</description>
 	<tags>
@@ -19,11 +19,22 @@
 				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>
-		<member kind="property" name="trigger_immediately" decorators="@export">
-			<signature>var trigger_immediately: bool = true</signature>
-			<description>输入首次变为活跃时是否立即触发。</description>
+		<member kind="property" name="initial_delay_seconds" decorators="@export">
+			<signature>var initial_delay_seconds: float = -1.0:</signature>
+			<description>首次周期脉冲的等待秒数，从输入激活时开始计时；有限负值统一存为 -1，表示使用 interval_seconds。
+0 表示激活时触发一次，并与 trigger_immediately 的脉冲合并，随后等待完整周期。
+非有限赋值会被拒绝并保留最后有效值。</description>
 			<tags>
 				<tag name="api">public</tag>
+				<tag name="since">unreleased</tag>
+			</tags>
+		</member>
+		<member kind="property" name="trigger_immediately" decorators="@export">
+			<signature>var trigger_immediately: bool = true</signature>
+			<description>输入首次变为活跃时是否立即触发；initial_delay_seconds 为 0 时始终在激活时触发一次。</description>
+			<tags>
+				<tag name="api">public</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 	</properties>
@@ -34,12 +45,16 @@
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">state: 触发器运行时状态字典。</tag>
-				<tag name="schema">state: Dictionary，由输入运行时持有，包含 was_active: bool 和 elapsed: float。</tag>
+				<tag name="schema">state: Dictionary，由输入运行时按动作和玩家隔离持有，包含 was_active: bool、initial_wait_pending: bool 和 elapsed: float。</tag>
+				<tag name="since">3.17.0</tag>
 			</tags>
 		</member>
 		<member kind="method" name="update">
 			<signature>func update(raw_active: bool, _value: Variant, delta: float, state: Dictionary) -&gt; TriggerState:</signature>
-			<description>更新运行时状态。</description>
+			<description>更新运行时状态；每次最多返回一个脉冲，跨期只保留周期余数，不补发历史脉冲。
+激活时产生即时脉冲会忽略当次 delta；否则首次等待消费当次 delta。
+持续活跃期间只有有限正 delta 才能触发新的脉冲，事件刷新不会重复触发。
+首次等待仅在等待阶段读取，周期每次读取；修改共享配置会影响引用它的动作，但不会共享计时进度。</description>
 			<tags>
 				<tag name="api">public</tag>
 				<tag name="param">raw_active: 原始输入是否处于激活状态。</tag>
@@ -48,7 +63,7 @@
 				<tag name="param">state: 触发器运行时状态字典。</tag>
 				<tag name="return">触发状态。</tag>
 				<tag name="schema">_value: Variant，由当前输入映射产生的动作值。</tag>
-				<tag name="schema">state: Dictionary，由输入运行时持有，包含 was_active: bool 和 elapsed: float。</tag>
+				<tag name="schema">state: Dictionary，由输入运行时按动作和玩家隔离持有，包含 was_active: bool、initial_wait_pending: bool 和 elapsed: float；elapsed 表示首次等待已用时间或周期余数。</tag>
 				<tag name="since">11.0.0</tag>
 			</tags>
 		</member>

--- a/docs/api_catalog/index.xml
+++ b/docs/api_catalog/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="72a419086218144a5afa4c13de94bec8444c81a42456b19e8b9b52e14dbd1f41" classCount="883" methodCount="7883" autoloadCount="1" autoloadMethodCount="65">
+<apiCatalog schemaVersion="3" name="GF Framework" sourceRoot="addons/gf" sourceDigest="fca3dc4115d64fc05884887a28a0be489207727c557ff9a5a982983a4b944901" classCount="883" methodCount="7883" autoloadCount="1" autoloadMethodCount="65">
 	<module id="kernel" label="Kernel" classCount="78" methodCount="826" autoloadCount="1" autoloadMethodCount="65">
 		<class name="GFAccessGenerator" path="classes/GFAccessGenerator.xml" sourcePath="addons/gf/kernel/editor/gf_access_generator.gd" extends="RefCounted" />
 		<class name="GFArchitecture" path="classes/GFArchitecture.xml" sourcePath="addons/gf/kernel/core/gf_architecture.gd" extends="Object" />

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -6,6 +6,7 @@
 
 ### 🚀 新增特性 (Added)
 
+- [周期输入脉冲](standard/input-flow/input-assist/input-modifiers-triggers.md#周期脉冲的首次等待) 支持独立首次等待，可在按下立即响应后等待较长时间，再按较短间隔重复；动作和玩家保持独立计时。
 - [配置化 Tween](extensions/action-queue/tween-config.md#自定义缓动曲线) 支持步骤级原生 `Curve`，可制作回弹与超调效果；运行时独立捕获曲线，Inspector 预览与时间定位使用同一配置快照。
 - 新增 [方格视野查询](standard/foundation/grid-spatial/grid-2d-hex/grid-math.md)，通过显式阻挡回调计算有限半径内的可见格，返回稳定顺序与失败诊断；视野不接管地图节点、探索记忆或阵营规则。
 - [Tween Inspector 预览](extensions/action-queue/tween-config.md#在-inspector-中预览) 支持时间滑条与秒数定位，可反复检查同一配置快照的中间姿态和动画终点；定位仅操作工具自有样机，并保持暂停。
@@ -52,6 +53,7 @@
 
 ### 🔧 API 变动说明 (API Changes)
 
+- `GFInputPulseTrigger` 新增 `initial_delay_seconds`，默认 `-1` 沿用 `interval_seconds`，`0` 表示激活当次触发一次。激活时已发出脉冲才忽略当次 delta；每次更新最多返回一个脉冲，不补发跨过的多个周期，也不改变动作开始事件的状态转换语义。
 - 新增 `GFGridVisibilityMath2D.compute_fov()`，显式接收网格范围、观察格、半径和遮挡规则；输入或查询失败时返回空的可见集合，保留既有两点视线查询合同。
 - `GFRepeaterBinder` 的模板同步支持 `identity_callable`，新增 `sync_container()` 提供结构化同步结果；自动刷新失败通过 `synchronization_failed` 通知。稳定 ID 更新验证重复键、克隆所有权和同步重入，不把项目回调副作用作为可回滚事务。
 - 新增 `GFCameraFramingRig2D`。2D Rig 的 `get_camera_pose()` 和 `get_camera_pose_data()` 增加可选 `Camera2D` 参数，Director 显式提供目标相机；自定义覆盖需要同步签名，`gf.camera` 的 `extension_version` 升为 `3.0.0`。

--- a/docs/zh/reference/api/classes/GFInputPulseTrigger.md
+++ b/docs/zh/reference/api/classes/GFInputPulseTrigger.md
@@ -16,6 +16,7 @@
 | 类型 | 名称 | 签名 |
 |---|---|---|
 | 属性 | [`interval_seconds`](#member-gfinputpulsetrigger-properties-interval_seconds) | `var interval_seconds: float = 0.1:` |
+| 属性 | [`initial_delay_seconds`](#member-gfinputpulsetrigger-properties-initial_delay_seconds) | `var initial_delay_seconds: float = -1.0:` |
 | 属性 | [`trigger_immediately`](#member-gfinputpulsetrigger-properties-trigger_immediately) | `var trigger_immediately: bool = true` |
 | 方法 | [`reset_trigger_state`](#member-gfinputpulsetrigger-methods-reset_trigger_state) | `func reset_trigger_state(state: Dictionary) -> void:` |
 | 方法 | [`update`](#member-gfinputpulsetrigger-methods-update) | `func update(raw_active: bool, _value: Variant, delta: float, state: Dictionary) -> TriggerState:` |
@@ -35,17 +36,31 @@ var interval_seconds: float = 0.1:
 
 脉冲间隔秒数。非有限赋值会被拒绝并保留最后有效值。
 
+<a id="member-gfinputpulsetrigger-properties-initial_delay_seconds"></a>
+
+### `initial_delay_seconds`
+
+- API：`public`
+- 首次版本：`unreleased`
+
+```gdscript
+var initial_delay_seconds: float = -1.0:
+```
+
+首次周期脉冲的等待秒数，从输入激活时开始计时；有限负值统一存为 -1，表示使用 interval_seconds。 0 表示激活时触发一次，并与 trigger_immediately 的脉冲合并，随后等待完整周期。 非有限赋值会被拒绝并保留最后有效值。
+
 <a id="member-gfinputpulsetrigger-properties-trigger_immediately"></a>
 
 ### `trigger_immediately`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 var trigger_immediately: bool = true
 ```
 
-输入首次变为活跃时是否立即触发。
+输入首次变为活跃时是否立即触发；initial_delay_seconds 为 0 时始终在激活时触发一次。
 
 ## 方法
 
@@ -54,6 +69,7 @@ var trigger_immediately: bool = true
 ### `reset_trigger_state`
 
 - API：`public`
+- 首次版本：`3.17.0`
 
 ```gdscript
 func reset_trigger_state(state: Dictionary) -> void:
@@ -69,7 +85,7 @@ func reset_trigger_state(state: Dictionary) -> void:
 
 结构：
 
-- `state`: Dictionary，由输入运行时持有，包含 was_active: bool 和 elapsed: float。
+- `state`: Dictionary，由输入运行时按动作和玩家隔离持有，包含 was_active: bool、initial_wait_pending: bool 和 elapsed: float。
 
 <a id="member-gfinputpulsetrigger-methods-update"></a>
 
@@ -82,7 +98,7 @@ func reset_trigger_state(state: Dictionary) -> void:
 func update(raw_active: bool, _value: Variant, delta: float, state: Dictionary) -> TriggerState:
 ```
 
-更新运行时状态。
+更新运行时状态；每次最多返回一个脉冲，跨期只保留周期余数，不补发历史脉冲。 激活时产生即时脉冲会忽略当次 delta；否则首次等待消费当次 delta。 持续活跃期间只有有限正 delta 才能触发新的脉冲，事件刷新不会重复触发。 首次等待仅在等待阶段读取，周期每次读取；修改共享配置会影响引用它的动作，但不会共享计时进度。
 
 参数：
 
@@ -98,4 +114,4 @@ func update(raw_active: bool, _value: Variant, delta: float, state: Dictionary) 
 结构：
 
 - `_value`: Variant，由当前输入映射产生的动作值。
-- `state`: Dictionary，由输入运行时持有，包含 was_active: bool 和 elapsed: float。
+- `state`: Dictionary，由输入运行时按动作和玩家隔离持有，包含 was_active: bool、initial_wait_pending: bool 和 elapsed: float；elapsed 表示首次等待已用时间或周期余数。

--- a/docs/zh/reference/api/classes/index.md
+++ b/docs/zh/reference/api/classes/index.md
@@ -7,7 +7,7 @@
 | 模块 | 类 | 成员 | 页面内索引 |
 |---|---:|---:|---|
 | Kernel | 78 | 1137 | [Kernel](#module-kernel) |
-| Standard | 480 | 7576 | [Standard](#module-standard) |
+| Standard | 480 | 7577 | [Standard](#module-standard) |
 | Action Queue | 16 | 215 | [Action Queue](#module-extensions-action_queue) |
 | Asset Metadata | 4 | 33 | [Asset Metadata](#module-extensions-asset_metadata) |
 | Behavior Tree | 22 | 89 | [Behavior Tree](#module-extensions-behavior_tree) |
@@ -392,7 +392,7 @@
 | [`GFInputNormalizeModifier`](GFInputNormalizeModifier.md#gfinputnormalizemodifier) | 资源定义 (`resource_definition`) | `GFInputModifier` | 3 | `addons/gf/standard/input/modifiers/gf_input_normalize_modifier.gd` |
 | [`GFInputPressedTrigger`](GFInputPressedTrigger.md#gfinputpressedtrigger) | 资源定义 (`resource_definition`) | `GFInputTrigger` | 2 | `addons/gf/standard/input/triggers/gf_input_pressed_trigger.gd` |
 | [`GFInputProfileBank`](GFInputProfileBank.md#gfinputprofilebank) | 资源定义 (`resource_definition`) | `Resource` | 16 | `addons/gf/standard/input/mapping/gf_input_profile_bank.gd` |
-| [`GFInputPulseTrigger`](GFInputPulseTrigger.md#gfinputpulsetrigger) | 资源定义 (`resource_definition`) | `GFInputTrigger` | 4 | `addons/gf/standard/input/triggers/gf_input_pulse_trigger.gd` |
+| [`GFInputPulseTrigger`](GFInputPulseTrigger.md#gfinputpulsetrigger) | 资源定义 (`resource_definition`) | `GFInputTrigger` | 5 | `addons/gf/standard/input/triggers/gf_input_pulse_trigger.gd` |
 | [`GFInputReleasedTrigger`](GFInputReleasedTrigger.md#gfinputreleasedtrigger) | 资源定义 (`resource_definition`) | `GFInputTrigger` | 2 | `addons/gf/standard/input/triggers/gf_input_released_trigger.gd` |
 | [`GFInputRemapConfig`](GFInputRemapConfig.md#gfinputremapconfig) | 资源定义 (`resource_definition`) | `Resource` | 13 | `addons/gf/standard/input/rebinding/gf_input_remap_config.gd` |
 | [`GFInputScaleModifier`](GFInputScaleModifier.md#gfinputscalemodifier) | 资源定义 (`resource_definition`) | `GFInputModifier` | 5 | `addons/gf/standard/input/modifiers/gf_input_scale_modifier.gd` |

--- a/docs/zh/reference/api/index.md
+++ b/docs/zh/reference/api/index.md
@@ -7,7 +7,7 @@
 - 源码根目录：`addons/gf`
 - 公开类：`883`
 - 公开 AutoLoad：`1`
-- 公开成员：`12723`
+- 公开成员：`12724`
 - 公开方法：`7883`
 - AutoLoad 公开方法：`65`
 
@@ -16,7 +16,7 @@
 | 模块 | 类 | AutoLoad | 成员 | 方法 | 页面 |
 |---|---:|---:|---:|---:|---|
 | Kernel | 78 | 1 | 1206 | 891 | [kernel.md](kernel.md) |
-| Standard | 480 | 0 | 7576 | 4806 | [standard.md](standard.md) |
+| Standard | 480 | 0 | 7577 | 4806 | [standard.md](standard.md) |
 | Action Queue | 16 | 0 | 215 | 136 | [extensions-action-queue.md](extensions-action-queue.md) |
 | Asset Metadata | 4 | 0 | 33 | 24 | [extensions-asset-metadata.md](extensions-asset-metadata.md) |
 | Behavior Tree | 22 | 0 | 89 | 65 | [extensions-behavior-tree.md](extensions-behavior-tree.md) |

--- a/docs/zh/reference/api/standard.md
+++ b/docs/zh/reference/api/standard.md
@@ -8,7 +8,7 @@
 |---|---:|---:|---:|
 | [运行时服务](#category-runtime_service) | 194 | 3478 | 2360 |
 | [协议与扩展点](#category-protocol) | 26 | 345 | 273 |
-| [资源定义](#category-resource_definition) | 122 | 1575 | 797 |
+| [资源定义](#category-resource_definition) | 122 | 1576 | 797 |
 | [运行时句柄](#category-runtime_handle) | 56 | 952 | 607 |
 | [值对象](#category-value_object) | 58 | 985 | 631 |
 | [领域模型](#category-domain_model) | 4 | 61 | 42 |

--- a/docs/zh/standard/input-flow/input-assist/input-modifiers-triggers.md
+++ b/docs/zh/standard/input-flow/input-assist/input-modifiers-triggers.md
@@ -8,7 +8,7 @@
 
 内置修饰器各自只处理通用数值变换：`GFInputDeadzoneModifier` 处理摇杆死区并可重映射剩余范围，`GFInputScaleModifier` 调节或反转轴分量，`GFInputNormalizeModifier` 限制二维/三维向量长度，`GFInputMapRangeModifier` 把输入范围线性映射到目标范围，`GFInputCurveModifier` 按 `Curve` 采样灵敏度或压力响应，`GFInputSwizzleModifier` 重排二维/三维分量，`GFInputMagnitudeModifier` 把多轴输入投影成幅值，`GFInputSignClampModifier` 只保留正向或负向分量，`GFInputVirtualCursorModifier` 把抽象速度积分为一个受限位置。`GFInputModifier` 提供通用运行时状态协议：无状态修饰器默认 no-op，有状态修饰器可通过 `supports_runtime_state()`、`get_modifier_runtime_state()`、`restore_modifier_runtime_state()` 和 runtime delta 入口参与回放或多人实例隔离。虚拟光标修饰器只维护数值坐标，不读取 Viewport 或 Control；若要移动真实节点、焦点或 UI 光标，应由项目层消费输出位置。内置触发器各自只处理通用动作时序：`GFInputPressedTrigger` 只在按下瞬间触发，`GFInputReleasedTrigger` 只在释放瞬间触发，`GFInputTapTrigger` 识别短按，`GFInputHoldTrigger` 识别长按，`GFInputPulseTrigger` 在持续输入时周期触发，`GFInputChordTrigger` 要求另一个动作同时活跃，`GFInputSequenceTrigger` 要求动作按顺序完成。组合键和动作序列都基于抽象 action id，不绑定具体键位。
 
-同一 Binding 或 Mapping 上的 modifier 严格按资源数组顺序执行，非交换变换不会被重排。运行时会为每个 binding/mapping 复制 modifier；虚拟光标等有状态 modifier 即使复用同一配置 Resource，也不会在两个动作之间共享 position/ticks。`GFInputDeadzoneModifier` 允许 lower 与 upper 相等并把它解释为硬阈值：低于共同阈值输出 0，达到或超过阈值时在 rescale 模式输出满幅。`GFInputPulseTrigger` 会忽略 NaN/Infinity/负 delta，并保证 elapsed remainder 保持有限，后续有限 tick 可以继续触发。
+同一 Binding 或 Mapping 上的 modifier 严格按资源数组顺序执行，非交换变换不会被重排。运行时会为每个 binding/mapping 复制 modifier；虚拟光标等有状态 modifier 即使复用同一配置 Resource，也不会在两个动作之间共享 position/ticks。`GFInputDeadzoneModifier` 允许 lower 与 upper 相等并把它解释为硬阈值：低于共同阈值输出 0，达到或超过阈值时在 rescale 模式输出满幅。
 
 简单序列可继续使用 `GFInputSequenceTrigger.required_action_ids`。需要多条可替代路径、单步最大间隔、按住时间或释放完成条件时，使用 `GFInputSequenceBranch` 和 `GFInputSequenceStep` 描述资源化序列：
 
@@ -32,3 +32,22 @@ trigger.branches = [branch]
 排查 `consume_action()` 没有触发时，先确认 `action_id` 与 `GFInputAction.action_id` 完全一致，包含大小写；确认对应 `GFInputContext` 已启用，且绑定的 `InputEvent` 类型与实际事件匹配；确认没有更高优先级上下文的动作通过 `block_lower_priority_actions` 阻断同一个输入；如果动作使用了 `Released`、`Tap`、`Hold`、`Pulse` 或 `Sequence` 触发器，还要按触发器语义检查它是在按下、释放、持续时间满足，还是序列完成时才会进入 just-started。
 
 `GFInputAction.ValueType` 支持 `BOOL`、`AXIS_1D`、`AXIS_2D` 与 `AXIS_3D`。`GFInputBinding.ValueTarget.AUTO` 会按动作值类型自动产出贡献值，但二维/三维动作默认写入 X 分量；摇杆 Y、右摇杆、Z 轴或按钮方向应使用显式 `AXIS_2D_*` / `AXIS_3D_*` 目标。`get_action_vector()` / `get_action_vector_for_player()` 返回 `Vector2`；需要三维输入时使用 `get_action_vector3()` 或 `get_action_vector3_for_player()`。
+
+## 周期脉冲的首次等待
+
+`GFInputPulseTrigger.initial_delay_seconds` 将首次等待与后续 `interval_seconds` 分开设置。例如，按下时立即触发一次，持续输入 0.4 秒后开始每 0.08 秒重复：
+
+```gdscript
+var pulse := GFInputPulseTrigger.new()
+pulse.trigger_immediately = true
+pulse.initial_delay_seconds = 0.4
+pulse.interval_seconds = 0.08
+```
+
+把触发器加入 Mapping 的 `triggers` 后，可用于菜单导航、数量调整或工具步进；具体动作、边界和循环规则由项目处理。计时状态按动作和玩家隔离，释放输入或重建上下文后重新开始首次等待。触发器配置 Resource 可以共享；修改首次等待会影响仍在等待的动作，已进入周期的动作在下次激活时采用新值。周期参数则在每次更新时读取。
+
+`initial_delay_seconds` 默认为 `-1`，表示首次等待沿用 `interval_seconds`；所有有限负值都会归一为 `-1`，NaN/Infinity 赋值被拒绝并保留原值。`trigger_immediately=false` 时，首次脉冲也要等待该时长。首次等待为 `0` 时，激活当次只触发一个脉冲，无论 `trigger_immediately` 如何设置；之后仍等待正常间隔。
+
+激活时若立即发出脉冲，则忽略当次 delta；若关闭立即触发且首次等待大于零，直接调用 `update()` 时，激活当次传入的 delta 也会计入等待，普通输入事件刷新则传入零。计时只使用有限正 delta，不读取墙钟；零值、负值或 NaN/Infinity delta 不推进计时。单次更新最多返回一个脉冲；跨过多个期限时仅保留有限的周期余数，不批量补发。
+
+`action_started` 与 `consume_action()` 的一次性标记仍来自动作由不活跃变为活跃的转换。低帧率下连续更新都可能命中脉冲，因而不会为每个理论周期分别产生开始事件；这类周期输入不适合作为必须精确累计次数的计数器。

--- a/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
+++ b/tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
@@ -152,6 +152,15 @@ func _configured_tween_action(action: GFVisualAction) -> GFConfiguredTweenAction
 	return null
 
 
+func _get_created_tween(previous_tweens: Array[Tween]) -> Tween:
+	var created_tweens: Array[Tween] = []
+	for tween: Tween in get_tree().get_processed_tweens():
+		if not previous_tweens.has(tween):
+			created_tweens.append(tween)
+	assert_eq(created_tweens.size(), 1, "同步执行动作应创建唯一可推进的 Tween。")
+	return created_tweens[0] if created_tweens.size() == 1 else null
+
+
 func _make_easing_curve(midpoint_y: float = 0.25) -> Curve:
 	var curve: Curve = Curve.new()
 	curve.min_value = minf(0.0, midpoint_y)
@@ -577,16 +586,28 @@ func test_configured_curve_action_keeps_marker_parallel_topology() -> void:
 		func(marker_id: StringName, _index: int, _target: Object) -> void:
 			markers.append(marker_id)
 	) as Error
+	var previous_tweens: Array[Tween] = get_tree().get_processed_tweens()
 	var result: Variant = action.execute()
+	var tween: Tween = _get_created_tween(previous_tweens)
+	if tween == null:
+		action.cancel()
+		return
+	action.pause()
 	var completed: Array[bool] = [false]
 	var wait_for_completion: Callable = func() -> void:
 		await action.await_result_safely(result)
 		completed[0] = true
 	wait_for_completion.call()
-	await get_tree().create_timer(0.05).timeout
+	var first_running: bool = tween.custom_step(0.05)
+	assert_true(first_running)
 	assert_gt(target.position.x, 0.0)
+	assert_lt(target.position.x, 8.0)
 	assert_gt(target.rotation, 0.0)
-	await get_tree().create_timer(0.25).timeout
+	assert_lt(target.rotation, 1.0)
+	assert_true(markers.is_empty(), "中间进度不得提前发出完成标记。")
+	assert_false(completed[0])
+	var _second_step: bool = tween.custom_step(0.2)
+	await get_tree().process_frame
 	assert_true(completed[0], "Natural completion must release the already registered waiter.")
 	if not completed[0]:
 		action.cancel()
@@ -749,13 +770,35 @@ func test_configured_tween_marker_does_not_serialize_following_parallel_step() -
 		func(marker_id: StringName, _step_index: int, _target: Object) -> void:
 			markers.append(marker_id)
 	) as Error
+	var previous_tweens: Array[Tween] = get_tree().get_processed_tweens()
 	var result: Variant = action.execute()
-	await get_tree().create_timer(0.05).timeout
+	var tween: Tween = _get_created_tween(previous_tweens)
+	if tween == null:
+		action.cancel()
+		return
+	action.pause()
+	var completed: Array[bool] = [false]
+	var wait_for_completion: Callable = func() -> void:
+		await action.await_result_safely(result)
+		completed[0] = true
+	wait_for_completion.call()
+	var first_running: bool = tween.custom_step(0.05)
 
+	assert_true(first_running)
 	assert_gt(node.position.x, 0.0, "第一步应已开始推进。")
+	assert_lt(node.position.x, 10.0)
 	assert_gt(node.rotation, 0.0, "marker callback 不得把声明 parallel 的第二步推迟到第一步之后。")
+	assert_lt(node.rotation, 1.0)
+	assert_true(markers.is_empty(), "中间进度不得提前发出完成标记。")
+	assert_false(completed[0])
 
-	await action.await_result_safely(result)
+	var _second_step: bool = tween.custom_step(0.2)
+	await get_tree().process_frame
+	assert_true(completed[0], "自然完成必须释放提前注册的等待者。")
+	if not completed[0]:
+		action.cancel()
+		await get_tree().process_frame
+		return
 	assert_eq(markers, [&"position_done"], "并行拓扑修复后 marker 仍应恰好发出一次。")
 
 

--- a/tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
+++ b/tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
@@ -663,6 +663,222 @@ func test_pulse_trigger_repeats_while_raw_input_is_active() -> void:
 	assert_true(_utility.is_action_active(&"repeat"), "达到间隔后应触发一次。")
 
 
+func test_pulse_trigger_keyboard_waits_before_faster_repeats() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger()
+	_utility.enable_context(_make_context(&"menu", [
+		_make_pulse_mapping(&"repeat", KEY_R, trigger),
+	]))
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+
+	assert_true(_utility.was_action_just_started(&"repeat"), "按下应立即产生开始状态。")
+	assert_true(_utility.consume_action(&"repeat"), "立即脉冲应能消费一次。")
+	assert_false(_utility.consume_action(&"repeat"), "同一脉冲不得重复消费。")
+	_utility.tick(0.25)
+	assert_false(_utility.is_action_active(&"repeat"), "首次等待不能缩短为后续间隔。")
+	assert_false(_utility.consume_action(&"repeat"), "等待期间不得产生可消费动作。")
+	_utility.tick(0.25)
+	assert_true(_utility.was_action_just_started(&"repeat"), "首次等待到期应重新开始。")
+	assert_true(_utility.consume_action(&"repeat"), "首次等待到期应产生重复脉冲。")
+	_utility.tick(0.0625)
+	assert_false(_utility.is_action_active(&"repeat"), "两次周期脉冲之间应结束动作。")
+	_utility.tick(0.0625)
+	assert_true(_utility.consume_action(&"repeat"), "后续重复应使用更短的周期。")
+
+	_utility.handle_input_event(_make_key_event(KEY_R, false))
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+	assert_true(_utility.consume_action(&"repeat"), "释放后重新按下应再次立即触发。")
+	_utility.tick(0.125)
+	assert_false(_utility.is_action_active(&"repeat"), "重新按下必须重新经历首次等待。")
+
+
+func test_pulse_trigger_virtual_input_can_delay_the_first_pulse() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	_utility.enable_context(_make_context(&"menu", [
+		_make_pulse_mapping(&"repeat", KEY_R, trigger),
+	]))
+	var source: GFVirtualInputSource = _utility.create_virtual_source(&"navigation")
+	assert_true(source.press(&"repeat"))
+	assert_false(_utility.consume_action(&"repeat"), "关闭立即触发时，虚拟输入也应等待。")
+	_utility.tick(0.25)
+	assert_false(_utility.is_action_active(&"repeat"))
+	_utility.tick(0.25)
+	assert_true(_utility.was_action_just_started(&"repeat"))
+	assert_true(_utility.consume_action(&"repeat"), "首个脉冲应在独立等待到期时产生。")
+	_utility.tick(0.0625)
+	_utility.tick(0.0625)
+	assert_true(_utility.consume_action(&"repeat"), "虚拟输入后续也应使用周期参数。")
+	assert_true(source.release(&"repeat"))
+	assert_true(source.press(&"repeat"))
+	_utility.tick(0.125)
+	assert_false(_utility.is_action_active(&"repeat"), "释放必须清理虚拟输入的周期阶段。")
+
+
+func test_pulse_trigger_consecutive_triggered_updates_keep_one_action_start() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	_utility.enable_context(_make_context(&"menu", [
+		_make_pulse_mapping(&"repeat", KEY_R, trigger),
+	]))
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+	_utility.tick(0.5)
+	assert_true(_utility.was_action_just_started(&"repeat"))
+	assert_true(_utility.consume_action(&"repeat"))
+	for _step: int in range(2):
+		_utility.tick(0.125)
+		assert_true(_utility.is_action_active(&"repeat"), "连续跨周期的更新仍保持动作活跃。")
+		assert_false(_utility.was_action_just_started(&"repeat"), "持续活跃不会为每个脉冲重新产生开始边沿。")
+		assert_false(_utility.consume_action(&"repeat"), "持续活跃不得重复消费同一次开始。")
+	_utility.tick(0.0625)
+	assert_false(_utility.is_action_active(&"repeat"))
+	_utility.tick(0.0625)
+	assert_true(_utility.was_action_just_started(&"repeat"))
+	assert_true(_utility.consume_action(&"repeat"), "动作先结束再触发才产生新的可消费开始。")
+
+
+func test_pulse_trigger_source_configuration_updates_enabled_mapping() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	_utility.enable_context(_make_context(&"menu", [
+		_make_pulse_mapping(&"repeat", KEY_R, trigger),
+	]))
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+	_utility.tick(0.25)
+	trigger.initial_delay_seconds = 1.0
+	_utility.tick(0.25)
+	assert_false(_utility.is_action_active(&"repeat"), "已启用映射应直接采用资源上延长的首次等待。")
+	trigger.initial_delay_seconds = 0.5
+	_utility.tick(0.125)
+	assert_true(_utility.consume_action(&"repeat"), "缩短来源资源等待无需重建映射即可生效。")
+	trigger.initial_delay_seconds = 4.0
+	_utility.tick(0.0625)
+	assert_false(_utility.is_action_active(&"repeat"))
+	_utility.tick(0.0625)
+	assert_true(_utility.consume_action(&"repeat"), "资源改动不得把已经进入周期的动作重新置于首次等待。")
+
+
+func test_pulse_trigger_context_disable_and_remap_rebuild_restart_waiting() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	var context: GFInputContext = _make_context(&"menu", [
+		_make_pulse_mapping(&"repeat", KEY_R, trigger),
+	])
+	_utility.enable_context(context)
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+	_utility.tick(0.375)
+	_utility.disable_context(context)
+	_utility.enable_context(context)
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+	_utility.tick(0.125)
+	assert_false(_utility.is_action_active(&"repeat"), "上下文重新启用不得继承旧等待进度。")
+	_utility.tick(0.375)
+	assert_true(_utility.consume_action(&"repeat"))
+
+	_utility.set_remap_config(null)
+	_utility.handle_input_event(_make_key_event(KEY_R, true))
+	_utility.tick(0.125)
+	assert_false(_utility.is_action_active(&"repeat"), "映射重建不得继承旧周期阶段。")
+	_utility.tick(0.375)
+	assert_true(_utility.consume_action(&"repeat"), "重建后完整首次等待仍能正常到期。")
+
+
+func test_shared_pulse_resource_keeps_actions_and_players_independent() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	_utility.enable_context(_make_context(&"menu", [
+		_make_pulse_mapping(&"first", KEY_R, trigger),
+		_make_pulse_mapping(&"second", KEY_T, trigger),
+	]))
+	var first_player: GFVirtualInputSource = _utility.create_virtual_source(&"first_player", 0)
+	var second_player: GFVirtualInputSource = _utility.create_virtual_source(&"second_player", 1)
+	assert_true(first_player.press(&"first"))
+	_utility.tick(0.25)
+	assert_true(second_player.press(&"first"))
+	assert_true(first_player.press(&"second"))
+	_utility.tick(0.25)
+
+	assert_true(_utility.consume_action_for_player(0, &"first"), "先激活动作应先完成首次等待。")
+	assert_false(_utility.is_action_active_for_player(1, &"first"), "同动作的其他玩家不得继承等待进度。")
+	assert_false(_utility.is_action_active_for_player(0, &"second"), "共享资源的其他动作不得继承等待进度。")
+	assert_true(first_player.release(&"first"))
+	_utility.tick(0.25)
+	assert_true(_utility.consume_action_for_player(1, &"first"), "释放其他玩家输入不得重置本玩家等待。")
+	assert_true(_utility.consume_action_for_player(0, &"second"), "释放其他动作不得重置共享资源的等待。")
+
+
+func test_pulse_trigger_large_delta_preserves_period_remainder_without_backlog() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger()
+	var state: Dictionary = {}
+	trigger.reset_trigger_state(state)
+
+	assert_eq(trigger.update(true, true, 8.0, state), GFInputTrigger.TriggerState.TRIGGERED)
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.ONGOING, "立即触发调用的 delta 不得计入首次等待。")
+	assert_eq(trigger.update(true, true, 0.5625, state), GFInputTrigger.TriggerState.TRIGGERED, "跨越首次等待与多个周期仍只返回一次触发。")
+	assert_eq(trigger.update(true, true, 0.0, state), GFInputTrigger.TriggerState.ONGOING, "不得通过零 delta 补发过期脉冲。")
+	assert_eq(trigger.update(true, true, 0.0625, state), GFInputTrigger.TriggerState.TRIGGERED, "跨首次期限后应保留后续周期余数。")
+	assert_eq(trigger.update(true, true, 1.0e308, state), GFInputTrigger.TriggerState.TRIGGERED, "极大有限 delta 仍应有界推进。")
+	assert_eq(trigger.update(true, true, 0.0, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.TRIGGERED, "极大 delta 后有限周期仍能正常工作。")
+
+
+func test_pulse_trigger_huge_finite_period_preserves_remainder_without_overflow() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger()
+	trigger.initial_delay_seconds = 0.0
+	trigger.interval_seconds = 1.6e308
+	var state: Dictionary = {}
+	trigger.reset_trigger_state(state)
+
+	assert_eq(trigger.update(true, true, 0.0, state), GFInputTrigger.TriggerState.TRIGGERED)
+	assert_eq(trigger.update(true, true, 1.2e308, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 1.2e308, state), GFInputTrigger.TriggerState.TRIGGERED, "有限累计时长超过浮点上限时仍应正常跨期。")
+	assert_eq(trigger.update(true, true, 0.7e308, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 0.2e308, state), GFInputTrigger.TriggerState.TRIGGERED, "跨期必须保留巨大有限余数，而不是丢弃或污染进度。")
+
+
+func test_pulse_trigger_zero_initial_delay_coalesces_activation() -> void:
+	for immediate: bool in [true, false]:
+		var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(immediate)
+		trigger.initial_delay_seconds = 0.0
+		var state: Dictionary = {}
+		trigger.reset_trigger_state(state)
+
+		assert_eq(trigger.update(true, true, 8.0, state), GFInputTrigger.TriggerState.TRIGGERED, "零等待在激活时只产生一个脉冲。")
+		assert_eq(trigger.update(true, true, 0.0, state), GFInputTrigger.TriggerState.ONGOING, "立即脉冲与零等待不得重复发放。")
+		assert_eq(trigger.update(true, true, 0.0625, state), GFInputTrigger.TriggerState.ONGOING)
+		assert_eq(trigger.update(true, true, 0.0625, state), GFInputTrigger.TriggerState.TRIGGERED, "零等待激活后直接使用周期参数。")
+
+
+func test_pulse_trigger_live_delay_changes_only_affect_waiting_phase() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	var state: Dictionary = {}
+	trigger.reset_trigger_state(state)
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.ONGOING)
+	trigger.initial_delay_seconds = 1.0
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.ONGOING, "等待中应采用当前首次等待设置。")
+	trigger.initial_delay_seconds = 0.25
+	assert_eq(trigger.update(true, true, 0.0, state), GFInputTrigger.TriggerState.ONGOING, "缩短等待不能通过零 delta 重复评估产生脉冲。")
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.TRIGGERED)
+	trigger.initial_delay_seconds = 4.0
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.TRIGGERED, "已进入周期后修改首次等待不应重新等待。")
+	trigger.interval_seconds = 0.25
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.ONGOING, "周期阶段应使用当前间隔。")
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.TRIGGERED)
+	assert_eq(trigger.update(false, false, 0.0, state), GFInputTrigger.TriggerState.INACTIVE)
+	assert_eq(trigger.update(true, true, 0.5, state), GFInputTrigger.TriggerState.ONGOING, "下一次激活才采用新的首次等待。")
+
+
+func test_pulse_trigger_negative_initial_delay_uses_current_interval() -> void:
+	var trigger: GFInputPulseTrigger = GFInputPulseTrigger.new()
+	trigger.trigger_immediately = false
+	trigger.interval_seconds = 0.25
+	var state: Dictionary = {}
+	trigger.reset_trigger_state(state)
+	assert_eq(trigger.initial_delay_seconds, -1.0, "未配置首次等待时应沿用周期。")
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.TRIGGERED)
+	assert_eq(trigger.update(false, false, 0.0, state), GFInputTrigger.TriggerState.INACTIVE)
+	trigger.initial_delay_seconds = -2.0
+	trigger.interval_seconds = 0.5
+	assert_eq(trigger.initial_delay_seconds, -1.0, "有限负值应规范为沿用周期的同一表示。")
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.TRIGGERED, "沿用周期应读取当前间隔，而非复制旧值。")
+
+
 func test_pulse_trigger_rejects_nonfinite_delta_and_recovers() -> void:
 	var trigger: GFInputPulseTrigger = GFInputPulseTrigger.new()
 	trigger.interval_seconds = 0.1
@@ -680,6 +896,23 @@ func test_pulse_trigger_rejects_nonfinite_delta_and_recovers() -> void:
 
 	var _released: GFInputTrigger.TriggerState = trigger.update(false, false, 0.0, state)
 	assert_eq(GFVariantData.get_option_float(state, "elapsed"), 0.0, "释放应完整清理受攻击后的时间状态。")
+
+
+func test_pulse_trigger_initial_delay_rejects_nonfinite_values_and_recovers() -> void:
+	var trigger: GFInputPulseTrigger = _make_delayed_pulse_trigger(false)
+	var state: Dictionary = {}
+	trigger.reset_trigger_state(state)
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.ONGOING)
+	for invalid_value: float in [NAN, INF, -INF]:
+		trigger.initial_delay_seconds = invalid_value
+		trigger.interval_seconds = invalid_value
+		assert_eq(trigger.initial_delay_seconds, 0.5, "非法首次等待应保留最后有效配置。")
+		assert_eq(trigger.interval_seconds, 0.125, "非法周期应保留最后有效配置。")
+		assert_eq(trigger.update(true, true, invalid_value, state), GFInputTrigger.TriggerState.ONGOING, "非法 delta 不得消耗等待时间。")
+	assert_eq(trigger.update(true, true, -1.0, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 0.25, state), GFInputTrigger.TriggerState.TRIGGERED, "非法输入后应保留已有等待进度。")
+	assert_eq(trigger.update(true, true, NAN, state), GFInputTrigger.TriggerState.ONGOING)
+	assert_eq(trigger.update(true, true, 0.125, state), GFInputTrigger.TriggerState.TRIGGERED, "周期阶段也应在非法 delta 后恢复。")
 
 
 ## 验证组合触发器依赖另一个抽象动作，而不是具体按键。
@@ -2749,6 +2982,20 @@ func test_input_conflict_analyzer_separates_joy_axis_positive_and_negative_bindi
 
 
 # --- 私有/辅助方法 ---
+
+func _make_delayed_pulse_trigger(immediate: bool = true) -> GFInputPulseTrigger:
+	var trigger: GFInputPulseTrigger = GFInputPulseTrigger.new()
+	trigger.initial_delay_seconds = 0.5
+	trigger.interval_seconds = 0.125
+	trigger.trigger_immediately = immediate
+	return trigger
+
+
+func _make_pulse_mapping(action_id: StringName, key: Key, trigger: GFInputPulseTrigger) -> GFInputMapping:
+	var mapping: GFInputMapping = _make_mapping(_make_action(action_id), [_make_key_binding(key)])
+	mapping.triggers = [trigger]
+	return mapping
+
 
 func _action_float(action_id: StringName) -> float:
 	return GFVariantData.to_float(_utility.get_action_value(action_id))

--- a/tests/gf_core/standard/utilities/nodes/test_gf_object_pool_shutdown.gd
+++ b/tests/gf_core/standard/utilities/nodes/test_gf_object_pool_shutdown.gd
@@ -152,11 +152,11 @@ func test_timed_out_shutdown_keeps_nonblocking_forced_cleanup_fallback() -> void
 	var probe: ShutdownProbe = ShutdownProbe.new()
 	var _connected: Error = lease.settled.connect(_count_settlement.bind(probe)) as Error
 	var blocker: PendingShutdownUtility = PendingShutdownUtility.new()
-	blocker.lifecycle_priority = 100
 	assert_true(await _architecture.register_utility_instance(blocker))
 
-	var shutdown_result: GFArchitectureShutdownResult = await _architecture.shutdown_async(null, 0.001)
+	var shutdown_result: GFArchitectureShutdownResult = await _architecture.shutdown_async(null, 0.1)
 
+	assert_true(blocker.did_begin_quiesce, "依赖模块必须先进入等待，才能验证超时后的 Pool 强制清理。")
 	assert_eq(shutdown_result.get_status(), GFArchitectureShutdownResult.Status.TIMED_OUT)
 	assert_true(_architecture.is_disposed())
 	assert_false(lease.is_settled(), "先行模块超时后走同步强制退出，不应绕过安全点。")
@@ -329,5 +329,12 @@ class ShutdownProbe extends RefCounted:
 
 
 class PendingShutdownUtility extends GFUtility:
+	var did_begin_quiesce: bool = false
+
+	func get_required_utilities() -> Array[Script]:
+		return [GFObjectPoolUtility]
+
+
 	func begin_quiesce(_scope: GFAsyncScope) -> GFAsyncCompletion:
+		did_begin_quiesce = true
 		return GFAsyncCompletion.new()


### PR DESCRIPTION
## Summary

Held input previously used one interval for both the first repeat and subsequent repeats. Add `GFInputPulseTrigger.initial_delay_seconds` so projects can respond immediately, wait 0.4 seconds, then repeat every 0.08 seconds using the existing input mapping pipeline.

Also correct two existing test premises exposed by full validation: the object pool shutdown fixture now explicitly orders its blocker before pool shutdown, and Tween topology tests advance the action's actual Tween deterministically. Their original cleanup, parallel progress, marker and completion assertions remain covered.

## Contract and Risk

- Change type: feat
- Consumer-visible behavior: independently configurable initial and repeat timing; release and mapping rebuild restart waiting. Each update emits at most one pulse, retains the period remainder, and does not replay missed pulses. Action-start and consume events still follow the existing state-transition contract.
- API or extension contract: add `initial_delay_seconds`; `-1` follows the current interval, finite negatives normalize to `-1`, and zero coalesces activation into one pulse. Nonfinite assignments retain the previous valid configuration. The documented trigger-state dictionary gains `initial_wait_pending`; generated API and knowledge references are updated. Extension contracts are unchanged.
- Persisted data, package, protocol, or ProjectSettings impact: existing trigger resources require no migration and retain their default timing. No package, protocol or ProjectSettings changes.
- Failure, cancellation, rollback, concurrency, and ownership impact: timing state remains isolated per action and player even when configuration resources are shared. Invalid deltas do not advance time; large finite deltas cannot overflow the stored remainder. Test reliability fixes do not change object pool or Tween runtime behavior.
- Compatibility and migration: existing resource configuration remains valid. Custom consumers of the documented runtime-state dictionary should initialize it through `reset_trigger_state()`. The intended `12.0.0-dev.0` line is unchanged; the new property remains `@since unreleased`.

## Verification

- [x] Focused tests cover the changed behavior and failure path. Repeated before commit: input mapping **114/114**, object pool shutdown **9/9**, visual actions **76/76**; **989 assertions**, zero unhandled warnings or orphans.
- [x] `python tools/gf_maintenance.py check --suite quick --failed-only`
- [x] `python tools/gf_maintenance.py check --suite full --failed-only` — **40/40** checks; GUT **7,407/7,407**, **91,552 assertions**; no skipped checks, unhandled warnings or orphans.
- [x] GDScript warning and strict LSP gates are clean.
- [x] Generated API and knowledge output is fresh.
- Draft PR feedback: not applicable; implementation, documentation, local full validation and independent frozen-snapshot reviews are complete before creating this Ready PR.
- [ ] Ready PR CI completed through `GF repository policy` and `GF merge gate`.

Focused GUT selectors used with `gf_gut_cli.gd`, `-gconfig=`, and the repository pre/post lifecycle hooks:

```text
-gtest=res://tests/gf_core/standard/input/runtime/test_gf_input_mapping_utility.gd
-gtest=res://tests/gf_core/standard/utilities/nodes/test_gf_object_pool_shutdown.gd
-gtest=res://tests/gf_core/extensions/action_queue/test_gf_visual_actions.gd
```

## Documentation and Release

- [x] Relevant input guide and `[未发布]` changelog entries are updated.
- [x] Development version impact is correct; this change does not alter the intended SemVer line.
- [x] This PR does not create a tag or publish a release.
